### PR TITLE
Fix: onLongPress property added to typings Card

### DIFF
--- a/example/src/TextInputExample.js
+++ b/example/src/TextInputExample.js
@@ -41,7 +41,7 @@ class TextInputExample extends React.Component<Props, State> {
     return (
       <KeyboardAvoidingView
         style={styles.wrapper}
-        behavior="padding"
+        behavior={Platform.OS !== 'android'?"padding":undefined}
         keyboardVerticalOffset={80}
       >
         <ScrollView

--- a/example/src/TextInputExample.js
+++ b/example/src/TextInputExample.js
@@ -6,6 +6,7 @@ import {
   View,
   ScrollView,
   KeyboardAvoidingView,
+  Platform
 } from 'react-native';
 import { TextInput, HelperText, withTheme } from 'react-native-paper';
 import type { Theme } from 'react-native-paper/types';

--- a/typings/components/Card.d.ts
+++ b/typings/components/Card.d.ts
@@ -18,6 +18,7 @@ export interface CardCoverProps extends ImageProps {
 
 export interface CardProps {
   elevation?: number;
+  onLongPress?: () => any;
   onPress?: () => any;
   children: React.ReactNode;
   style?: any;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Missing property in Type Definition

### Test plan
Test the onLongPress property in TS

 <Card
          style={styles.card}
          onLongPress={() => {
            Alert.alert('The City is Long Pressed');
          }}
    >