### PR TITLE
fixed typings on Card.d.ts

### DIFF
--- a/typings/components/Card.d.ts
+++ b/typings/components/Card.d.ts
@@ -1,7 +1,9 @@
 import * as React from 'react';
-import { ImageProps, ViewProps } from 'react-native';
+
+import { ImageProps, StyleProp, TextStyle, ViewProps, ViewStyle } from 'react-native';
+import { StyledProps } from 'types/styled-components';
+
 import { ThemeShape } from '../types';
-import { AvatarIcon } from './Avatar';
 
 export interface CardContentProps extends ViewProps {
 }


### PR DESCRIPTION
Currently typescript definition of Card component (Card.d.ts) is missing required imports, and importing an inexistent type from Avatar causing typescript to return errors with the latest release. 
This PR aims to fix that issue by importing the required typings from react-native.

### Motivation
Solve typescript errors for projects that use it.

### Test plan

Simply run tsc on the project and the types should be proper now.