### PR TITLE
fix: support static properties in withTheme HOC

### DIFF
--- a/example/src/RootNavigator.js
+++ b/example/src/RootNavigator.js
@@ -23,6 +23,7 @@ const routes = Object.keys(examples)
           <ToolbarContent title={(Comp: any).title} />
         </Toolbar>
       ),
+      /* $FlowFixMe */
       ...(typeof Comp.navigationOptions === 'function'
         ? Comp.navigationOptions(props)
         : Comp.navigationOptions),

--- a/src/core/withTheme.js
+++ b/src/core/withTheme.js
@@ -31,14 +31,13 @@ const REACT_METHODS = [
   'updateComponent',
 ];
 
-const isClassComponent = (Component: Function) =>
-  !!(Component && Component.prototype && Component.prototype.render);
+const isClassComponent = (Component: any) =>
+  Boolean(Component.prototype && Component.prototype.isReactComponent);
 
-export default function withTheme<Props: {}>(
-  Comp: React.ComponentType<Props>
-): React.ComponentType<
-  $Diff<Props, { theme: Theme }> & { theme?: $Shape<Theme> }
-> {
+export default function withTheme<P: {}, C: React.ComponentType<P>>(
+  Comp: C
+): C &
+  React.ComponentType<$Diff<P, { theme: Theme }> & { theme?: $Shape<Theme> }> {
   class ThemedComponent extends React.Component<*> {
     /* $FlowFixMe */
     static displayName = `withTheme(${Comp.displayName || Comp.name})`;
@@ -131,9 +130,6 @@ export default function withTheme<Props: {}>(
             // $FlowFixMe
             Comp.prototype[prop].apply(this.getWrappedInstance(), args);
           };
-          // Set the function name for better debugging
-          // $FlowFixMe
-          ThemedComponent.prototype[prop].name = prop;
         } else {
           // Copy properties as getters and setters
           // This make sure dynamic properties always stay up-to-date


### PR DESCRIPTION
Currently, there is no way to preserve types of static properties of React components when they are wrapped in the `withTheme` HOC. This PR adds a HOC named `withStatics` which helps to add static properties to a component

API:

```js
export default withStatics(withTheme(Toast), {
  DURATION_LONG: 3500
});
```

The document generator won't handle such static properties. So we'll need to write those manually.