### PR TITLE
feat: allow custom content in DataTableCells

### DIFF
--- a/example/src/DataTableExample.js
+++ b/example/src/DataTableExample.js
@@ -2,7 +2,13 @@
 
 import * as React from 'react';
 import { ScrollView, StyleSheet } from 'react-native';
-import { DataTable, Card, withTheme, type Theme } from 'react-native-paper';
+import {
+  DataTable,
+  Card,
+  IconButton,
+  withTheme,
+  type Theme,
+} from 'react-native-paper';
 
 type Props = {
   theme: Theme,
@@ -105,6 +111,7 @@ class DataTableExample extends React.Component<Props, State> {
               </DataTable.Title>
               <DataTable.Title right>Calories</DataTable.Title>
               <DataTable.Title right>Fat (g)</DataTable.Title>
+              <DataTable.Title right />
             </DataTable.Header>
 
             {items.slice(from, to).map(item => (
@@ -114,6 +121,9 @@ class DataTableExample extends React.Component<Props, State> {
                 </DataTable.Cell>
                 <DataTable.Cell right>{item.calories}</DataTable.Cell>
                 <DataTable.Cell right>{item.fat}</DataTable.Cell>
+                <DataTable.Cell right>
+                  <IconButton icon="info" onPress={() => {}} />
+                </DataTable.Cell>
               </DataTable.Row>
             ))}
 

--- a/src/components/DataTable/DataTableCell.js
+++ b/src/components/DataTable/DataTableCell.js
@@ -33,7 +33,11 @@ class DataTableCell extends React.Component<Props> {
         {...rest}
         style={[styles.container, right && styles.right, style]}
       >
-        <Text numberOfLines={1}>{children}</Text>
+        {typeof children === 'string' || typeof children === 'number' ? (
+          <Text numberOfLines={1}>{children}</Text>
+        ) : (
+          children
+        )}
       </TouchableRipple>
     );
   }

--- a/src/components/__tests__/DataTable.test.js
+++ b/src/components/__tests__/DataTable.test.js
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import renderer from 'react-test-renderer';
 import DataTable from '../DataTable/DataTable';
+import IconButton from '../IconButton';
 
 it('renders data table header', () => {
   const tree = renderer
@@ -58,6 +59,18 @@ it('renders data table cell', () => {
 it('renders right aligned data table cell', () => {
   const tree = renderer
     .create(<DataTable.Cell right>356</DataTable.Cell>)
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders data table cell with custom content', () => {
+  const tree = renderer
+    .create(
+      <DataTable.Cell>
+        <IconButton icon="info" onPress={() => {}} />
+      </DataTable.Cell>
+    )
     .toJSON();
 
   expect(tree).toMatchSnapshot();

--- a/src/components/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.js.snap
@@ -41,6 +41,103 @@ exports[`renders data table cell 1`] = `
 </View>
 `;
 
+exports[`renders data table cell with custom content 1`] = `
+<View
+  accessible={true}
+  isTVSelectable={true}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flex": 1,
+        "flexDirection": "row",
+      },
+      undefined,
+      undefined,
+    ]
+  }
+>
+  <View
+    accessibilityRole="button"
+    accessible={true}
+    hitSlop={
+      Object {
+        "bottom": 6,
+        "left": 6,
+        "right": 6,
+        "top": 6,
+      }
+    }
+    isTVSelectable={true}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "borderRadius": 18,
+          "height": 36,
+          "justifyContent": "center",
+          "margin": 6,
+          "width": 36,
+        },
+        undefined,
+        null,
+      ]
+    }
+  >
+    <View
+      style={null}
+    >
+      <Text
+        accessibilityElementsHidden={true}
+        allowFontScaling={false}
+        importantForAccessibility="no-hide-descendants"
+        pointerEvents="none"
+        style={
+          Array [
+            Object {
+              "color": "#000000",
+              "fontSize": 24,
+            },
+            Array [
+              Object {
+                "transform": Array [
+                  Object {
+                    "scaleX": 1,
+                  },
+                ],
+              },
+              Object {
+                "backgroundColor": "transparent",
+              },
+            ],
+            Object {
+              "fontFamily": "Material Icons",
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {},
+          ]
+        }
+      >
+        
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
 exports[`renders data table header 1`] = `
 <View
   style={


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Currently, only text and numbers can be rendered in `DataTableCell`s.

### Test plan

Test included.