### PR TITLE
docs: fix link to platform adaptation guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## Features
 
 - Follows [material design guidelines](https://material.io/guidelines/)
-- Works on both iOS and Android following [platform adaptation guidelines](https://material.io/guidelines/platforms/platform-adaptation.html)
+- Works on both iOS and Android following [platform adaptation guidelines](https://material.io/design/platform-guidance/cross-platform-adaptation.html)
 - Full [theming support](https://callstack.github.io/react-native-paper/theming.html)
 
 Currently supported React Native version: `>= 0.50.3`


### PR DESCRIPTION
### Motivation

The url of the material design platform adaptation guidelines page has changed, so clicking the link in the README doesn't go to the correct page.

### Test plan

The new link should go directly to the correct page on material design platform adaptation guidelines.
