### PR TITLE
refactor: change the flow typing for functions

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -54,7 +54,7 @@ type Props = {
   /**
    * Function to execute on press.
    */
-  onPress?: Function,
+  onPress?: () => mixed,
   style?: any,
   /**
    * @optional

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -21,7 +21,7 @@ type Props = {
   /**
    * Function to execute on press.
    */
-  onPress?: Function,
+  onPress?: () => mixed,
   /**
    * Content of the `Card`.
    */

--- a/src/components/Checkbox.ios.js
+++ b/src/components/Checkbox.ios.js
@@ -20,7 +20,7 @@ type Props = {
   /**
    * Function to execute on press.
    */
-  onPress?: Function,
+  onPress?: () => mixed,
   /**
    * Custom color for checkbox.
    */

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -20,7 +20,7 @@ type Props = {
   /**
    * Function to execute on press.
    */
-  onPress?: Function,
+  onPress?: () => mixed,
   /**
    * Custom color for unchecked checkbox.
    */

--- a/src/components/Dialog/Dialog.js
+++ b/src/components/Dialog/Dialog.js
@@ -21,7 +21,7 @@ type Props = {
   /**
    * Callback that is called when the user dismisses the dialog.
    */
-  onDismiss: Function,
+  onDismiss: () => mixed,
   /**
    * Determines Whether the dialog is visible.
    */

--- a/src/components/DrawerItem.js
+++ b/src/components/DrawerItem.js
@@ -26,7 +26,7 @@ type Props = {
   /**
    * Function to execute on press.
    */
-  onPress?: Function,
+  onPress?: () => mixed,
   /**
    * Custom color for the drawer text and icon.
    */

--- a/src/components/FAB.js
+++ b/src/components/FAB.js
@@ -31,7 +31,7 @@ type Props = {
   /**
    * Function to execute on press.
    */
-  onPress?: Function,
+  onPress?: () => mixed,
   style?: any,
   /**
    * @optional

--- a/src/components/List/ListItem.js
+++ b/src/components/List/ListItem.js
@@ -30,7 +30,7 @@ type Props = {
   /**
    * Function to execute on press.
    */
-  onPress?: Function,
+  onPress?: () => mixed,
   /**
    * @optional
    */

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -20,7 +20,7 @@ type Props = {
   /**
    * Callback that is called when the user dismisses the modal.
    */
-  onDismiss: Function,
+  onDismiss: () => mixed,
   /**
    * Determines Whether the modal is visible.
    */

--- a/src/components/RadioButton.ios.js
+++ b/src/components/RadioButton.ios.js
@@ -25,7 +25,7 @@ type Props = {
   /**
    * Function to execute on press.
    */
-  onPress?: Function,
+  onPress?: () => mixed,
   /**
    * Custom color for radio.
    */

--- a/src/components/RadioButton.js
+++ b/src/components/RadioButton.js
@@ -24,7 +24,7 @@ type Props = {
   /**
    * Function to execute on press.
    */
-  onPress?: Function,
+  onPress?: () => mixed,
   /**
    * Custom color for unchecked radio.
    */

--- a/src/components/Searchbar.js
+++ b/src/components/Searchbar.js
@@ -30,7 +30,7 @@ type Props = {
   /**
    * Callback to execute if we want the left icon to act as button.
    */
-  onIconPress?: Function,
+  onIconPress?: () => mixed,
   style?: any,
   /**
    * @optional

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -56,11 +56,11 @@ type Props = {
   /**
    * Callback that is called when the text input is focused.
    */
-  onFocus?: Function,
+  onFocus?: () => mixed,
   /**
    * Callback that is called when the text input is blurred.
    */
-  onBlur?: Function,
+  onBlur?: () => mixed,
   /**
    * Value of the text input.
    */

--- a/src/components/Toolbar/ToolbarAction.js
+++ b/src/components/Toolbar/ToolbarAction.js
@@ -27,7 +27,7 @@ type Props = {
   /**
    * Function to execute on press.
    */
-  onPress?: Function,
+  onPress?: () => mixed,
   style?: any,
 };
 

--- a/src/components/Toolbar/ToolbarBackAction.js
+++ b/src/components/Toolbar/ToolbarBackAction.js
@@ -18,7 +18,7 @@ type Props = {
   /**
    * Function to execute on press.
    */
-  onPress?: Function,
+  onPress?: () => mixed,
   style?: any,
 };
 


### PR DESCRIPTION
Changes the flow for functions:
`Function` -> `() => mixed`
Fixes https://github.com/callstack/react-native-paper/pull/349#discussion_r186289709