### PR TITLE
Add title and subtitle scaling attributes to Appbar.Content

### DIFF
--- a/src/components/Appbar/AppbarContent.js
+++ b/src/components/Appbar/AppbarContent.js
@@ -43,6 +43,14 @@ type Props = $RemoveChildren<typeof View> & {|
   onPress?: () => mixed,
   style?: any,
   /**
+   *  Title uses font scaling
+   */
+  allowTitleFontScaling?: boolean,
+  /**
+   * Subtitle uses font scaling
+   */
+  allowSubtitleFontScaling?: boolean,
+  /**
    * @optional
    */
   theme: Theme,
@@ -54,6 +62,11 @@ type Props = $RemoveChildren<typeof View> & {|
 class AppbarContent extends React.Component<Props> {
   static displayName = 'Appbar.Content';
 
+  static defaultProps = {
+    allowTitleFontScaling: true,
+    allowSubtitleFontScaling: true,
+  };
+
   render() {
     const {
       color: titleColor = black,
@@ -64,6 +77,8 @@ class AppbarContent extends React.Component<Props> {
       titleStyle,
       theme,
       title,
+      allowTitleFontScaling,
+      allowSubtitleFontScaling,
       ...rest
     } = this.props;
     const { fonts } = theme;
@@ -89,6 +104,7 @@ class AppbarContent extends React.Component<Props> {
             numberOfLines={1}
             accessibilityTraits="header"
             accessibilityRole="header"
+            allowFontScaling={allowTitleFontScaling}
           >
             {title}
           </Text>
@@ -96,6 +112,7 @@ class AppbarContent extends React.Component<Props> {
             <Text
               style={[styles.subtitle, { color: subtitleColor }, subtitleStyle]}
               numberOfLines={1}
+              allowFontScaling={allowSubtitleFontScaling}
             >
               {subtitle}
             </Text>

--- a/typings/components/Appbar.d.ts
+++ b/typings/components/Appbar.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleProp, TextStyle, ViewStyle, ViewProps, TouchableNativeFeedbackProps } from 'react-native';
+import { StyleProp, TextStyle, ViewProps, ViewStyle } from 'react-native';
 import { IconSource, ThemeShape } from '../types';
 import { TouchableRipplePropsWithoutChildren } from './TouchableRipple';
 
@@ -11,6 +11,8 @@ export interface AppbarContentProps {
   subtitleStyle?: StyleProp<TextStyle>;
   style?: StyleProp<ViewStyle>;
   theme?: ThemeShape;
+  allowTitleFontScaling?: boolean;
+  allowSubtitleFontScaling?: boolean;
 }
 
 export interface AppbarActionProps extends TouchableRipplePropsWithoutChildren {


### PR DESCRIPTION
This PR is a re-submittal of #693 , the history in that branch was messier than I liked. Resubmitting for simplicity's sake.

### Motivation

This adds the ability to indicate whether or not navigation bar title and subtitle should be affected by font scaling.  It adds two properties to `Appbar.Content`, `allowTitleFontScaling` and `allowSubtitleFontScaling`, which allow you to individually control whether or not the `title` or `subtitle` should be affected by font scaling.

### Test plan

1. Create an `Appbar` with an `Appbar.Content` whose `title` and `subtitle` are set to a string value.
1. Run the app in an iOS Simulator
1. Open the *Accessibility Inspector*  ( `/Applications/Xcode.app/Contents/Applications/Accessibility Inspector.app` ), and set its `Target` to the Simulator running your test app
1. Choose the `Settings` button ( a Gear icon ) in Accessibility Inspector, and change `Font size` to the maximum possible value
1. Observe the title and subtitle being clipped out of the navigation bar
1. Change `allowTitleFontScaling` and `allowSubtitleFontScaling` to `true`, and reload the app
1. Observe the title and subtitle not being affected by the font scaling changes

Clipped behavior:
![screen shot 2018-12-12 at 2 15 56 pm](https://user-images.githubusercontent.com/3809/49893340-24cf4100-fe19-11e8-9f95-5fbfb839353c.png)

Not clipped behavior:
![screen shot 2018-12-12 at 2 15 08 pm](https://user-images.githubusercontent.com/3809/49893353-2dc01280-fe19-11e8-8ebc-8d48b0ee5ae8.png)

I could see an argument for the default being to *not* allow for scaling, as that would likely correspond with the desirable behavior of not causing the text content to be clipped, but I erred on the side of respecting older behavior first and allowing you to opt in.