### PR TITLE
update SearchBar.js according to TextInput.js

### DIFF
--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -71,8 +71,30 @@ type Props = {
  */
 class SearchBar extends React.Component<Props> {
   _handleClearPress = () => {
-    this.props.onChangeText('');
+    this.clear();
   };
+  _root: any;
+  _setRef: any = (c: Object) => {
+    this._root = c;
+  };
+  setNativeProps(...args) {
+    return this._root.setNativeProps(...args);
+  }
+  isFocused(...args) {
+    return this._root.isFocused(...args);
+  }
+
+  clear(...args) {
+    return this._root.clear(...args);
+  }
+
+  focus(...args) {
+    return this._root.focus(...args);
+  }
+
+  blur(...args) {
+    return this._root.blur(...args);
+  }
 
   render() {
     const {
@@ -129,6 +151,7 @@ class SearchBar extends React.Component<Props> {
           selectionColor={colors.primary}
           underlineColorAndroid="transparent"
           returnKeyType="search"
+          ref={this._setRef}
           value={value}
           {...rest}
         />

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -151,7 +151,9 @@ class SearchBar extends React.Component<Props> {
           selectionColor={colors.primary}
           underlineColorAndroid="transparent"
           returnKeyType="search"
-          ref={c => { this._root = c; }}
+          ref={c => {
+            this._root = c;
+          }}
           value={value}
           {...rest}
         />

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -71,7 +71,7 @@ type Props = {
  */
 class SearchBar extends React.Component<Props> {
   _handleClearPress = () => {
-    this.clear();
+    this.props.onChangeText('');
   };
   _root: any;
   _setRef: any = (c: Object) => {

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -73,13 +73,13 @@ class SearchBar extends React.Component<Props> {
   _handleClearPress = () => {
     this.props.onChangeText('');
   };
-  _root: any;
-  _setRef: any = (c: Object) => {
-    this._root = c;
-  };
+
+  _root: TextInput;
+
   setNativeProps(...args) {
     return this._root.setNativeProps(...args);
   }
+
   isFocused(...args) {
     return this._root.isFocused(...args);
   }
@@ -151,7 +151,7 @@ class SearchBar extends React.Component<Props> {
           selectionColor={colors.primary}
           underlineColorAndroid="transparent"
           returnKeyType="search"
-          ref={this._setRef}
+          ref={c => { this._root = c; }}
           value={value}
           {...rest}
         />


### PR DESCRIPTION
added focus(),clear()blur(),isFocused(),setNativeProps() methods to SearchBar.js, exactly the same way as the TextInput.js....
although I prefer adding textInputRef props to expose the TextInput ref to the SearchBar..
onChangeText no longer a required props for the clear button to work.

<!-- Please provide enough information so that others can review your pull request. -->

<!-- Keep pull requests small and focused on a single change. -->

### Motivation
SearchBar is kind of a  textInput groomed with one additional icon and clear button. Basic  Functionality like focus(), blur() is better exposed to user. a very common use cases is when user click on the search icon, the textinput get focused. something like onIconPress=> this.ref.searchbar.focus().
this issue can be solved with a different approach, that is expose the underlying nativeTextInput ref to SearchBar. But the TextInput already doing it this way, so ... consistent.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
