### PR TITLE
docs: FAB.Group should use padding instead of margin

### DIFF
--- a/src/components/FAB/FABGroup.js
+++ b/src/components/FAB/FABGroup.js
@@ -68,7 +68,7 @@ type Props = {|
   visible: boolean,
   /**
    * Style for the group. You can use it to pass additional styles if you need.
-   * For example, you can set an additional margin if you have a tab bar at the bottom.
+   * For example, you can set an additional padding if you have a tab bar at the bottom.
    */
   style?: any,
   /**


### PR DESCRIPTION
The FAB.Groups docs state the style prop can use a margin in order to position it properly. It's a bit misleading since using the margin repositions the overlay as well. Padding might be the way to go.

With margin:
<img width="274" alt="screen shot 2019-01-25 at 15 22 34" src="https://user-images.githubusercontent.com/7827311/51752031-b2f44380-20b6-11e9-8d83-bbdf174bcc41.png">

With padding:
<img width="276" alt="screen shot 2019-01-25 at 15 27 39" src="https://user-images.githubusercontent.com/7827311/51752046-b7b8f780-20b6-11e9-813e-9b4c08100efc.png">

Snack https://snack.expo.io/S1YnC9uQE