### PR TITLE
docs: add the missing CardCover props

### DIFF
--- a/src/components/Card/CardCover.js
+++ b/src/components/Card/CardCover.js
@@ -33,6 +33,8 @@ type Props = {
  *   </Card>
  * );
  * ```
+ *
+ * @extends Image props https://facebook.github.io/react-native/docs/image.html#props
  */
 const CardCover = (props: Props) => {
   const { index, total, style, theme } = props;


### PR DESCRIPTION
Added the missing CardCover props documentation. It's now linking to react-native Image component.