### PR TITLE
fix: Fix flow issues with ref

### DIFF
--- a/src/components/Searchbar.js
+++ b/src/components/Searchbar.js
@@ -74,41 +74,41 @@ class Searchbar extends React.Component<Props> {
     this.props.onChangeText && this.props.onChangeText('');
   };
 
-  _root: TextInput;
+  _root: ?TextInput;
 
   /**
    * @internal
    */
   setNativeProps(...args) {
-    return this._root.setNativeProps(...args);
+    return this._root && this._root.setNativeProps(...args);
   }
 
   /**
    * Returns `true` if the input is currently focused, `false` otherwise.
    */
   isFocused() {
-    return this._root.isFocused();
+    return this._root && this._root.isFocused();
   }
 
   /**
    * Removes all text from the TextInput.
    */
   clear() {
-    return this._root.clear();
+    return this._root && this._root.clear();
   }
 
   /**
    * Focuses the input.
    */
   focus() {
-    return this._root.focus();
+    return this._root && this._root.focus();
   }
 
   /**
    * Removes focus from the input.
    */
   blur() {
-    return this._root.blur();
+    return this._root && this._root.blur();
   }
 
   render() {

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -234,7 +234,7 @@ class TextInput extends React.Component<Props, State> {
     });
 
   _timer: TimeoutID;
-  _root: NativeTextInput;
+  _root: ?NativeTextInput;
 
   _showError = () => {
     Animated.timing(this.state.error, {
@@ -299,35 +299,35 @@ class TextInput extends React.Component<Props, State> {
    * @internal
    */
   setNativeProps(...args) {
-    return this._root.setNativeProps(...args);
+    return this._root && this._root.setNativeProps(...args);
   }
 
   /**
    * Returns `true` if the input is currently focused, `false` otherwise.
    */
   isFocused() {
-    return this._root.isFocused();
+    return this._root && this._root.isFocused();
   }
 
   /**
    * Removes all text from the TextInput.
    */
   clear() {
-    return this._root.clear();
+    return this._root && this._root.clear();
   }
 
   /**
    * Focuses the input.
    */
   focus() {
-    return this._root.focus();
+    return this._root && this._root.focus();
   }
 
   /**
    * Removes focus from the input.
    */
   blur() {
-    return this._root.blur();
+    return this._root && this._root.blur();
   }
 
   render() {

--- a/src/components/Typography/Text.js
+++ b/src/components/Typography/Text.js
@@ -19,13 +19,13 @@ type Props = {
  * @extends Text props https://facebook.github.io/react-native/docs/text.html#props
  */
 class Text extends React.Component<Props> {
-  _root: NativeText;
+  _root: ?NativeText;
 
   /**
    * @internal
    */
   setNativeProps(...args) {
-    return this._root.setNativeProps(...args);
+    return this._root && this._root.setNativeProps(...args);
   }
 
   render() {


### PR DESCRIPTION
Partial fix for #451. Handles the `Cannot assign c to this._root` flow errors in recent versions of RN and flow.

Since `c` is a maybe type, it's not compatible with the `_root` type. React calls the `ref` callback with null when the component unmounts, that's why it's typed as being possibly `null`. The PR adds some extra checks to suppress that.