### PR TITLE
Fixing 'remote image' button example

### DIFF
--- a/example/src/ButtonExample.js
+++ b/example/src/ButtonExample.js
@@ -21,7 +21,9 @@ class ButtonExample extends React.Component<Props, State> {
   };
 
   render() {
-    const uri = { uri: 'https://facebook.github.io/react/img/logo_og.png' };
+    const uri = {
+      uri: 'https://callstack.com/static/assets/react-native-logo.svg',
+    };
     const source = require('../assets/chameleon.jpg');
     const { theme: { colors: { background } } } = this.props;
     return (

--- a/example/src/ButtonExample.js
+++ b/example/src/ButtonExample.js
@@ -22,7 +22,8 @@ class ButtonExample extends React.Component<Props, State> {
 
   render() {
     const uri = {
-      uri: 'https://callstack.com/static/assets/react-native-logo.svg',
+      // Callstack company avatar from github.
+      uri: 'https://avatars0.githubusercontent.com/u/17571969?v=3&s=400',
     };
     const source = require('../assets/chameleon.jpg');
     const { theme: { colors: { background } } } = this.props;


### PR DESCRIPTION
The old URI points to a 404 right now, as the React's logo on Facebook's page is now a data URI. Ideally, we could host the used image on callstack.github.io, but the current push process prevents us from that.