### PR TITLE
fix: limit Dialog.ScrollArea height

### DIFF
--- a/example/src/Examples/Dialogs/DialogWithLongText.js
+++ b/example/src/Examples/Dialogs/DialogWithLongText.js
@@ -15,7 +15,7 @@ const DialogWithLongText = ({
     <Dialog
       onDismiss={close}
       visible={visible}
-      style={{ maxHeight: 0.9 * Dimensions.get('window').height }}
+      style={{ maxHeight: 0.6 * Dimensions.get('window').height }}
     >
       <Dialog.Title>Alert</Dialog.Title>
       <Dialog.ScrollArea style={{ paddingHorizontal: 0 }}>

--- a/example/src/Examples/Dialogs/DialogWithLongText.js
+++ b/example/src/Examples/Dialogs/DialogWithLongText.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import * as React from 'react';
-import { ScrollView } from 'react-native';
+import { Dimensions, ScrollView } from 'react-native';
 import { Paragraph, Button, Portal, Dialog } from 'react-native-paper';
 
 const DialogWithLongText = ({
@@ -12,12 +12,34 @@ const DialogWithLongText = ({
   close: Function,
 }) => (
   <Portal>
-    <Dialog onDismiss={close} visible={visible}>
+    <Dialog
+      onDismiss={close}
+      visible={visible}
+      style={{ maxHeight: 0.9 * Dimensions.get('window').height }}
+    >
       <Dialog.Title>Alert</Dialog.Title>
-      <Dialog.ScrollArea style={{ maxHeight: 220, paddingHorizontal: 0 }}>
+      <Dialog.ScrollArea style={{ paddingHorizontal: 0 }}>
         <ScrollView contentContainerStyle={{ paddingHorizontal: 24 }}>
           <Paragraph>
             Material is the metaphor
+            {'\n'}
+            {'\n'}A material metaphor is the unifying theory of a rationalized
+            space and a system of motion. The material is grounded in tactile
+            reality, inspired by the study of paper and ink, yet technologically
+            advanced and open to imagination and magic.
+            {'\n'}
+            {'\n'}
+            Surfaces and edges of the material provide visual cues that are
+            grounded in reality. The use of familiar tactile attributes helps
+            users quickly understand affordances. Yet the flexibility of the
+            material creates new affordances that supersede those in the
+            physical world, without breaking the rules of physics.
+            {'\n'}
+            {'\n'}
+            The fundamentals of light, surface, and movement are key to
+            conveying how objects move, interact, and exist in space and in
+            relation to each other. Realistic lighting shows seams, divides
+            space, and indicates moving parts.
             {'\n'}
             {'\n'}A material metaphor is the unifying theory of a rationalized
             space and a system of motion. The material is grounded in tactile

--- a/src/components/Dialog/DialogScrollArea.js
+++ b/src/components/Dialog/DialogScrollArea.js
@@ -64,6 +64,8 @@ const styles = StyleSheet.create({
     borderTopWidth: StyleSheet.hairlineWidth,
     borderBottomWidth: StyleSheet.hairlineWidth,
     paddingHorizontal: 24,
+    flexGrow: 1,
+    flexShrink: 1,
   },
 });
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

If you don't set `maxHeight` on the `DialogScrollArea` itself but instead on `Dialog` (which is mostly what you want) the content of the dialog takes too much space and the actions won't be visible anymore:
![image](https://user-images.githubusercontent.com/5358638/52570995-071c5900-2e15-11e9-9959-84c7c3eb73a0.png)

### Test plan

Open the example for the dialog with long text:
![image](https://user-images.githubusercontent.com/5358638/52571041-1ac7bf80-2e15-11e9-8643-a9afa9e66d14.png)

Tests on iDevice and web.