### PR TITLE
Appbar.Content multiline title

### DIFF
--- a/src/components/Appbar/AppbarContent.js
+++ b/src/components/Appbar/AppbarContent.js
@@ -86,7 +86,7 @@ class AppbarContent extends React.Component<Props> {
               styles.title,
               titleStyle,
             ]}
-            numberOfLines={1}
+            numberOfLines={subtitle ? 1 : 2}
             accessibilityTraits="header"
             accessibilityRole="header"
           >


### PR DESCRIPTION
If subtitle is present limit the number of lines for the title to 1, else let it spread over 2 lines.
Suitable for longer titles, especially when Appbar.Action's taking up space are present.

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
On smaller screens a title of decent length is truncated. It can be rendered over 2 lines at best.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
