### PR TITLE
fix: justify content centered in Modals

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -171,9 +171,9 @@ export default Modal;
 const styles = StyleSheet.create({
   wrapper: {
     ...StyleSheet.absoluteFillObject,
-    justifyContent: 'center',
   },
   childrenWrapper: {
     flex: 1,
+    justifyContent: 'center',
   },
 });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Since #491 the content is not centered automatically anymore because the children take up 100% and `justifyContent` on the parent container has no effect.

### Test plan

n/a
