### PR TITLE
refactor: use touchable's disabled prop

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -215,9 +215,10 @@ class Button extends React.Component<Props, State> {
         <TouchableRipple
           borderless
           delayPressIn={0}
-          onPress={disabled ? undefined : onPress}
-          onPressIn={disabled ? undefined : this._handlePressIn}
-          onPressOut={disabled ? undefined : this._handlePressOut}
+          onPress={onPress}
+          onPressIn={this._handlePressIn}
+          onPressOut={this._handlePressOut}
+          disabled={disabled}
           rippleColor={rippleColor}
           style={touchableStyle}
         >

--- a/src/components/Checkbox.ios.js
+++ b/src/components/Checkbox.ios.js
@@ -61,7 +61,8 @@ class Checkbox extends React.Component<Props> {
         {...rest}
         borderless
         rippleColor={rippleColor}
-        onPress={disabled ? undefined : onPress}
+        onPress={onPress}
+        disabled={disabled}
         style={styles.container}
       >
         <View style={{ opacity: checked ? 1 : 0 }}>

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -141,7 +141,8 @@ class Checkbox extends React.Component<Props, State> {
         {...rest}
         borderless
         rippleColor={rippleColor}
-        onPress={disabled ? undefined : onPress}
+        onPress={onPress}
+        disabled={disabled}
         style={styles.container}
       >
         <Animated.View style={{ transform: [{ scale: this.state.scaleAnim }] }}>


### PR DESCRIPTION
I have noticed there's a "disabled" prop for TouchableRipple. It should be able to simplify some code areas, like the multiple conditions inside the Button component. Is this okay to use?

### Test plan

Snapshot tests working fine.