### PR TITLE
Update SearchBar.js

### DIFF
--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -115,7 +115,7 @@ class SearchBar extends React.Component<Props> {
             name={icon || 'search'}
           />
         ) : (
-          <Icon style={styles.icon} name="search" size={24} color={iconColor} />
+          <Icon style={styles.icon} name={icon || 'search'} size={24} color={iconColor} />
         )}
         <TextInput
           style={[styles.input, { color: textColor }]}

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -115,7 +115,12 @@ class SearchBar extends React.Component<Props> {
             name={icon || 'search'}
           />
         ) : (
-          <Icon style={styles.icon} name={icon || 'search'} size={24} color={iconColor} />
+          <Icon
+            style={styles.icon}
+            name={icon || 'search'}
+            size={24}
+            color={iconColor}
+          />
         )}
         <TextInput
           style={[styles.input, { color: textColor }]}


### PR DESCRIPTION
icon props is fixed to be 'search' only if onIconPress is not defined. It should change according to the string  provided to icon props

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
