### PR TITLE
fix: do not require the TextInput numberOfLines prop

### DIFF
--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -41,7 +41,7 @@ type Props = {
   /**
    * The number of lines to show in the input (Android only).
    */
-  numberOfLines: number,
+  numberOfLines?: number,
   /**
    * Callback that is called when the text input is focused.
    */


### PR DESCRIPTION
Same as #266, the numberOfLines prop for TextInput shouldn't be required. Causes a flow error when not provided.