### PR TITLE
docs: fix dialog component typo

### DIFF
--- a/src/components/Dialog/Dialog.js
+++ b/src/components/Dialog/Dialog.js
@@ -56,8 +56,8 @@ type Props = {
  *     visible: false,
  *   };
  *
- *   _showDialog = () => this.setState({ visble: true });
- *   _hideDialog = () => this.setState({ visble: false });
+ *   _showDialog = () => this.setState({ visible: true });
+ *   _hideDialog = () => this.setState({ visible: false });
  *
  *   render() {
  *     const { visible } = this.state;


### PR DESCRIPTION
Hey,
I've been just trying the dialog component docs example. Sending a typo fix.