### PR TITLE
Added ProgressBarComponent as fallback for generic platforms

### DIFF
--- a/src/components/ProgressBar/ProgressBarComponent.js
+++ b/src/components/ProgressBar/ProgressBarComponent.js
@@ -1,0 +1,1 @@
+export { ProgressBar as default } from 'react-native';


### PR DESCRIPTION
### Motivation

Tried using react-native-paper with react-native-dom and saw ProgressBarComponent crashes because it doesn't have a fallback defined for generic platforms (react-native-dom listens to .dom.js rather than .web.js). As far as I can see it's the only file missing fallback in the project.

### Test plan

Use it with react-native-dom or any other platform using an undefined pattern.
