### PR TITLE
Add title and subtitle scaling attributes to Appbar.Content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-paper",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Material design for React Native",
   "main": "src/index.js",
   "typings": "typings/index.d.ts",

--- a/src/components/Appbar/AppbarContent.js
+++ b/src/components/Appbar/AppbarContent.js
@@ -90,23 +90,6 @@ class AppbarContent extends React.Component<Props> {
             style={[
               {
                 color: titleColor,
-                fontFamily: Platform.OS === 'ios' ? fonts.regular : fonts.medium,
-              },
-              styles.title,
-              titleStyle,
-            ]}
-            numberOfLines={1}
-            allowFontScaling={allowTitleFontScaling}
-            accessibilityTraits="header"
-            accessibilityRole="header"
-          >
-            {title}
-          </Text>
-          {subtitle ? (
-          <Text
-            style={[
-              {
-                color: titleColor,
                 fontFamily:
                   Platform.OS === 'ios' ? fonts.regular : fonts.medium,
               },
@@ -116,7 +99,7 @@ class AppbarContent extends React.Component<Props> {
             numberOfLines={1}
             accessibilityTraits="header"
             accessibilityRole="header"
-            allowFontScaling={allowSubtitleFontScaling}
+            allowFontScaling={allowTitleFontScaling}
           >
             {title}
           </Text>
@@ -124,6 +107,7 @@ class AppbarContent extends React.Component<Props> {
             <Text
               style={[styles.subtitle, { color: subtitleColor }, subtitleStyle]}
               numberOfLines={1}
+              allowFontScaling={allowSubtitleFontScaling}
             >
               {subtitle}
             </Text>

--- a/src/components/Appbar/AppbarContent.js
+++ b/src/components/Appbar/AppbarContent.js
@@ -43,6 +43,14 @@ type Props = $RemoveChildren<typeof View> & {|
   onPress?: () => mixed,
   style?: any,
   /**
+   *  Title uses font scaling
+   */
+  allowTitleFontScaling?: boolean,
+  /**
+   * Subtitle uses font scaling
+   */
+  allowSubtitleFontScaling?: boolean,
+  /**
    * @optional
    */
   theme: Theme,
@@ -64,6 +72,8 @@ class AppbarContent extends React.Component<Props> {
       titleStyle,
       theme,
       title,
+      allowTitleFontScaling,
+      allowSubtitleFontScaling,
       ...rest
     } = this.props;
     const { fonts } = theme;
@@ -80,6 +90,23 @@ class AppbarContent extends React.Component<Props> {
             style={[
               {
                 color: titleColor,
+                fontFamily: Platform.OS === 'ios' ? fonts.regular : fonts.medium,
+              },
+              styles.title,
+              titleStyle,
+            ]}
+            numberOfLines={1}
+            allowFontScaling={allowTitleFontScaling}
+            accessibilityTraits="header"
+            accessibilityRole="header"
+          >
+            {title}
+          </Text>
+          {subtitle ? (
+          <Text
+            style={[
+              {
+                color: titleColor,
                 fontFamily:
                   Platform.OS === 'ios' ? fonts.regular : fonts.medium,
               },
@@ -89,6 +116,7 @@ class AppbarContent extends React.Component<Props> {
             numberOfLines={1}
             accessibilityTraits="header"
             accessibilityRole="header"
+            allowSubtitleFontScaling={allowSubtitleFontScaling}
           >
             {title}
           </Text>

--- a/src/components/Appbar/AppbarContent.js
+++ b/src/components/Appbar/AppbarContent.js
@@ -1,7 +1,12 @@
 /* @flow */
 
 import * as React from 'react';
-import { View, StyleSheet, Platform } from 'react-native';
+import {
+  View,
+  StyleSheet,
+  Platform,
+  TouchableWithoutFeedback,
+} from 'react-native';
 import color from 'color';
 
 import Text from '../Typography/Text';
@@ -32,6 +37,10 @@ type Props = $RemoveChildren<typeof View> & {|
    * Style for the subtitle.
    */
   subtitleStyle?: any,
+  /**
+   * Function to execute on press.
+   */
+  onPress?: () => mixed,
   style?: any,
   /**
    * @optional
@@ -50,6 +59,7 @@ class AppbarContent extends React.Component<Props> {
       color: titleColor = black,
       subtitle,
       subtitleStyle,
+      onPress,
       style,
       titleStyle,
       theme,
@@ -64,31 +74,34 @@ class AppbarContent extends React.Component<Props> {
       .string();
 
     return (
-      <View style={[styles.container, style]} {...rest}>
-        <Text
-          style={[
-            {
-              color: titleColor,
-              fontFamily: Platform.OS === 'ios' ? fonts.regular : fonts.medium,
-            },
-            styles.title,
-            titleStyle,
-          ]}
-          numberOfLines={1}
-          accessibilityTraits="header"
-          accessibilityRole="header"
-        >
-          {title}
-        </Text>
-        {subtitle ? (
+      <TouchableWithoutFeedback onPress={onPress}>
+        <View style={[styles.container, style]} {...rest}>
           <Text
-            style={[styles.subtitle, { color: subtitleColor }, subtitleStyle]}
+            style={[
+              {
+                color: titleColor,
+                fontFamily:
+                  Platform.OS === 'ios' ? fonts.regular : fonts.medium,
+              },
+              styles.title,
+              titleStyle,
+            ]}
             numberOfLines={1}
+            accessibilityTraits="header"
+            accessibilityRole="header"
           >
-            {subtitle}
+            {title}
           </Text>
-        ) : null}
-      </View>
+          {subtitle ? (
+            <Text
+              style={[styles.subtitle, { color: subtitleColor }, subtitleStyle]}
+              numberOfLines={1}
+            >
+              {subtitle}
+            </Text>
+          ) : null}
+        </View>
+      </TouchableWithoutFeedback>
     );
   }
 }

--- a/src/components/Appbar/AppbarContent.js
+++ b/src/components/Appbar/AppbarContent.js
@@ -116,7 +116,7 @@ class AppbarContent extends React.Component<Props> {
             numberOfLines={1}
             accessibilityTraits="header"
             accessibilityRole="header"
-            allowSubtitleFontScaling={allowSubtitleFontScaling}
+            allowFontScaling={allowSubtitleFontScaling}
           >
             {title}
           </Text>

--- a/src/components/Appbar/AppbarContent.js
+++ b/src/components/Appbar/AppbarContent.js
@@ -62,6 +62,11 @@ type Props = $RemoveChildren<typeof View> & {|
 class AppbarContent extends React.Component<Props> {
   static displayName = 'Appbar.Content';
 
+  static defaultProps = {
+    allowTitleFontScaling: true,
+    allowSubtitleFontScaling: true,
+  };
+
   render() {
     const {
       color: titleColor = black,

--- a/src/components/TouchableRipple.js
+++ b/src/components/TouchableRipple.js
@@ -13,6 +13,7 @@ import { withTheme } from '../core/theming';
 import type { Theme } from '../types';
 
 const ANDROID_VERSION_LOLLIPOP = 21;
+const ANDROID_VERSION_NOUGAT = 27;
 
 type Props = React.ElementConfig<typeof TouchableWithoutFeedback> & {|
   /**
@@ -83,7 +84,9 @@ class TouchableRipple extends React.Component<Props, void> {
    * Whether ripple effect is supported.
    */
   static supported =
-    Platform.OS === 'android' && Platform.Version >= ANDROID_VERSION_LOLLIPOP;
+    Platform.OS === 'android' &&
+    Platform.Version >= ANDROID_VERSION_LOLLIPOP &&
+    Platform.Version <= ANDROID_VERSION_NOUGAT;
 
   render() {
     const {

--- a/typings/components/Appbar.d.ts
+++ b/typings/components/Appbar.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleProp, TextStyle, ViewStyle, ViewProps, TouchableNativeFeedbackProps } from 'react-native';
+import { StyleProp, TextStyle, ViewProps, ViewStyle } from 'react-native';
 import { IconSource, ThemeShape } from '../types';
 import { TouchableRipplePropsWithoutChildren } from './TouchableRipple';
 
@@ -11,6 +11,8 @@ export interface AppbarContentProps {
   subtitleStyle?: StyleProp<TextStyle>;
   style?: StyleProp<ViewStyle>;
   theme?: ThemeShape;
+  allowTitleFontScaling?: boolean;
+  allowSubtitleFontScaling?: boolean;
 }
 
 export interface AppbarActionProps extends TouchableRipplePropsWithoutChildren {


### PR DESCRIPTION
### Motivation

This adds the ability to indicate whether or not navigation bar title and subtitle should be affected by font scaling.  It adds two properties to `Appbar.Content`, `allowTitleFontScaling` and `allowSubtitleFontScaling`, which allow you to individually control whether or not the `title` or `subtitle` should be affected by font scaling.

### Test plan

1. Create an `Appbar` with an `Appbar.Content` whose `title` and `subtitle` are set to a string value.
1. Run the app in an iOS Simulator
1. Open the *Accessibility Inspector*  ( `/Applications/Xcode.app/Contents/Applications/Accessibility Inspector.app` ), and set its `Target` to the Simulator running your test app
1. Choose the `Settings` button ( a Gear icon ) in Accessibility Inspector, and change `Font size` to the maximum possible value
1. Observe the title and subtitle being clipped out of the navigation bar
1. Change `allowTitleFontScaling` and `allowSubtitleFontScaling` to `true`, and reload the app
1. Observe the title and subtitle not being affected by the font scaling changes

Clipped behavior:
![screen shot 2018-12-12 at 2 15 56 pm](https://user-images.githubusercontent.com/3809/49893340-24cf4100-fe19-11e8-9f95-5fbfb839353c.png)

Not clipped behavior:
![screen shot 2018-12-12 at 2 15 08 pm](https://user-images.githubusercontent.com/3809/49893353-2dc01280-fe19-11e8-8ebc-8d48b0ee5ae8.png)

I could see an argument for the default being to *not* allow for scaling, as that would likely correspond with the desirable behavior of not causing the text content to be clipped, but I erred on the side of respecting older behavior first and allowing you to opt in.