### PR TITLE
fix: rework portal to isolate rendering of portals. fixes #216

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import Expo from 'expo';
+import Expo, { KeepAwake } from 'expo';
 import * as React from 'react';
 import { StatusBar } from 'react-native';
 import {
@@ -49,6 +49,7 @@ class PaperExample extends React.Component<{}, State> {
             theme: this.state.theme,
           }}
         />
+        <KeepAwake />
       </PaperProvider>
     );
   }

--- a/example/package.json
+++ b/example/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@expo/vector-icons": "^6.2.0",
     "color": "^2.0.1",
+    "create-react-context": "^0.2.1",
     "deepmerge": "^2.0.1",
     "expo": "~23.0.2",
     "prop-types": "^15.6.0",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1431,6 +1431,13 @@ create-react-class@^15.5.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+create-react-context@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.1.tgz#425a3d96f4b7690c2fbf20aed5aeae2e2007a959"
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
+
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -1899,7 +1906,7 @@ fbjs-scripts@^0.8.1:
     semver "^5.1.0"
     through2 "^2.0.0"
 
-fbjs@^0.8.14, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
+fbjs@^0.8.0, fbjs@^0.8.14, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -2226,6 +2233,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6,
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
+
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
 
 gulp-util@^3.0.4:
   version "3.0.8"

--- a/src/components/Portal/Portal.js
+++ b/src/components/Portal/Portal.js
@@ -1,8 +1,9 @@
 /* @flow */
+/* eslint-disable react/no-unused-prop-types */
 
 import * as React from 'react';
-import PropTypes from 'prop-types';
-import { manager } from './PortalHost';
+import PortalConsumer from './PortalConsumer';
+import { PortalContext } from './PortalHost';
 
 export type PortalProps = {
   /**
@@ -15,40 +16,13 @@ export type PortalProps = {
   children: React.Node,
 };
 
-type Props = PortalProps;
-
 /**
  * Portal allows to render a component at a different place in the parent tree.
  */
-export default class Portal extends React.Component<Props> {
-  static contextTypes = {
-    [manager]: PropTypes.object,
-  };
-
-  componentWillMount() {
-    if (
-      typeof this.context[manager] !== 'object' ||
-      this.context[manager] === null
-    ) {
-      throw new Error(
-        "Couldn't find portal manager in the context or props. " +
-          "You need to wrap your root component in '<PortalHost />'"
-      );
-    }
-    this._key = this.context[manager].mount(this.props);
-  }
-
-  componentWillReceiveProps(nextProps: Props) {
-    this.context[manager].update(this._key, nextProps);
-  }
-
-  componentWillUnmount() {
-    this.context[manager].unmount(this._key);
-  }
-
-  _key: any;
-
-  render() {
-    return null;
-  }
+export default function Portal(props: PortalProps) {
+  return (
+    <PortalContext.Consumer>
+      {manager => <PortalConsumer manager={manager} props={props} />}
+    </PortalContext.Consumer>
+  );
 }

--- a/src/components/Portal/PortalConsumer.js
+++ b/src/components/Portal/PortalConsumer.js
@@ -1,0 +1,31 @@
+/* @flow */
+/* eslint-disable react/no-unused-prop-types */
+
+import * as React from 'react';
+import type { PortalMethods } from './PortalHost';
+import type { PortalProps } from './Portal';
+
+type Props = {
+  manager: PortalMethods,
+  props: PortalProps,
+};
+
+export default class PortalConsumer extends React.Component<Props> {
+  componentWillMount() {
+    this._key = this.props.manager.mount(this.props.props);
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    this.props.manager.update(this._key, nextProps.props);
+  }
+
+  componentWillUnmount() {
+    this.props.manager.unmount(this._key);
+  }
+
+  _key: any;
+
+  render() {
+    return null;
+  }
+}

--- a/src/components/Portal/PortalHost.js
+++ b/src/components/Portal/PortalHost.js
@@ -1,8 +1,9 @@
 /* @flow */
 
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { View, StyleSheet } from 'react-native';
+import PortalManager from './PortalManager';
+import createReactContext, { type Context } from 'create-react-context';
 import type { PortalProps } from './Portal';
 
 type Props = {
@@ -10,91 +11,105 @@ type Props = {
   style?: any,
 };
 
-type State = {
-  portals: Array<{
-    key: number,
-    props: PortalProps,
-  }>,
+type Operation =
+  | { type: 'mount', key: number, props: PortalProps }
+  | { type: 'update', key: number, props: PortalProps }
+  | { type: 'unmount', key: number };
+
+export type PortalMethods = {
+  mount: (props: PortalProps) => number,
+  update: (key: number, props: PortalProps) => void,
+  unmount: (key: number) => void,
 };
 
-export const manager = 'react-native-paper$portal-manager';
+export const PortalContext: Context<PortalMethods> = createReactContext(
+  (null: any)
+);
 
 /**
  * Portal host is the component which actually renders all Portals.
  */
-export default class Portals extends React.Component<Props, State> {
-  static childContextTypes = {
-    [manager]: PropTypes.object,
-  };
-
-  state = {
-    portals: [],
-  };
-
-  getChildContext() {
-    return {
-      [manager]: {
-        mount: this._mountPortal,
-        unmount: this._unmountPortal,
-        update: this._updatePortal,
-      },
-    };
-  }
-
-  _nextId = 0;
-
-  _mountPortal = (props: PortalProps) => {
+export default class PortalHost extends React.Component<Props> {
+  _mount = (props: PortalProps) => {
     const key = this._nextId++;
-    this.setState(state => ({
-      portals: [...state.portals, { key, props }],
-    }));
+
+    if (this._manager) {
+      this._manager.mount(key, props);
+    } else {
+      this._queue.push({ type: 'mount', key, props });
+    }
+
     return key;
   };
 
-  _unmountPortal = (key: number) =>
-    this.setState(state => ({
-      portals: state.portals.filter(item => item.key !== key),
-    }));
+  _update = (key: number, props: PortalProps) => {
+    if (this._manager) {
+      this._manager.update(key, props);
+    } else {
+      const op = { type: 'update', key, props };
+      const index = this._queue.findIndex(
+        o => o.type === 'mount' || (o.type === 'update' && o.key === key)
+      );
 
-  _updatePortal = (key: number, props: PortalProps) =>
-    this.setState(state => ({
-      portals: state.portals.map(item => {
-        if (item.key === key) {
-          return { ...item, props };
-        }
-        return item;
-      }),
-    }));
+      if (index > -1) {
+        /* $FlowFixMe */
+        this._queue = this._queue[index] = op;
+      } else {
+        this._queue.push(op);
+      }
+    }
+  };
+
+  _unmount = (key: number) => {
+    if (this._manager) {
+      this._manager.unmount(key);
+    } else {
+      this._queue.push({ type: 'unmount', key });
+    }
+  };
+
+  _handleRef = (manager: ?PortalManager) => {
+    this._manager = manager;
+
+    while (this._queue.length && manager) {
+      const action = this._queue.pop();
+
+      // eslint-disable-next-line default-case
+      switch (action.type) {
+        case 'mount':
+          manager.mount(action.key, action.props);
+          break;
+        case 'update':
+          manager.update(action.key, action.props);
+          break;
+        case 'unmount':
+          manager.unmount(action.key);
+          break;
+      }
+    }
+  };
+
+  _nextId = 0;
+  _queue: Operation[] = [];
+  _manager: ?PortalManager;
 
   render() {
-    const { portals } = this.state;
     return (
-      <View {...this.props} style={[styles.container, this.props.style]}>
-        {this.props.children}
-        {portals
-          .reduce((acc, curr) => {
-            const { position = 0, children } = curr.props;
-            let group = acc.find(it => it.position === position);
-            if (group) {
-              group = {
-                position,
-                items: group.items.concat([children]),
-              };
-              return acc.map(g => {
-                if (group && g.position === position) {
-                  return group;
-                }
-                return g;
-              });
-            }
-            group = { position, items: [children] };
-            return [...acc, group];
-          }, [])
-          .map(({ position, items }) => (
-            <View key={position} style={StyleSheet.absoluteFill}>
-              {items}
-            </View>
-          ))}
+      <View
+        pointerEvents="box-none"
+        {...this.props}
+        style={[styles.container, this.props.style]}
+      >
+        <PortalContext.Provider
+          value={{
+            mount: this._mount,
+            update: this._update,
+            unmount: this._unmount,
+          }}
+        >
+          {this.props.children}
+        </PortalContext.Provider>
+        <PortalManager ref={this._handleRef} />
       </View>
     );
   }

--- a/src/components/Portal/PortalManager.js
+++ b/src/components/Portal/PortalManager.js
@@ -1,0 +1,73 @@
+/* @flow */
+
+import * as React from 'react';
+import { View, StyleSheet } from 'react-native';
+import type { PortalProps } from './Portal';
+
+type State = {
+  portals: Array<{
+    key: number,
+    props: PortalProps,
+  }>,
+};
+
+/**
+ * Portal host is the component which actually renders all Portals.
+ */
+export default class PortalManager extends React.PureComponent<{}, State> {
+  state = {
+    portals: [],
+  };
+
+  mount = (key: number, props: PortalProps) => {
+    this.setState(state => ({
+      portals: [...state.portals, { key, props }],
+    }));
+  };
+
+  update = (key: number, props: PortalProps) =>
+    this.setState(state => ({
+      portals: state.portals.map(item => {
+        if (item.key === key) {
+          return { ...item, props };
+        }
+        return item;
+      }),
+    }));
+
+  unmount = (key: number) =>
+    this.setState(state => ({
+      portals: state.portals.filter(item => item.key !== key),
+    }));
+
+  render() {
+    return this.state.portals
+      .reduce((acc, curr) => {
+        const { position = 0, children } = curr.props;
+        let group = acc.find(it => it.position === position);
+        if (group) {
+          group = {
+            position,
+            items: group.items.concat([children]),
+          };
+          return acc.map(g => {
+            if (group && g.position === position) {
+              return group;
+            }
+            return g;
+          });
+        }
+        group = { position, items: [children] };
+        return [...acc, group];
+      }, [])
+      .map(({ position, items }) => (
+        <View
+          key={position}
+          pointerEvents="box-none"
+          style={StyleSheet.absoluteFill}
+        >
+          {items}
+        </View>
+      ));
+  }
+}

--- a/src/components/Portal/ThemedPortal.js
+++ b/src/components/Portal/ThemedPortal.js
@@ -19,7 +19,7 @@ class ThemedPortal extends React.Component<Props> {
     return (
       <Portal {...this.props}>
         <ThemeProvider theme={this.props.theme}>
-          {React.Children.only(this.props.children)}
+          {this.props.children}
         </ThemeProvider>
       </Portal>
     );

--- a/src/components/__tests__/Portal.test.js
+++ b/src/components/__tests__/Portal.test.js
@@ -1,0 +1,21 @@
+/* @flow */
+
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import { Text } from 'react-native';
+import PortalHost from '../Portal/PortalHost';
+import Portal from '../Portal/Portal';
+
+it('renders portal with siblings', () => {
+  const wrapper = shallow(
+    <PortalHost>
+      <Text>Outside content</Text>
+      <Portal>
+        <Text>Portal content</Text>
+      </Portal>
+    </PortalHost>
+  );
+
+  expect(toJson(wrapper)).toMatchSnapshot();
+});

--- a/src/components/__tests__/__snapshots__/Portal.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Portal.test.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders portal with siblings 1`] = `
+<View
+  pointerEvents="box-none"
+  style={
+    Array [
+      Object {
+        "flex": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <Provider
+    value={
+      Object {
+        "mount": [Function],
+        "unmount": [Function],
+        "update": [Function],
+      }
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+    >
+      Outside content
+    </Text>
+    <Portal>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+      >
+        Portal content
+      </Text>
+    </Portal>
+  </Provider>
+  <PortalManager />
+</View>
+`;

--- a/src/core/Provider.js
+++ b/src/core/Provider.js
@@ -15,7 +15,7 @@ export default class Provider extends React.Component<Props> {
     return (
       <PortalHost>
         <ThemeProvider theme={this.props.theme}>
-          {React.Children.only(this.props.children)}
+          {this.props.children}
         </ThemeProvider>
       </PortalHost>
     );

--- a/src/core/ThemeProvider.js
+++ b/src/core/ThemeProvider.js
@@ -54,6 +54,6 @@ export default class ThemeProvider extends React.Component<Props> {
   _get = () => this.props.theme;
 
   render() {
-    return React.Children.only(this.props.children);
+    return this.props.children;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1514,6 +1514,13 @@ create-react-class@^15.5.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+create-react-context@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.1.tgz#425a3d96f4b7690c2fbf20aed5aeae2e2007a959"
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
+
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -2249,7 +2256,7 @@ fbjs-scripts@^0.8.1:
     semver "^5.1.0"
     through2 "^2.0.0"
 
-fbjs@^0.8.14, fbjs@^0.8.16:
+fbjs@^0.8.0, fbjs@^0.8.14, fbjs@^0.8.16:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -2540,6 +2547,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.4,
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
+
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
 
 gulp-util@^3.0.4:
   version "3.0.8"


### PR DESCRIPTION
The PR reworks the portal implementation so that the portals render under a different tree under a pure component, which is not affected by the parent component's re-renders.

This also updates the portal code to use the new context API.