### PR TITLE
fix ToggleButton onPress

### DIFF
--- a/src/components/ToggleButton/ToggleButton.js
+++ b/src/components/ToggleButton/ToggleButton.js
@@ -126,9 +126,9 @@ class ToggleButton extends React.Component<Props> {
             <IconButton
               borderless={false}
               icon={icon}
-              onPress={() => {
+              onPress={(e) => {
                 if (this.props.onPress) {
-                  this.props.onPress(status);
+                  this.props.onPress(e);
                 }
 
                 if (context) {

--- a/src/components/ToggleButton/ToggleButton.js
+++ b/src/components/ToggleButton/ToggleButton.js
@@ -127,8 +127,8 @@ class ToggleButton extends React.Component<Props> {
               borderless={false}
               icon={icon}
               onPress={(e) => {
-                if (this.props.onPress) {
-                  this.props.onPress(e);
+                if (onPress) {
+                  onPress(e);
                 }
 
                 if (context) {

--- a/src/components/ToggleButton/ToggleButton.js
+++ b/src/components/ToggleButton/ToggleButton.js
@@ -101,6 +101,7 @@ class ToggleButton extends React.Component<Props> {
       style,
       value,
       status,
+      onPress,
       ...rest
     } = this.props;
     const borderRadius = theme.roundness;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

When using `ToggleButton` like this:
```js
<ToggleButton
    icon="update"
    status={jobSort === "recent" ? "checked" : "unchecked"}
    disabled={jobSort === "recent"}
    value={"recent"}
    onPress={value => {
        console.log(value);
    }}
/>
```
the output after pressing on button is `SyntheticEvent`.  Expected output should be the value either `checked` or `unchecked`.

### Test plan

When onPress prop is available, expect return value to be `checked || unchecked`.
