### PR TITLE
added 'transitionDuration' prop to Modal and Dialog components

### DIFF
--- a/src/components/Dialog/Dialog.js
+++ b/src/components/Dialog/Dialog.js
@@ -24,6 +24,10 @@ type Props = {|
    */
   visible: boolean,
   /**
+   * Duration of the Dialog transition.
+   */
+  transitionDuration: number | {enter: number, exit: number},
+  /**
    * Content of the `Dialog`.
    */
   children: React.Node,
@@ -102,6 +106,7 @@ class Dialog extends React.Component<Props, void> {
       dismissable,
       onDismiss,
       visible,
+      transitionDuration,
       style,
       theme,
     } = this.props;
@@ -111,6 +116,7 @@ class Dialog extends React.Component<Props, void> {
         dismissable={dismissable}
         onDismiss={onDismiss}
         visible={visible}
+        transitionDuration={transitionDuration}
         contentContainerStyle={[
           {
             borderRadius: theme.roundness,

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -13,6 +13,7 @@ import { polyfill } from 'react-lifecycles-compat';
 import Surface from './Surface';
 import { withTheme } from '../core/theming';
 import type { Theme } from '../types';
+import {oneOf, oneOfType} from "prop-types";
 
 type Props = {|
   /**
@@ -27,6 +28,10 @@ type Props = {|
    * Determines Whether the modal is visible.
    */
   visible: boolean,
+  /**
+   * Duration of the Modal transition.
+   */
+  transitionDuration: number | {enter: number, exit: number},
   /**
    * Content of the `Modal`.
    */
@@ -81,6 +86,7 @@ class Modal extends React.Component<Props, State> {
   static defaultProps = {
     dismissable: true,
     visible: false,
+    transitionDuration: 280
   };
 
   static getDerivedStateFromProps(nextProps: Props, prevState: State) {
@@ -116,24 +122,23 @@ class Modal extends React.Component<Props, State> {
   };
 
   _showModal = () => {
+    const {transitionDuration} = this.props;
     BackHandler.addEventListener('hardwareBackPress', this._handleBack);
     Animated.timing(this.state.opacity, {
       toValue: 1,
-      duration: 280,
+      duration: isNaN(transitionDuration) ? transitionDuration.enter : transitionDuration,
       easing: Easing.ease,
     }).start();
   };
 
   _hideModal = () => {
+    const {transitionDuration} = this.props;
     BackHandler.removeEventListener('hardwareBackPress', this._handleBack);
     Animated.timing(this.state.opacity, {
       toValue: 0,
-      duration: 280,
+      duration: isNaN(transitionDuration) ? transitionDuration.exit : transitionDuration,
       easing: Easing.ease,
-    }).start(({ finished }) => {
-      if (!finished) {
-        return;
-      }
+    }).start(() => {
       if (this.props.visible && this.props.onDismiss) {
         this.props.onDismiss();
       }
@@ -148,6 +153,7 @@ class Modal extends React.Component<Props, State> {
   };
 
   render() {
+    console.log(this.props.transitionDuration)
     if (!this.state.rendered) return null;
 
     const { children, dismissable, theme, contentContainerStyle } = this.props;

--- a/typings/components/Dialog.d.ts
+++ b/typings/components/Dialog.d.ts
@@ -17,6 +17,7 @@ export interface DialogProps {
   dismissable?: boolean;
   onDismiss: () => any;
   visible: boolean;
+  transitionDuration: number | {enter: number, exit: number},
   children: React.ReactNode;
   style?: any;
   theme?: ThemeShape;

--- a/typings/components/Modal.d.ts
+++ b/typings/components/Modal.d.ts
@@ -5,6 +5,7 @@ export interface ModalProps {
   dismissable?: boolean;
   onDismiss: () => any;
   visible: boolean;
+  transitionDuration: number | {enter: number, exit: number},
   children: React.ReactNode;
   theme?: ThemeShape;
 }


### PR DESCRIPTION
### Motivation

Modal and Dialog components have too long fadeIn/fadeOiut animations (for me).

### Test plan

1. You can add transitionDuration to Modal or Dialog component.
2. transitionDuration prop accept number (in this case, both fadeIn/fadeOut animation will use this timing)
3. transitionDuration prop accept object: {enter: number, exit: number}