### PR TITLE
fix: hidden snackbar if initially visible

### DIFF
--- a/src/components/Snackbar.js
+++ b/src/components/Snackbar.js
@@ -128,6 +128,10 @@ class Snackbar extends React.Component<Props, State> {
     hidden: !this.props.visible,
   };
 
+  componentDidMount() {
+    this._toggle();
+  }
+
   componentDidUpdate(prevProps) {
     if (prevProps.visible !== this.props.visible) {
       this._toggle();


### PR DESCRIPTION
### Motivation

Snackbar stays hidden if the `visible` property is initially `true`. See: https://snack.expo.io/ryaOtYho7 

### Test plan
n/a
