### PR TITLE
feat: provide nice error message for users that use Portal without Provider.

### DIFF
--- a/src/components/Portal/PortalConsumer.js
+++ b/src/components/Portal/PortalConsumer.js
@@ -18,7 +18,7 @@ export default class PortalConsumer extends React.Component<Props> {
           'https://callstack.github.io/react-native-paper/getting-started.html'
       );
     }
-    
+
     this._key = this.props.manager.mount(this.props.children);
   }
 

--- a/src/components/Portal/PortalConsumer.js
+++ b/src/components/Portal/PortalConsumer.js
@@ -13,12 +13,12 @@ export default class PortalConsumer extends React.Component<Props> {
   componentDidMount() {
     if (!this.props.manager) {
       throw new Error(
-        'This error occured because you forgot to wrap your root component with Provider component from react-native-paper.\n\n' +
-          "Please read our getting-started guide and make sure you've done all required steps.\n\n" +
+        'Looks like you forgot to wrap your root component with `Provider` component from `react-native-paper`.\n\n' +
+          "Please read our getting-started guide and make sure you've followed all the required steps.\n\n" +
           'https://callstack.github.io/react-native-paper/getting-started.html'
       );
     }
-
+    
     this._key = this.props.manager.mount(this.props.children);
   }
 

--- a/src/components/Portal/PortalConsumer.js
+++ b/src/components/Portal/PortalConsumer.js
@@ -11,15 +11,15 @@ type Props = {
 
 export default class PortalConsumer extends React.Component<Props> {
   componentDidMount() {
-    try {
-      this._key = this.props.manager.mount(this.props.children);
-    } catch (err) {
+    if (!this.props.manager) {
       throw new Error(
         'This error occured because you forgot to wrap your root component with Provider component from react-native-paper.\n\n' +
           "Please read our getting-started guide and make sure you've done all required steps.\n\n" +
           'https://callstack.github.io/react-native-paper/getting-started.html'
       );
     }
+
+    this._key = this.props.manager.mount(this.props.children);
   }
 
   componentDidUpdate() {

--- a/src/components/Portal/PortalConsumer.js
+++ b/src/components/Portal/PortalConsumer.js
@@ -11,7 +11,15 @@ type Props = {
 
 export default class PortalConsumer extends React.Component<Props> {
   componentDidMount() {
-    this._key = this.props.manager.mount(this.props.children);
+    try {
+      this._key = this.props.manager.mount(this.props.children);
+    } catch (err) {
+      throw new Error(
+        'This error occured because you forgot to wrap your root component with Provider component from react-native-paper.\n\n' +
+          "Please read our getting-started guide and make sure you've done all required steps.\n\n" +
+          'https://callstack.github.io/react-native-paper/getting-started.html'
+      );
+    }
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
### Motivation

This PR makes clear what is the cause of app crash when user doesn't wrap his components' tree with Provider component.

### Test plan

Render Portal component without wrapping components' tree with Provider component.
Nice error message with link to our docs will be presented.
