### PR TITLE
fix: Add SafeAreaView to FAB Group

### DIFF
--- a/src/components/FAB/FABGroup.js
+++ b/src/components/FAB/FABGroup.js
@@ -7,6 +7,7 @@ import {
   Animated,
   TouchableWithoutFeedback,
   StatusBar,
+  SafeAreaView,
 } from 'react-native';
 import { polyfill } from 'react-lifecycles-compat';
 import color from 'color';
@@ -246,80 +247,82 @@ class FABGroup extends React.Component<Props, State> {
             ]}
           />
         </TouchableWithoutFeedback>
-        <View pointerEvents={open ? 'box-none' : 'none'}>
-          {actions.map((it, i) => (
-            <View
-              key={i} // eslint-disable-line react/no-array-index-key
-              style={styles.item}
-              pointerEvents="box-none"
-            >
-              {it.label && (
-                <Card
+        <SafeAreaView pointerEvents="box-none" style={styles.safeArea}>
+          <View pointerEvents={open ? 'box-none' : 'none'}>
+            {actions.map((it, i) => (
+              <View
+                key={i} // eslint-disable-line react/no-array-index-key
+                style={styles.item}
+                pointerEvents="box-none"
+              >
+                {it.label && (
+                  <Card
+                    style={[
+                      styles.label,
+                      {
+                        transform: [{ scale: scales[i] }],
+                        opacity: opacities[i],
+                      },
+                    ]}
+                    onPress={() => {
+                      it.onPress();
+                      this._close();
+                    }}
+                    accessibilityLabel={
+                      it.accessibilityLabel !== 'undefined'
+                        ? it.accessibilityLabel
+                        : it.label
+                    }
+                    accessibilityTraits="button"
+                    accessibilityComponentType="button"
+                    accessibilityRole="button"
+                  >
+                    <Text style={{ color: labelColor }}>{it.label}</Text>
+                  </Card>
+                )}
+                <FAB
+                  small
+                  icon={it.icon}
+                  color={it.color}
                   style={[
-                    styles.label,
                     {
                       transform: [{ scale: scales[i] }],
                       opacity: opacities[i],
+                      backgroundColor: theme.colors.surface,
                     },
+                    it.style,
                   ]}
                   onPress={() => {
                     it.onPress();
                     this._close();
                   }}
                   accessibilityLabel={
-                    it.accessibilityLabel !== 'undefined'
+                    typeof it.accessibilityLabel !== 'undefined'
                       ? it.accessibilityLabel
                       : it.label
                   }
                   accessibilityTraits="button"
                   accessibilityComponentType="button"
                   accessibilityRole="button"
-                >
-                  <Text style={{ color: labelColor }}>{it.label}</Text>
-                </Card>
-              )}
-              <FAB
-                small
-                icon={it.icon}
-                color={it.color}
-                style={[
-                  {
-                    transform: [{ scale: scales[i] }],
-                    opacity: opacities[i],
-                    backgroundColor: theme.colors.surface,
-                  },
-                  it.style,
-                ]}
-                onPress={() => {
-                  it.onPress();
-                  this._close();
-                }}
-                accessibilityLabel={
-                  typeof it.accessibilityLabel !== 'undefined'
-                    ? it.accessibilityLabel
-                    : it.label
-                }
-                accessibilityTraits="button"
-                accessibilityComponentType="button"
-                accessibilityRole="button"
-              />
-            </View>
-          ))}
-        </View>
-        <FAB
-          onPress={() => {
-            onPress && onPress();
-            this._toggle();
-          }}
-          icon={icon}
-          color={this.props.color}
-          accessibilityLabel={accessibilityLabel}
-          accessibilityTraits="button"
-          accessibilityComponentType="button"
-          accessibilityRole="button"
-          style={[styles.fab, fabStyle]}
-          visible={visible}
-        />
+                />
+              </View>
+            ))}
+          </View>
+          <FAB
+            onPress={() => {
+              onPress && onPress();
+              this._toggle();
+            }}
+            icon={icon}
+            color={this.props.color}
+            accessibilityLabel={accessibilityLabel}
+            accessibilityTraits="button"
+            accessibilityComponentType="button"
+            accessibilityRole="button"
+            style={[styles.fab, fabStyle]}
+            visible={visible}
+          />
+        </SafeAreaView>
       </View>
     );
   }
@@ -330,9 +333,11 @@ polyfill(FABGroup);
 export default withTheme(FABGroup);
 
 const styles = StyleSheet.create({
+  safeArea: {
+    alignItems: 'flex-end',
+  },
   container: {
     ...StyleSheet.absoluteFillObject,
-    alignItems: 'flex-end',
     justifyContent: 'flex-end',
   },
   fab: {


### PR DESCRIPTION
FAB Group currently doesn't support SafeAreaView. It results in an inconsistent behavior between different phones when using a bottom navigation or such.

Since SafeAreaView is already there for components like Snackbar or BottomNavigation, it might be a good idea to add it here as well.

It's also not so obvious to handle it per project cause of the dark overlay that breaks when SafeAreaView applied outside the component. For now I've ended up using react-native-iphone-x-helper package for my local projects to apply different padding values when notch is there, so hopefully the PR provides a better solution.

Before:
![unadjustednonraw_thumb_b4a](https://user-images.githubusercontent.com/7827311/52528062-442d0200-2cd4-11e9-9110-3389eedfd306.jpg)

After:
![unadjustednonraw_thumb_b4b](https://user-images.githubusercontent.com/7827311/52528064-48591f80-2cd4-11e9-9a53-4ad3c201e370.jpg)
