### PR TITLE
fix: do not pass on elevation as property

### DIFF
--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -107,6 +107,7 @@ class Card extends React.Component<Props, State> {
   render() {
     const {
       children,
+      elevation: cardElevation,
       onLongPress,
       onPress,
       style,


### PR DESCRIPTION
### Motivation

Otherwise the `elevation` prop will be passed on to `Animated.View` in `Surface` component and cause this warning on web: You are setting the style `{ elevation: ... }` as a prop. You should nest it in a style object. E.g. `{ style: { elevation: ... } }`

### Test plan

n/a