### PR TITLE
Fix tab focus animation bug from react-native@~0.57 on Android

### DIFF
--- a/src/components/BottomNavigation.js
+++ b/src/components/BottomNavigation.js
@@ -374,20 +374,31 @@ class BottomNavigation<T: *> extends React.Component<Props<T>, State> {
     };
   }
 
+  componentDidMount() {
+    this._animateToCurrentIndex();
+  }
+
   componentDidUpdate(prevProps) {
     if (prevProps.navigationState.index === this.props.navigationState.index) {
       return;
     }
 
-    const shifting = this._isShifting();
-    const { routes, index } = this.props.navigationState;
-
     // Reset offsets of previous and current tabs before animation
     this.state.offsets.forEach((offset, i) => {
-      if (i === index || i === prevProps.navigationState.index) {
+      if (
+        i === this.props.navigationState.index ||
+        i === prevProps.navigationState.index
+      ) {
         offset.setValue(0);
       }
     });
+
+    this._animateToCurrentIndex();
+  }
+
+  _animateToCurrentIndex = () => {
+    const shifting = this._isShifting();
+    const { routes, index } = this.props.navigationState;
 
     // Reset the ripple to avoid glitch if it's currently animating
     this.state.ripple.setValue(MIN_RIPPLE_SCALE);
@@ -425,7 +436,7 @@ class BottomNavigation<T: *> extends React.Component<Props<T>, State> {
         });
       }
     });
-  }
+  };
 
   _handleLayout = e =>
     this.setState({


### PR DESCRIPTION
### Motivation

Fixes https://github.com/react-navigation/react-navigation-material-bottom-tabs/issues/22.

I believe the underlying cause is a bug with native animated on Android, because when I disable `useNativeDriver` for these animations that also resolves the problem.

### Test plan

I reproduced this in https://github.com/brentvatne/lol-test-bottom-tabs by just installing react-native-paper and copy+pasting the example from the react-native-paper docs.

To reproduce, clone that repo and run it on Android. Tap on the "Albums" tab, you'll see that both "Albums" and "Music" remain selected in the tab bar. The next time you change, the tab bar works as expected. Or apply this patch and it will work as expected on the first tap.

![screenshot_20181104-084809](https://user-images.githubusercontent.com/90494/47958416-84b80980-df88-11e8-9e2f-32b124905791.png)
