### PR TITLE
textInputStyle prop for TextInput

### DIFF
--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -56,6 +56,10 @@ type Props = {
   value?: string,
   style?: any,
   /**
+   * Style of native text input.
+   */
+  textInputStyle?: any,
+  /**
    * @optional
    */
   theme: Theme,
@@ -209,6 +213,7 @@ class TextInput extends React.Component<Props, State> {
       label,
       underlineColor,
       style,
+      textInputStyle,
       theme,
       ...rest
     } = this.props;
@@ -291,6 +296,7 @@ class TextInput extends React.Component<Props, State> {
               color: inputTextColor,
               fontFamily,
             },
+            textInputStyle,
           ]}
         />
         <View pointerEvents="none" style={styles.bottomLineContainer}>


### PR DESCRIPTION
### Motivation
#### What existing problem does the pull request solve?
It was impossible to change style(padding in my case) of the NativeTextInput.

#### Can you solve the issue with a different approach?
No.

#### Test plan
List the steps with which we can test this change. Provide screenshots if this changes anything visual.
just pass textInputStyle={{paddingTop: 0}} to the TextInput component.


