### PR TITLE
feat: RTL toggle

### DIFF
--- a/example/DrawerItems.js
+++ b/example/DrawerItems.js
@@ -15,6 +15,8 @@ import type { Theme } from 'react-native-paper/types';
 type Props = {
   theme: Theme,
   toggleTheme: Function,
+  toggleRTL: Function,
+  isRTL: boolean,
 };
 
 type State = {
@@ -77,6 +79,22 @@ class DrawerItems extends React.Component<Props, State> {
               <Paragraph>Dark Theme</Paragraph>
               <View pointerEvents="none">
                 <Switch value={this.state.isDark} />
+              </View>
+            </View>
+          </TouchableRipple>
+          <TouchableRipple onPress={this.props.toggleRTL}>
+            <View
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                paddingVertical: 8,
+                paddingHorizontal: 16,
+              }}
+            >
+              <Paragraph>RTL</Paragraph>
+              <View pointerEvents="none">
+                <Switch value={this.props.isRTL} />
               </View>
             </View>
           </TouchableRipple>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
The expo app on IOS is always LTR even if the device is RTL, this feature helps paper's example app to display in RTL on IOS devices.

### Issues on Android
- ~~mainDrawer is not filliping, i think it is react-navigation related issue~~
- It doesn't flip to LTR if the device is currently RTL
 
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
![untit11led](https://user-images.githubusercontent.com/11161020/44566443-462af500-a776-11e8-968c-1c1886bca65b.png)

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
