### PR TITLE
fix: set text input selection color to accent color

### DIFF
--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -304,6 +304,7 @@ class TextInput extends React.Component<Props, State> {
     const fontFamily = fonts.regular;
     const {
       primary: primaryColor,
+      accent: accentColor,
       disabled: inactiveColor,
       error: errorColor,
     } = colors;
@@ -370,7 +371,7 @@ class TextInput extends React.Component<Props, State> {
           placeholder={label ? this.state.placeholder : this.props.placeholder}
           placeholderTextColor={colors.placeholder}
           editable={!disabled}
-          selectionColor={labelColor}
+          selectionColor={accentColor}
           onFocus={this._handleFocus}
           onBlur={this._handleBlur}
           underlineColorAndroid="transparent"


### PR DESCRIPTION
This fixes https://github.com/callstack/react-native-paper/issues/344 or https://github.com/callstack/react-native-paper/issues/401

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

With this PR, the `selectionColor` is set to the `accent` color. `selectionColor` is used to change the `TextInput` cursor and text highlight color. 
Previously, it was set to `primary` color which makes it difficult to view the highlighted text if the primary color is dark. So, to separate it from the `primary` color used for the label and underline color, we can use `accent` color for the same.

