### PR TITLE
Add style overwrite for title and description for ListItem Component

### DIFF
--- a/src/components/List/ListItem.js
+++ b/src/components/List/ListItem.js
@@ -95,7 +95,7 @@ class ListItem extends React.Component<Props> {
           <View style={[styles.item, styles.content]} pointerEvents="none">
             <Text
               numberOfLines={1}
-              style={[styles.title, { color: titleColor }, style.title]}
+              style={[styles.title, { color: titleColor }, style.title || {}]}
             >
               {title}
             </Text>
@@ -107,7 +107,7 @@ class ListItem extends React.Component<Props> {
                   {
                     color: descriptionColor,
                   },
-                  style.description
+                  style.description || {},
                 ]}
               >
                 {description}

--- a/src/components/List/ListItem.js
+++ b/src/components/List/ListItem.js
@@ -95,7 +95,11 @@ class ListItem extends React.Component<Props> {
           <View style={[styles.item, styles.content]} pointerEvents="none">
             <Text
               numberOfLines={1}
-              style={[styles.title, { color: titleColor }, style && style.title? style.title : {}]}
+              style={[
+                 styles.title,
+                 { color: titleColor },
+                 style && style.title? style.title : {},
+               ]}
             >
               {title}
             </Text>

--- a/src/components/List/ListItem.js
+++ b/src/components/List/ListItem.js
@@ -96,10 +96,10 @@ class ListItem extends React.Component<Props> {
             <Text
               numberOfLines={1}
               style={[
-                 styles.title,
-                 { color: titleColor },
-                 style && style.title? style.title : {},
-               ]}
+                styles.title,
+                { color: titleColor },
+                style && style.title ? style.title : {},
+              ]}
             >
               {title}
             </Text>
@@ -111,7 +111,7 @@ class ListItem extends React.Component<Props> {
                   {
                     color: descriptionColor,
                   },
-                  style && style.description? style.description : {},
+                  style && style.description ? style.description : {},
                 ]}
               >
                 {description}

--- a/src/components/List/ListItem.js
+++ b/src/components/List/ListItem.js
@@ -95,7 +95,7 @@ class ListItem extends React.Component<Props> {
           <View style={[styles.item, styles.content]} pointerEvents="none">
             <Text
               numberOfLines={1}
-              style={[styles.title, { color: titleColor }, style.title || {}]}
+              style={[styles.title, { color: titleColor }, style && style.title? style.title : {}]}
             >
               {title}
             </Text>
@@ -107,7 +107,7 @@ class ListItem extends React.Component<Props> {
                   {
                     color: descriptionColor,
                   },
-                  style.description || {},
+                  style && style.description? style.description : {},
                 ]}
               >
                 {description}

--- a/src/components/List/ListItem.js
+++ b/src/components/List/ListItem.js
@@ -95,7 +95,7 @@ class ListItem extends React.Component<Props> {
           <View style={[styles.item, styles.content]} pointerEvents="none">
             <Text
               numberOfLines={1}
-              style={[styles.title, { color: titleColor }]}
+              style={[styles.title, { color: titleColor }, style.title]}
             >
               {title}
             </Text>
@@ -107,6 +107,7 @@ class ListItem extends React.Component<Props> {
                   {
                     color: descriptionColor,
                   },
+                  style.description
                 ]}
               >
                 {description}


### PR DESCRIPTION
### Motivation

I wanted to be able to change the color of the title/description independently of each other.

An alternative would be to use two different theme colors for title and description rather than having both use 'text', but I would like to be able to control the opacity so my solution allows you to be able to change other aspects besides color

My use case: Want title to be color #041F41 without opacity, but description to black with opacity  Currently, changing the 'text' theme to #041F41 creates a hard to read description.

### Test plan

```jsx
import { List } from "react-native-paper";

const listItem = () => (<List.Item
    title="Title"
    description="Description"
    style = {{
      title: {
        color:'#041F41'
      },
      description: {
        color:'#000000'
      },
    }}
  />)
