### PR TITLE
fix: button borderWidth

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -144,7 +144,7 @@ class Button extends React.Component<Props, State> {
     const { colors, roundness } = theme;
     const fontFamily = theme.fonts.medium;
 
-    let backgroundColor, borderColor, textColor;
+    let backgroundColor, borderColor, textColor, borderWidth;
 
     if (mode === 'contained') {
       if (disabled) {
@@ -166,6 +166,7 @@ class Button extends React.Component<Props, State> {
         .alpha(0.29)
         .rgb()
         .string();
+      borderWidth = StyleSheet.hairlineWidth;
     } else {
       borderColor = 'transparent';
     }
@@ -201,6 +202,7 @@ class Button extends React.Component<Props, State> {
     const buttonStyle = {
       backgroundColor,
       borderColor,
+      borderWidth,
       borderRadius: roundness,
     };
     const touchableStyle = { borderRadius: roundness };
@@ -268,7 +270,6 @@ class Button extends React.Component<Props, State> {
 const styles = StyleSheet.create({
   button: {
     minWidth: 88,
-    borderWidth: StyleSheet.hairlineWidth,
     borderStyle: 'solid',
   },
   compact: {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
`borderWidth: StyleSheet.hairlineWidth` is only needed for outlined buttons, it is causing unwanted white bottom border on contained buttons.

### Screenshots
#### before:
![screenshot_20180803-143947](https://user-images.githubusercontent.com/11161020/43641826-c1a0bffc-972d-11e8-9c47-1618a57d9493.png)
#### expected:
![screenshot_20180803-143727](https://user-images.githubusercontent.com/11161020/43641858-df31ffc2-972d-11e8-98b5-90ccdc135394.png)



<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
