### PR TITLE
fix: Always show error outline when including when unfocused (#595)

### DIFF
--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -484,7 +484,8 @@ class TextInput extends React.Component<Props, State> {
               {
                 borderRadius: theme.roundness,
                 borderWidth: this.state.focused ? 2 : 1,
-                borderColor: this.state.focused ? activeColor : outlineColor,
+                borderColor:
+                  this.state.focused || error ? activeColor : outlineColor,
               },
             ]}
           />
@@ -581,7 +582,7 @@ class TextInput extends React.Component<Props, State> {
                   color: activeColor,
                   opacity: this.state.labeled.interpolate({
                     inputRange: [0, 1],
-                    outputRange: [this.state.focused ? 1 : 0, 0],
+                    outputRange: [this.state.focused || error ? 1 : 0, 0],
                   }),
                 },
               ]}
@@ -598,7 +599,7 @@ class TextInput extends React.Component<Props, State> {
                 labelStyle,
                 {
                   color: placeholderColor,
-                  opacity: this.state.focused ? this.state.labeled : 1,
+                  opacity: this.state.focused || error ? this.state.labeled : 1,
                 },
               ]}
               numberOfLines={1}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
TextInput with outline in an error state should correctly indicate an error when unfocused. This would also close #595 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

It could also be possible to add a different prop `keepOutline` (not 100% on the name) instead of relying on the error state. However I'm unsure how that might be useful. 

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

![focused-cropped](https://user-images.githubusercontent.com/5732291/46907418-eea13e00-cf09-11e8-8a16-725ef016f88c.png)
![unfocused-cropped](https://user-images.githubusercontent.com/5732291/46907419-eea13e00-cf09-11e8-9539-95020b73ec71.png)

