### PR TITLE
fix: fix statusbar height on old versions of ios

### DIFF
--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -1,7 +1,13 @@
 /* @flow */
 
 import * as React from 'react';
-import { View, Platform, StyleSheet, SafeAreaView } from 'react-native';
+import {
+  View,
+  Platform,
+  StyleSheet,
+  StatusBar,
+  SafeAreaView,
+} from 'react-native';
 import color from 'color';
 
 import withTheme from '../../core/withTheme';
@@ -34,6 +40,19 @@ type Props = {
 };
 
 const DEFAULT_TOOLBAR_HEIGHT = 56;
+const DEFAULT_STATUSBAR_HEIGHT_EXPO =
+  global.__expo && global.__expo.Constants
+    ? global.__expo.Constants.statusBarHeight
+    : undefined;
+const DEFAULT_STATUSBAR_HEIGHT = Platform.select({
+  android: DEFAULT_STATUSBAR_HEIGHT_EXPO,
+  ios:
+    Platform.Version < 11
+      ? DEFAULT_STATUSBAR_HEIGHT_EXPO === undefined
+        ? StatusBar.currentHeight
+        : DEFAULT_STATUSBAR_HEIGHT_EXPO
+      : undefined,
+});
 
 /**
  * Toolbar is usually used as a header placed at the top of the screen.
@@ -77,10 +96,7 @@ const DEFAULT_TOOLBAR_HEIGHT = 56;
 class Toolbar extends React.Component<Props> {
   static defaultProps = {
     // TODO: handle orientation changes
-    statusBarHeight:
-      Platform.OS === 'android' && global.__expo && global.__expo.Constants
-        ? global.__expo.Constants.statusBarHeight
-        : undefined,
+    statusBarHeight: DEFAULT_STATUSBAR_HEIGHT,
   };
 
   render() {
@@ -155,12 +171,7 @@ class Toolbar extends React.Component<Props> {
         style={[{ backgroundColor }, styles.toolbar, restStyle]}
         {...rest}
       >
-        <View
-          style={[
-            { height: height + statusBarHeight, paddingTop: statusBarHeight },
-            styles.wrapper,
-          ]}
-        >
+        <View style={[{ height, marginTop: statusBarHeight }, styles.wrapper]}>
           {childrenArray.filter(Boolean).map((child: any, i) => {
             const props: { dark: ?boolean, style?: any } = {
               dark:


### PR DESCRIPTION
Earlier we used `SafeAreaView` on iOS to offset for status bar height, but seems it doesn't work on iOS < 11. This PR attempts to handle old versions of iOS.