### PR TITLE
fix: automatically apply contentContainerStyle in Dialog.ScrollArea

### DIFF
--- a/example/src/Examples/Dialogs/DialogWithLongText.js
+++ b/example/src/Examples/Dialogs/DialogWithLongText.js
@@ -14,8 +14,8 @@ const DialogWithLongText = ({
   <Portal>
     <Dialog onDismiss={close} visible={visible}>
       <Dialog.Title>Alert</Dialog.Title>
-      <Dialog.ScrollArea style={{ maxHeight: 220, paddingHorizontal: 0 }}>
-        <ScrollView contentContainerStyle={{ paddingHorizontal: 24 }}>
+      <Dialog.ScrollArea style={{ maxHeight: 220 }}>
+        <ScrollView>
           <Paragraph>
             Material is the metaphor
             {'\n'}

--- a/example/src/Examples/Dialogs/DialogWithLongText.js
+++ b/example/src/Examples/Dialogs/DialogWithLongText.js
@@ -15,29 +15,31 @@ const DialogWithLongText = ({
     <Dialog onDismiss={close} visible={visible}>
       <Dialog.Title>Alert</Dialog.Title>
       <Dialog.ScrollArea style={{ maxHeight: 220 }}>
-        <ScrollView>
-          <Paragraph>
-            Material is the metaphor
-            {'\n'}
-            {'\n'}A material metaphor is the unifying theory of a rationalized
-            space and a system of motion. The material is grounded in tactile
-            reality, inspired by the study of paper and ink, yet technologically
-            advanced and open to imagination and magic.
-            {'\n'}
-            {'\n'}
-            Surfaces and edges of the material provide visual cues that are
-            grounded in reality. The use of familiar tactile attributes helps
-            users quickly understand affordances. Yet the flexibility of the
-            material creates new affordances that supersede those in the
-            physical world, without breaking the rules of physics.
-            {'\n'}
-            {'\n'}
-            The fundamentals of light, surface, and movement are key to
-            conveying how objects move, interact, and exist in space and in
-            relation to each other. Realistic lighting shows seams, divides
-            space, and indicates moving parts.
-          </Paragraph>
-        </ScrollView>
+        {scrollViewProps => (
+          <ScrollView {...scrollViewProps}>
+            <Paragraph>
+              Material is the metaphor
+              {'\n'}
+              {'\n'}A material metaphor is the unifying theory of a rationalized
+              space and a system of motion. The material is grounded in tactile
+              reality, inspired by the study of paper and ink, yet
+              technologically advanced and open to imagination and magic.
+              {'\n'}
+              {'\n'}
+              Surfaces and edges of the material provide visual cues that are
+              grounded in reality. The use of familiar tactile attributes helps
+              users quickly understand affordances. Yet the flexibility of the
+              material creates new affordances that supersede those in the
+              physical world, without breaking the rules of physics.
+              {'\n'}
+              {'\n'}
+              The fundamentals of light, surface, and movement are key to
+              conveying how objects move, interact, and exist in space and in
+              relation to each other. Realistic lighting shows seams, divides
+              space, and indicates moving parts.
+            </Paragraph>
+          </ScrollView>
+        )}
       </Dialog.ScrollArea>
       <Dialog.Actions>
         <Button onPress={close}>OK</Button>

--- a/example/src/Examples/Dialogs/DialogWithLongText.js
+++ b/example/src/Examples/Dialogs/DialogWithLongText.js
@@ -15,31 +15,29 @@ const DialogWithLongText = ({
     <Dialog onDismiss={close} visible={visible}>
       <Dialog.Title>Alert</Dialog.Title>
       <Dialog.ScrollArea style={{ maxHeight: 220 }}>
-        {scrollViewProps => (
-          <ScrollView {...scrollViewProps}>
-            <Paragraph>
-              Material is the metaphor
-              {'\n'}
-              {'\n'}A material metaphor is the unifying theory of a rationalized
-              space and a system of motion. The material is grounded in tactile
-              reality, inspired by the study of paper and ink, yet
-              technologically advanced and open to imagination and magic.
-              {'\n'}
-              {'\n'}
-              Surfaces and edges of the material provide visual cues that are
-              grounded in reality. The use of familiar tactile attributes helps
-              users quickly understand affordances. Yet the flexibility of the
-              material creates new affordances that supersede those in the
-              physical world, without breaking the rules of physics.
-              {'\n'}
-              {'\n'}
-              The fundamentals of light, surface, and movement are key to
-              conveying how objects move, interact, and exist in space and in
-              relation to each other. Realistic lighting shows seams, divides
-              space, and indicates moving parts.
-            </Paragraph>
-          </ScrollView>
-        )}
+        <ScrollView>
+          <Paragraph>
+            Material is the metaphor
+            {'\n'}
+            {'\n'}A material metaphor is the unifying theory of a rationalized
+            space and a system of motion. The material is grounded in tactile
+            reality, inspired by the study of paper and ink, yet technologically
+            advanced and open to imagination and magic.
+            {'\n'}
+            {'\n'}
+            Surfaces and edges of the material provide visual cues that are
+            grounded in reality. The use of familiar tactile attributes helps
+            users quickly understand affordances. Yet the flexibility of the
+            material creates new affordances that supersede those in the
+            physical world, without breaking the rules of physics.
+            {'\n'}
+            {'\n'}
+            The fundamentals of light, surface, and movement are key to
+            conveying how objects move, interact, and exist in space and in
+            relation to each other. Realistic lighting shows seams, divides
+            space, and indicates moving parts.
+          </Paragraph>
+        </ScrollView>
       </Dialog.ScrollArea>
       <Dialog.Actions>
         <Button onPress={close}>OK</Button>

--- a/example/src/Examples/Dialogs/DialogWithRadioBtns.js
+++ b/example/src/Examples/Dialogs/DialogWithRadioBtns.js
@@ -33,62 +33,70 @@ export default class extends React.Component<Props, State> {
         <Dialog onDismiss={close} visible={visible}>
           <Dialog.Title>Choose an option</Dialog.Title>
           <Dialog.ScrollArea style={{ maxHeight: 170 }}>
-            <ScrollView>
-              <View>
-                <TouchableRipple
-                  onPress={() => this.setState({ checked: 'normal' })}
-                >
-                  <View style={styles.row}>
-                    <View pointerEvents="none">
-                      <RadioButton
-                        value="normal"
-                        status={checked === 'normal' ? 'checked' : 'unchecked'}
-                      />
+            {scrollViewProps => (
+              <ScrollView {...scrollViewProps}>
+                <View>
+                  <TouchableRipple
+                    onPress={() => this.setState({ checked: 'normal' })}
+                  >
+                    <View style={styles.row}>
+                      <View pointerEvents="none">
+                        <RadioButton
+                          value="normal"
+                          status={
+                            checked === 'normal' ? 'checked' : 'unchecked'
+                          }
+                        />
+                      </View>
+                      <Subheading style={styles.text}>Option 1</Subheading>
                     </View>
-                    <Subheading style={styles.text}>Option 1</Subheading>
-                  </View>
-                </TouchableRipple>
-                <TouchableRipple
-                  onPress={() => this.setState({ checked: 'second' })}
-                >
-                  <View style={styles.row}>
-                    <View pointerEvents="none">
-                      <RadioButton
-                        value="second"
-                        status={checked === 'second' ? 'checked' : 'unchecked'}
-                      />
+                  </TouchableRipple>
+                  <TouchableRipple
+                    onPress={() => this.setState({ checked: 'second' })}
+                  >
+                    <View style={styles.row}>
+                      <View pointerEvents="none">
+                        <RadioButton
+                          value="second"
+                          status={
+                            checked === 'second' ? 'checked' : 'unchecked'
+                          }
+                        />
+                      </View>
+                      <Subheading style={styles.text}>Option 2</Subheading>
                     </View>
-                    <Subheading style={styles.text}>Option 2</Subheading>
-                  </View>
-                </TouchableRipple>
-                <TouchableRipple
-                  onPress={() => this.setState({ checked: 'third' })}
-                >
-                  <View style={styles.row}>
-                    <View pointerEvents="none">
-                      <RadioButton
-                        value="third"
-                        status={checked === 'third' ? 'checked' : 'unchecked'}
-                      />
+                  </TouchableRipple>
+                  <TouchableRipple
+                    onPress={() => this.setState({ checked: 'third' })}
+                  >
+                    <View style={styles.row}>
+                      <View pointerEvents="none">
+                        <RadioButton
+                          value="third"
+                          status={checked === 'third' ? 'checked' : 'unchecked'}
+                        />
+                      </View>
+                      <Subheading style={styles.text}>Option 3</Subheading>
                     </View>
-                    <Subheading style={styles.text}>Option 3</Subheading>
-                  </View>
-                </TouchableRipple>
-                <TouchableRipple
-                  onPress={() => this.setState({ checked: 'fourth' })}
-                >
-                  <View style={styles.row}>
-                    <View pointerEvents="none">
-                      <RadioButton
-                        value="fourth"
-                        status={checked === 'fourth' ? 'checked' : 'unchecked'}
-                      />
+                  </TouchableRipple>
+                  <TouchableRipple
+                    onPress={() => this.setState({ checked: 'fourth' })}
+                  >
+                    <View style={styles.row}>
+                      <View pointerEvents="none">
+                        <RadioButton
+                          value="fourth"
+                          status={
+                            checked === 'fourth' ? 'checked' : 'unchecked'
+                          }
+                        />
+                      </View>
+                      <Subheading style={styles.text}>Option 4</Subheading>
                     </View>
-                    <Subheading style={styles.text}>Option 4</Subheading>
-                  </View>
-                </TouchableRipple>
-              </View>
-            </ScrollView>
+                  </TouchableRipple>
+                </View>
+              </ScrollView>
+            )}
           </Dialog.ScrollArea>
           <Dialog.Actions>
             <Button onPress={close}>Cancel</Button>

--- a/example/src/Examples/Dialogs/DialogWithRadioBtns.js
+++ b/example/src/Examples/Dialogs/DialogWithRadioBtns.js
@@ -32,7 +32,7 @@ export default class extends React.Component<Props, State> {
       <Portal>
         <Dialog onDismiss={close} visible={visible}>
           <Dialog.Title>Choose an option</Dialog.Title>
-          <Dialog.ScrollArea style={{ maxHeight: 170, paddingHorizontal: 0 }}>
+          <Dialog.ScrollArea style={{ maxHeight: 170 }}>
             <ScrollView>
               <View>
                 <TouchableRipple

--- a/src/components/Dialog/DialogScrollArea.js
+++ b/src/components/Dialog/DialogScrollArea.js
@@ -3,11 +3,13 @@
 import * as React from 'react';
 import { View, StyleSheet } from 'react-native';
 
-type Props = React.ElementConfig<typeof View> & {
+type Props = {
   /**
    * Content of the `DialogScrollArea`.
    */
-  children: React.Node,
+  children: (scrollViewProps: {
+    contentContainerStyle: any,
+  }) => React.Node,
   style?: any,
 };
 
@@ -35,9 +37,11 @@ type Props = React.ElementConfig<typeof View> & {
  *           visible={this.state.visible}
  *           onDismiss={this._hideDialog}>
  *           <Dialog.ScrollArea>
- *             <ScrollView>
- *               This is a scrollable area
- *             </ScrollView>
+ *             {(scrollViewProps) =>
+ *               <ScrollView {...scrollViewProps}>
+ *                 This is a scrollable area
+ *               </ScrollView>
+ *             }
  *           </Dialog.ScrollArea>
  *         </Dialog>
  *       </Portal>
@@ -50,17 +54,13 @@ class DialogScrollArea extends React.Component<Props> {
   static displayName = 'Dialog.ScrollArea';
 
   render() {
+    const { children } = this.props;
+
     return (
       <View {...this.props} style={[styles.container, this.props.style]}>
-        {React.Children.map(this.props.children, child =>
-          React.cloneElement(child, {
-            ...child.props,
-            contentContainerStyle: [
-              styles.contentContainer,
-              child.props.contentContainerStyle,
-            ],
-          })
-        )}
+        {children({
+          contentContainerStyle: styles.contentContainer,
+        })}
       </View>
     );
   }
@@ -71,6 +71,8 @@ const styles = StyleSheet.create({
     borderColor: 'rgba(0, 0, 0, .12)',
     borderTopWidth: StyleSheet.hairlineWidth,
     borderBottomWidth: StyleSheet.hairlineWidth,
+    flexGrow: 1,
+    flexShrink: 1,
   },
 
   contentContainer: {

--- a/src/components/Dialog/DialogScrollArea.js
+++ b/src/components/Dialog/DialogScrollArea.js
@@ -7,9 +7,11 @@ type Props = {
   /**
    * Content of the `DialogScrollArea`.
    */
-  children: (scrollViewProps: {
-    contentContainerStyle: any,
-  }) => React.Node,
+  children:
+    | React.Node
+    | ((scrollViewProps: {
+        contentContainerStyle: any,
+      }) => React.Node),
   style?: any,
 };
 
@@ -58,9 +60,13 @@ class DialogScrollArea extends React.Component<Props> {
 
     return (
       <View {...this.props} style={[styles.container, this.props.style]}>
-        {children({
-          contentContainerStyle: styles.contentContainer,
-        })}
+        {typeof children === 'function' ? (
+          children({
+            contentContainerStyle: styles.contentContainer,
+          })
+        ) : (
+          <View style={styles.contentContainer}>{children}</View>
+        )}
       </View>
     );
   }

--- a/src/components/Dialog/DialogScrollArea.js
+++ b/src/components/Dialog/DialogScrollArea.js
@@ -35,7 +35,7 @@ type Props = React.ElementConfig<typeof View> & {
  *           visible={this.state.visible}
  *           onDismiss={this._hideDialog}>
  *           <Dialog.ScrollArea>
- *             <ScrollView contentContainerStyle={{ paddingHorizontal: 24 }}>
+ *             <ScrollView>
  *               This is a scrollable area
  *             </ScrollView>
  *           </Dialog.ScrollArea>
@@ -52,7 +52,15 @@ class DialogScrollArea extends React.Component<Props> {
   render() {
     return (
       <View {...this.props} style={[styles.container, this.props.style]}>
-        {this.props.children}
+        {React.Children.map(this.props.children, child =>
+          React.cloneElement(child, {
+            ...child.props,
+            contentContainerStyle: [
+              styles.contentContainer,
+              child.props.contentContainerStyle,
+            ],
+          })
+        )}
       </View>
     );
   }
@@ -63,6 +71,9 @@ const styles = StyleSheet.create({
     borderColor: 'rgba(0, 0, 0, .12)',
     borderTopWidth: StyleSheet.hairlineWidth,
     borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+
+  contentContainer: {
     paddingHorizontal: 24,
   },
 });

--- a/typings/components/Dialog.d.ts
+++ b/typings/components/Dialog.d.ts
@@ -10,7 +10,7 @@ interface DialogBaseProps {
 export interface DialogContentProps extends DialogBaseProps {}
 export interface DialogActionsProps extends DialogBaseProps {}
 export interface DialogScrollAreaProps {
-  children?: (scrollAreaProps: { contentContainerStyle: ViewStyle }) => React.ReactNode;
+  children?: React.ReactNode | ((scrollAreaProps: { contentContainerStyle: ViewStyle }) => React.ReactNode);
   style?: any; 
 }
 export interface DialogTitleProps extends DialogBaseProps {

--- a/typings/components/Dialog.d.ts
+++ b/typings/components/Dialog.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { ThemeShape } from '../types';
+import { ScrollViewProps } from 'react-native';
 
 interface DialogBaseProps {
   children: React.ReactNode;
@@ -8,7 +9,10 @@ interface DialogBaseProps {
 
 export interface DialogContentProps extends DialogBaseProps {}
 export interface DialogActionsProps extends DialogBaseProps {}
-export interface DialogScrollAreaProps extends DialogBaseProps {}
+export interface DialogScrollAreaProps {
+  children: React.ReactElement<ScrollViewProps>
+  style?: any; 
+}
 export interface DialogTitleProps extends DialogBaseProps {
   theme?: ThemeShape;
 }

--- a/typings/components/Dialog.d.ts
+++ b/typings/components/Dialog.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ThemeShape } from '../types';
-import { ScrollViewProps } from 'react-native';
+import { ScrollViewProps, ViewStyle } from 'react-native';
 
 interface DialogBaseProps {
   children: React.ReactNode;
@@ -10,7 +10,7 @@ interface DialogBaseProps {
 export interface DialogContentProps extends DialogBaseProps {}
 export interface DialogActionsProps extends DialogBaseProps {}
 export interface DialogScrollAreaProps {
-  children: React.ReactElement<ScrollViewProps>
+  children?: (scrollAreaProps: { contentContainerStyle: ViewStyle }) => React.ReactNode;
   style?: any; 
 }
 export interface DialogTitleProps extends DialogBaseProps {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

`Dialog.ScrollArea` is supposed to be a container for any scrollable content. Hence, it should be safe to assume that its child has a `contentContainerStyle` prop (see https://facebook.github.io/react-native/docs/scrollview#contentcontainerstyle). This change automatically applies the padding to the content instead of the wrapper. 

~~Since this is a breaking change I would suggest to introduce it with 3.0.~~ I changed the API so the behaviour is not breaking and still compatible to the current version.

### Test plan

Open dialog examples with scroll areas:
- "Show dialog with long text" shows how to use React nodes as children
- "Show dialog with radio buttons" shows to use a callback as children