### PR TITLE
fix: fix Snackbar static constants type for typescript

### DIFF
--- a/typings/components/Snackbar.d.ts
+++ b/typings/components/Snackbar.d.ts
@@ -15,7 +15,7 @@ export interface SnackbarProps {
 }
 
 export declare class Snackbar extends React.Component<SnackbarProps> {
-  static DURATION_SHORT: string;
-  static DURATION_MEDIUM: string;
-  static DURATION_LONG: string;
+  static DURATION_SHORT: number;
+  static DURATION_MEDIUM: number;
+  static DURATION_LONG: number;
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

paper version: v2.1.3
typescript version: v3.0.1

Below `Snackbar` usage has error.

<img width="332" alt="2018-10-18 20 18 21" src="https://user-images.githubusercontent.com/434227/47150896-19790100-d313-11e8-8794-256703ab654b.png">

And error message:

```
path/to/my/component.tsx:131:17 - error TS2322: Type 'string' is not assignable to type 'number | undefined'.

131                 duration={Snackbar.DURATION_SHORT}
                    ~~~~~~~~

  node_modules/react-native-paper/typings/components/Snackbar.d.ts:10:3
    10   duration?: number;
         ~~~~~~~~
    The expected type comes from property 'duration' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<Snackbar> & Readonly<{ children?: ReactNode; }> & Readonly<SnackbarProps>'
```

Because `duration` was defined as a `string` in the type definition file. I fixed it.

### Test plan

Typecheck for below jsx.

```jsx
<Snackbar
    visible={true}
    duration={Snackbar.DURATION_SHORT}>
    Foo
</Snackbar>
```