### PR TITLE
feat: ContentStyle prop for Button

### DIFF
--- a/example/src/ButtonExample.js
+++ b/example/src/ButtonExample.js
@@ -103,6 +103,20 @@ class ButtonExample extends React.Component<Props, State> {
             Custom component
           </Button>
         </View>
+        <View style={styles.row}>
+          <Button
+            raised
+            primary
+            style={{ flex: 1, height: 50 }}
+            contentStyle={{
+              flex: 1,
+              alignItems: 'center',
+            }}
+            onPress={() => {}}
+          >
+            Custom styles
+          </Button>
+        </View>
       </View>
     );
   }

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -56,6 +56,7 @@ type Props = {
    */
   onPress?: Function,
   style?: any,
+  contentStyle?: any,
   /**
    * @optional
    */
@@ -123,6 +124,7 @@ class Button extends React.Component<Props, State> {
       children,
       onPress,
       style,
+      contentStyle,
       theme,
     } = this.props;
     const { colors, roundness } = theme;
@@ -181,12 +183,12 @@ class Button extends React.Component<Props, State> {
       .rgb()
       .string();
     const buttonStyle = { backgroundColor, borderRadius: roundness };
-    const touchableStyle = { borderRadius: roundness };
+    const touchableStyle = [{ borderRadius: roundness }, contentStyle];
     const textStyle = { color: textColor, fontFamily };
     const elevation = disabled ? 0 : this.state.elevation;
 
     const content = (
-      <View style={styles.content}>
+      <View style={[styles.content, contentStyle]}>
         {icon && loading !== true ? (
           <Icon name={icon} size={16} color={textColor} style={styles.icon} />
         ) : null}


### PR DESCRIPTION
### Motivation

Sometimes in project we need more customisation for component, that probably will make it not following guidelines. Full width buttons / custom height buttons - are good samples for it. So I've added extra prop to allow adding extra styles to buttons content.
Also I was thinking about height / fullWidth / fullSize prop. But think it will be overengineering.

### Test plan

I've added usage  example and also screenshot is here
[Examples Screenshot](https://user-images.githubusercontent.com/17987276/39042739-4226d1bc-4494-11e8-8841-696979ab0a25.jpeg)