### PR TITLE
Updated the color of the Label to match the background color. 

### DIFF
--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -510,6 +510,7 @@ class TextInput extends React.Component<Props, State> {
             style={[
               styles.outlinedLabelBackground,
               {
+                color: backgroundColor,
                 backgroundColor,
                 fontFamily,
                 fontSize: MINIMIZED_LABEL_FONT_SIZE,


### PR DESCRIPTION
Fixes the "shadow" problem in the issue #657

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->
The label on the outlined mode had a "shadow" like shown in the issue, caused by the "transparent" color of the font. I've set the color to the same as the background color of the label

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
I had the same problem as the issue in my application

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
