### PR TITLE
Allow List.Accordion to behave as a controlled component

### DIFF
--- a/example/src/ListAccordionExample.js
+++ b/example/src/ListAccordionExample.js
@@ -20,7 +20,7 @@ class ListAccordionExample extends React.Component<Props, State> {
     expanded: true,
   };
 
-  _onPress = () => {
+  _handlePress = () => {
     this.setState({ expanded: !this.state.expanded });
   };
 
@@ -45,7 +45,7 @@ class ListAccordionExample extends React.Component<Props, State> {
             left={props => <List.Icon {...props} icon="folder" />}
             title="Start expanded"
             expanded={this.state.expanded}
-            onPress={this._onPress}
+            onPress={this._handlePress}
           >
             <List.Item title="List item 1" />
           </List.Accordion>

--- a/example/src/ListAccordionExample.js
+++ b/example/src/ListAccordionExample.js
@@ -9,8 +9,20 @@ type Props = {
   theme: Theme,
 };
 
-class ListAccordionExample extends React.Component<Props> {
+type State = {
+  expanded: boolean,
+};
+
+class ListAccordionExample extends React.Component<Props, State> {
   static title = 'List.Accordion';
+
+  state = {
+    expanded: true,
+  };
+
+  _onPress = () => {
+    this.setState({ expanded: !this.state.expanded });
+  };
 
   render() {
     const {
@@ -18,6 +30,7 @@ class ListAccordionExample extends React.Component<Props> {
         colors: { background },
       },
     } = this.props;
+
     return (
       <ScrollView style={[styles.container, { backgroundColor: background }]}>
         <List.Section title="Expandable list item">
@@ -27,6 +40,14 @@ class ListAccordionExample extends React.Component<Props> {
           >
             <List.Item title="List item 1" />
             <List.Item title="List item 2" />
+          </List.Accordion>
+          <List.Accordion
+            left={props => <List.Icon {...props} icon="folder" />}
+            title="Start expanded"
+            expanded={this.state.expanded}
+            onPress={this._onPress}
+          >
+            <List.Item title="List item 1" />
           </List.Accordion>
         </List.Section>
         <Divider />

--- a/src/components/List/ListAccordion.js
+++ b/src/components/List/ListAccordion.js
@@ -23,6 +23,10 @@ type Props = {
    */
   left?: (props: { color: string }) => React.Node,
   /**
+   * Default state of visibility for accordion
+   */
+  expanded?: React.Node,
+  /**
    * Content of the section.
    */
   children: React.Node,

--- a/src/components/List/ListAccordion.js
+++ b/src/components/List/ListAccordion.js
@@ -68,7 +68,8 @@ class ListAccordion extends React.Component<Props, State> {
   static displayName = 'List.Accordion';
 
   state = {
-    expanded: false,
+    expanded: this.props.expanded || false,
+
   };
 
   _handlePress = () =>

--- a/src/components/List/ListAccordion.js
+++ b/src/components/List/ListAccordion.js
@@ -128,7 +128,7 @@ class ListAccordion extends React.Component<Props, State> {
       .rgb()
       .string();
 
-    const expanded = this.props.onPress
+    const expanded = this.props.expanded !== undefined && this.props.onPress
       ? this.props.expanded
       : this.state.expanded;
 

--- a/src/components/List/ListAccordion.js
+++ b/src/components/List/ListAccordion.js
@@ -23,7 +23,7 @@ type Props = {
    */
   left?: (props: { color: string }) => React.Node,
   /**
-   * Whether the accordion is expanded or not.
+   * Whether the accordion is expanded
    * If this prop is provided, the accordion will behave as a "controlled component".
    * You'll need to update this prop when you want to toggle the component or on `onPress`.
    */
@@ -66,9 +66,11 @@ type State = {
  *     expanded: true
  *   }
  *
- *   _onPress = () => {
- *     this.setState({expanded: !this.state.expanded})
- *   }
+ *   _handlePress = () => {
+ *     this.setState({
+ *       expanded: !this.state.expanded
+ *     });
+ *   };
  *
  *   render() {
  *     return (
@@ -85,7 +87,7 @@ type State = {
  *           title="Controlled Accordion"
  *           left={props => <List.Icon {...props} icon="folder" />}
  *           expanded={this.state.expanded}
- *           onPress={this._onPress}
+ *           onPress={this._handlePress}
  *         >
  *           <List.Item title="First item" />
  *           <List.Item title="Second item" />

--- a/src/components/List/ListAccordion.js
+++ b/src/components/List/ListAccordion.js
@@ -116,13 +116,13 @@ class ListAccordion extends React.Component<Props, State> {
       } else {
         this.props.onPress();
       }
+    } else {
+      this.props.onPress && this.props.onPress();
 
-      return;
+      this.setState(state => ({
+        expanded: !state.expanded,
+      }));
     }
-
-    this.setState(state => ({
-      expanded: !state.expanded,
-    }));
   };
 
   render() {

--- a/src/components/List/ListAccordion.js
+++ b/src/components/List/ListAccordion.js
@@ -69,7 +69,6 @@ class ListAccordion extends React.Component<Props, State> {
 
   state = {
     expanded: this.props.expanded || false,
-
   };
 
   _handlePress = () =>

--- a/src/components/List/ListAccordion.js
+++ b/src/components/List/ListAccordion.js
@@ -23,10 +23,9 @@ type Props = {
    */
   left?: (props: { color: string }) => React.Node,
   /**
-   * Whether the list accordion is expanded or not.
-   * If this is provided the accordion will behave as a "controlled component"
-   * which means that you need to provide the onPress prop to know when your
-   * user is trying to toggle it.
+   * Whether the accordion is expanded or not.
+   * If this prop is provided, the accordion will behave as a "controlled component".
+   * You'll need to update this prop when you want to toggle the component or on `onPress`.
    */
   expanded?: boolean,
   /**
@@ -107,8 +106,15 @@ class ListAccordion extends React.Component<Props, State> {
   };
 
   _handlePress = () => {
-    if (this.props.expanded !== undefined && this.props.onPress) {
-      this.props.onPress();
+    if (this.props.expanded !== undefined) {
+      if (typeof this.props.onPress === 'undefined') {
+        throw new Error(
+          'The `onPress` prop must be passed when the `expanded` prop is passed to List.Accordion.'
+        );
+      } else {
+        this.props.onPress();
+      }
+
       return;
     }
 
@@ -128,9 +134,10 @@ class ListAccordion extends React.Component<Props, State> {
       .rgb()
       .string();
 
-    const expanded = this.props.expanded !== undefined && this.props.onPress
-      ? this.props.expanded
-      : this.state.expanded;
+    const expanded =
+      this.props.expanded !== undefined
+        ? this.props.expanded
+        : this.state.expanded;
 
     return (
       <View>

--- a/src/components/List/ListAccordion.js
+++ b/src/components/List/ListAccordion.js
@@ -66,11 +66,10 @@ type State = {
  *     expanded: true
  *   }
  *
- *   _handlePress = () => {
+ *   _handlePress = () =>
  *     this.setState({
  *       expanded: !this.state.expanded
  *     });
- *   };
  *
  *   render() {
  *     return (
@@ -108,17 +107,11 @@ class ListAccordion extends React.Component<Props, State> {
   };
 
   _handlePress = () => {
-    if (this.props.expanded !== undefined) {
-      if (typeof this.props.onPress === 'undefined') {
-        throw new Error(
-          'The `onPress` prop must be passed when the `expanded` prop is passed to List.Accordion.'
-        );
-      } else {
-        this.props.onPress();
-      }
-    } else {
-      this.props.onPress && this.props.onPress();
+    this.props.onPress && this.props.onPress();
 
+    if (this.props.expanded === undefined) {
+      // Only update state of the `expanded` prop was not passed
+      // If it was passed, the component will act as a controlled component
       this.setState(state => ({
         expanded: !state.expanded,
       }));

--- a/src/components/__tests__/ListAccordion.test.js
+++ b/src/components/__tests__/ListAccordion.test.js
@@ -53,3 +53,15 @@ it('renders list accordion with left items', () => {
 
   expect(tree).toMatchSnapshot();
 });
+
+it('renders expanded accordion', () => {
+  const tree = renderer
+    .create(
+      <ListAccordion title="Accordion item 1" expanded>
+        <ListItem title="List item 1" />
+      </ListAccordion>
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.js.snap
@@ -1,5 +1,240 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders expanded accordion 1`] = `
+<View>
+  <View
+    accessibilityComponentType="button"
+    accessibilityTraits="button"
+    accessible={true}
+    isTVSelectable={true}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "padding": 8,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      pointerEvents="none"
+      style={
+        Object {
+          "flexDirection": "row",
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "margin": 8,
+            },
+            Object {
+              "flex": 1,
+              "justifyContent": "center",
+            },
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          numberOfLines={1}
+          style={
+            Array [
+              Object {
+                "color": "#000000",
+                "fontFamily": "Helvetica Neue",
+                "textAlign": "left",
+                "writingDirection": "ltr",
+              },
+              Array [
+                Object {
+                  "fontSize": 16,
+                },
+                Object {
+                  "color": "#6200ee",
+                },
+              ],
+            ]
+          }
+          theme={
+            Object {
+              "colors": Object {
+                "accent": "#03dac4",
+                "backdrop": "rgba(0, 0, 0, 0.5)",
+                "background": "#f6f6f6",
+                "disabled": "rgba(0, 0, 0, 0.26)",
+                "error": "#B00020",
+                "placeholder": "rgba(0, 0, 0, 0.54)",
+                "primary": "#6200ee",
+                "surface": "#ffffff",
+                "text": "#000000",
+              },
+              "dark": false,
+              "fonts": Object {
+                "light": "HelveticaNeue-Light",
+                "medium": "HelveticaNeue-Medium",
+                "regular": "Helvetica Neue",
+                "thin": "HelveticaNeue-Thin",
+              },
+              "roundness": 4,
+            }
+          }
+        >
+          Accordion item 1
+        </Text>
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "margin": 8,
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          accessible={true}
+          allowFontScaling={false}
+          ellipsizeMode="tail"
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          style={
+            Array [
+              Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontSize": 24,
+              },
+              Array [
+                Object {
+                  "transform": Array [
+                    Object {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                Object {
+                  "backgroundColor": "transparent",
+                },
+              ],
+              Object {
+                "fontFamily": "Material Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+  <View
+    accessible={true}
+    isTVSelectable={true}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "padding": 8,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "flexDirection": "row",
+        }
+      }
+    >
+      <View
+        pointerEvents="none"
+        style={
+          Array [
+            Object {
+              "margin": 8,
+            },
+            Object {
+              "flex": 1,
+              "justifyContent": "center",
+            },
+          ]
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          numberOfLines={1}
+          style={
+            Array [
+              Object {
+                "color": "#000000",
+                "fontFamily": "Helvetica Neue",
+                "textAlign": "left",
+                "writingDirection": "ltr",
+              },
+              Array [
+                Object {
+                  "fontSize": 16,
+                },
+                Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                },
+              ],
+            ]
+          }
+          theme={
+            Object {
+              "colors": Object {
+                "accent": "#03dac4",
+                "backdrop": "rgba(0, 0, 0, 0.5)",
+                "background": "#f6f6f6",
+                "disabled": "rgba(0, 0, 0, 0.26)",
+                "error": "#B00020",
+                "placeholder": "rgba(0, 0, 0, 0.54)",
+                "primary": "#6200ee",
+                "surface": "#ffffff",
+                "text": "#000000",
+              },
+              "dark": false,
+              "fonts": Object {
+                "light": "HelveticaNeue-Light",
+                "medium": "HelveticaNeue-Medium",
+                "regular": "Helvetica Neue",
+                "thin": "HelveticaNeue-Thin",
+              },
+              "roundness": 4,
+            }
+          }
+        >
+          List item 1
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
 exports[`renders list accordion with children 1`] = `
 <View>
   <View

--- a/typings/components/List.d.ts
+++ b/typings/components/List.d.ts
@@ -4,6 +4,7 @@ import { ThemeShape, IconSource } from '../types';
 export interface AccordionProps {
   title: React.ReactNode;
   description?: React.ReactNode;
+  expanded?: React.ReactNode;
   left?: (props: { color: string }) => React.ReactNode;
   children: React.ReactNode;
   theme?: ThemeShape;

--- a/typings/components/List.d.ts
+++ b/typings/components/List.d.ts
@@ -4,7 +4,8 @@ import { ThemeShape, IconSource } from '../types';
 export interface AccordionProps {
   title: React.ReactNode;
   description?: React.ReactNode;
-  expanded?: React.ReactNode;
+  expanded?: boolean;
+  onPress?: () => any;
   left?: (props: { color: string }) => React.ReactNode;
   children: React.ReactNode;
   theme?: ThemeShape;


### PR DESCRIPTION
### Motivation
This PR aims to FIX #616 and FIX #635 and CLOSE #618 
It allows the List.Accordion to behave as a [controlled component](https://reactjs.org/docs/forms.html#controlled-components) by passing a `expanded` and `onPress` prop.
This also enables users to start the accordion as expanded. 

### Test plan
I added a controlled List.Accordion to the example app and also added a snapshot test.


**Thank you @jimmiehansson for starting this out in #618, I left your commits on my branch so you can take your deserved credits ❤️** 

