### PR TITLE
fixing parenthesis locations

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -38,7 +38,7 @@ const App = createDrawerNavigator(
     ),
     // set drawerPosition to support rtl toggle on android
     drawerPosition:
-      (Platform.OS === 'android' && I18nManager.isRTL) ? 'right' : 'left',
+      Platform.OS === 'android' && I18nManager.isRTL ? 'right' : 'left',
   }
 );
 

--- a/example/App.js
+++ b/example/App.js
@@ -38,7 +38,7 @@ const App = createDrawerNavigator(
     ),
     // set drawerPosition to support rtl toggle on android
     drawerPosition:
-      Platform.OS === 'android' && (I18nManager.isRTL ? 'right' : 'left'),
+      (Platform.OS === 'android' && I18nManager.isRTL) ? 'right' : 'left',
   }
 );
 


### PR DESCRIPTION
On the following line the parenthesis are not properly located:
https://github.com/callstack/react-native-paper/blob/bcef4a60ba72669d51cd9418a341193c9bb0cfc8/example/App.js#L41

this is how it is right now:
drawerPosition: Platform.OS === 'android' && (I18nManager.isRTL ? 'right' : 'left'),

this is how it should be:
drawerPosition: (Platform.OS === 'android' && I18nManager.isRTL) ? 'right' : 'left',

since "drawerPosition" accepts the values: { 'left', 'right' }

Thanks.