### PR TITLE
fix TypeScript typings for TextInput methods

### DIFF
--- a/typings/components/TextInput.d.ts
+++ b/typings/components/TextInput.d.ts
@@ -36,4 +36,9 @@ export interface RenderProps extends NativeTextInputProps {
   value?: string;
 }
 
-export declare class TextInput extends React.Component<TextInputProps> {}
+export declare class TextInput extends React.Component<TextInputProps> {
+  isFocused: () => boolean;
+  clear: () => void;
+  focus(): void;
+  blur(): void;
+}


### PR DESCRIPTION
### Motivation

* paper version: v2.6.1
* typescript version: v3.2.2

The `TextInput` class has public methods `isFocused`, `clear`, `focus`, `blur`.

https://github.com/callstack/react-native-paper/blob/v2.6.1/src/components/TextInput.js#L348-L374

However, they are not declared in d.ts as below.

![2019-01-24 17 51 02](https://user-images.githubusercontent.com/434227/51666158-ab726300-2000-11e9-9da1-b5a8be0ad32d.png)

### Test plan

Typecheck for below function.

```typescript
import { TextInput } from "react-native-paper";

function doAnything(textInput: TextInput) {
  textInput.isFocused();
  textInput.clear();
  textInput.focus();
  textInput.blur();
}
```