### PR TITLE
Set proper elevation for Card and decrease animation time.

### DIFF
--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -77,7 +77,7 @@ class Card extends React.Component<Props, State> {
   static Cover = CardCover;
 
   static defaultProps = {
-    elevation: 2,
+    elevation: 1,
   };
 
   state = {
@@ -88,7 +88,7 @@ class Card extends React.Component<Props, State> {
   _handlePressIn = () => {
     Animated.timing(this.state.elevation, {
       toValue: 8,
-      duration: 200,
+      duration: 150,
     }).start();
   };
 


### PR DESCRIPTION
Change elevation of Card component according to Material Design Guidelines and decrease a bit elevation animation time, it makes elevation change effect more noticeable.
