### PR TITLE
fix: adjust gestures distance for iOS on example app

### DIFF
--- a/example/src/RootNavigator.native.js
+++ b/example/src/RootNavigator.native.js
@@ -37,6 +37,9 @@ export default createStackNavigator(
   },
   {
     navigationOptions: ({ navigation }) => ({
+      gestureResponseDistance: {
+        horizontal: 45,
+      },
       header: (
         <Appbar.Header>
           <Appbar.Action icon="menu" onPress={() => navigation.openDrawer()} />


### PR DESCRIPTION
### Motivation

Fixes #282 in example app. It gives extra space for gestures in `react-navigation`.
This is also a fix for the previous PR #754 

### Test plan

Open the example app, change screen and test the gestures in iOS.
