### PR TITLE
fix: empty string causes error

### DIFF
--- a/src/components/List/ListItem.js
+++ b/src/components/List/ListItem.js
@@ -104,7 +104,7 @@ class ListItem extends React.Component<Props> {
             >
               {title}
             </Text>
-            {description && (
+            {description ? (
               <Text
                 numberOfLines={2}
                 style={[
@@ -116,7 +116,7 @@ class ListItem extends React.Component<Props> {
               >
                 {description}
               </Text>
-            )}
+            ) : null}
           </View>
           {avatar && icon ? (
             <View


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

When `description` is an empty string, the empty string is rendered instead of the `Text` node.

### Test plan

Pass empty string for `description` property.
