### PR TITLE
Allow TouchableRipple for Modern Android Versions

### DIFF
--- a/src/components/TouchableRipple.js
+++ b/src/components/TouchableRipple.js
@@ -13,7 +13,6 @@ import { withTheme } from '../core/theming';
 import type { Theme } from '../types';
 
 const ANDROID_VERSION_LOLLIPOP = 21;
-const ANDROID_VERSION_NOUGAT = 27;
 
 type Props = React.ElementConfig<typeof TouchableWithoutFeedback> & {|
   /**
@@ -85,8 +84,7 @@ class TouchableRipple extends React.Component<Props, void> {
    */
   static supported =
     Platform.OS === 'android' &&
-    Platform.Version >= ANDROID_VERSION_LOLLIPOP &&
-    Platform.Version <= ANDROID_VERSION_NOUGAT;
+    Platform.Version >= ANDROID_VERSION_LOLLIPOP;
 
   render() {
     const {


### PR DESCRIPTION
### Motivation

TouchableRipple uses hard-coded values to prohibit use on Android versions > 27. This means that each time a new version of android is released, the maintainers of this library must update this file to allow TouchableRipple to be used. The proposed change is to allow TouchableRipple to be used on newer versions of Android, namely API level 28.

### Test plan

1. Verify that TouchableRipple now works on Android API level 28.