### PR TITLE
TextInput: Helper Text & error text

### DIFF
--- a/example/src/TextInputExample.js
+++ b/example/src/TextInputExample.js
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react';
 import { ScrollView, StyleSheet } from 'react-native';
-import { Colors, TextInput, withTheme } from 'react-native-paper';
+import { TextInput, withTheme } from 'react-native-paper';
 
 class TextInputExample extends Component {
   static title = 'TextInput';
@@ -30,8 +30,10 @@ class TextInputExample extends Component {
         <TextInput
           disabled
           style={styles.inputContainerStyle}
-          helperText="Helper text"
+          helperText="Helper: won't be visible for disabled"
           label="Disabled Input"
+          hasError
+          errorText="Error: Disable styles should override error styles"
         />
         <TextInput
           style={styles.inputContainerStyle}
@@ -44,14 +46,6 @@ class TextInputExample extends Component {
             this.setState({ hasError: this.state.errorTestText !== 'fix' })}
           hasError={this.state.hasError}
           errorText="Error: Type fix to remove the error"
-        />
-        <TextInput
-          disabled
-          style={styles.inputContainerStyle}
-          helperText="Helper: won't be visible for disabled"
-          label="Disabled with error"
-          hasError
-          errorText="Error: Disable styles should override error styles"
         />
       </ScrollView>
     );

--- a/example/src/TextInputExample.js
+++ b/example/src/TextInputExample.js
@@ -48,10 +48,10 @@ class TextInputExample extends Component {
         <TextInput
           disabled
           style={styles.inputContainerStyle}
-          helperText="Helper: Disable styles should override error styles"
+          helperText="Helper: won't be visible for disabled"
           label="Disabled with error"
           hasError
-          errorText="Error: Type fix to remove the error"
+          errorText="Error: Disable styles should override error styles"
         />
       </ScrollView>
     );

--- a/example/src/TextInputExample.js
+++ b/example/src/TextInputExample.js
@@ -2,9 +2,9 @@
 
 import React, { Component } from 'react';
 import { ScrollView, StyleSheet } from 'react-native';
-import { Colors, TextInput } from 'react-native-paper';
+import { Colors, TextInput, withTheme } from 'react-native-paper';
 
-export default class TextInputExample extends Component {
+class TextInputExample extends Component {
   static title = 'TextInput';
 
   state = {
@@ -14,8 +14,11 @@ export default class TextInputExample extends Component {
   };
 
   render() {
+    const themeBackground = this.props.theme.colors.background;
     return (
-      <ScrollView style={styles.container}>
+      <ScrollView
+        style={[styles.container, { backgroundColor: themeBackground }]}
+      >
         <TextInput
           style={styles.inputContainerStyle}
           label="Normal input"
@@ -58,10 +61,11 @@ export default class TextInputExample extends Component {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: Colors.white,
     padding: 8,
   },
   inputContainerStyle: {
     margin: 8,
   },
 });
+
+export default withTheme(TextInputExample);

--- a/example/src/TextInputExample.js
+++ b/example/src/TextInputExample.js
@@ -9,6 +9,8 @@ export default class TextInputExample extends Component {
 
   state = {
     text: '',
+    errorTestText: '',
+    hasError: false,
   };
 
   render() {
@@ -25,7 +27,28 @@ export default class TextInputExample extends Component {
         <TextInput
           disabled
           style={styles.inputContainerStyle}
+          helperText="Helper text"
           label="Disabled Input"
+        />
+        <TextInput
+          style={styles.inputContainerStyle}
+          label="Error input"
+          placeholder="Type something & then unfocus"
+          helperText="Helper: This will be replaced by error"
+          value={this.state.errorTestText}
+          onChangeText={errorTestText => this.setState({ errorTestText })}
+          onBlur={() =>
+            this.setState({ hasError: this.state.errorTestText !== 'fix' })}
+          hasError={this.state.hasError}
+          errorText="Error: Type fix to remove the error"
+        />
+        <TextInput
+          disabled
+          style={styles.inputContainerStyle}
+          helperText="Helper: Disable styles should override error styles"
+          label="Disabled with error"
+          hasError
+          errorText="Error: Type fix to remove the error"
         />
       </ScrollView>
     );

--- a/example/src/TextInputExample.js
+++ b/example/src/TextInputExample.js
@@ -18,6 +18,7 @@ export default class TextInputExample extends Component {
           style={styles.inputContainerStyle}
           label="Normal input"
           placeholder="Type something"
+          helperText="Helper text"
           value={this.state.text}
           onChangeText={text => this.setState({ text })}
         />

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -60,12 +60,21 @@ type Props = {
    * Text that gives context about a field’s input
    */
   helperText?: string,
+  /**
+   * Represents error state, true represents an invalid input
+   */
+  hasError?: boolean,
+  /**
+   * Text to show for error state, visible only when hasError prop is true
+   */
+  errorText?: string,
   style?: any,
   theme: Theme,
 };
 
 type DefaultProps = {
   disabled: boolean,
+  hasError: boolean,
 };
 
 type State = {
@@ -112,11 +121,14 @@ class TextInput extends Component<DefaultProps, Props, State> {
     style: ViewPropTypes.style,
     value: PropTypes.string,
     helperText: PropTypes.string,
+    hasError: PropTypes.bool,
+    errorText: PropTypes.string,
     theme: PropTypes.object.isRequired,
   };
 
   static defaultProps = {
     disabled: false,
+    hasError: false,
   };
 
   constructor(props: Props) {
@@ -220,6 +232,8 @@ class TextInput extends Component<DefaultProps, Props, State> {
       label,
       underlineColor,
       helperText,
+      hasError,
+      errorText,
       style,
       theme,
       ...rest
@@ -227,16 +241,20 @@ class TextInput extends Component<DefaultProps, Props, State> {
     const { colors, fonts } = theme;
     const fontFamily = fonts.regular;
     const primaryColor = colors.primary;
-    const inactiveColor = colors.disabled;
+    let inactiveColor = colors.disabled;
+    let helperTextColor = colors.helperText;
 
     let inputTextColor, labelColor, bottomLineColor;
 
-    if (!disabled) {
+    if (disabled) {
+      inputTextColor = labelColor = bottomLineColor = inactiveColor;
+    } else if (hasError) {
+      helperTextColor = labelColor = bottomLineColor = inactiveColor =
+        colors.error;
+    } else {
       inputTextColor = colors.text;
       labelColor = primaryColor;
       bottomLineColor = underlineColor || primaryColor;
-    } else {
-      inputTextColor = labelColor = bottomLineColor = inactiveColor;
     }
 
     const labelColorAnimation = this.state.focused.interpolate({
@@ -313,17 +331,12 @@ class TextInput extends Component<DefaultProps, Props, State> {
             style={[styles.bottomLine, styles.focusLine, bottomLineStyle]}
           />
         </View>
-        {
-          helperText &&
-            <Text
-              style={[
-                styles.helperText,
-                { color: colors.helperText }
-              ]}
-            >
-              {helperText}
+        {helperText &&
+          !disabled && (
+            <Text style={[styles.helperText, { color: helperTextColor }]}>
+              {hasError ? errorText : helperText}
             </Text>
-        }
+          )}
       </View>
     );
   }

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -241,10 +241,12 @@ class TextInput extends Component<DefaultProps, Props, State> {
     const { colors, fonts } = theme;
     const fontFamily = fonts.regular;
     const primaryColor = colors.primary;
+
     let inactiveColor = colors.disabled;
     let helperTextColor = colors.helperText;
-
-    let inputTextColor, labelColor, bottomLineColor;
+    let inputTextColor = colors.text,
+      labelColor,
+      bottomLineColor;
 
     if (disabled) {
       inputTextColor = labelColor = bottomLineColor = inactiveColor;
@@ -252,7 +254,6 @@ class TextInput extends Component<DefaultProps, Props, State> {
       helperTextColor = labelColor = bottomLineColor = inactiveColor =
         colors.error;
     } else {
-      inputTextColor = colors.text;
       labelColor = primaryColor;
       bottomLineColor = underlineColor || primaryColor;
     }

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -316,7 +316,10 @@ class TextInput extends Component<DefaultProps, Props, State> {
         {
           helperText &&
             <Text
-              style={styles.helperText}
+              style={[
+                styles.helperText,
+                { color: colors.helperText }
+              ]}
             >
               {helperText}
             </Text>
@@ -361,6 +364,7 @@ const styles = StyleSheet.create({
     textAlign: 'left',
     paddingTop: 4,
     paddingBottom: 4,
+    fontSize: 12,
   },
 });
 

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -56,6 +56,10 @@ type Props = {
    * Value of the text input
    */
   value?: string,
+  /**
+   * Text that gives context about a field’s input
+   */
+  helperText?: string,
   style?: any,
   theme: Theme,
 };
@@ -107,6 +111,7 @@ class TextInput extends Component<DefaultProps, Props, State> {
     onBlur: PropTypes.func,
     style: ViewPropTypes.style,
     value: PropTypes.string,
+    helperText: PropTypes.string,
     theme: PropTypes.object.isRequired,
   };
 
@@ -214,6 +219,7 @@ class TextInput extends Component<DefaultProps, Props, State> {
       disabled,
       label,
       underlineColor,
+      helperText,
       style,
       theme,
       ...rest
@@ -307,6 +313,14 @@ class TextInput extends Component<DefaultProps, Props, State> {
             style={[styles.bottomLine, styles.focusLine, bottomLineStyle]}
           />
         </View>
+        {
+          helperText &&
+            <Text
+              style={styles.helperText}
+            >
+              {helperText}
+            </Text>
+        }
       </View>
     );
   }
@@ -342,6 +356,11 @@ const styles = StyleSheet.create({
   },
   focusLine: {
     height: StyleSheet.hairlineWidth * 4,
+  },
+  helperText: {
+    textAlign: 'left',
+    paddingTop: 4,
+    paddingBottom: 4,
   },
 });
 

--- a/src/styles/DarkTheme.js
+++ b/src/styles/DarkTheme.js
@@ -3,7 +3,7 @@
 import color from 'color';
 import _ from 'lodash';
 import DefaultTheme from './DefaultTheme';
-import { white, grey800, cyan500, cyan700 } from './colors';
+import { white, grey800, cyan500, cyan700, redA400 } from './colors';
 
 const DarkTheme = {
   dark: true,
@@ -22,6 +22,10 @@ const DarkTheme = {
     placeholder: color(white)
       .alpha(0.38)
       .rgbaString(),
+    helperText: color(white)
+      .alpha(0.7)
+      .rgbaString(),
+    error: redA400,
   },
 };
 

--- a/src/styles/DefaultTheme.js
+++ b/src/styles/DefaultTheme.js
@@ -1,7 +1,15 @@
 /* @flow */
 
 import color from 'color';
-import { indigo500, indigo700, pinkA200, black, white, grey50 } from './colors';
+import {
+  indigo500,
+  indigo700,
+  pinkA200,
+  black,
+  white,
+  grey50,
+  redA400,
+} from './colors';
 import fonts from './fonts';
 
 export default {
@@ -26,6 +34,7 @@ export default {
     helperText: color(black)
       .alpha(0.54)
       .rgbaString(),
+    error: redA400,
   },
   fonts,
 };

--- a/src/styles/DefaultTheme.js
+++ b/src/styles/DefaultTheme.js
@@ -34,7 +34,9 @@ export default {
     helperText: color(black)
       .alpha(0.54)
       .rgbaString(),
-    error: redA400,
+    error: color(redA400)
+      .alpha(0.87)
+      .rgbaString(),
   },
   fonts,
 };

--- a/src/styles/DefaultTheme.js
+++ b/src/styles/DefaultTheme.js
@@ -23,6 +23,9 @@ export default {
     placeholder: color(black)
       .alpha(0.38)
       .rgbaString(),
+    helperText: color(black)
+      .alpha(0.54)
+      .rgbaString(),
   },
   fonts,
 };

--- a/src/types/Theme.js
+++ b/src/types/Theme.js
@@ -14,6 +14,7 @@ export type Theme = {
     disabled: string,
     placeholder: string,
     helperText: string,
+    error: string,
   },
   fonts: {
     regular: string,

--- a/src/types/Theme.js
+++ b/src/types/Theme.js
@@ -13,6 +13,7 @@ export type Theme = {
     secondaryText: string,
     disabled: string,
     placeholder: string,
+    helperText: string,
   },
   fonts: {
     regular: string,


### PR DESCRIPTION
#### What ? 
Add Helper text & error text based on 
https://material.io/guidelines/components/text-fields.html

Issue: https://github.com/callstack/react-native-paper/issues/175

#### Style specifications for helperText & errorText
<img width="712" alt="screen shot 2017-10-19 at 4 12 32 pm" src="https://user-images.githubusercontent.com/8057916/31767498-f01463ca-b4e8-11e7-8e55-e4e8c92f09a7.png">

<img width="772" alt="screen shot 2017-10-19 at 4 17 19 pm" src="https://user-images.githubusercontent.com/8057916/31767515-03dc2ece-b4e9-11e7-9805-bda7cd2fb920.png">


#### Things to clear up 
- [ ] bottomLineContainer has a margin Bottom of 4px, why is it needed ? 
As i'm adding helper text below that i'm maintaining a 8px margin on top of it by having 4px on top of helper i.e (4px + 4px = 8px) & 4px below helper to maintain an overall margin-bottom below the TextInput that was previously put by bottomLineContainer.
- [ ] This is the behaviour of error state:
1. Whenever hasError is true, error state will show up
2. HelperText will be replaced by errorText until the error is fixed i.e hasError is false
3. HelperText, label & borderLine will have the color mentioned in the guidelines for invalid input
4. For disabled inputs, there won't be possibility for having an error state, hence even when hasError is provided & true. The styles of `disabled` will take priority over `error` styles.