### PR TITLE
fix: textInput label wrong position in RTL

### DIFF
--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -472,7 +472,8 @@ class TextInput extends React.Component<Props, State> {
           translateX: this.state.labeled.interpolate({
             inputRange: [0, 1],
             outputRange: [
-              -(1 - MINIMIZED_LABEL_FONT_SIZE / MAXIMIZED_LABEL_FONT_SIZE) *
+              (I18nManager.isRTL ? 1 : -1) *
+                (1 - MINIMIZED_LABEL_FONT_SIZE / MAXIMIZED_LABEL_FONT_SIZE) *
                 (this.state.labelLayout.width / 2),
               0,
             ],


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
Fixes issues like this #562 due to the transformed offset that imitates transform origin on label scale do not count for RTL and make the offset in the wrong direction