### PR TITLE
fix: View in Icon component should not receive color as props.style key

### DIFF
--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -38,6 +38,10 @@ const Icon = ({ name, ...props }: Props) => {
       />
     );
   }
+  const style = { ...props.style };
+  if (style) {
+    delete style.color;
+  }
   return (
     <View
       {...props}
@@ -47,7 +51,7 @@ const Icon = ({ name, ...props }: Props) => {
           height: props.size,
         },
         styles.container,
-        props.style,
+        style,
       ]}
     >
       {(name: any)}


### PR DESCRIPTION
### Motivation

This fix suggestion is linked to [issue 191](https://github.com/callstack/react-native-paper/issues/291).
It aims at suppressing `Warning: Failed prop type: Invalid props.style key 'color' supplied to 'View'` generated by the Icon component in certain cases.

### Example case

When using the `FAB` component with a custom Icon like below

```
import { Icon } from 'myComponents';
 
<FAB
        icon={<Icon name="chevron-left" size={13} color="#ffffff" />}
        onPress={() => null}
/>
```

In my case I am using the [react-native-vector-icons](https://oblador.github.io/react-native-vector-icons/) lib to generate icons. 


