### PR TITLE
Allow Chip to expand to font sizing changes

### DIFF
--- a/src/components/Chip.js
+++ b/src/components/Chip.js
@@ -294,7 +294,7 @@ const styles = StyleSheet.create({
     padding: 4,
   },
   text: {
-    height: 24,
+    minHeight: 24,
     lineHeight: 24,
     textAlignVertical: 'center',
     marginVertical: 4,

--- a/src/components/__tests__/__snapshots__/Chip.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.js.snap
@@ -96,9 +96,9 @@ exports[`renders chip with close button 1`] = `
             },
             Array [
               Object {
-                "height": 24,
                 "lineHeight": 24,
                 "marginVertical": 4,
+                "minHeight": 24,
                 "textAlignVertical": "center",
               },
               Object {
@@ -264,9 +264,9 @@ exports[`renders chip with icon 1`] = `
             },
             Array [
               Object {
-                "height": 24,
                 "lineHeight": 24,
                 "marginVertical": 4,
+                "minHeight": 24,
                 "textAlignVertical": "center",
               },
               Object {
@@ -336,9 +336,9 @@ exports[`renders chip with onPress 1`] = `
             },
             Array [
               Object {
-                "height": 24,
                 "lineHeight": 24,
                 "marginVertical": 4,
+                "minHeight": 24,
                 "textAlignVertical": "center",
               },
               Object {
@@ -412,9 +412,9 @@ exports[`renders outlined disabled chip 1`] = `
             },
             Array [
               Object {
-                "height": 24,
                 "lineHeight": 24,
                 "marginVertical": 4,
+                "minHeight": 24,
                 "textAlignVertical": "center",
               },
               Object {
@@ -533,9 +533,9 @@ exports[`renders selected chip 1`] = `
             },
             Array [
               Object {
-                "height": 24,
                 "lineHeight": 24,
                 "marginVertical": 4,
+                "minHeight": 24,
                 "textAlignVertical": "center",
               },
               Object {


### PR DESCRIPTION
### Motivation

The `Chip` component had a strict height on its `Text` component, which would clip the text internally if the user had adjusted the font size of the application.

### Test plan

1. Create an app with a `Chip` component
1. Adjust your font size in the device's Accessibility settings to the largest possible font size
1. Start the app
1. Observe that the text is not clipped inside the `Chip` component

