### PR TITLE
fix: do not require the TextInput multiline prop

### DIFF
--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -37,7 +37,7 @@ type Props = {
   /**
    * Whether the input can have multiple lines.
    */
-  multiline: boolean,
+  multiline?: boolean,
   /**
    * The number of lines to show in the input (Android only).
    */
@@ -109,6 +109,7 @@ type State = {
 class TextInput extends React.Component<Props, State> {
   static defaultProps = {
     disabled: false,
+    multiline: false,
   };
 
   constructor(props) {


### PR DESCRIPTION
The pull request changes the TextInput multiline prop to optional. Defaults to false.

### Motivation

Not providing the multiline prop is causing a flow error, while the docs example states it's not required.