### PR TITLE
fix: removing erroneous queue reassignment in PortalHost

### DIFF
--- a/src/components/Portal/PortalHost.js
+++ b/src/components/Portal/PortalHost.js
@@ -74,7 +74,8 @@ export default class PortalHost extends React.Component<Props> {
       );
 
       if (index > -1) {
-        this._queue[index] = op;
+        // $FlowFixMe
+        this._queue[index].props = props;
       } else {
         this._queue.push(op);
       }

--- a/src/components/Portal/PortalHost.js
+++ b/src/components/Portal/PortalHost.js
@@ -74,8 +74,7 @@ export default class PortalHost extends React.Component<Props> {
       );
 
       if (index > -1) {
-        /* $FlowFixMe */
-        this._queue = this._queue[index] = op;
+        this._queue[index] = op;
       } else {
         this._queue.push(op);
       }


### PR DESCRIPTION
In PortalHost there is a piece of code:
```javascript

 1      const op = { type: 'update', key, props };
 2      const index = this._queue.findIndex(
 3        o => o.type === 'mount' || (o.type === 'update' && o.key === key)
 4      );
 5      if (index > -1) {
 6        /* $FlowFixMe */
 7        this._queue = this._queue[index] = op;
 8      } else {
 9        this._queue.push(op);
10      }
```

It is run (in some cases) in `render()` of a component containing `<Portal>`. You can see that if you execute it three times, with initial `this._queue` set to `[]`, it will:
   1. Execute line 9 on the first run.
   1. Execute line 7 (replacing `this._queue` with an object) on the second run.
   1. Fail on line 2 on the third execution.

This PR removes the reassignment of a queue item to the whole queue.
