### PR TITLE
feat: Leading and Trailing Icon

### DIFF
--- a/typings/components/TextInput.d.ts
+++ b/typings/components/TextInput.d.ts
@@ -6,6 +6,12 @@ export interface TextInputProps extends NativeTextInputProps {
   mode?: 'flat' | 'outlined';
   disabled?: boolean;
   label?: string;
+  leadingIcon?: IconSource,
+  leadingIconOnPressIn?: () => void,
+  leadingIconOnPressOut?: () => void,
+  trailingIcon?: IconSource,
+  trailingIconOnPressIn?: () => void,
+  trailingIconOnPressOut?: () => void,
   placeholder?: string;
   error?: boolean;
   onChangeText?: (text: string) => void;
@@ -20,6 +26,7 @@ export interface TextInputProps extends NativeTextInputProps {
   theme?: ThemeShape;
 }
 
+// TODO: Adjust this types to Typescript
 export interface RenderProps extends NativeTextInputProps {
   ref: (ref: any) => void;
   onChangeText: (text: string) => void;


### PR DESCRIPTION
Leading and Trailing Icon with onPressIn- and out event support for manipulating secureTextEntry. Changes in conditional color properties to fit the material design guidelines

### Motivation

I needed leading icons for the input fields for a login screen. Placing an icon next to the input field doesn't look good.

### Test plan

The new Props are: leadingIcon, leadingIconPressIn, leadingIconPressOut, trailingIcon, trailingIconPressIn and trailingIconPressOut. You could test those.

![screenshot_20181010-131519__01](https://user-images.githubusercontent.com/3472731/46733136-c27a8880-cc8f-11e8-9626-333e77229ed9.jpg)
![screenshot_20181010-131533__01](https://user-images.githubusercontent.com/3472731/46733137-c27a8880-cc8f-11e8-8757-a7c317e63a81.jpg)
![screenshot_20181010-131453__01](https://user-images.githubusercontent.com/3472731/46733138-c27a8880-cc8f-11e8-82f8-40381ba11163.jpg)


