### PR TITLE
fix: use fontFamily of theme for Searchbar

### DIFF
--- a/src/components/Searchbar.js
+++ b/src/components/Searchbar.js
@@ -122,7 +122,7 @@ class Searchbar extends React.Component<Props> {
     } = this.props;
     const { colors, roundness, dark, fonts } = theme;
     const textColor = colors.text;
-    const fontFamily = fonts.regular
+    const fontFamily = fonts.regular;
     const iconColor = dark
       ? textColor
       : color(textColor)

--- a/src/components/Searchbar.js
+++ b/src/components/Searchbar.js
@@ -120,8 +120,9 @@ class Searchbar extends React.Component<Props> {
       style,
       ...rest
     } = this.props;
-    const { colors, roundness, dark } = theme;
+    const { colors, roundness, dark, fonts } = theme;
     const textColor = colors.text;
+    const fontFamily = fonts.regular
     const iconColor = dark
       ? textColor
       : color(textColor)
@@ -149,7 +150,7 @@ class Searchbar extends React.Component<Props> {
           icon={icon || 'search'}
         />
         <TextInput
-          style={[styles.input, { color: textColor }]}
+          style={[styles.input, { color: textColor, fontFamily }]}
           placeholder={placeholder || ''}
           placeholderTextColor={colors.placeholder}
           selectionColor={colors.primary}


### PR DESCRIPTION
### Motivation

Searchbar doesn't use fontFamily described in custom theme.

### Other solutions

I wonder that why Searchbar doesn't use fontFamily of TextInput. maybe someone can explain it.
