### PR TITLE
fix: prevent focus and blur if disabled

### DIFF
--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -228,7 +228,7 @@ class TextInput extends React.Component<Props, State> {
     if (this.props.disabled) {
       return;
     }
-    
+
     this.setState({ focused: true });
 
     if (this.props.onFocus) {
@@ -240,7 +240,7 @@ class TextInput extends React.Component<Props, State> {
     if (this.props.disabled) {
       return;
     }
-    
+
     this.setState({ focused: false });
 
     if (this.props.onBlur) {

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -225,6 +225,10 @@ class TextInput extends React.Component<Props, State> {
     }).start();
 
   _handleFocus = (...args) => {
+    if (this.props.disabled) {
+      return;
+    }
+    
     this.setState({ focused: true });
 
     if (this.props.onFocus) {
@@ -233,6 +237,10 @@ class TextInput extends React.Component<Props, State> {
   };
 
   _handleBlur = (...args) => {
+    if (this.props.disabled) {
+      return;
+    }
+    
     this.setState({ focused: false });
 
     if (this.props.onBlur) {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Focus and blur events are still triggered even if the input is disabled

### Test plan

Set disabled to true and see how you can still focus and blur an input field.
