### PR TITLE
fix: optimize Avatar.Icon look

### DIFF
--- a/src/components/Avatar/AvatarIcon.js
+++ b/src/components/Avatar/AvatarIcon.js
@@ -77,7 +77,7 @@ class Avatar extends React.Component<Props> {
           restStyle,
         ]}
       >
-        <Icon source={icon} color={textColor} size={size / 2} />
+        <Icon source={icon} color={textColor} size={size * 0.75} />
       </View>
     );
   }

--- a/src/components/Avatar/AvatarIcon.js
+++ b/src/components/Avatar/AvatarIcon.js
@@ -77,7 +77,7 @@ class Avatar extends React.Component<Props> {
           restStyle,
         ]}
       >
-        <Icon source={icon} color={textColor} size={size * 0.75} />
+        <Icon source={icon} color={textColor} size={size * 0.6} />
       </View>
     );
   }

--- a/src/components/__tests__/__snapshots__/Avatar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Avatar.test.js.snap
@@ -27,7 +27,7 @@ exports[`renders avatar with icon 1`] = `
       Array [
         Object {
           "color": "#ffffff",
-          "fontSize": 32,
+          "fontSize": 48,
         },
         Array [
           Object {
@@ -82,7 +82,7 @@ exports[`renders avatar with icon and custom background color 1`] = `
       Array [
         Object {
           "color": "#ffffff",
-          "fontSize": 32,
+          "fontSize": 48,
         },
         Array [
           Object {

--- a/src/components/__tests__/__snapshots__/Avatar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Avatar.test.js.snap
@@ -27,7 +27,7 @@ exports[`renders avatar with icon 1`] = `
       Array [
         Object {
           "color": "#ffffff",
-          "fontSize": 48,
+          "fontSize": 38.4,
         },
         Array [
           Object {
@@ -82,7 +82,7 @@ exports[`renders avatar with icon and custom background color 1`] = `
       Array [
         Object {
           "color": "#ffffff",
-          "fontSize": 48,
+          "fontSize": 38.4,
         },
         Array [
           Object {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

The icons in `Avatar.Icon` look quite small if the size is high.

### Test plan

Before:
![image](https://user-images.githubusercontent.com/5358638/52340953-8a067380-2a11-11e9-847f-45d1e2f1fdf2.png)

After:
![image](https://user-images.githubusercontent.com/5358638/52340963-8ecb2780-2a11-11e9-8994-ec964402c553.png)

