### PR TITLE
fix: make example typescript compatible

### DIFF
--- a/src/components/Banner.js
+++ b/src/components/Banner.js
@@ -69,7 +69,7 @@ type NativeEvent = {
  *
  * ## Usage
  * ```js
- * import React from 'react';
+ * import * as React from 'react';
  * import { Image } from 'react-native';
  * import { Banner } from 'react-native-paper';
  *


### PR DESCRIPTION
### Motivation

Other PRs break because of this (e.g. see `typescript` deploy script at https://github.com/callstack/react-native-paper/pull/620)

### Test plan

Run `yarn typescript` and it should not break anymore.
