### PR TITLE
fix: fix path to ToggleButtonGroup component.

### DIFF
--- a/src/components/ToggleButton/ToggleButton.js
+++ b/src/components/ToggleButton/ToggleButton.js
@@ -88,7 +88,7 @@ type Props = {
  * ```
  */
 class ToggleButton extends React.Component<Props> {
-  // @component ./ToggleButton.js
+  // @component ./ToggleButtonGroup.js
   static Group = ToggleButtonGroup;
 
   render() {


### PR DESCRIPTION
Path to ToggleButtonGroup is wrong and that's why it's not displayed correctly in docs.
