### PR TITLE
fix: disable Touchable if no press handler was passed

### DIFF
--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -116,6 +116,7 @@ class Card extends React.Component<Props, State> {
       <AnimatedSurface style={[{ borderRadius: roundness, elevation }, style]}>
         <TouchableWithoutFeedback
           delayPressIn={0}
+          disabled={!onPress}
           onPress={onPress}
           onPressIn={onPress ? this._handlePressIn : undefined}
           onPressOut={onPress ? this._handlePressOut : undefined}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Disable `Touchable` if no press handler was passed. Otherwise a pointer cursor will always appear on web platform though it's not clickable.

### Test plan

n/a