### PR TITLE
fix: Allow to change background for FAB Group

### DIFF
--- a/src/components/FAB/FABGroup.js
+++ b/src/components/FAB/FABGroup.js
@@ -72,6 +72,10 @@ type Props = {|
    */
   style?: any,
   /**
+   * Style for the FAB. It allows to pass the FAB button styles, such as backgroundColor.
+   */
+  fabStyle?: any,
+  /**
    * @optional
    */
   theme: Theme,
@@ -198,6 +202,7 @@ class FABGroup extends React.Component<Props, State> {
       accessibilityLabel,
       theme,
       style,
+      fabStyle,
       visible,
     } = this.props;
     const { colors } = theme;
@@ -226,10 +231,8 @@ class FABGroup extends React.Component<Props, State> {
           : 1
     );
 
-    const { backgroundColor, ...rest } = style || {};
-
     return (
-      <View pointerEvents="box-none" style={[styles.container, rest]}>
+      <View pointerEvents="box-none" style={[styles.container, style]}>
         {open ? <StatusBar barStyle="light-content" /> : null}
         <TouchableWithoutFeedback onPress={this._close}>
           <Animated.View
@@ -314,7 +317,7 @@ class FABGroup extends React.Component<Props, State> {
           accessibilityTraits="button"
           accessibilityComponentType="button"
           accessibilityRole="button"
-          style={[styles.fab, backgroundColor ? { backgroundColor } : null]}
+          style={[styles.fab, fabStyle]}
           visible={visible}
         />
       </View>

--- a/src/components/FAB/FABGroup.js
+++ b/src/components/FAB/FABGroup.js
@@ -226,8 +226,10 @@ class FABGroup extends React.Component<Props, State> {
           : 1
     );
 
+    const { backgroundColor, ...rest } = style || {};
+
     return (
-      <View pointerEvents="box-none" style={[styles.container, style]}>
+      <View pointerEvents="box-none" style={[styles.container, rest]}>
         {open ? <StatusBar barStyle="light-content" /> : null}
         <TouchableWithoutFeedback onPress={this._close}>
           <Animated.View
@@ -312,7 +314,7 @@ class FABGroup extends React.Component<Props, State> {
           accessibilityTraits="button"
           accessibilityComponentType="button"
           accessibilityRole="button"
-          style={styles.fab}
+          style={[styles.fab, backgroundColor ? { backgroundColor } : null]}
           visible={visible}
         />
       </View>

--- a/typings/components/FAB.d.ts
+++ b/typings/components/FAB.d.ts
@@ -21,6 +21,7 @@ export interface FABGroupProps {
   onStateChange: (state: { open: boolean }) => any;
   visible?: boolean;
   style?: any;
+  fabStyle?: any;
   theme?: ThemeShape;
 }
 


### PR DESCRIPTION
### Motivation

It's currently possible to change the background color for FAB and also items within FAB.Group components. Changing the background color in FAB Group causes the overlay background to change.

This PR makes it possible to change the background for the FAB Group main button.

Current behavior:
<img width="377" alt="screen shot 2019-01-25 at 17 41 56" src="https://user-images.githubusercontent.com/7827311/51761486-797b0280-20cd-11e9-93de-1eaf1ba64ff8.png">

### Test plan

https://snack.expo.io/ryjNEaO7E
