### PR TITLE
RadioButton dialog should use status props.

### DIFF
--- a/example/src/Dialogs/DialogWithRadioBtns.js
+++ b/example/src/Dialogs/DialogWithRadioBtns.js
@@ -17,12 +17,12 @@ type Props = {
 };
 
 type State = {
-  checked: number,
+  checked: 'normal' | 'first' | 'second' | 'third' | 'fourth',
 };
 
 export default class extends React.Component<Props, State> {
   state = {
-    checked: 0
+    checked: 'normal',
   };
 
   render() {
@@ -35,34 +35,54 @@ export default class extends React.Component<Props, State> {
           <Dialog.ScrollArea style={{ maxHeight: 170, paddingHorizontal: 0 }}>
             <ScrollView>
               <View>
-                <TouchableRipple onPress={() => this.setState({ checked: 0 })}>
+                <TouchableRipple
+                  onPress={() => this.setState({ checked: 'normal' })}
+                >
                   <View style={styles.row}>
                     <View pointerEvents="none">
-                      <RadioButton value="normal" status={checked === 0 ? 'checked' : 'unchecked'} />
+                      <RadioButton
+                        value="normal"
+                        status={checked === 'normal' ? 'checked' : 'unchecked'}
+                      />
                     </View>
                     <Subheading style={styles.text}>Option 1</Subheading>
                   </View>
                 </TouchableRipple>
-                <TouchableRipple onPress={() => this.setState({ checked: 1 })}>
+                <TouchableRipple
+                  onPress={() => this.setState({ checked: 'second' })}
+                >
                   <View style={styles.row}>
                     <View pointerEvents="none">
-                      <RadioButton value="normal" status={checked === 1 ? 'checked' : 'unchecked'} />
+                      <RadioButton
+                        value="second"
+                        status={checked === 'second' ? 'checked' : 'unchecked'}
+                      />
                     </View>
                     <Subheading style={styles.text}>Option 2</Subheading>
                   </View>
                 </TouchableRipple>
-                <TouchableRipple onPress={() => this.setState({ checked: 2 })}>
+                <TouchableRipple
+                  onPress={() => this.setState({ checked: 'third' })}
+                >
                   <View style={styles.row}>
                     <View pointerEvents="none">
-                      <RadioButton value="normal" status={checked === 2 ? 'checked' : 'unchecked'} />
+                      <RadioButton
+                        value="third"
+                        status={checked === 'third' ? 'checked' : 'unchecked'}
+                      />
                     </View>
                     <Subheading style={styles.text}>Option 3</Subheading>
                   </View>
                 </TouchableRipple>
-                <TouchableRipple onPress={() => this.setState({ checked: 3 })}>
+                <TouchableRipple
+                  onPress={() => this.setState({ checked: 'fourth' })}
+                >
                   <View style={styles.row}>
                     <View pointerEvents="none">
-                      <RadioButton value="normal" status={checked === 3 ? 'checked' : 'unchecked'} />
+                      <RadioButton
+                        value="fourth"
+                        status={checked === 'fourth' ? 'checked' : 'unchecked'}
+                      />
                     </View>
                     <Subheading style={styles.text}>Option 4</Subheading>
                   </View>

--- a/example/src/Dialogs/DialogWithRadioBtns.js
+++ b/example/src/Dialogs/DialogWithRadioBtns.js
@@ -22,7 +22,7 @@ type State = {
 
 export default class extends React.Component<Props, State> {
   state = {
-    checked: 0,
+    checked: 0
   };
 
   render() {
@@ -38,7 +38,7 @@ export default class extends React.Component<Props, State> {
                 <TouchableRipple onPress={() => this.setState({ checked: 0 })}>
                   <View style={styles.row}>
                     <View pointerEvents="none">
-                      <RadioButton value="normal" checked={checked === 0} />
+                      <RadioButton value="normal" status={checked === 0 ? 'checked' : 'unchecked'} />
                     </View>
                     <Subheading style={styles.text}>Option 1</Subheading>
                   </View>
@@ -46,7 +46,7 @@ export default class extends React.Component<Props, State> {
                 <TouchableRipple onPress={() => this.setState({ checked: 1 })}>
                   <View style={styles.row}>
                     <View pointerEvents="none">
-                      <RadioButton value="normal" checked={checked === 1} />
+                      <RadioButton value="normal" status={checked === 1 ? 'checked' : 'unchecked'} />
                     </View>
                     <Subheading style={styles.text}>Option 2</Subheading>
                   </View>
@@ -54,7 +54,7 @@ export default class extends React.Component<Props, State> {
                 <TouchableRipple onPress={() => this.setState({ checked: 2 })}>
                   <View style={styles.row}>
                     <View pointerEvents="none">
-                      <RadioButton value="normal" checked={checked === 2} />
+                      <RadioButton value="normal" status={checked === 2 ? 'checked' : 'unchecked'} />
                     </View>
                     <Subheading style={styles.text}>Option 3</Subheading>
                   </View>
@@ -62,7 +62,7 @@ export default class extends React.Component<Props, State> {
                 <TouchableRipple onPress={() => this.setState({ checked: 3 })}>
                   <View style={styles.row}>
                     <View pointerEvents="none">
-                      <RadioButton value="normal" checked={checked === 3} />
+                      <RadioButton value="normal" status={checked === 3 ? 'checked' : 'unchecked'} />
                     </View>
                     <Subheading style={styles.text}>Option 4</Subheading>
                   </View>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

This pr has used correct props in radio button dialog , earlier it was using different props instead `status`.
### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
We have make changes as per RadioButton props and use `status` props properties that change radio button state.
### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
Steps to reach out issue:- 
Example -> Dialog -> Show dialog with RadioButton.

#591 
