### PR TITLE
fix: ref set to null on updates

### DIFF
--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2120,7 +2120,11 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
-deepmerge@2.1.0, deepmerge@^1.3.0, deepmerge@^1.5.1, deepmerge@^2.1.0:
+deepmerge@^1.3.0, deepmerge@^1.5.1:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
+
+deepmerge@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.1.0.tgz#511a54fff405fc346f0240bb270a3e9533a31102"
 
@@ -3012,7 +3016,7 @@ hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
-hoist-non-react-statics@2.5.0, hoist-non-react-statics@^2.2.0, hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.2.0, hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
@@ -4870,7 +4874,7 @@ react-google-maps@^7.3.0:
     scriptjs "2.5.8"
     warning "3.0.0"
 
-react-lifecycles-compat@3.0.4, react-lifecycles-compat@^3, react-lifecycles-compat@^3.0.4:
+react-lifecycles-compat@^3, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 

--- a/src/components/Portal/PortalHost.js
+++ b/src/components/Portal/PortalHost.js
@@ -27,6 +27,14 @@ export const PortalContext: Context<PortalMethods> = createReactContext(
  * Portal host is the component which actually renders all Portals.
  */
 export default class PortalHost extends React.Component<Props> {
+  constructor(props: Props) {
+    super(props);
+
+    this._setManager = (manager: Object) => {
+      this._manager = manager;
+    };
+  }
+  
   componentDidMount() {
     const manager = this._manager;
     const queue = this._queue;
@@ -102,9 +110,7 @@ export default class PortalHost extends React.Component<Props> {
       >
         {this.props.children}
         <PortalManager
-          ref={c => {
-            this._manager = c;
-          }}
+          ref={this._setManager}
         />
       </PortalContext.Provider>
     );

--- a/src/components/Portal/PortalHost.js
+++ b/src/components/Portal/PortalHost.js
@@ -49,7 +49,7 @@ export default class PortalHost extends React.Component<Props> {
     }
   }
 
-  _setManager = (manager: Object) => {
+  _setManager = (manager: ?Object) => {
     this._manager = manager;
   };
 

--- a/src/components/Portal/PortalHost.js
+++ b/src/components/Portal/PortalHost.js
@@ -34,7 +34,7 @@ export default class PortalHost extends React.Component<Props> {
       this._manager = manager;
     };
   }
-  
+
   componentDidMount() {
     const manager = this._manager;
     const queue = this._queue;
@@ -109,9 +109,7 @@ export default class PortalHost extends React.Component<Props> {
         }}
       >
         {this.props.children}
-        <PortalManager
-          ref={this._setManager}
-        />
+        <PortalManager ref={this._setManager} />
       </PortalContext.Provider>
     );
   }

--- a/src/components/Portal/PortalHost.js
+++ b/src/components/Portal/PortalHost.js
@@ -27,14 +27,6 @@ export const PortalContext: Context<PortalMethods> = createReactContext(
  * Portal host is the component which actually renders all Portals.
  */
 export default class PortalHost extends React.Component<Props> {
-  constructor(props: Props) {
-    super(props);
-
-    this._setManager = (manager: Object) => {
-      this._manager = manager;
-    };
-  }
-
   componentDidMount() {
     const manager = this._manager;
     const queue = this._queue;
@@ -56,6 +48,10 @@ export default class PortalHost extends React.Component<Props> {
       }
     }
   }
+
+  _setManager = (manager: Object) => {
+    this._manager = manager;
+  };
 
   _mount = (children: React.Node) => {
     const key = this._nextKey++;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

The ref function is called twice on updates (see https://reactjs.org/docs/refs-and-the-dom.html#caveats-with-callback-refs). This behaviour causes the variable `this._manager` sometimes to be null during rendering and in that case actions are pushed to the queue again. Since the queue is only processed once (during componentDidMount), somes changes will never be visible. The simple solution is to bind the ref-function as mentioned in the link above.

### Test plan

Dynamically change `visible` parameter of Modal. The Modal won't be visible on the second time.
