### PR TITLE
fix: Searchbar is exported twice

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,6 @@ export { default as ProgressBar } from './components/ProgressBar/ProgressBar';
 export { default as RadioButton } from './components/RadioButton';
 export { default as RadioButtonGroup } from './components/RadioButtonGroup';
 export { default as Searchbar } from './components/Searchbar';
-export { default as SearchBar } from './components/Searchbar';
 export { default as Snackbar } from './components/Snackbar';
 export { default as Switch } from './components/Switch';
 export { default as FABGroup } from './components/FABGroup';


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

SearchBar is exported twice and can cause issues while linting.

### Test plan

n/a
