### PR TITLE
Indirectly import ProgressViewIOS / ProgressBarAndroid to fix web support

### DIFF
--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -1,13 +1,9 @@
 /* @flow */
 
 import * as React from 'react';
-import {
-  Platform,
-  StyleSheet,
-  ProgressViewIOS,
-  ProgressBarAndroid,
-} from 'react-native';
+import { StyleSheet } from 'react-native';
 import setColor from 'color';
+import ProgressBarComponent from './ProgressBarComponent';
 import withTheme from '../core/withTheme';
 import type { Theme } from '../types';
 
@@ -26,11 +22,6 @@ type Props = {
    */
   theme: Theme,
 };
-
-const ProgressBarComponent = Platform.select({
-  ios: ProgressViewIOS,
-  android: ProgressBarAndroid,
-});
 
 /**
  * Progress bar is an indicator used to present progress of some activity in the app.

--- a/src/components/ProgressBarComponent.android.js
+++ b/src/components/ProgressBarComponent.android.js
@@ -1,0 +1,3 @@
+import { ProgressBarAndroid } from 'react-native';
+
+export default ProgressBarAndroid;

--- a/src/components/ProgressBarComponent.ios.js
+++ b/src/components/ProgressBarComponent.ios.js
@@ -1,0 +1,3 @@
+import { ProgressViewIOS } from 'react-native';
+
+export default ProgressViewIOS;

--- a/src/components/ProgressBarComponent.web.js
+++ b/src/components/ProgressBarComponent.web.js
@@ -1,0 +1,3 @@
+import { ProgressBar } from 'react-native';
+
+export default ProgressBar;


### PR DESCRIPTION
### Motivation

ProgressViewIOS / ProgressBarAndroid aren't included in react-native-web, so if we import them in the ProgressBar component then we break web support.

### Test plan

I ran tests and the example app.
