### PR TITLE
fix: disable unpressable data table title

### DIFF
--- a/src/components/DataTable/DataTableTitle.js
+++ b/src/components/DataTable/DataTableTitle.js
@@ -90,7 +90,7 @@ class DataTableTitle extends React.Component<Props, State> {
     ) : null;
 
     return (
-      <TouchableWithoutFeedback onPress={onPress} {...rest}>
+      <TouchableWithoutFeedback disabled={!onPress} onPress={onPress} {...rest}>
         <View style={[styles.container, numeric && styles.right, style]}>
           {icon}
 


### PR DESCRIPTION
### Motivation

If no `onPress` handler is passed, there is no reason to enable the `Touchable`.

### Test plan

n/a
