### PR TITLE
Docs: Add Babel example with env setting from CRNA

### DIFF
--- a/docs/pages/2.getting-started.md
+++ b/docs/pages/2.getting-started.md
@@ -37,6 +37,22 @@ To get smaller bundle size by excluding modules you don't use, you can use our o
 }
 ```
 
+If you created your project using CRNA or Expo, you'll have an `env` section. You can create a new `production` key and place it below so it looks like this:
+
+```json
+{
+  "presets": ["babel-preset-expo"],
+  "env": {
+    "development": {
+      "plugins": ["transform-react-jsx-source"]
+    },
+    "production": {
+      "plugins": ["react-native-paper/babel"]
+    }
+  }
+}
+```
+
 **Note:** The plugin only works if you are importing the library using ES2015 import statements and not with `require`.
 
 ## Usage


### PR DESCRIPTION
I generated a new project with CRNA. My babelrc file had an `env` key so I thought this clarification could help beginners.

Thanks!