### PR TITLE
fix: snackbar not actually rendering when visible=true during mounting

### DIFF
--- a/src/components/Snackbar.js
+++ b/src/components/Snackbar.js
@@ -128,6 +128,12 @@ class Snackbar extends React.Component<Props, State> {
     hidden: !this.props.visible,
   };
 
+  componentDidMount() {
+    if (this.props.visible) {
+      this._show();
+    }
+  }
+
   componentDidUpdate(prevProps) {
     if (prevProps.visible !== this.props.visible) {
       this._toggle();

--- a/src/components/__tests__/Snackbar.test.js
+++ b/src/components/__tests__/Snackbar.test.js
@@ -7,6 +7,20 @@ import Snackbar from '../Snackbar';
 
 jest.useFakeTimers();
 
+// mock the Animated and make sure any animation finishes before checking the snapshot results
+jest.mock('Animated', () => {
+  const ActualAnimated = jest.requireActual('Animated');
+  return {
+    ...ActualAnimated,
+    timing: (value, config) => ({
+      start: callback => {
+        value.setValue(config.toValue);
+        callback && callback();
+      },
+    }),
+  };
+});
+
 it('renders snackbar with content', () => {
   const tree = renderer
     .create(

--- a/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
@@ -44,10 +44,10 @@ exports[`renders snackbar with Text as a child 1`] = `
     pointerEvents="box-none"
     style={
       Object {
-        "opacity": 0,
+        "opacity": 1,
         "transform": Array [
           Object {
-            "scale": 0.9,
+            "scale": 1,
           },
         ],
       }
@@ -152,10 +152,10 @@ exports[`renders snackbar with action button 1`] = `
     pointerEvents="box-none"
     style={
       Object {
-        "opacity": 0,
+        "opacity": 1,
         "transform": Array [
           Object {
-            "scale": 0.9,
+            "scale": 1,
           },
         ],
       }
@@ -364,10 +364,10 @@ exports[`renders snackbar with content 1`] = `
     pointerEvents="box-none"
     style={
       Object {
-        "opacity": 0,
+        "opacity": 1,
         "transform": Array [
           Object {
-            "scale": 0.9,
+            "scale": 1,
           },
         ],
       }


### PR DESCRIPTION
The Snackbar was not actually displayed if during mounting the visible property was set to true, mostly because the _show function was never called to start the animation (componentDidUpdate is not called on the initial render).

To prove it, simply run the updated test which now mock the Animated module to finalise the animation before asserting it's visibility, and you will see the previous snapshots are still valid, even though they mention that the opacity of the view is 0, thus transparent.

### Motivation

Currently, the example you have provided works because the snack bar is mounted with visible = false and it's property changes once you hit the button. But in a real life scenario, you could receive the property from a redux store instead of a button, and there you can have it visible = true.

### Test plan

- Simply set the property to visible = true and see that now the Snackbar appears and will disappear after duration is hit.