### PR TITLE
docs: fix wrong URL to 'getting started'

### DIFF
--- a/docs/pages/src/Home.js
+++ b/docs/pages/src/Home.js
@@ -21,7 +21,7 @@ export default class Home extends React.Component<{}> {
           />
           <p>Cross-platform Material Design for React Native</p>
           <div {...styles(buttons)}>
-            <Link {...styles(button, primary)} to="getting-started.html">
+            <Link {...styles(button, primary)} to="getting-started">
               Get started
             </Link>
             <a


### PR DESCRIPTION
I've noticed that link to the _getting started_ page in the docs seems to not working as expected since `*.html` extension is added anyway and it makes the link broken:
`https://callstack.github.io/react-native-paper/getting-started.html.html`.

### Motivation

The documentation is important part of the library and should be working properly.

### Test plan

Enter `/docs`, install using `yarn` and run it with `yarn start`.

> **NOTE:** _the current version works on localhost and breaks only in the prod env. Suggested change will probably work in both, but needs to be verified by someone who knows the deployment process._