### PR TITLE
Allow Drawer.Item and Drawer.Section to render multi-line text

### DIFF
--- a/src/components/Drawer/DrawerItem.js
+++ b/src/components/Drawer/DrawerItem.js
@@ -24,6 +24,10 @@ type Props = {
    */
   active?: boolean,
   /**
+   * Number of lines to display for text, defaults to 1.
+   */
+  numberOfLines?: number,
+  /**
    * Function to execute on press.
    */
   onPress?: () => mixed,
@@ -53,7 +57,7 @@ class DrawerItem extends React.Component<Props> {
   static displayName = 'Drawer.Item';
 
   render() {
-    const { icon, label, active, theme, style, onPress, ...rest } = this.props;
+    const { icon, label, active, theme, style, onPress, numberOfLines, ...rest } = this.props;
     const { colors, roundness } = theme;
     const backgroundColor = active
       ? color(colors.primary)
@@ -69,7 +73,7 @@ class DrawerItem extends React.Component<Props> {
           .string();
     const fontFamily = theme.fonts.medium;
     const labelMargin = icon ? 32 : 0;
-
+    const numLines = typeof(numberOfLines) === "undefined" ? 1 : numberOfLines;
     return (
       <View
         {...rest}
@@ -94,7 +98,7 @@ class DrawerItem extends React.Component<Props> {
               <Icon source={icon} size={24} color={contentColor} />
             ) : null}
             <Text
-              numberOfLines={1}
+              numberOfLines={numLines}
               style={[
                 styles.label,
                 {

--- a/src/components/Drawer/DrawerItem.js
+++ b/src/components/Drawer/DrawerItem.js
@@ -1,3 +1,4 @@
+yarn exec v1.12.3
 /* @flow */
 
 import color from 'color';
@@ -57,7 +58,16 @@ class DrawerItem extends React.Component<Props> {
   static displayName = 'Drawer.Item';
 
   render() {
-    const { icon, label, active, theme, style, onPress, numberOfLines, ...rest } = this.props;
+    const {
+      icon,
+      label,
+      active,
+      theme,
+      style,
+      onPress,
+      numberOfLines,
+      ...rest
+    } = this.props;
     const { colors, roundness } = theme;
     const backgroundColor = active
       ? color(colors.primary)
@@ -133,3 +143,4 @@ const styles = StyleSheet.create({
 });
 
 export default withTheme(DrawerItem);
+Done in 0.28s.

--- a/src/components/Drawer/DrawerItem.js
+++ b/src/components/Drawer/DrawerItem.js
@@ -73,7 +73,7 @@ class DrawerItem extends React.Component<Props> {
           .string();
     const fontFamily = theme.fonts.medium;
     const labelMargin = icon ? 32 : 0;
-    const numLines = typeof numberOfLines === "undefined" ? 1 : numberOfLines;
+    const numLines = typeof numberOfLines === 'undefined' ? 1 : numberOfLines;
     return (
       <View
         {...rest}

--- a/src/components/Drawer/DrawerItem.js
+++ b/src/components/Drawer/DrawerItem.js
@@ -142,4 +142,3 @@ const styles = StyleSheet.create({
 });
 
 export default withTheme(DrawerItem);
-Done in 0.28s.

--- a/src/components/Drawer/DrawerItem.js
+++ b/src/components/Drawer/DrawerItem.js
@@ -73,7 +73,7 @@ class DrawerItem extends React.Component<Props> {
           .string();
     const fontFamily = theme.fonts.medium;
     const labelMargin = icon ? 32 : 0;
-    const numLines = typeof(numberOfLines) === "undefined" ? 1 : numberOfLines;
+    const numLines = typeof numberOfLines === "undefined" ? 1 : numberOfLines;
     return (
       <View
         {...rest}

--- a/src/components/Drawer/DrawerItem.js
+++ b/src/components/Drawer/DrawerItem.js
@@ -1,4 +1,3 @@
-yarn exec v1.12.3
 /* @flow */
 
 import color from 'color';

--- a/src/components/Drawer/DrawerSection.js
+++ b/src/components/Drawer/DrawerSection.js
@@ -72,7 +72,7 @@ class DrawerSection extends React.Component<Props> {
       .rgb()
       .string();
     const fontFamily = fonts.medium;
-    const numLines = typeof numberOfLines === "undefined" ? 1 : numberOfLines;
+    const numLines = typeof numberOfLines === 'undefined' ? 1 : numberOfLines;
     return (
       <View {...rest}>
         {title && (

--- a/src/components/Drawer/DrawerSection.js
+++ b/src/components/Drawer/DrawerSection.js
@@ -14,6 +14,10 @@ type Props = React.ElementConfig<typeof View> & {
    */
   title?: string,
   /**
+   * Number of lines to display for text, defaults to 1.
+   */
+  numberOfLines?: number,
+  /**
    * Content of the `Drawer.Section`.
    */
   children: React.Node,
@@ -61,20 +65,20 @@ class DrawerSection extends React.Component<Props> {
   static displayName = 'Drawer.Section';
 
   render() {
-    const { children, title, theme, ...rest } = this.props;
+    const { children, title, theme, numberOfLines, ...rest } = this.props;
     const { colors, fonts } = theme;
     const titleColor = color(colors.text)
       .alpha(0.54)
       .rgb()
       .string();
     const fontFamily = fonts.medium;
-
+    const numLines = typeof(numberOfLines) === "undefined" ? 1 : numberOfLines;
     return (
       <View {...rest}>
         {title && (
-          <View style={{ height: 40, justifyContent: 'center' }}>
+          <View style={{ minHeight: 40, justifyContent: 'center' }}>
             <Text
-              numberOfLines={1}
+              numberOfLines={numLines}
               style={{ color: titleColor, fontFamily, marginLeft: 16 }}
             >
               {title}

--- a/src/components/Drawer/DrawerSection.js
+++ b/src/components/Drawer/DrawerSection.js
@@ -72,7 +72,7 @@ class DrawerSection extends React.Component<Props> {
       .rgb()
       .string();
     const fontFamily = fonts.medium;
-    const numLines = typeof(numberOfLines) === "undefined" ? 1 : numberOfLines;
+    const numLines = typeof numberOfLines === "undefined" ? 1 : numberOfLines;
     return (
       <View {...rest}>
         {title && (

--- a/typings/components/Drawer.d.ts
+++ b/typings/components/Drawer.d.ts
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { ViewProps } from 'react-native';
-import { ThemeShape, IconSource } from '../types';
+import { IconSource, ThemeShape } from '../types';
 
 export interface ItemProps extends ViewProps {
   label: string;
   icon?: IconSource;
   active?: boolean;
+  numberOfLines?: number | null;
   theme?: ThemeShape;
   onPress?: () => void;
 }
@@ -15,6 +16,7 @@ export declare class Item extends React.Component<ItemProps> {}
 export interface SectionProps extends ViewProps {
   children: React.ReactNode;
   title?: string;
+  numberOfLines?: number | null;
   theme?: ThemeShape;
 }
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

`Drawer.Item` and `Drawer.Section` were biased to only show 1 line of text, and only at a specific height ( `40` pixels in height in the case of `Drawer.Section` ). This PR changes it such that, when the font size is increased or the content is larger than expected, both `Drawer.Item` and `Drawer.Section` **may** wrap the content and display it as multiline text.

The behavior change is such that:

* IF no `numberOfLines` is specified (`undefined`), the previous behavior is maintained, which is to say that only 1 line of text will be shown
* IF a `numberOfLines` is specified that is a number, the text will show up to that many lines of text
* IF a `numberOfLines` is specified that is `null`, that will be sent as the property value, which will cause the **default** value of the `Text` element to be used for the number of lines.

This is a slightly convoluted path, but it allows the prior behavior to be maintained.

### Test plan

1. Create a `Drawer` which has a `Drawer.Section` and `Drawer.Item` whose label values will be multiple lines worth of content
1. Run the app 
1. Observe that the contents of the `Drawer.Section` and `Drawer.Item` are truncated
1. Change the `numberOfLines` attribute to a number, observe that the number of lines specified are now shown
1. Change the `numberOfLines` attribute to `null`, observe that the default behavior of the `Text` element is used ( show all content ).

Clipped Content
![screen shot 2018-12-12 at 2 51 28 pm](https://user-images.githubusercontent.com/3809/49895422-5dbde480-fe1e-11e8-9874-bd3ff8182db0.png)

Unclipped Content
![screen shot 2018-12-12 at 2 52 45 pm](https://user-images.githubusercontent.com/3809/49895433-68787980-fe1e-11e8-9906-53fa570cb76c.png)

The above screenshots exhibit the clipped / unclipped behavior by increasing the font size using the Accessibility Inspector ( `/Applications/Xcode.app/Contents/Applications/Accessibility Inspector.app` ).