### PR TITLE
Add missing onLongPress method to Card typings

### DIFF
--- a/typings/components/Card.d.ts
+++ b/typings/components/Card.d.ts
@@ -19,6 +19,7 @@ export interface CardCoverProps extends ImageProps {
 export interface CardProps {
   elevation?: number;
   onPress?: () => any;
+  onLongPress?: () => any;
   children: React.ReactNode;
   style?: any;
   theme?: ThemeShape;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
Small bug.
Missing onLongPress method in the Card Typescript typings file.
