### PR TITLE
fix: Remove style prop from touchable

### DIFF
--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -122,7 +122,6 @@ class Card extends React.Component<Props, State> {
           onPress={onPress}
           onPressIn={onPress ? this._handlePressIn : undefined}
           onPressOut={onPress ? this._handlePressOut : undefined}
-          style={styles.container}
         >
           <View style={styles.innerContainer}>
             {React.Children.map(
@@ -144,9 +143,6 @@ class Card extends React.Component<Props, State> {
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
   innerContainer: {
     flexGrow: 1,
   },


### PR DESCRIPTION
### Motivation

`TouchableWithoutFeedback` has no style prop. Causes a flow error (flow 0.75). Related to #451.
The PR removes the style prop.

### Test plan

https://facebook.github.io/react-native/docs/touchablewithoutfeedback
<img width="541" alt="screen shot 2018-09-18 at 19 01 37" src="https://user-images.githubusercontent.com/7827311/45704107-659b1f00-bb76-11e8-9b5f-64cc07870dd4.png">
The Expo Card example looks the same.