### PR TITLE
Fix issue with portal groups

### DIFF
--- a/src/components/Portal/PortalManager.js
+++ b/src/components/Portal/PortalManager.js
@@ -71,6 +71,7 @@ export default class PortalManager extends React.PureComponent<{}, State> {
         }
         group = {
           key: typeof elevation === 'undefined' ? curr.key : elevation,
+          elevation,
           items: [React.cloneElement(children, { key: curr.key })],
         };
         return [...acc, group];


### PR DESCRIPTION
### Motivation

Components rendered in portals with same elevation prop are placed in different groups.

### Expected behaviour

Components rendered in portals with same elevation should be placed in the same group and should be rendered one by one