### PR TITLE
Remove console.error from Icon.js

### DIFF
--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -10,9 +10,6 @@ try {
   // Optionally require vector-icons
   MaterialIcons = require('react-native-vector-icons/MaterialIcons').default;
 } catch (e) {
-  // eslint-disable-next-line no-console
-  console.error(e);
-
   if (global.__expo && global.__expo.Icon && global.__expo.Icon.MaterialIcons) {
     // Snack doesn't properly bundle vector icons from subpath
     // Use icons from the __expo global if available


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
the `console.error` looks like it was included in #769 by accident.
it causes a red error screen to popup in DEV mode.
![simulator screen shot - iphone 8 plus - 2019-02-06 at 16 38 24](https://user-images.githubusercontent.com/798942/52357537-3a827080-2a2e-11e9-82a1-dc7af507a846.png)

### Test plan
Use react-native-paper with https://github.com/satya164/babel-plugin-optional-require and check if red error screen is shown.
