### PR TITLE
Don't extend ripple outside of button border

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -223,7 +223,6 @@ class Button extends React.Component<Props, State> {
         ]}
       >
         <TouchableRipple
-          borderless
           delayPressIn={0}
           onPress={onPress}
           onPressIn={this._handlePressIn}

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -207,7 +207,7 @@ class Button extends React.Component<Props, State> {
       borderWidth,
       borderRadius: roundness,
     };
-    const touchableStyle = { borderRadius: roundness };
+    const touchableStyle = [{ borderRadius: roundness }, { height: style.height }];
     const textStyle = { color: textColor, fontFamily };
     const elevation = disabled ? 0 : this.state.elevation;
 

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -388,7 +388,8 @@ class TextInput extends React.Component<Props, State> {
     } = this.props;
 
     const { colors, fonts } = theme;
-    const fontFamily = fonts.regular;
+    const fontFamilyLabel = fonts.regular;
+    const fontFamilyInput = fonts.medium;
     const hasActiveOutline = this.state.focused || error;
     const { backgroundColor = colors.background } =
       StyleSheet.flatten(style) || {};
@@ -431,7 +432,7 @@ class TextInput extends React.Component<Props, State> {
     }
 
     const labelStyle = {
-      fontFamily,
+      fontFamilyLabel,
       fontSize: MAXIMIZED_LABEL_FONT_SIZE,
       transform: [
         {
@@ -510,7 +511,7 @@ class TextInput extends React.Component<Props, State> {
               styles.outlinedLabelBackground,
               {
                 backgroundColor,
-                fontFamily,
+                fontFamilyLabel,
                 fontSize: MINIMIZED_LABEL_FONT_SIZE,
                 // Hide the background when scale will be 0
                 // There's a bug in RN which makes scale: 0 act weird
@@ -640,7 +641,7 @@ class TextInput extends React.Component<Props, State> {
                 : styles.inputFlatWithoutLabel,
             {
               color: inputTextColor,
-              fontFamily,
+              fontFamilyInput,
               textAlignVertical: multiline ? 'top' : 'center',
             },
           ],

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -432,7 +432,7 @@ class TextInput extends React.Component<Props, State> {
     }
 
     const labelStyle = {
-      fontFamilyLabel,
+      fontFamily: fontFamilyLabel,
       fontSize: MAXIMIZED_LABEL_FONT_SIZE,
       transform: [
         {
@@ -511,7 +511,7 @@ class TextInput extends React.Component<Props, State> {
               styles.outlinedLabelBackground,
               {
                 backgroundColor,
-                fontFamilyLabel,
+                fontFamily: fontFamilyLabel,
                 fontSize: MINIMIZED_LABEL_FONT_SIZE,
                 // Hide the background when scale will be 0
                 // There's a bug in RN which makes scale: 0 act weird
@@ -641,7 +641,7 @@ class TextInput extends React.Component<Props, State> {
                 : styles.inputFlatWithoutLabel,
             {
               color: inputTextColor,
-              fontFamilyInput,
+              fontFamily: fontFamilyInput,
               textAlignVertical: multiline ? 'top' : 'center',
             },
           ],

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -660,7 +660,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: 0,
     fontSize: 16,
-    paddingHorizontal: 12,
+    paddingHorizontal: 0,
   },
   placeholderFlat: {
     top: 19,
@@ -691,7 +691,7 @@ const styles = StyleSheet.create({
   },
   input: {
     flexGrow: 1,
-    paddingHorizontal: 12,
+    paddingHorizontal: 1,
     fontSize: 16,
     margin: 0,
     minHeight: 58,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

`Button` component has ripple that extends out of button boundary.

### Test plan

Render a `Button` component - verify that tapping on button on Android shows a ripple, and that the ripple does not extend past the button border.