### PR TITLE
fix: replace 'orderRadius' with 'borderRadius' in Snackbar component

### DIFF
--- a/src/components/Snackbar.js
+++ b/src/components/Snackbar.js
@@ -196,7 +196,7 @@ class Snackbar extends React.Component<Props, State> {
           style={[
             styles.container,
             {
-              orderRadius: roundness,
+              borderRadius: roundness,
               opacity: this.state.opacity,
               transform: [
                 {

--- a/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
@@ -26,7 +26,6 @@ exports[`renders snackbar with Text as a child 1`] = `
         "justifyContent": "space-between",
         "margin": 8,
         "opacity": 1,
-        "orderRadius": 4,
         "shadowColor": "#000000",
         "shadowOffset": Object {
           "height": 5,
@@ -98,7 +97,6 @@ exports[`renders snackbar with action button 1`] = `
         "justifyContent": "space-between",
         "margin": 8,
         "opacity": 1,
-        "orderRadius": 4,
         "shadowColor": "#000000",
         "shadowOffset": Object {
           "height": 5,
@@ -251,7 +249,6 @@ exports[`renders snackbar with content 1`] = `
         "justifyContent": "space-between",
         "margin": 8,
         "opacity": 1,
-        "orderRadius": 4,
         "shadowColor": "#000000",
         "shadowOffset": Object {
           "height": 5,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

The `borderRadius` / `roundness` prop was not working as expected because there was a typo in its name.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

n/a