### PR TITLE
feat: add background color prop on FAB group action item

### DIFF
--- a/src/components/FABGroup.js
+++ b/src/components/FABGroup.js
@@ -25,14 +25,14 @@ type Props = {
    * - `icon`: icon to display (required)
    * - `label`: optional label text
    * - `color`: custom icon color of the action item
-   * - `backgroundColor`: custom icon background color of the action item
+   * - `style`: pass additional styles, for example, backgroundColor
    * - `onPress`: callback that is called when `FAB` is pressed (required)
    */
   actions: Array<{
     icon: string,
     label?: string,
     color?: string,
-    backgroundColor?: string,
+    style?: any,
     onPress: () => mixed,
   }>,
   /**
@@ -256,7 +256,9 @@ class FABGroup extends React.Component<Props, State> {
                       {
                         transform: [{ scale: scales[i] }],
                         backgroundColor:
-                          it.backgroundColor || theme.colors.paper,
+                          it.style && it.style.backgroundColor
+                            ? it.style.backgroundColor
+                            : theme.colors.paper,
                       },
                     ]}
                     onPress={() => {

--- a/src/components/FABGroup.js
+++ b/src/components/FABGroup.js
@@ -25,12 +25,14 @@ type Props = {
    * - `icon`: icon to display (required)
    * - `label`: optional label text
    * - `color`: custom icon color of the action item
+   * - `backgroundColor`: custom icon background color of the action item
    * - `onPress`: callback that is called when `FAB` is pressed (required)
    */
   actions: Array<{
     icon: string,
     label?: string,
     color?: string,
+    backgroundColor?: string,
     onPress: () => mixed,
   }>,
   /**
@@ -253,7 +255,8 @@ class FABGroup extends React.Component<Props, State> {
                     style={[
                       {
                         transform: [{ scale: scales[i] }],
-                        backgroundColor: theme.colors.paper,
+                        backgroundColor:
+                          it.backgroundColor || theme.colors.paper,
                       },
                     ]}
                     onPress={() => {


### PR DESCRIPTION
### Motivation
Adds optional background color property to action item of FAB group component.

### Test plan

![image](https://user-images.githubusercontent.com/2385241/43462075-cc7bade4-94dd-11e8-92ce-3b580a7050fd.png)

