### PR TITLE
fix: elevation on every platform

### DIFF
--- a/src/components/Appbar/AppbarHeader.js
+++ b/src/components/Appbar/AppbarHeader.js
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 
 import Appbar, { DEFAULT_APPBAR_HEIGHT } from './Appbar';
+import Card from '../Card/Card';
 import withTheme from '../../core/withTheme';
 import type { Theme } from '../../types';
 
@@ -119,15 +120,17 @@ class AppbarHeader extends React.Component<Props> {
       typeof this.props.statusBarHeight === 'number' ? View : SafeAreaView;
 
     return (
-      <Wrapper style={[{ backgroundColor, elevation }]}>
-        <Appbar
-          style={[
-            { height, backgroundColor, marginTop: statusBarHeight },
-            styles.appbar,
-            restStyle,
-          ]}
-          {...rest}
-        />
+      <Wrapper>
+        <Card style={[{ backgroundColor, elevation }]}>
+          <Appbar
+            style={[
+              { height, backgroundColor, marginTop: statusBarHeight },
+              styles.appbar,
+              restStyle,
+            ]}
+            {...rest}
+          />
+        </Card>
       </Wrapper>
     );
   }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

On any other platform than Android there's no shadow since elevation property is passed to View/SafeAreaView.

### Test plan

n/a
