### PR TITLE
docs: change Text imports

### DIFF
--- a/src/components/Dialog/Dialog.js
+++ b/src/components/Dialog/Dialog.js
@@ -48,7 +48,7 @@ type Props = {
  * ## Usage
  * ```js
  * import * as React from 'react';
- * import { Text, View } from 'react-native';
+ * import { View } from 'react-native';
  * import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Paragraph } from 'react-native-paper';
  *
  * export default class MyComponent extends React.Component {

--- a/src/components/Divider.js
+++ b/src/components/Divider.js
@@ -25,8 +25,8 @@ type Props = {
  * ## Usage
  * ```js
  * import * as React from 'react';
- * import { Text, View } from 'react-native';
- * import { Divider } from 'react-native-paper';
+ * import { View } from 'react-native';
+ * import { Divider, Text } from 'react-native-paper';
  *
  * const MyComponent = () => (
  *   <View>

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -42,8 +42,7 @@ type State = {
  * ## Usage
  * ```js
  * import * as React from 'react';
- * import { Text } from 'react-native';
- * import { Modal } from 'react-native-paper';
+ * import { Modal, Text } from 'react-native-paper';
  *
  * export default class MyComponent extends React.Component {
  *   state = {

--- a/src/components/Paper.js
+++ b/src/components/Paper.js
@@ -32,8 +32,7 @@ type Props = {
  * ## Usage
  * ```js
  * import * as React from 'react';
- * import { Text } from 'react-native';
- * import { Paper } from 'react-native-paper';
+ * import { Paper, Text } from 'react-native-paper';
  *
  * const MyComponent = () => (
  *   <Paper style={styles.paper}>

--- a/src/components/RadioButtonGroup.js
+++ b/src/components/RadioButtonGroup.js
@@ -34,7 +34,7 @@ export const RadioButtonContext: Context<?RadioButtonContextType> = createReactC
  * ```js
  * import * as React from 'react';
  * import { View } from 'react-native';
- * import { RadioButtonGroup, RadioButton } from 'react-native-paper';
+ * import { RadioButtonGroup, RadioButton, Text } from 'react-native-paper';
  *
  * export default class MyComponent extends Component {
  *   state = {


### PR DESCRIPTION
Fixes Text component imports. Prefer paper over react-native. Add missing imports, remove obsolete imports.