### PR TITLE
Fix: Card action buttons align

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -274,11 +274,11 @@ class Button extends React.Component<Props, State> {
 
 const styles = StyleSheet.create({
   button: {
-    minWidth: 88,
+    minWidth: 64,
     borderStyle: 'solid',
   },
   compact: {
-    minWidth: 64,
+    minWidth: 'auto',
   },
   content: {
     flexDirection: 'row',

--- a/src/components/Card/CardActions.js
+++ b/src/components/Card/CardActions.js
@@ -56,7 +56,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'flex-start',
-    padding: 4,
+    padding: 8,
   },
 });
 

--- a/src/components/Dialog/DialogActions.js
+++ b/src/components/Dialog/DialogActions.js
@@ -68,7 +68,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'flex-end',
-    padding: 4,
+    padding: 8,
   },
 });
 

--- a/src/components/__tests__/__snapshots__/Banner.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.js.snap
@@ -3,29 +3,17 @@
 exports[`renders hidden banner, without action buttons and without image 1`] = `
 <View
   style={
-    Array [
-      Object {
-        "backgroundColor": "#ffffff",
+    Object {
+      "backgroundColor": "#ffffff",
+      "elevation": 1,
+      "shadowColor": "#000000",
+      "shadowOffset": Object {
+        "height": 0.5,
+        "width": 0,
       },
-      Object {
-        "backgroundColor": "#ffffff",
-      },
-      Object {
-        "shadowColor": "#000000",
-        "shadowOffset": Object {
-          "height": 0.5,
-          "width": 0,
-        },
-        "shadowOpacity": 0.24,
-        "shadowRadius": 0.75,
-      },
-      Array [
-        Object {
-          "elevation": 1,
-        },
-        undefined,
-      ],
-    ]
+      "shadowOpacity": 0.24,
+      "shadowRadius": 0.75,
+    }
   }
   visible={false}
 >
@@ -123,29 +111,17 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
 exports[`renders visible banner, with action buttons and with image 1`] = `
 <View
   style={
-    Array [
-      Object {
-        "backgroundColor": "#ffffff",
+    Object {
+      "backgroundColor": "#ffffff",
+      "elevation": 1,
+      "shadowColor": "#000000",
+      "shadowOffset": Object {
+        "height": 0.5,
+        "width": 0,
       },
-      Object {
-        "backgroundColor": "#ffffff",
-      },
-      Object {
-        "shadowColor": "#000000",
-        "shadowOffset": Object {
-          "height": 0.5,
-          "width": 0,
-        },
-        "shadowOpacity": 0.24,
-        "shadowRadius": 0.75,
-      },
-      Array [
-        Object {
-          "elevation": 1,
-        },
-        undefined,
-      ],
-    ]
+      "shadowOpacity": 0.24,
+      "shadowRadius": 0.75,
+    }
   }
   visible={true}
 >
@@ -248,25 +224,23 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
     >
       <View
         style={
-          Array [
-            Object {
-              "backgroundColor": "#ffffff",
+          Object {
+            "backgroundColor": "transparent",
+            "borderColor": "transparent",
+            "borderRadius": 4,
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "elevation": 0,
+            "margin": 4,
+            "minWidth": "auto",
+            "shadowColor": "#000000",
+            "shadowOffset": Object {
+              "height": NaN,
+              "width": 0,
             },
-            Object {
-              "backgroundColor": "#ffffff",
-            },
-            0,
-            Object {
-              "backgroundColor": "transparent",
-              "borderColor": "transparent",
-              "borderRadius": 4,
-              "borderStyle": "solid",
-              "borderWidth": 0,
-              "elevation": 0,
-              "margin": 4,
-              "minWidth": 64,
-            },
-          ]
+            "shadowOpacity": 0.24,
+            "shadowRadius": 0,
+          }
         }
       >
         <View
@@ -365,29 +339,17 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
 exports[`renders visible banner, with action buttons and without image 1`] = `
 <View
   style={
-    Array [
-      Object {
-        "backgroundColor": "#ffffff",
+    Object {
+      "backgroundColor": "#ffffff",
+      "elevation": 1,
+      "shadowColor": "#000000",
+      "shadowOffset": Object {
+        "height": 0.5,
+        "width": 0,
       },
-      Object {
-        "backgroundColor": "#ffffff",
-      },
-      Object {
-        "shadowColor": "#000000",
-        "shadowOffset": Object {
-          "height": 0.5,
-          "width": 0,
-        },
-        "shadowOpacity": 0.24,
-        "shadowRadius": 0.75,
-      },
-      Array [
-        Object {
-          "elevation": 1,
-        },
-        undefined,
-      ],
-    ]
+      "shadowOpacity": 0.24,
+      "shadowRadius": 0.75,
+    }
   }
   visible={true}
 >
@@ -469,25 +431,23 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
     >
       <View
         style={
-          Array [
-            Object {
-              "backgroundColor": "#ffffff",
+          Object {
+            "backgroundColor": "transparent",
+            "borderColor": "transparent",
+            "borderRadius": 4,
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "elevation": 0,
+            "margin": 4,
+            "minWidth": "auto",
+            "shadowColor": "#000000",
+            "shadowOffset": Object {
+              "height": NaN,
+              "width": 0,
             },
-            Object {
-              "backgroundColor": "#ffffff",
-            },
-            0,
-            Object {
-              "backgroundColor": "transparent",
-              "borderColor": "transparent",
-              "borderRadius": 4,
-              "borderStyle": "solid",
-              "borderWidth": 0,
-              "elevation": 0,
-              "margin": 4,
-              "minWidth": 64,
-            },
-          ]
+            "shadowOpacity": 0.24,
+            "shadowRadius": 0,
+          }
         }
       >
         <View
@@ -580,25 +540,23 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
       </View>
       <View
         style={
-          Array [
-            Object {
-              "backgroundColor": "#ffffff",
+          Object {
+            "backgroundColor": "transparent",
+            "borderColor": "transparent",
+            "borderRadius": 4,
+            "borderStyle": "solid",
+            "borderWidth": 0,
+            "elevation": 0,
+            "margin": 4,
+            "minWidth": "auto",
+            "shadowColor": "#000000",
+            "shadowOffset": Object {
+              "height": NaN,
+              "width": 0,
             },
-            Object {
-              "backgroundColor": "#ffffff",
-            },
-            0,
-            Object {
-              "backgroundColor": "transparent",
-              "borderColor": "transparent",
-              "borderRadius": 4,
-              "borderStyle": "solid",
-              "borderWidth": 0,
-              "elevation": 0,
-              "margin": 4,
-              "minWidth": 64,
-            },
-          ]
+            "shadowOpacity": 0.24,
+            "shadowRadius": 0,
+          }
         }
       >
         <View
@@ -697,29 +655,17 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
 exports[`renders visible banner, without action buttons and with image 1`] = `
 <View
   style={
-    Array [
-      Object {
-        "backgroundColor": "#ffffff",
+    Object {
+      "backgroundColor": "#ffffff",
+      "elevation": 1,
+      "shadowColor": "#000000",
+      "shadowOffset": Object {
+        "height": 0.5,
+        "width": 0,
       },
-      Object {
-        "backgroundColor": "#ffffff",
-      },
-      Object {
-        "shadowColor": "#000000",
-        "shadowOffset": Object {
-          "height": 0.5,
-          "width": 0,
-        },
-        "shadowOpacity": 0.24,
-        "shadowRadius": 0.75,
-      },
-      Array [
-        Object {
-          "elevation": 1,
-        },
-        undefined,
-      ],
-    ]
+      "shadowOpacity": 0.24,
+      "shadowRadius": 0.75,
+    }
   }
   visible={true}
 >
@@ -827,29 +773,17 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
 exports[`renders visible banner, without action buttons and without image 1`] = `
 <View
   style={
-    Array [
-      Object {
-        "backgroundColor": "#ffffff",
+    Object {
+      "backgroundColor": "#ffffff",
+      "elevation": 1,
+      "shadowColor": "#000000",
+      "shadowOffset": Object {
+        "height": 0.5,
+        "width": 0,
       },
-      Object {
-        "backgroundColor": "#ffffff",
-      },
-      Object {
-        "shadowColor": "#000000",
-        "shadowOffset": Object {
-          "height": 0.5,
-          "width": 0,
-        },
-        "shadowOpacity": 0.24,
-        "shadowRadius": 0.75,
-      },
-      Array [
-        Object {
-          "elevation": 1,
-        },
-        undefined,
-      ],
-    ]
+      "shadowOpacity": 0.24,
+      "shadowRadius": 0.75,
+    }
   }
   visible={true}
 >

--- a/src/components/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.js.snap
@@ -10,7 +10,7 @@ exports[`renders button with color 1`] = `
       "borderStyle": "solid",
       "borderWidth": 0,
       "elevation": 0,
-      "minWidth": 88,
+      "minWidth": 64,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": NaN,
@@ -119,7 +119,7 @@ exports[`renders button with icon 1`] = `
       "borderStyle": "solid",
       "borderWidth": 0,
       "elevation": 0,
-      "minWidth": 88,
+      "minWidth": 64,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": NaN,
@@ -273,7 +273,7 @@ exports[`renders contained contained with mode 1`] = `
       "borderStyle": "solid",
       "borderWidth": 0,
       "elevation": 2,
-      "minWidth": 88,
+      "minWidth": 64,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": NaN,
@@ -382,7 +382,7 @@ exports[`renders disabled button 1`] = `
       "borderStyle": "solid",
       "borderWidth": 0,
       "elevation": 0,
-      "minWidth": 88,
+      "minWidth": 64,
     }
   }
 >
@@ -489,7 +489,7 @@ exports[`renders loading button 1`] = `
       "borderStyle": "solid",
       "borderWidth": 0,
       "elevation": 0,
-      "minWidth": 88,
+      "minWidth": 64,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": NaN,
@@ -611,7 +611,7 @@ exports[`renders outlined button with mode 1`] = `
       "borderStyle": "solid",
       "borderWidth": 0.5,
       "elevation": 0,
-      "minWidth": 88,
+      "minWidth": 64,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": NaN,
@@ -720,7 +720,7 @@ exports[`renders text button by default 1`] = `
       "borderStyle": "solid",
       "borderWidth": 0,
       "elevation": 0,
-      "minWidth": 88,
+      "minWidth": 64,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": NaN,
@@ -829,7 +829,7 @@ exports[`renders text button with mode 1`] = `
       "borderStyle": "solid",
       "borderWidth": 0,
       "elevation": 0,
-      "minWidth": 88,
+      "minWidth": 64,
       "shadowColor": "#000000",
       "shadowOffset": Object {
         "height": NaN,

--- a/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
@@ -244,7 +244,7 @@ exports[`renders snackbar with action button 1`] = `
             "elevation": 0,
             "marginHorizontal": 8,
             "marginVertical": 6,
-            "minWidth": 64,
+            "minWidth": "auto",
             "shadowColor": "#000000",
             "shadowOffset": Object {
               "height": NaN,


### PR DESCRIPTION
### Motivation

Fixes #556. It appears like the default card actions padding is slightly wrong. The issue affects buttons as well.

This is somehow a possible minor, but breaking change for existing projects, so I'll try to explain what's going on.

### Resources

Cards
![screen shot 2018-09-26 at 17 17 27](https://user-images.githubusercontent.com/7827311/46172602-37b78800-c2a4-11e8-8b92-aa43065950f1.png)
According to MD guidelines the card actions padding is 8. The content's padding is 16. Cards use the "compact" buttons with smaller padding - 8 instead of standard 16.

Buttons
![screen shot 2018-09-27 at 22 09 27](https://user-images.githubusercontent.com/7827311/46172613-3d14d280-c2a4-11e8-8f7d-502c4f007cf8.png)
The standard horizontal padding is 16. Although it's different for card action buttons. Notice the min-width value, which is 64, but the buttons section doesn't really describe the compact buttons.

### Solution

The example provided by @brunohkbx presented a case where it got caught into the min-width trap. The text was too small and caused a larger button padding. If you run this [expo snack](https://snack.expo.io/HyqcT35KX), it presents the same case, just with different button text. First goes too far to the right, second goes too far to the left.

The first thing to fix was the card actions padding - switch from 4 to 8. It results in:
<img width="377" alt="screen shot 2018-09-27 at 22 21 01" src="https://user-images.githubusercontent.com/7827311/46172934-2a4ecd80-c2a5-11e8-9364-17911a79cce3.png">
So it works for the expo examples case, but not really for the [mentioned issue](#556). It still gives an extra button padding due to too short text (min-width).

After removing the min-width from compact buttons, it seems like it's finally there:
<img width="376" alt="screen shot 2018-09-27 at 22 13 03" src="https://user-images.githubusercontent.com/7827311/46173141-b95be580-c2a5-11e8-88dd-82a15f5981a5.png">

Finally, it also switches the dialog actions to 8 padding, since that's basically the same thing.

### Test plan

https://snack.expo.io/HydBnn5t7
Snapshot tests updated