### PR TITLE
Disabled SnackBar content rendering when SnackBar is not visible

### DIFF
--- a/src/components/Snackbar.js
+++ b/src/components/Snackbar.js
@@ -44,6 +44,7 @@ type Props = {
 
 type State = {
   opacity: Animated.Value,
+  hidden: boolean,
 };
 
 const DURATION_SHORT = 4000;
@@ -124,6 +125,7 @@ class Snackbar extends React.Component<Props, State> {
 
   state = {
     opacity: new Animated.Value(0.0),
+    hidden: !this.props.visible,
   };
 
   componentDidUpdate(prevProps) {
@@ -146,6 +148,9 @@ class Snackbar extends React.Component<Props, State> {
 
   _show = () => {
     clearTimeout(this._hideTimeout);
+    this.setState({
+      hidden: false,
+    });
     Animated.timing(this.state.opacity, {
       toValue: 1,
       duration: 200,
@@ -163,7 +168,7 @@ class Snackbar extends React.Component<Props, State> {
       toValue: 0,
       duration: 100,
       useNativeDriver: true,
-    }).start();
+    }).start(() => this.setState({ hidden: true }));
   };
 
   _hideTimeout: TimeoutID;
@@ -171,7 +176,6 @@ class Snackbar extends React.Component<Props, State> {
   render() {
     const { children, visible, action, onDismiss, theme, style } = this.props;
     const { colors, roundness } = theme;
-
     return (
       <SafeAreaView pointerEvents="box-none" style={styles.wrapper}>
         <Animated.View
@@ -191,28 +195,30 @@ class Snackbar extends React.Component<Props, State> {
             ],
           }}
         >
-          <View
-            pointerEvents="box-none"
-            style={[styles.container, { borderRadius: roundness }, style]}
-          >
-            <Text style={[styles.content, { marginRight: action ? 0 : 16 }]}>
-              {children}
-            </Text>
-            {action ? (
-              <Button
-                onPress={() => {
-                  action.onPress();
-                  onDismiss();
-                }}
-                style={styles.button}
-                color={colors.accent}
-                compact
-                mode="text"
-              >
-                {action.label.toUpperCase()}
-              </Button>
-            ) : null}
-          </View>
+          {!this.state.hidden ? (
+            <View
+              pointerEvents="box-none"
+              style={[styles.container, { borderRadius: roundness }, style]}
+            >
+              <Text style={[styles.content, { marginRight: action ? 0 : 16 }]}>
+                {children}
+              </Text>
+              {action ? (
+                <Button
+                  onPress={() => {
+                    action.onPress();
+                    onDismiss();
+                  }}
+                  style={styles.button}
+                  color={colors.accent}
+                  compact
+                  mode="text"
+                >
+                  {action.label.toUpperCase()}
+                </Button>
+              ) : null}
+            </View>
+          ) : null}
         </Animated.View>
       </SafeAreaView>
     );

--- a/src/components/__tests__/Snackbar.test.js
+++ b/src/components/__tests__/Snackbar.test.js
@@ -19,7 +19,7 @@ it('renders snackbar with content', () => {
   expect(tree).toMatchSnapshot();
 });
 
-it('renders not visible snackbar with content', () => {
+it('renders not visible snackbar with content wrapper but no actual content', () => {
   const tree = renderer
     .create(
       <Snackbar visible={false} onDismiss={jest.fn()}>

--- a/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders not visible snackbar with content 1`] = `
+exports[`renders not visible snackbar with content wrapper but no actual content 1`] = `
 <RCTSafeAreaView
   pointerEvents="box-none"
   style={
@@ -24,80 +24,7 @@ exports[`renders not visible snackbar with content 1`] = `
         ],
       }
     }
-  >
-    <View
-      pointerEvents="box-none"
-      style={
-        Array [
-          Object {
-            "alignItems": "center",
-            "backgroundColor": "#323232",
-            "borderRadius": 4,
-            "elevation": 6,
-            "flexDirection": "row",
-            "justifyContent": "space-between",
-            "margin": 8,
-          },
-          Object {
-            "borderRadius": 4,
-          },
-          undefined,
-        ]
-      }
-    >
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Array [
-            Object {
-              "color": "#000000",
-              "fontFamily": "Helvetica Neue",
-              "textAlign": "left",
-              "writingDirection": "ltr",
-            },
-            Array [
-              Object {
-                "color": "#ffffff",
-                "flex": 1,
-                "flexWrap": "wrap",
-                "marginLeft": 16,
-                "marginVertical": 14,
-              },
-              Object {
-                "marginRight": 16,
-              },
-            ],
-          ]
-        }
-        theme={
-          Object {
-            "colors": Object {
-              "accent": "#03dac4",
-              "background": "#f6f6f6",
-              "disabled": "rgba(0, 0, 0, 0.26)",
-              "error": "#B00020",
-              "placeholder": "rgba(0, 0, 0, 0.38)",
-              "primary": "#6200ee",
-              "surface": "#ffffff",
-              "text": "#000000",
-            },
-            "dark": false,
-            "fonts": Object {
-              "light": "HelveticaNeue-Light",
-              "medium": "HelveticaNeue-Medium",
-              "regular": "Helvetica Neue",
-              "thin": "HelveticaNeue-Thin",
-            },
-            "roundness": 4,
-          }
-        }
-      >
-        Snackbar content
-      </Text>
-    </View>
-  </View>
+  />
 </RCTSafeAreaView>
 `;
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Fixed invisible Snackbar content rendering because it blocked touch events when clickable content was rendered beneath Snackbar.

Content is now rendered before show animation starts and unmounted after hide animation ends.

### Test plan
Align a button to the bottom of the page, even when SnackBar is invisible touching prioritises SnackBar over the button beneath. After fix the button beneath is clickable and SnackBar and its content still shows and hides correctly.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
