### PR TITLE
Export nested types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,15 @@
 /* @flow */
 
 import * as Colors from './styles/colors';
-import type { Theme as _Theme } from './types';
+import type {
+  Theme as _Theme,
+  ThemeColors as _ThemeColors,
+  ThemeFonts as _ThemeFonts,
+} from './types';
 
 export type Theme = _Theme;
+export type ThemeColors = _ThemeColors;
+export type ThemeFonts = _ThemeFonts;
 
 export { Colors };
 

--- a/src/types.js
+++ b/src/types.js
@@ -2,26 +2,30 @@
 
 import * as React from 'react';
 
+export type ThemeColors = {
+  primary: string,
+  background: string,
+  surface: string,
+  accent: string,
+  error: string,
+  text: string,
+  disabled: string,
+  placeholder: string,
+  backdrop: string,
+};
+
+export type ThemeFonts = {
+  regular: string,
+  medium: string,
+  light: string,
+  thin: string,
+};
+
 export type Theme = {
   dark: boolean,
   roundness: number,
-  colors: {
-    primary: string,
-    background: string,
-    surface: string,
-    accent: string,
-    error: string,
-    text: string,
-    disabled: string,
-    placeholder: string,
-    backdrop: string,
-  },
-  fonts: {
-    regular: string,
-    medium: string,
-    light: string,
-    thin: string,
-  },
+  colors: ThemeColors,
+  fonts: ThemeFonts,
 };
 
 export type ThemeShape = $Shape<{

--- a/types.js
+++ b/types.js
@@ -5,6 +5,12 @@
  * @flow
  */
 
-import type { Theme as _Theme } from './src/types';
+import type {
+  Theme as _Theme,
+  ThemeColors as _ThemeColors,
+  ThemeFonts as _ThemeFonts,
+} from './src/types';
 
 export type Theme = _Theme;
+export type ThemeColors = _ThemeColors;
+export type ThemeFonts = _ThemeFonts;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

In order to extend the theme in my app, I need:

```js
export type ThemeType = {
  ...Theme,
  colors: {
    // PR is for this part, as doing ...Theme.colors is not supported
    ...TypeColors,
    // These are my colors
    ...ThemeCustomColors,
  },
};

export type ThemeShape = $Shape<{
  ...ThemeType,
  colors: $Shape<$PropertyType<ThemeType, 'colors'>>,
  fonts: $Shape<$PropertyType<ThemeType, 'fonts'>>,
}>;

export default ((withTheme: any): WithThemeType<ThemeType, ThemeShape>);
```

### Test plan

`yarn flow`