### PR TITLE
feat: Toolbar platform adaptation for iOS

### DIFF
--- a/example/src/RootNavigator.js
+++ b/example/src/RootNavigator.js
@@ -1,7 +1,6 @@
 /* @flow */
 
 import React from 'react';
-import { Platform } from 'react-native';
 import Expo from 'expo';
 import { StackNavigator } from 'react-navigation';
 import { Colors } from 'react-native-paper';
@@ -36,8 +35,7 @@ export default StackNavigator(
       headerStyle: {
         backgroundColor: Colors.indigo500,
         paddingTop: Expo.Constants.statusBarHeight,
-        height:
-          (Platform.OS === 'ios' ? 44 : 56) + Expo.Constants.statusBarHeight,
+        height: 56 + Expo.Constants.statusBarHeight,
       },
     },
   }

--- a/example/src/ToolbarExample.js
+++ b/example/src/ToolbarExample.js
@@ -4,6 +4,8 @@ import React, { Component } from 'react';
 import { View, Platform, StatusBar, StyleSheet } from 'react-native';
 import { Colors, Button, Toolbar } from 'react-native-paper';
 
+const MORE_ICON = Platform.OS === 'android' ? 'more-vert' : 'more-horiz';
+
 export default class ToolbarExample extends Component {
   static title = 'Toolbar';
   static navigationOptions = {
@@ -12,11 +14,18 @@ export default class ToolbarExample extends Component {
 
   state = {
     showLeftIcon: true,
-    showSubtitle: true,
+    showSearchIcon: Platform.OS === 'android',
+    showMoreIcon: true,
+    showSubtitle: Platform.OS === 'android',
   };
 
   render() {
-    const { showLeftIcon, showSubtitle } = this.state;
+    const {
+      showLeftIcon,
+      showSearchIcon,
+      showMoreIcon,
+      showSubtitle,
+    } = this.state;
 
     return (
       <View style={styles.container}>
@@ -25,8 +34,7 @@ export default class ToolbarExample extends Component {
           statusBarHeight={Platform.OS === 'ios' ? 20 : StatusBar.currentHeight}
         >
           {showLeftIcon && (
-            <Toolbar.Action
-              icon="arrow-back"
+            <Toolbar.BackAction
               onPress={() => this.props.navigation.goBack()}
             />
           )}
@@ -34,8 +42,12 @@ export default class ToolbarExample extends Component {
             title="Title"
             subtitle={showSubtitle ? 'Subtitle' : null}
           />
-          <Toolbar.Action icon="search" onPress={() => {}} />
-          <Toolbar.Action icon="more-vert" onPress={() => {}} />
+          {showSearchIcon && (
+            <Toolbar.Action icon="search" onPress={() => {}} />
+          )}
+          {showMoreIcon && (
+            <Toolbar.Action icon={MORE_ICON} onPress={() => {}} />
+          )}
         </Toolbar>
         <View style={styles.content}>
           <Button
@@ -53,6 +65,22 @@ export default class ToolbarExample extends Component {
               this.setState({ showSubtitle: !this.state.showSubtitle })}
           >
             {`Subtitle: ${showSubtitle ? 'On' : 'Off'}`}
+          </Button>
+          <Button
+            accent
+            raised
+            onPress={() =>
+              this.setState({ showSearchIcon: !this.state.showSearchIcon })}
+          >
+            {`Search icon: ${showSearchIcon ? 'On' : 'Off'}`}
+          </Button>
+          <Button
+            accent
+            raised
+            onPress={() =>
+              this.setState({ showMoreIcon: !this.state.showMoreIcon })}
+          >
+            {`More icon: ${showMoreIcon ? 'On' : 'Off'}`}
           </Button>
         </View>
       </View>

--- a/example/src/ToolbarExample.js
+++ b/example/src/ToolbarExample.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import { View, Platform, StatusBar, StyleSheet } from 'react-native';
 import { Colors, Button, Toolbar } from 'react-native-paper';
 
-const MORE_ICON = Platform.OS === 'android' ? 'more-vert' : 'more-horiz';
+const MORE_ICON = Platform.OS === 'ios' ? 'more-horiz' : 'more-vert';
 
 export default class ToolbarExample extends Component {
   static title = 'Toolbar';
@@ -14,9 +14,9 @@ export default class ToolbarExample extends Component {
 
   state = {
     showLeftIcon: true,
-    showSearchIcon: Platform.OS === 'android',
+    showSearchIcon: Platform.OS !== 'ios',
     showMoreIcon: true,
-    showSubtitle: Platform.OS === 'android',
+    showSubtitle: Platform.OS !== 'ios',
   };
 
   render() {

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -41,8 +41,10 @@ const Icon = ({ name, ...props }: Props) => {
       {...props}
       style={[
         {
-          width: props.size,
-          height: props.size,
+          width: '100%',
+          height: '100%',
+          justifyContent: 'center',
+          alignItems: 'center',
           overflow: 'hidden',
         },
         props.style,

--- a/src/components/Toolbar/ToolbarAction.js
+++ b/src/components/Toolbar/ToolbarAction.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React, { Component } from 'react';
-import { Platform, StyleSheet } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import color from 'color';
 
 import { black, white } from '../../styles/colors';
@@ -58,7 +58,9 @@ export default class ToolbarAction extends Component<void, Props, void> {
         style={[styles.button, style]}
         {...rest}
       >
-        <Icon color={iconColor} name={icon} size={size || 24} />
+        <View>
+          <Icon color={iconColor} name={icon} size={size || 24} />
+        </View>
       </TouchableRipple>
     );
   }

--- a/src/components/Toolbar/ToolbarAction.js
+++ b/src/components/Toolbar/ToolbarAction.js
@@ -1,8 +1,7 @@
 /* @flow */
 
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { Platform, StyleSheet, ViewPropTypes } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 import color from 'color';
 
 import { black, white } from '../../styles/colors';
@@ -13,31 +12,28 @@ import type { IconSource } from '../Icon';
 const ANDROID_VERSION_LOLLIPOP = 21;
 
 type Props = {
+  /**
+   * Theme color for the action icon, a dark action icon will render a light icon and vice-versa
+   */
   dark?: boolean,
+  /**
+   * Name of the icon to show
+   */
   icon: IconSource,
+  /**
+   * Optional icon size, defaults to 24
+   */
+  size?: number,
+  /**
+   * Function to execute on press
+   */
   onPress?: Function,
   style?: any,
 };
 
 export default class ToolbarAction extends Component<void, Props, void> {
-  static propTypes = {
-    /**
-     * Theme color for the action icon, a dark action icon will render a light icon and vice-versa
-     */
-    dark: PropTypes.bool,
-    /**
-     * Name of the icon to show
-     */
-    icon: PropTypes.string,
-    /**
-     * Function to execute on press
-     */
-    onPress: PropTypes.func,
-    style: ViewPropTypes.style,
-  };
-
   render() {
-    const { dark, icon, onPress, style, ...rest } = this.props;
+    const { dark, icon, onPress, size, style, ...rest } = this.props;
 
     const iconColor = dark
       ? white
@@ -62,7 +58,7 @@ export default class ToolbarAction extends Component<void, Props, void> {
         style={[styles.button, style]}
         {...rest}
       >
-        <Icon color={iconColor} name={icon} size={24} />
+        <Icon color={iconColor} name={icon} size={size || 24} />
       </TouchableRipple>
     );
   }
@@ -86,7 +82,6 @@ const styles = StyleSheet.create({
           // minWidth: 24,
           // maxWidth: 36,
           marginHorizontal: 6,
-          paddingHorizontal: 2,
           borderRadius: 44 / 2,
           justifyContent: 'center',
           alignItems: 'center',

--- a/src/components/Toolbar/ToolbarBackAction.js
+++ b/src/components/Toolbar/ToolbarBackAction.js
@@ -1,0 +1,34 @@
+/* @flow */
+
+import React from 'react';
+import { Platform } from 'react-native';
+import color from 'color';
+
+import ToolbarAction from './ToolbarAction';
+import Icon from '../Icon';
+import { black, white } from '../../styles/colors';
+
+const getBackIcon = Platform.select({
+  ios: ({ dark }: Props) => {
+    const iconColor = dark
+      ? white
+      : color(black)
+          .alpha(0.54)
+          .rgbaString();
+    return <Icon name="keyboard-arrow-left" size={36} color={iconColor} />;
+  },
+  android: () => 'arrow-back',
+});
+
+type Props = {
+  dark?: boolean,
+  onPress?: Function,
+  style?: any,
+};
+
+const ToolbarBackAction = (props: Props) => {
+  const BackIcon = getBackIcon(props);
+  return <ToolbarAction icon={BackIcon} {...props} />;
+};
+
+export default ToolbarBackAction;

--- a/src/components/Toolbar/ToolbarBackAction.js
+++ b/src/components/Toolbar/ToolbarBackAction.js
@@ -9,7 +9,7 @@ import Icon from '../Icon';
 import { black, white } from '../../styles/colors';
 
 const getBackIcon = Platform.select({
-  ios: ({ dark }: Props) => {
+  ios: (dark?: boolean) => {
     const iconColor = dark
       ? white
       : color(black)
@@ -21,14 +21,28 @@ const getBackIcon = Platform.select({
 });
 
 type Props = {
+  /**
+   * Theme color for the back icon, a dark action icon will render a light icon and vice-versa
+   */
   dark?: boolean,
+  /**
+   * Function to execute on press
+   */
   onPress?: Function,
   style?: any,
 };
 
 const ToolbarBackAction = (props: Props) => {
-  const BackIcon = getBackIcon(props);
-  return <ToolbarAction icon={BackIcon} {...props} />;
+  const { dark, onPress, style } = props;
+  const BackIcon = getBackIcon(dark);
+  return (
+    <ToolbarAction
+      icon={BackIcon}
+      dark={dark}
+      onPress={onPress}
+      style={style}
+    />
+  );
 };
 
 export default ToolbarBackAction;

--- a/src/components/Toolbar/ToolbarContent.js
+++ b/src/components/Toolbar/ToolbarContent.js
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { View, Platform, StyleSheet, ViewPropTypes } from 'react-native';
+import { View, StyleSheet, ViewPropTypes } from 'react-native';
 import color from 'color';
 
 import Text from '../Typography/Text';
@@ -99,10 +99,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
   },
   title: {
-    fontSize: Platform.OS === 'ios' ? 18 : 20,
+    fontSize: 20,
   },
   subtitle: {
-    fontSize: Platform.OS === 'ios' ? 12 : 14,
+    fontSize: 14,
   },
 });
 

--- a/src/components/TouchableRipple.js
+++ b/src/components/TouchableRipple.js
@@ -89,7 +89,7 @@ export default class TouchableItem extends PureComponent<
                 .rgbaString()
         }
       >
-        <View>{Children.only(children)}</View>
+        {Children.only(children)}
       </TouchableHighlight>
     );
   }

--- a/src/components/TouchableRipple.js
+++ b/src/components/TouchableRipple.js
@@ -89,7 +89,7 @@ export default class TouchableItem extends PureComponent<
                 .rgbaString()
         }
       >
-        {Children.only(children)}
+        <View>{Children.only(children)}</View>
       </TouchableHighlight>
     );
   }


### PR DESCRIPTION
Fixes #138.

Following https://material.io/guidelines/platforms/platform-adaptation.html

- [x] iOS toolbar has same height than Android
- [x] Title is centered when `leftActions < 2 &&  rightActions < 2`
- [x] Back button uses iOS default icon

## Example screenshots:
![simulator screen shot - iphone 6 plus - 2017-09-25 at 16 00 49](https://user-images.githubusercontent.com/774577/30812330-c124d31a-a20a-11e7-9fa0-c880aec88e29.png)
![simulator screen shot - iphone 6 plus - 2017-09-25 at 16 00 55](https://user-images.githubusercontent.com/774577/30812329-c11caf96-a20a-11e7-97c2-60c92887ced2.png)
![simulator screen shot - iphone 6 plus - 2017-09-25 at 16 01 00](https://user-images.githubusercontent.com/774577/30812328-c11c373c-a20a-11e7-86a0-82e974c6ca4e.png)
![simulator screen shot - iphone 6 plus - 2017-09-25 at 16 01 06](https://user-images.githubusercontent.com/774577/30812331-c145647c-a20a-11e7-8907-3111c925da1f.png)

