### PR TITLE
fix: update typescript types for button

### DIFF
--- a/typings/components/Button.d.ts
+++ b/typings/components/Button.d.ts
@@ -11,6 +11,7 @@ export interface ButtonProps extends TouchableRippleProps {
   loading?: boolean;
   style?: StyleProp<ViewStyle>;
   icon?: IconSource;
+  uppercase?: boolean;
   theme?: ThemeShape;
 }
 


### PR DESCRIPTION
Add uppercase property

### Motivation

Missing uppercase typescript definition property for button component.

### Test plan

N/A
