### PR TITLE
fix: makes icon load errors more informative

### DIFF
--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -10,6 +10,9 @@ try {
   // Optionally require vector-icons
   MaterialIcons = require('react-native-vector-icons/MaterialIcons').default;
 } catch (e) {
+  console.warn(`Error loading the icon '${name}' in a component from 'react-native-paper', but 'react-native-vector-icons' is not installed. To remove this warning, install 'react-native-vector-icons' or use another method to specify icon: https://callstack.github.io/react-native-paper/icons.html.`)
+  console.error(e)
+
   if (global.__expo && global.__expo.Icon && global.__expo.Icon.MaterialIcons) {
     // Snack doesn't properly bundle vector icons from subpath
     // Use icons from the __expo global if available
@@ -18,10 +21,6 @@ try {
     // Fallback component for icons
     MaterialIcons = ({ name, color, size, ...rest }) => {
       // eslint-disable-next-line no-console
-      console.warn(
-        `Tried to use the icon '${name}' in a component from 'react-native-paper', but 'react-native-vector-icons' is not installed. To remove this warning, install 'react-native-vector-icons' or use another method to specify icon: https://callstack.github.io/react-native-paper/icons.html.`
-      );
-
       return (
         <Text
           {...rest}

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -10,7 +10,6 @@ try {
   // Optionally require vector-icons
   MaterialIcons = require('react-native-vector-icons/MaterialIcons').default;
 } catch (e) {
-  console.warn(`Error loading the icon '${name}' in a component from 'react-native-paper', but 'react-native-vector-icons' is not installed. To remove this warning, install 'react-native-vector-icons' or use another method to specify icon: https://callstack.github.io/react-native-paper/icons.html.`)
   console.error(e)
 
   if (global.__expo && global.__expo.Icon && global.__expo.Icon.MaterialIcons) {
@@ -20,6 +19,10 @@ try {
   } else {
     // Fallback component for icons
     MaterialIcons = ({ name, color, size, ...rest }) => {
+      console.warn(		
+        `Tried to use the icon '${name}' in a component from 'react-native-paper', but 'react-native-vector-icons' is not installed. To remove this warning, install 'react-native-vector-icons' or use another method to specify icon: https://callstack.github.io/react-native-paper/icons.html.`		
+      );
+
       // eslint-disable-next-line no-console
       return (
         <Text

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -19,11 +19,11 @@ try {
   } else {
     // Fallback component for icons
     MaterialIcons = ({ name, color, size, ...rest }) => {
+      // eslint-disable-next-line no-console
       console.warn(		
         `Tried to use the icon '${name}' in a component from 'react-native-paper', but 'react-native-vector-icons' is not installed. To remove this warning, install 'react-native-vector-icons' or use another method to specify icon: https://callstack.github.io/react-native-paper/icons.html.`		
       );
 
-      // eslint-disable-next-line no-console
       return (
         <Text
           {...rest}

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -20,7 +20,7 @@ try {
     // Fallback component for icons
     MaterialIcons = ({ name, color, size, ...rest }) => {
       // eslint-disable-next-line no-console
-      console.warn(		
+      console.warn(
         `Tried to use the icon '${name}' in a component from 'react-native-paper', but 'react-native-vector-icons' is not installed. To remove this warning, install 'react-native-vector-icons' or use another method to specify icon: https://callstack.github.io/react-native-paper/icons.html.`		
       );
 

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -10,6 +10,7 @@ try {
   // Optionally require vector-icons
   MaterialIcons = require('react-native-vector-icons/MaterialIcons').default;
 } catch (e) {
+  // eslint-disable-next-line no-console
   console.error(e)
 
   if (global.__expo && global.__expo.Icon && global.__expo.Icon.MaterialIcons) {
@@ -21,7 +22,8 @@ try {
     MaterialIcons = ({ name, color, size, ...rest }) => {
       // eslint-disable-next-line no-console
       console.warn(
-        `Tried to use the icon '${name}' in a component from 'react-native-paper', but 'react-native-vector-icons' is not installed. To remove this warning, install 'react-native-vector-icons' or use another method to specify icon: https://callstack.github.io/react-native-paper/icons.html.`
+        `Tried to use the icon '${name}' in a component from 'react-native-paper', but 'react-native-vector-icons' could not be loaded.`,
+        `To remove this warning, try installing 'react-native-vector-icons' or use another method to specify icon: https://callstack.github.io/react-native-paper/icons.html.`		
       );
 
       return (

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -21,7 +21,7 @@ try {
     MaterialIcons = ({ name, color, size, ...rest }) => {
       // eslint-disable-next-line no-console
       console.warn(
-        `Tried to use the icon '${name}' in a component from 'react-native-paper', but 'react-native-vector-icons' is not installed. To remove this warning, install 'react-native-vector-icons' or use another method to specify icon: https://callstack.github.io/react-native-paper/icons.html.`		
+        `Tried to use the icon '${name}' in a component from 'react-native-paper', but 'react-native-vector-icons' is not installed. To remove this warning, install 'react-native-vector-icons' or use another method to specify icon: https://callstack.github.io/react-native-paper/icons.html.`
       );
 
       return (


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

The error messages from try block loading Icons were conditional and did not include the actual error. makes icon load errors more informative

### Test plan

don't install icons, so that you render the squares. look for error in console