### PR TITLE
fix: set number of lines to 1 in Card.Title

### DIFF
--- a/example/src/Examples/CardExample.js
+++ b/example/src/Examples/CardExample.js
@@ -53,7 +53,7 @@ class CardExample extends React.Component<Props> {
         </Card>
         <Card style={styles.card}>
           <Card.Title
-            title="Berries"
+            title="Berries that are trimmed at the end"
             subtitle="Omega Ruby"
             left={props => <Avatar.Icon {...props} icon="folder" />}
             right={props => (

--- a/src/components/Card/CardTitle.js
+++ b/src/components/Card/CardTitle.js
@@ -105,13 +105,20 @@ class CardTitle extends React.Component<Props> {
 
         <View style={[styles.titles]}>
           {title ? (
-            <Title style={[{ marginBottom: subtitle ? 0 : 2 }, titleStyle]}>
+            <Title
+              style={[
+                styles.title,
+                { marginBottom: subtitle ? 0 : 2 },
+                titleStyle,
+              ]}
+              numberOfLines={1}
+            >
               {title}
             </Title>
           ) : null}
 
           {subtitle ? (
-            <Caption style={[styles.subtitle, subtitleStyle]}>
+            <Caption style={[styles.subtitle, subtitleStyle]} numberOfLines={1}>
               {subtitle}
             </Caption>
           ) : null}
@@ -142,10 +149,15 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'column',
     justifyContent: 'center',
-    height: 40,
+    height: 50,
+  },
+
+  title: {
+    minHeight: 30,
   },
 
   subtitle: {
+    minHeight: 20,
     marginVertical: 0,
   },
 });


### PR DESCRIPTION
### Motivation

`Card.Title` breaks on web into multiples lines if the title is long enough. This fix sets `numberOfLines` to 1 but also sets a `minHeight` so letters are not cut at the bottom.

### Test plan

![image](https://user-images.githubusercontent.com/5358638/52415443-3f572b00-2ae7-11e9-9452-4a931d972a46.png)

