### PR TITLE
feat: add onLongPress to Card

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ The core team works directly on GitHub and all work is public.
 
 1. Fork the repo and create your branch from `master` (a guide on [how to fork a repository](https://help.github.com/articles/fork-a-repo/)).
 2. Run `yarn bootstrap` to setup the developement environment.
+3. Go to the `docs` directory and run `npm i`.
 3. Do the changes you want and test them out in the example app before sending a pull request.
 
 ### Commit message convention
@@ -57,7 +58,7 @@ When you're working on a component:
 
 The example app uses [Expo](https://expo.io/). You will need to install the Expo app for [Android](https://play.google.com/store/apps/details?id=host.exp.exponent) and [iOS](https://itunes.apple.com/app/apple-store/id982107779) to start developing.
 
-After you're done, you can run `yarn start` in the `example/` folder and scan the QR code to launch it on your device.
+After you're done, you can run `yarn && yarn start` in the `example/` folder and scan the QR code to launch it on your device.
 
 ### Working on documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,7 @@ The core team works directly on GitHub and all work is public.
 
 1. Fork the repo and create your branch from `master` (a guide on [how to fork a repository](https://help.github.com/articles/fork-a-repo/)).
 2. Run `yarn bootstrap` to setup the developement environment.
-3. Go to the `docs` directory and run `npm i`.
-4. Do the changes you want and test them out in the example app before sending a pull request.
+3. Do the changes you want and test them out in the example app before sending a pull request.
 
 ### Commit message convention
 
@@ -58,7 +57,7 @@ When you're working on a component:
 
 The example app uses [Expo](https://expo.io/). You will need to install the Expo app for [Android](https://play.google.com/store/apps/details?id=host.exp.exponent) and [iOS](https://itunes.apple.com/app/apple-store/id982107779) to start developing.
 
-After you're done, you can run `yarn && yarn start` in the `example/` folder and scan the QR code to launch it on your device.
+After you're done, you can run `yarn start` or `expo start` in the `example/` folder and scan the QR code to launch it on your device.
 
 ### Working on documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ The core team works directly on GitHub and all work is public.
 1. Fork the repo and create your branch from `master` (a guide on [how to fork a repository](https://help.github.com/articles/fork-a-repo/)).
 2. Run `yarn bootstrap` to setup the developement environment.
 3. Go to the `docs` directory and run `npm i`.
-3. Do the changes you want and test them out in the example app before sending a pull request.
+4. Do the changes you want and test them out in the example app before sending a pull request.
 
 ### Commit message convention
 

--- a/example/src/CardExample.js
+++ b/example/src/CardExample.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import * as React from 'react';
-import { ScrollView, StyleSheet } from 'react-native';
+import { Alert, ScrollView, StyleSheet } from 'react-native';
 import {
   Title,
   Caption,
@@ -67,7 +67,37 @@ class CardExample extends React.Component<Props> {
           </Card.Content>
         </Card>
         <Card style={styles.card}>
+          <Title>Just Strawberries</Title>
           <Card.Cover source={require('../assets/strawberries.jpg')} />
+        </Card>
+        <Card
+          style={styles.card}
+          onPress={() => {
+            Alert.alert('The Chameleon is Pressed');
+          }}
+        >
+          <Card.Cover source={require('../assets/chameleon.jpg')} />
+          <Card.Content>
+            <Title>Pressable Chameleon</Title>
+            <Paragraph>
+              This is a pressable chameleon. If you press me, I will alert.
+            </Paragraph>
+          </Card.Content>
+        </Card>
+        <Card
+          style={styles.card}
+          onLongPress={() => {
+            Alert.alert('The City is Long Pressed');
+          }}
+        >
+          <Card.Cover source={require('../assets/city.jpg')} />
+          <Card.Content>
+            <Title>Long Pressable City</Title>
+            <Paragraph>
+              This is a long press only city. If you long press me, I will
+              alert.
+            </Paragraph>
+          </Card.Content>
         </Card>
       </ScrollView>
     );

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -122,7 +122,7 @@ class Card extends React.Component<Props, State> {
       <AnimatedSurface style={[{ borderRadius: roundness, elevation }, style]}>
         <TouchableWithoutFeedback
           delayPressIn={0}
-          disabled={!onPress}
+          disabled={!(onPress || onLongPress)}
           onLongPress={onLongPress}
           onPress={onPress}
           onPressIn={onPress ? this._handlePressIn : undefined}

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -22,6 +22,10 @@ type Props = {
    */
   elevation?: number,
   /**
+   * Function to execute on long press.
+   */
+  onLongPress?: () => mixed,
+  /**
    * Function to execute on press.
    */
   onPress?: () => mixed,
@@ -103,7 +107,7 @@ class Card extends React.Component<Props, State> {
   };
 
   render() {
-    const { children, onPress, style, theme } = this.props;
+    const { children, onLongPress, onPress, style, theme } = this.props;
     const { elevation } = this.state;
     const { roundness } = theme;
     const total = React.Children.count(children);
@@ -119,6 +123,7 @@ class Card extends React.Component<Props, State> {
         <TouchableWithoutFeedback
           delayPressIn={0}
           disabled={!onPress}
+          onLongPress={onLongPress}
           onPress={onPress}
           onPressIn={onPress ? this._handlePressIn : undefined}
           onPressOut={onPress ? this._handlePressOut : undefined}


### PR DESCRIPTION
First contribution to this repo; feel free to critique however is needed to merge.  :)

### Motivation

This adds `onLongPress` to `Card.js` so that if you use a `<Card>` you can specify an `onLongPress` instead of just `onPress` if desired.  I have a use case where a long press on a card is desirable.

Makes minor updates to `CONTRIBUTING.md` that I needed and should make it easier for another first contributor.

### Test plan

The `CardExample.js` has been updated with both `onPress` and `onLongPress` examples.
Testing was done primarily on an iPhone X in the iOS simulator running 11.4.
If desired, happy to do other testing.

The current test suites pass fine as well:
```
yarn test v0.27.5
$ jest
 PASS  src/components/__tests__/Snackbar.test.js
 PASS  src/components/__tests__/ListAccordion.test.js
 PASS  src/babel/__tests__/index.js
 PASS  src/components/__tests__/FAB.test.js
 PASS  src/components/__tests__/BottomNavigation.test.js
 PASS  src/components/__tests__/Checkbox.test.js
 PASS  src/components/__tests__/Button.test.js
 PASS  src/components/__tests__/ListItem.test.js
 PASS  src/components/__tests__/ListSection.test.js
 PASS  src/components/__tests__/IconButton.test.js
 PASS  src/components/__tests__/DrawerItem.test.js
 PASS  src/components/__tests__/Chip.test.js
 PASS  src/components/__tests__/Portal.test.js

Test Suites: 13 passed, 13 total
Tests:       52 passed, 52 total
Snapshots:   51 passed, 51 total
Time:        7.381s
Ran all test suites.
Done in 9.47s.
```

Screenshots as requested:
![new_cards](https://user-images.githubusercontent.com/333037/45259271-8a74e280-b37d-11e8-9f43-026687456c40.png)
![chameleon_pressed](https://user-images.githubusercontent.com/333037/45259272-8ea10000-b37d-11e8-9006-e25860b7a70d.png)
![city_pressed](https://user-images.githubusercontent.com/333037/45259273-92348700-b37d-11e8-8b62-dffcb1bea149.png)
