### PR TITLE
fix: show beginning of text in input

### DIFF
--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -79,6 +79,10 @@ type State = {
   focused: boolean,
   placeholder: ?string,
   value: ?string,
+  selection: ?{
+    start: number,
+    end: number,
+  },
 };
 
 /**
@@ -143,6 +147,7 @@ class TextInput extends React.Component<Props, State> {
     focused: false,
     placeholder: '',
     value: this.props.value,
+    selection: null,
   };
 
   componentDidUpdate(prevProps, prevState) {
@@ -229,7 +234,14 @@ class TextInput extends React.Component<Props, State> {
       return;
     }
 
-    this.setState({ focused: true });
+    const { value } = this.state;
+    const selection = value ? { start: value.length, end: value.length } : null;
+    this.setState({ focused: true, selection }, () => {
+      // Reset selection once it was set in order to not block any manual selection
+      this.setState({
+        selection: null,
+      });
+    });
 
     if (this.props.onFocus) {
       this.props.onFocus(...args);
@@ -241,7 +253,7 @@ class TextInput extends React.Component<Props, State> {
       return;
     }
 
-    this.setState({ focused: false });
+    this.setState({ focused: false, selection: { start: 0, end: 0 } });
 
     if (this.props.onBlur) {
       this.props.onBlur(...args);
@@ -379,6 +391,7 @@ class TextInput extends React.Component<Props, State> {
           placeholderTextColor={colors.placeholder}
           editable={!disabled}
           selectionColor={labelColor}
+          selection={this.state.selection}
           onFocus={this._handleFocus}
           onBlur={this._handleBlur}
           underlineColorAndroid="transparent"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

When the string is larger than the width of TextInput and the component is mounted or lose it's focus, the component does not display the string from the very beginning. Rather, the component starts displaying the string by the end.
See issue https://github.com/callstack/react-native-paper/issues/450

### Test plan

Enter text longer than the screen width and afterwards unfocus TextInput. The beginning of the text in the input should be visible. Once you focus the TextInput again, the selection is at the very end.
