### PR TITLE
refactor: use paper's typography for drawer

### DIFF
--- a/src/components/DrawerItem.js
+++ b/src/components/DrawerItem.js
@@ -2,11 +2,12 @@
 
 import color from 'color';
 import * as React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import Icon from './Icon';
 import TouchableRipple from './TouchableRipple';
 import { grey300, grey700 } from '../styles/colors';
 import withTheme from '../core/withTheme';
+import Text from './Typography/Text';
 import type { Theme } from '../types';
 import type { IconSource } from './Icon';
 

--- a/src/components/DrawerSection.js
+++ b/src/components/DrawerSection.js
@@ -2,9 +2,10 @@
 
 import color from 'color';
 import * as React from 'react';
-import { View, Text } from 'react-native';
+import { View } from 'react-native';
 import Divider from './Divider';
 import withTheme from '../core/withTheme';
+import Text from './Typography/Text';
 import type { Theme } from '../types';
 
 type Props = {


### PR DESCRIPTION
Use paper's typography instead of the react-native Text component for DrawerItem and DrawerSection. Other components seem to follow the same principle.