### PR TITLE
feat: allow disabling of AppbarAction

### DIFF
--- a/src/components/Appbar/AppbarAction.js
+++ b/src/components/Appbar/AppbarAction.js
@@ -20,6 +20,10 @@ type Props = {
    */
   size?: number,
   /**
+   * Whether the button is disabled. A disabled button is greyed out and `onPress` is not called on touch.
+   */
+  disabled?: boolean,
+  /**
    * Accessibility label for the button. This is read by the screen reader when the user taps the button.
    */
   accessibilityLabel?: string,
@@ -47,6 +51,7 @@ export default class AppbarAction extends React.Component<Props> {
         .rgb()
         .string(),
       icon,
+      disabled,
       onPress,
       accessibilityLabel,
       ...rest
@@ -57,6 +62,7 @@ export default class AppbarAction extends React.Component<Props> {
         onPress={onPress}
         color={iconColor}
         icon={icon}
+        disabled={disabled}
         accessibilityLabel={accessibilityLabel}
         {...rest}
       />


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Currently, AppbarActions cannot be disabled. This allows to pass on the `disabled` property.

### Test plan

n/a
