### PR TITLE
uncheckedColor prop for Checkbox and RadioButton 

### DIFF
--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -108,9 +108,9 @@ class Checkbox extends React.Component<Props, State> {
   render() {
     const { checked, disabled, onPress, theme, ...rest } = this.props;
     const checkedColor = this.props.color || theme.colors.accent;
-    const uncheckedColor = this.props.uncheckedColor || (theme.dark
-      ? 'rgba(255, 255, 255, .7)'
-      : 'rgba(0, 0, 0, .54)');
+    const uncheckedColor =
+      this.props.uncheckedColor ||
+      (theme.dark ? 'rgba(255, 255, 255, .7)' : 'rgba(0, 0, 0, .54)');
 
     let rippleColor, checkboxColor;
 

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -22,6 +22,10 @@ type Props = {
    */
   onPress?: Function,
   /**
+   * Custom color for unchecked checkbox.
+   */
+  uncheckedColor?: string,
+  /**
    * Custom color for checkbox.
    */
   color?: string,
@@ -104,9 +108,9 @@ class Checkbox extends React.Component<Props, State> {
   render() {
     const { checked, disabled, onPress, theme, ...rest } = this.props;
     const checkedColor = this.props.color || theme.colors.accent;
-    const uncheckedColor = theme.dark
+    const uncheckedColor = this.props.uncheckedColor || (theme.dark
       ? 'rgba(255, 255, 255, .7)'
-      : 'rgba(0, 0, 0, .54)';
+      : 'rgba(0, 0, 0, .54)');
 
     let rippleColor, checkboxColor;
 

--- a/src/components/RadioButton.js
+++ b/src/components/RadioButton.js
@@ -134,9 +134,9 @@ class RadioButton extends React.Component<Props, State> {
         {context => {
           const { disabled, onPress, theme, ...rest } = this.props;
           const checkedColor = this.props.color || theme.colors.accent;
-          const uncheckedColor = this.props.uncheckedColor || (theme.dark
-            ? 'rgba(255, 255, 255, .7)'
-            : 'rgba(0, 0, 0, .54)');
+          const uncheckedColor =
+            this.props.uncheckedColor ||
+            (theme.dark ? 'rgba(255, 255, 255, .7)' : 'rgba(0, 0, 0, .54)');
 
           let rippleColor, radioColor;
 

--- a/src/components/RadioButton.js
+++ b/src/components/RadioButton.js
@@ -26,6 +26,10 @@ type Props = {
    */
   onPress?: Function,
   /**
+   * Custom color for unchecked radio.
+   */
+  uncheckedColor?: string,
+  /**
    * Custom color for radio.
    */
   color?: string,
@@ -130,9 +134,9 @@ class RadioButton extends React.Component<Props, State> {
         {context => {
           const { disabled, onPress, theme, ...rest } = this.props;
           const checkedColor = this.props.color || theme.colors.accent;
-          const uncheckedColor = theme.dark
+          const uncheckedColor = this.props.uncheckedColor || (theme.dark
             ? 'rgba(255, 255, 255, .7)'
-            : 'rgba(0, 0, 0, .54)';
+            : 'rgba(0, 0, 0, .54)');
 
           let rippleColor, radioColor;
 


### PR DESCRIPTION
### Motivation
#### What existing problem does the pull request solve?
It was impossible to set the color of Checkbox/RadioButton in the unchecked state.

#### Can you solve the issue with a different approach?
No, most likely only this way.

#### Test plan
List the steps with which we can test this change. Provide screenshots if this changes anything visual.
just pass uncheckedColor="white" to the Checkbox/RadioButton component.

result:
![img_20180415_114757](https://user-images.githubusercontent.com/4183510/38797437-21218c80-4167-11e8-870f-c53c9f18858c.jpg)