### PR TITLE
Fix issue that `Modal` children cannot grow

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -154,7 +154,7 @@ class Modal extends React.Component<Props, State> {
             <View style={StyleSheet.absoluteFill} />
           </TouchableWithoutFeedback>
         )}
-        <Animated.View style={[{ opacity: this.state.opacity }]}>
+        <Animated.View style={[{ opacity: this.state.opacity }, styles.childrenWrapper]}>
           {children}
         </Animated.View>
       </Animated.View>
@@ -171,4 +171,7 @@ const styles = StyleSheet.create({
     ...StyleSheet.absoluteFillObject,
     justifyContent: 'center',
   },
+  childrenWrapper: {
+    flex: 1
+  }
 });


### PR DESCRIPTION
Add `flex:1` to Modal to fix the issue that `Modal` children cannot grow

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

See https://github.com/callstack/react-native-paper/issues/471

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

See https://github.com/callstack/react-native-paper/issues/471

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
