### PR TITLE
feat: Ability to adjust the button height

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -239,7 +239,12 @@ class Button extends React.Component<Props, State> {
           rippleColor={rippleColor}
           style={touchableStyle}
         >
-          <View style={styles.content}>
+          <View
+            style={[
+              styles.content,
+              { height: style && style.height ? style.height : 'auto' },
+            ]}
+          >
             {icon && loading !== true ? (
               <View style={styles.icon}>
                 <Icon source={icon} size={16} color={textColor} />

--- a/src/components/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.js.snap
@@ -42,11 +42,16 @@ exports[`renders button with color 1`] = `
   >
     <View
       style={
-        Object {
-          "alignItems": "center",
-          "flexDirection": "row",
-          "justifyContent": "center",
-        }
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          Object {
+            "height": "auto",
+          },
+        ]
       }
     >
       <Text
@@ -153,11 +158,16 @@ exports[`renders button with icon 1`] = `
   >
     <View
       style={
-        Object {
-          "alignItems": "center",
-          "flexDirection": "row",
-          "justifyContent": "center",
-        }
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          Object {
+            "height": "auto",
+          },
+        ]
       }
     >
       <View
@@ -317,11 +327,16 @@ exports[`renders contained contained with mode 1`] = `
   >
     <View
       style={
-        Object {
-          "alignItems": "center",
-          "flexDirection": "row",
-          "justifyContent": "center",
-        }
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          Object {
+            "height": "auto",
+          },
+        ]
       }
     >
       <Text
@@ -433,11 +448,16 @@ exports[`renders disabled button 1`] = `
   >
     <View
       style={
-        Object {
-          "alignItems": "center",
-          "flexDirection": "row",
-          "justifyContent": "center",
-        }
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          Object {
+            "height": "auto",
+          },
+        ]
       }
     >
       <Text
@@ -544,11 +564,16 @@ exports[`renders loading button 1`] = `
   >
     <View
       style={
-        Object {
-          "alignItems": "center",
-          "flexDirection": "row",
-          "justifyContent": "center",
-        }
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          Object {
+            "height": "auto",
+          },
+        ]
       }
     >
       <ActivityIndicator
@@ -668,11 +693,16 @@ exports[`renders outlined button with mode 1`] = `
   >
     <View
       style={
-        Object {
-          "alignItems": "center",
-          "flexDirection": "row",
-          "justifyContent": "center",
-        }
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          Object {
+            "height": "auto",
+          },
+        ]
       }
     >
       <Text
@@ -779,11 +809,16 @@ exports[`renders text button by default 1`] = `
   >
     <View
       style={
-        Object {
-          "alignItems": "center",
-          "flexDirection": "row",
-          "justifyContent": "center",
-        }
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          Object {
+            "height": "auto",
+          },
+        ]
       }
     >
       <Text
@@ -890,11 +925,16 @@ exports[`renders text button with mode 1`] = `
   >
     <View
       style={
-        Object {
-          "alignItems": "center",
-          "flexDirection": "row",
-          "justifyContent": "center",
-        }
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          Object {
+            "height": "auto",
+          },
+        ]
       }
     >
       <Text

--- a/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
@@ -276,11 +276,16 @@ exports[`renders snackbar with action button 1`] = `
         >
           <View
             style={
-              Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "center",
-              }
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                },
+                Object {
+                  "height": "auto",
+                },
+              ]
             }
           >
             <Text


### PR DESCRIPTION
### Motivation

Another way to fix #352. Uses the TextInput font size approach (#543). Takes the container height and uses it for the content view.

It's not really a clean way to handle customization, but on the other side there's no point in using the height style attribute otherwise. So I'd like to check if this one goes through.

### Test plan

Updated the snapshot tests. `yarn test` works fine.

Sample button:

```
<Button onPress={() => {}} style={{ height: 80 }}>
  Default
</Button>
```