### PR TITLE
fix: TextInput align top with multiline

### DIFF
--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -383,6 +383,7 @@ class TextInput extends React.Component<Props, State> {
       style,
       theme,
       render,
+      multiline,
       ...rest
     } = this.props;
 
@@ -629,6 +630,7 @@ class TextInput extends React.Component<Props, State> {
           onFocus: this._handleFocus,
           onBlur: this._handleBlur,
           underlineColorAndroid: 'transparent',
+          multiline,
           style: [
             styles.input,
             mode === 'outlined'

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -639,6 +639,7 @@ class TextInput extends React.Component<Props, State> {
             {
               color: inputTextColor,
               fontFamily,
+              textAlignVertical: multiline ? 'top' : 'center',
             },
           ],
         })}


### PR DESCRIPTION
### Motivation

Fixes `TextInput` alignment with `multiline` set to `true`. #648