### PR TITLE
Fix links to default theme file

### DIFF
--- a/docs/pages/1.getting-started.md
+++ b/docs/pages/1.getting-started.md
@@ -42,7 +42,7 @@ The `PaperProvider` component provides the theme to all the components in the fr
 
 ## Customization
 
-You can provide a custom theme to customize the colors, fonts etc. with the `Provider` component. Check the [default theme](blob/master/src/styles/DefaultTheme.js) to see what customization options are supported.
+You can provide a custom theme to customize the colors, fonts etc. with the `Provider` component. Check the [default theme](https://github.com/callstack/react-native-paper/blob/master/src/styles/DefaultTheme.js) to see what customization options are supported.
 
 Example:
 

--- a/docs/pages/2.theming.md
+++ b/docs/pages/2.theming.md
@@ -16,7 +16,7 @@ export default function Main() {
 }
 ```
 
-If no prop is specified, this will apply the [default theme](src/styles/DefaultTheme.js) to the components. You can also provide a `theme` prop with a theme object with same properties as the default theme. The theme will be merged into the default theme.
+If no prop is specified, this will apply the [default theme](https://github.com/callstack/react-native-paper/blob/master/src/styles/DefaultTheme.js) to the components. You can also provide a `theme` prop with a theme object with same properties as the default theme. The theme will be merged into the default theme.
 
 ```js
 const theme = {


### PR DESCRIPTION
Hello, Callstack developers

I fixed 2 links to [defaultTheme.js](https://github.com/callstack/react-native-paper/blob/master/src/styles/DefaultTheme.js) which are invalid on GitHub Pages.

<img width="780" alt="2018-01-04 19 30 24" src="https://user-images.githubusercontent.com/1425259/34559624-e60c29c4-f185-11e7-99e4-7fa56d378054.png">
