### PR TITLE
fix: hide checkbox on iOS instead of removing it

### DIFF
--- a/src/components/Checkbox.ios.js
+++ b/src/components/Checkbox.ios.js
@@ -64,16 +64,14 @@ class Checkbox extends React.Component<Props> {
         onPress={disabled ? undefined : onPress}
         style={styles.container}
       >
-        <View style={styles.iconContainer}>
-          {checked && (
-            <Icon
-              allowFontScaling={false}
-              name={checked && 'done'}
-              size={24}
-              color={checkedColor}
-              style={styles.icon}
-            />
-          )}
+        <View style={[styles.iconContainer, { opacity: checked ? 1 : 0 }]}>
+          <Icon
+            allowFontScaling={false}
+            name="done"
+            size={24}
+            color={checkedColor}
+            style={styles.icon}
+          />
         </View>
       </TouchableRipple>
     );

--- a/src/components/Checkbox.ios.js
+++ b/src/components/Checkbox.ios.js
@@ -64,7 +64,7 @@ class Checkbox extends React.Component<Props> {
         onPress={disabled ? undefined : onPress}
         style={styles.container}
       >
-        <View style={[styles.iconContainer, { opacity: checked ? 1 : 0 }]}>
+        <View style={{ opacity: checked ? 1 : 0 }}>
           <Icon
             allowFontScaling={false}
             name="done"
@@ -84,9 +84,6 @@ const styles = StyleSheet.create({
   },
   icon: {
     margin: 6,
-  },
-  iconContainer: {
-    height: 36,
   },
 });
 


### PR DESCRIPTION
The way is done now, it removes the view completely so the space is not filled anymore (which is weird from check<->uncheck).