### PR TITLE
Update 1.getting-started.md

### DIFF
--- a/docs/pages/1.getting-started.md
+++ b/docs/pages/1.getting-started.md
@@ -11,11 +11,26 @@ Open a Terminal in your project's folder and run,
 yarn add react-native-paper
 ```
 
-If you're on a vanilla React Native project, you also need to install and link [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons). If you use CRNA or Expo, you don't need this step.
+If you're on a vanilla React Native project, you also need to install and link [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons).
 
 ```sh
 yarn add react-native-vector-icons
 react-native link react-native-vector-icons
+```
+
+If you use CRNA or Expo, you don't need this step, but you will need to install `babel-preset-expo` as a dev dependency and add it to the `.babelrc` config:
+
+```sh
+yarn add -D babel-preset-expo
+```
+
+**.babelrc**
+```json
+{
+  "presets": [
+    "expo"
+  ]
+}
 ```
 
 ## Usage


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Currently there's a bug while using react-native-paper with CRNA, it cannot find `MaterialIcons` font.

### Test plan

Adding `babel-preset-expo` and using it within `.babelrc` fixes this problem.
