### PR TITLE
The keyboard appearance should change depending on theme

### DIFF
--- a/src/components/Searchbar.js
+++ b/src/components/Searchbar.js
@@ -121,7 +121,7 @@ class Searchbar extends React.Component<Props> {
       style,
       ...rest
     } = this.props;
-    const { colors, dark: isDarkTheme, roundness, dark } = theme;
+    const { colors, roundness, dark } = theme;
     const textColor = colors.text;
     const iconColor = dark
       ? textColor
@@ -156,7 +156,7 @@ class Searchbar extends React.Component<Props> {
           selectionColor={colors.primary}
           underlineColorAndroid="transparent"
           returnKeyType="search"
-          keyboardAppearance={isDarkTheme ? 'dark' : 'light'}
+          keyboardAppearance={dark ? 'dark' : 'light'}
           accessibilityTraits="search"
           accessibilityRole="search"
           ref={c => {


### PR DESCRIPTION
### Motivation

If the dark theme is active, currently there is still a light keyboard shown (iOS). The change will check which theme is active and show the right keyboard.