### PR TITLE
BREAKING: TextInput redesign

### DIFF
--- a/example/src/TextInputExample.js
+++ b/example/src/TextInputExample.js
@@ -12,6 +12,7 @@ type Props = {
 type State = {
   text: string,
   name: string,
+  outlinedText: string,
 };
 
 class TextInputExample extends React.Component<Props, State> {
@@ -20,6 +21,7 @@ class TextInputExample extends React.Component<Props, State> {
   state = {
     text: '',
     name: '',
+    outlinedText: '',
   };
 
   _isUsernameValid = () => /^[a-z]*$/.test(this.state.name);
@@ -44,6 +46,14 @@ class TextInputExample extends React.Component<Props, State> {
           disabled
           style={styles.inputContainerStyle}
           label="Disabled Input"
+        />
+        <TextInput
+          mode="outlined"
+          style={styles.inputContainerStyle}
+          label="Outlined input"
+          placeholder="Type something"
+          value={this.state.outlinedText}
+          onChangeText={outlinedText => this.setState({ outlinedText })}
         />
         <View style={styles.inputContainerStyle}>
           <TextInput

--- a/src/components/HelperText.js
+++ b/src/components/HelperText.js
@@ -156,6 +156,7 @@ const styles = StyleSheet.create({
   text: {
     fontSize: 12,
     paddingVertical: 4,
+    paddingHorizontal: 12,
   },
 });
 

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -9,8 +9,10 @@ import {
 } from 'react-native';
 import { polyfill } from 'react-lifecycles-compat';
 import Text from './Typography/Text';
+import Icon from './Icon';
 import withTheme from '../core/withTheme';
 import type { Theme } from '../types';
+import type { IconSource } from './Icon';
 
 const AnimatedText = Animated.createAnimatedComponent(Text);
 
@@ -49,6 +51,14 @@ type Props = {
    * Callback that is called when the text input's text changes. Changed text is passed as an argument to the callback handler.
    */
   onChangeText?: Function,
+  /**
+   * Leading icon of the TextInput.
+   */
+  leadingIcon?: IconSource,
+  /**
+   * Trailing icon of the TextInput.
+   */
+  trailingIcon?: IconSource,
   /**
    * Underline color of the input.
    */
@@ -320,19 +330,14 @@ class TextInput extends React.Component<Props, State> {
     return this._root.blur();
   }
 
-  /**
-  TODO
-  - flat - check if background can be calculated out of current theme
-  - leading icon
-  - trailing icon
-   */
-
   render() {
     const {
       mode,
       disabled,
       label,
       error,
+      leadingIcon,
+      trailingIcon,
       underlineColor,
       outlinedBackgroundColor,
       style,
@@ -433,7 +438,11 @@ class TextInput extends React.Component<Props, State> {
         {mode === 'outlined' ? (
           <AnimatedText
             pointerEvents="none"
-            style={[styles.outlinedLabel, outlinedLabelStyle]}
+            style={[
+              styles.outlinedLabel,
+              outlinedLabelStyle,
+              leadingIcon ? styles.outlinedWithIcon : null,
+            ]}
             numberOfLines={1}
           >
             {label}
@@ -441,41 +450,66 @@ class TextInput extends React.Component<Props, State> {
         ) : null}
         <AnimatedText
           pointerEvents="none"
-          style={[styles.placeholder, labelStyle]}
+          style={[
+            styles.placeholder,
+            labelStyle,
+            leadingIcon ? styles.placeholderIcon : null,
+          ]}
           onLayout={event => {
             this._setMaxLabelWidth(event);
           }}
         >
           {label}
         </AnimatedText>
-        <NativeTextInput
-          {...rest}
-          ref={c => {
-            this._root = c;
-          }}
-          onChangeText={this._handleChangeText}
-          placeholder={label ? this.state.placeholder : this.props.placeholder}
-          placeholderTextColor={colors.placeholder}
-          editable={!disabled}
-          selectionColor={labelColor}
-          onFocus={this._handleFocus}
-          onBlur={this._handleBlur}
-          underlineColorAndroid="transparent"
-          style={[
-            styles.input,
-            label ? styles.inputWithLabel : styles.inputWithoutLabel,
-            rest.multiline
-              ? label
-                ? styles.multilineWithLabel
-                : styles.multilineWithoutLabel
-              : null,
-            mode === 'outlined' ? styles.inputOutlined : null,
-            {
-              color: inputTextColor,
-              fontFamily,
-            },
-          ]}
-        />
+        <View style={styles.iconContainer}>
+          {leadingIcon ? (
+            <View style={styles.icon}>
+              <Icon source={leadingIcon} color={inputTextColor} size={24} />
+            </View>
+          ) : null}
+          <NativeTextInput
+            {...rest}
+            ref={c => {
+              this._root = c;
+            }}
+            onChangeText={this._handleChangeText}
+            placeholder={
+              label ? this.state.placeholder : this.props.placeholder
+            }
+            placeholderTextColor={colors.placeholder}
+            editable={!disabled}
+            selectionColor={labelColor}
+            onFocus={this._handleFocus}
+            onBlur={this._handleBlur}
+            underlineColorAndroid="transparent"
+            style={[
+              styles.input,
+              label ? styles.inputWithLabel : styles.inputWithoutLabel,
+              rest.multiline
+                ? label
+                  ? styles.multilineWithLabel
+                  : styles.multilineWithoutLabel
+                : null,
+              mode === 'outlined' ? styles.inputOutlined : null,
+              {
+                color: inputTextColor,
+                fontFamily,
+                flex: 1,
+              },
+              leadingIcon ? styles.withIcon : null,
+            ]}
+          />
+          {trailingIcon ? (
+            <View style={styles.icon}>
+              <Icon
+                source={trailingIcon}
+                color={inputTextColor}
+                size={24}
+                style={styles.icon}
+              />
+            </View>
+          ) : null}
+        </View>
         {mode === 'flat' ? (
           <View pointerEvents="none" style={styles.bottomLineContainer}>
             <View
@@ -569,5 +603,23 @@ const styles = StyleSheet.create({
   },
   focusLine: {
     height: StyleSheet.hairlineWidth * 4,
+  },
+  iconContainer: {
+    flexDirection: 'row',
+    height: 56,
+  },
+  icon: {
+    marginTop: 18,
+    marginHorizontal: 12,
+  },
+  placeholderIcon: {
+    left: 36,
+  },
+  withIcon: {
+    left: -12,
+    flex: 1,
+  },
+  outlinedWithIcon: {
+    left: 42,
   },
 });


### PR DESCRIPTION
TextInput redesign - work in progress

So far:

<img width="373" alt="screen shot 2018-06-21 at 23 25 13" src="https://user-images.githubusercontent.com/7827311/41746595-2b28d080-75ab-11e8-82ac-2d7b50467940.png">

[TODO](https://github.com/callstack/react-native-paper/pull/429/files#diff-668f4dd23f3a0a24c50d7c852c1fa633R301)

Fixes #359.
