### PR TITLE
Remove whitespace around icon selection

### DIFF
--- a/docs/pages/src/components/IconsList.js
+++ b/docs/pages/src/components/IconsList.js
@@ -102,7 +102,7 @@ export default class IconsList extends React.Component<{}, State> {
   _handleIconClick = (e: SyntheticEvent<HTMLButtonElement>) => {
     const range = document.createRange();
 
-    range.selectNode(e.currentTarget.childNodes[1]);
+    range.selectNode(e.currentTarget.childNodes[1].childNodes[0]);
 
     window.getSelection().removeAllRanges();
     window.getSelection().addRange(range);


### PR DESCRIPTION
### Motivation

On [docs/react-native-paper/icons](https://callstack.github.io/react-native-paper/icons.html), when I click on icon and copy this selection to clipboard it contains whitespace after.

Example:
```js
1  account-balance
2
```
The number represents lines in editor.

To prevent whitespace we can select the inner text node, which will result in trimmed string like this:
```js
1 account-balance
```


