### PR TITLE
Improve OutlinedInput on the web

### DIFF
--- a/example/public/index.html
+++ b/example/public/index.html
@@ -10,7 +10,9 @@
     html, body, #root {
       height: 100%;
     }
-
+    input:focus,textarea:focus{
+      outline:none;
+    }
     #root {
       display: flex;
       flex-direction: column;

--- a/example/src/Examples/TextInputExample.js
+++ b/example/src/Examples/TextInputExample.js
@@ -87,6 +87,29 @@ class TextInputExample extends React.Component<Props, State> {
               Error: Only letters are allowed
             </HelperText>
           </View>
+          <TextInput
+            // name="email"
+            // autoComplete="email"
+            // type="email"
+            keyboardType="email-address"
+            autoCapitalize="none"
+            textContentType="username"
+            style={styles.inputContainerStyle}
+            label="Flat autocomplete"
+            placeholder="Type something"
+          />
+          <TextInput
+            // name="email"
+            // autoComplete="email"
+            // type="email"
+            keyboardType="email-address"
+            autoCapitalize="none"
+            textContentType="username"
+            mode="outlined"
+            style={styles.inputContainerStyle}
+            label="Outlined autocomplete"
+            placeholder="Type something"
+          />
         </ScrollView>
       </KeyboardAvoidingView>
     );

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -58,4 +58,14 @@ module.exports = {
     contentBase: [path.join(__dirname, 'public')],
     historyApiFallback: true,
   },
+  resolve: {
+    // This will only alias the exact import "react-native"
+    alias: {
+      'react-native$': 'react-native-web',
+    },
+    // If you're working on a multi-platform React Native app, web-specific
+    // module implementations should be written in files using the extension
+    // `.web.js`.
+    extensions: ['.web.js', '.js'],
+  },
 };

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   },
   "husky": {
     "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -99,8 +99,7 @@
   },
   "husky": {
     "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "yarn lint && yarn flow check && yarn typescript && yarn test"
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   },
   "husky": {
     "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
     }
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
   },
   "husky": {
     "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+      "pre-commit": "yarn lint && yarn flow check && yarn typescript && yarn test"
     }
   },
   "jest": {

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -246,7 +246,7 @@ class Button extends React.Component<Props, State> {
           accessibilityStates={disabled ? ['disabled'] : undefined}
           disabled={disabled}
           rippleColor={rippleColor}
-          style={touchableStyle}
+          style={[styles.touchable, touchableStyle]}
         >
           <View style={[styles.content, contentStyle]}>
             {icon && loading !== true ? (
@@ -289,6 +289,10 @@ const styles = StyleSheet.create({
   button: {
     minWidth: 64,
     borderStyle: 'solid',
+  },
+  touchable: {
+    width: '100%',
+    flex: 1,
   },
   compact: {
     minWidth: 'auto',

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -12,6 +12,7 @@ import { polyfill } from 'react-lifecycles-compat';
 import color from 'color';
 import Text from './Typography/Text';
 import { withTheme } from '../core/theming';
+import TextInputOutlinedLabel from './TextInputOutlinedLabel';
 import type { Theme } from '../types';
 
 const AnimatedText = Animated.createAnimatedComponent(Text);
@@ -75,6 +76,7 @@ type Props = React.ElementConfig<typeof NativeTextInput> & {|
    * Selection color of the input
    */
   selectionColor?: string,
+
   /**
    * Underline color of the input.
    */
@@ -505,53 +507,13 @@ class TextInput extends React.Component<Props, State> {
           // Render the outline separately from the container
           // This is so that the label can overlap the outline
           // Otherwise the border will cut off the label on Android
-          <View
-            pointerEvents="none"
-            style={[
-              styles.outline,
-              {
-                borderRadius: theme.roundness,
-                borderWidth: hasActiveOutline ? 2 : 1,
-                borderColor: hasActiveOutline ? activeColor : outlineColor,
-              },
-            ]}
+          <TextInputOutlinedLabel
+            label={label}
+            labeled={this.state.labeled}
+            backgroundColor={backgroundColor}
+            borderWidth={hasActiveOutline ? 2 : 1}
+            borderColor={hasActiveOutline ? activeColor : outlineColor}
           />
-        ) : null}
-
-        {mode === 'outlined' && label ? (
-          // When mode == 'outlined', the input label stays on top of the outline
-          // The background of the label covers the outline so it looks cut off
-          // To achieve the effect, we position the actual label with a background on top of it
-          // We set the color of the text to transparent so only the background is visible
-          <AnimatedText
-            pointerEvents="none"
-            style={[
-              styles.outlinedLabelBackground,
-              {
-                backgroundColor,
-                fontFamily,
-                fontSize: MINIMIZED_LABEL_FONT_SIZE,
-                // Hide the background when scale will be 0
-                // There's a bug in RN which makes scale: 0 act weird
-                opacity: this.state.labeled.interpolate({
-                  inputRange: [0, 0.9, 1],
-                  outputRange: [1, 1, 0],
-                }),
-                transform: [
-                  {
-                    // Animate the scale when label is moved up
-                    scaleX: this.state.labeled.interpolate({
-                      inputRange: [0, 1],
-                      outputRange: [1, 0],
-                    }),
-                  },
-                ],
-              },
-            ]}
-            numberOfLines={1}
-          >
-            {label}
-          </AnimatedText>
         ) : null}
 
         {mode === 'flat' ? (
@@ -655,6 +617,9 @@ class TextInput extends React.Component<Props, State> {
           multiline,
           style: [
             styles.input,
+            mode === 'outlined' && {
+              borderRadius: theme.roundness,
+            },
             mode === 'outlined'
               ? styles.inputOutlined
               : this.props.label
@@ -696,20 +661,7 @@ const styles = StyleSheet.create({
     bottom: 0,
     height: 2,
   },
-  outline: {
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    top: 6,
-    bottom: 0,
-  },
-  outlinedLabelBackground: {
-    position: 'absolute',
-    top: 0,
-    left: 8,
-    paddingHorizontal: 4,
-    color: 'transparent',
-  },
+
   input: {
     flexGrow: 1,
     paddingHorizontal: 12,
@@ -722,7 +674,8 @@ const styles = StyleSheet.create({
   inputOutlined: {
     paddingTop: 20,
     paddingBottom: 16,
-    minHeight: 64,
+    minHeight: 58,
+    marginTop: 6,
   },
   inputFlatWithLabel: {
     paddingTop: 24,

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -669,7 +669,6 @@ const styles = StyleSheet.create({
     margin: 0,
     minHeight: 58,
     textAlign: I18nManager.isRTL ? 'right' : 'left',
-    zIndex: 1,
   },
   inputOutlined: {
     paddingTop: 20,

--- a/src/components/TextInputOutlinedLabel.js
+++ b/src/components/TextInputOutlinedLabel.js
@@ -55,8 +55,9 @@ class TextInputOutlinedLabel extends React.Component<Props> {
     const { fonts } = theme;
     const fontFamily = fonts.regular;
 
-    return (
+    return [
       <View
+        key="background"
         pointerEvents="none"
         style={[
           styles.outline,
@@ -66,44 +67,44 @@ class TextInputOutlinedLabel extends React.Component<Props> {
             borderColor,
           },
         ]}
-      >
-        {label ? (
-          // When mode == 'outlined', the input label stays on top of the outline
-          // The background of the label covers the outline so it looks cut off
-          // To achieve the effect, we position the actual label with a background on top of it
-          // We set the color of the text to transparent so only the background is visible
-          <AnimatedText
-            pointerEvents="none"
-            style={[
-              styles.outlinedLabelBackground,
-              {
-                backgroundColor,
-                fontFamily,
-                fontSize: MINIMIZED_LABEL_FONT_SIZE,
-                // Hide the background when scale will be 0
-                // There's a bug in RN which makes scale: 0 act weird
-                opacity: labeled.interpolate({
-                  inputRange: [0, 0.9, 1],
-                  outputRange: [1, 1, 0],
-                }),
-                transform: [
-                  {
-                    // Animate the scale when label is moved up
-                    scaleX: labeled.interpolate({
-                      inputRange: [0, 1],
-                      outputRange: [1, 0],
-                    }),
-                  },
-                ],
-              },
-            ]}
-            numberOfLines={1}
-          >
-            {label}
-          </AnimatedText>
-        ) : null}
-      </View>
-    );
+      />,
+      label && (
+        // When mode == 'outlined', the input label stays on top of the outline
+        // The background of the label covers the outline so it looks cut off
+        // To achieve the effect, we position the actual label with a background on top of it
+        // We set the color of the text to transparent so only the background is visible
+        <AnimatedText
+          key="label-text"
+          pointerEvents="none"
+          style={[
+            styles.outlinedLabelBackground,
+            {
+              backgroundColor,
+              fontFamily,
+              fontSize: MINIMIZED_LABEL_FONT_SIZE,
+              // Hide the background when scale will be 0
+              // There's a bug in RN which makes scale: 0 act weird
+              opacity: labeled.interpolate({
+                inputRange: [0, 0.9, 1],
+                outputRange: [1, 1, 0],
+              }),
+              transform: [
+                {
+                  // Animate the scale when label is moved up
+                  scaleX: labeled.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [1, 0],
+                  }),
+                },
+              ],
+            },
+          ]}
+          numberOfLines={1}
+        >
+          {label}
+        </AnimatedText>
+      ),
+    ];
   }
 }
 
@@ -116,13 +117,13 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: 0,
     right: 0,
-    top: 0,
+    top: 6,
     bottom: 0,
   },
   outlinedLabelBackground: {
-    // position: 'absolute',
+    position: 'absolute',
     top: 0,
-    marginLeft: 8,
+    left: 8,
     paddingHorizontal: 4,
     color: 'transparent',
   },

--- a/src/components/TextInputOutlinedLabel.js
+++ b/src/components/TextInputOutlinedLabel.js
@@ -1,0 +1,129 @@
+/* @flow */
+
+import * as React from 'react';
+import { View, Animated, StyleSheet } from 'react-native';
+import { polyfill } from 'react-lifecycles-compat';
+
+import Text from './Typography/Text';
+import { withTheme } from '../core/theming';
+import type { Theme } from '../types';
+
+const AnimatedText = Animated.createAnimatedComponent(Text);
+
+const MINIMIZED_LABEL_FONT_SIZE = 12;
+
+type Props = React.ElementConfig<typeof View> & {|
+  /**
+   * Labeled will be used to animate the border removed
+   */
+  labeled: Animated.Value,
+  /**
+   * Label of the input to calculate which part of outline will be removed
+   */
+  label?: string,
+  /**
+   * The color of border remover (will be placed above border)
+   */
+  backgroundColor?: null | string,
+  /**
+   * The color of border around the input.
+   */
+  borderColor?: null | string,
+  /**
+   * The width of the border around the input.
+   */
+  borderWidth?: number,
+  /**
+   * @optional
+   */
+  theme: Theme,
+|};
+
+class TextInputOutlinedLabel extends React.Component<Props> {
+  static defaultProps = {};
+
+  render() {
+    const {
+      theme,
+      label,
+      labeled,
+      backgroundColor,
+      borderWidth,
+      borderColor,
+    } = this.props;
+
+    const { fonts } = theme;
+    const fontFamily = fonts.regular;
+
+    return (
+      <View
+        pointerEvents="none"
+        style={[
+          styles.outline,
+          {
+            borderRadius: theme.roundness,
+            borderWidth,
+            borderColor,
+          },
+        ]}
+      >
+        {label ? (
+          // When mode == 'outlined', the input label stays on top of the outline
+          // The background of the label covers the outline so it looks cut off
+          // To achieve the effect, we position the actual label with a background on top of it
+          // We set the color of the text to transparent so only the background is visible
+          <AnimatedText
+            pointerEvents="none"
+            style={[
+              styles.outlinedLabelBackground,
+              {
+                backgroundColor,
+                fontFamily,
+                fontSize: MINIMIZED_LABEL_FONT_SIZE,
+                // Hide the background when scale will be 0
+                // There's a bug in RN which makes scale: 0 act weird
+                opacity: labeled.interpolate({
+                  inputRange: [0, 0.9, 1],
+                  outputRange: [1, 1, 0],
+                }),
+                transform: [
+                  {
+                    // Animate the scale when label is moved up
+                    scaleX: labeled.interpolate({
+                      inputRange: [0, 1],
+                      outputRange: [1, 0],
+                    }),
+                  },
+                ],
+              },
+            ]}
+            numberOfLines={1}
+          >
+            {label}
+          </AnimatedText>
+        ) : null}
+      </View>
+    );
+  }
+}
+
+polyfill(TextInputOutlinedLabel);
+
+export default withTheme(TextInputOutlinedLabel);
+
+const styles = StyleSheet.create({
+  outline: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+  },
+  outlinedLabelBackground: {
+    // position: 'absolute',
+    top: 0,
+    marginLeft: 8,
+    paddingHorizontal: 4,
+    color: 'transparent',
+  },
+});

--- a/src/components/TextInputOutlinedLabel.web.js
+++ b/src/components/TextInputOutlinedLabel.web.js
@@ -1,0 +1,146 @@
+/* @flow */
+
+import * as React from 'react';
+//  We import createElement wich does not exist in react-native but does in
+//  react-native-web
+//  $FlowFixMe
+import { createElement, View, Animated, StyleSheet } from 'react-native';
+import { polyfill } from 'react-lifecycles-compat';
+
+import { withTheme } from '../core/theming';
+import type { Theme } from '../types';
+
+//  We use a legend web versions because we don't need a background
+//  to remove the border so it fixes autocomplete issues
+
+const MINIMIZED_LABEL_FONT_SIZE = 12;
+
+type Props = React.ElementConfig<typeof View> & {|
+  /**
+   * Labeled will be used to animate the border removed
+   */
+  labeled: Animated.Value,
+  /**
+   * Label of the input to calculate which part of outline will be removed
+   */
+  label?: string,
+  /**
+   * The color of border around the input.
+   */
+  borderColor?: null | string,
+  /**
+   * The width of the border around the input.
+   */
+  borderWidth?: number,
+  /**
+   * @optional
+   */
+  theme: Theme,
+|};
+
+class TextInputOutlinedLabel extends React.Component<Props> {
+  static defaultProps = {};
+
+  render() {
+    const { theme, label, labeled, borderWidth, borderColor } = this.props;
+
+    const { fonts } = theme;
+    const fontFamily = fonts.regular;
+
+    return (
+      <Fieldset
+        pointerEvents="none"
+        style={[
+          styles.outline,
+          {
+            borderRadius: theme.roundness,
+            borderWidth,
+            borderColor,
+          },
+        ]}
+      >
+        {label ? (
+          // When mode == 'outlined', the input label stays on top of the outline
+          // The background of the label covers the outline so it looks cut off
+          // To achieve the effect, we position the actual label with a background on top of it
+          // We set the color of the text to transparent so only the background is visible
+          <AnimatedText
+            pointerEvents="none"
+            style={[
+              styles.outlinedLabelBackground,
+              {
+                fontFamily,
+                fontSize: MINIMIZED_LABEL_FONT_SIZE,
+                maxWidth: labeled.interpolate({
+                  inputRange: [0, 1],
+                  outputRange: ['100%', '0%'],
+                }),
+                paddingRight: labeled.interpolate({
+                  inputRange: [0, 1],
+                  outputRange: [6, 0],
+                }),
+                paddingLeft: labeled.interpolate({
+                  inputRange: [0, 1],
+                  outputRange: [6, 0],
+                }),
+                // Hide the background when scale will be 0
+                // There's a bug in RN which makes scale: 0 act weird
+                opacity: labeled.interpolate({
+                  inputRange: [0, 0.9, 1],
+                  outputRange: [1, 1, 0],
+                }),
+                transform: [
+                  {
+                    // Animate the scale when label is moved up
+                    scaleX: labeled.interpolate({
+                      inputRange: [0, 1],
+                      outputRange: [1, 0],
+                    }),
+                  },
+                ],
+              },
+            ]}
+            numberOfLines={1}
+          >
+            {label}
+          </AnimatedText>
+        ) : null}
+      </Fieldset>
+    );
+  }
+}
+
+polyfill(TextInputOutlinedLabel);
+
+export default withTheme(TextInputOutlinedLabel);
+
+const styles = StyleSheet.create({
+  outline: {
+    position: 'absolute',
+    bottom: 0,
+    right: 0,
+    top: 0,
+    left: 0,
+    margin: 0,
+    padding: 0,
+    paddingLeft: 6,
+  },
+  outlinedLabelBackground: {
+    color: 'transparent',
+    textAlign: 'left',
+    padding: 0,
+    overflow: 'hidden',
+    height: 11,
+    lineHeight: 11,
+  },
+});
+
+const Fieldset = props => createElement('fieldset', props);
+//  eslint-disable-next-line
+class Legend extends React.Component<Props> {
+  render() {
+    return createElement('legend', this.props);
+  }
+}
+//  eslint-disable-next-line
+const AnimatedText = Animated.createAnimatedComponent(Legend);

--- a/src/components/__tests__/__snapshots__/Banner.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.js.snap
@@ -205,9 +205,15 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              Object {
-                "borderRadius": 4,
-              },
+              Array [
+                Object {
+                  "flex": 1,
+                  "width": "100%",
+                },
+                Object {
+                  "borderRadius": 4,
+                },
+              ],
             ]
           }
         >
@@ -366,9 +372,15 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              Object {
-                "borderRadius": 4,
-              },
+              Array [
+                Object {
+                  "flex": 1,
+                  "width": "100%",
+                },
+                Object {
+                  "borderRadius": 4,
+                },
+              ],
             ]
           }
         >
@@ -456,9 +468,15 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              Object {
-                "borderRadius": 4,
-              },
+              Array [
+                Object {
+                  "flex": 1,
+                  "width": "100%",
+                },
+                Object {
+                  "borderRadius": 4,
+                },
+              ],
             ]
           }
         >

--- a/src/components/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.js.snap
@@ -36,9 +36,15 @@ exports[`renders button with color 1`] = `
         Object {
           "overflow": "hidden",
         },
-        Object {
-          "borderRadius": 4,
-        },
+        Array [
+          Object {
+            "flex": 1,
+            "width": "100%",
+          },
+          Object {
+            "borderRadius": 4,
+          },
+        ],
       ]
     }
   >
@@ -126,9 +132,15 @@ exports[`renders button with icon 1`] = `
         Object {
           "overflow": "hidden",
         },
-        Object {
-          "borderRadius": 4,
-        },
+        Array [
+          Object {
+            "flex": 1,
+            "width": "100%",
+          },
+          Object {
+            "borderRadius": 4,
+          },
+        ],
       ]
     }
   >
@@ -260,9 +272,15 @@ exports[`renders contained contained with mode 1`] = `
         Object {
           "overflow": "hidden",
         },
-        Object {
-          "borderRadius": 4,
-        },
+        Array [
+          Object {
+            "flex": 1,
+            "width": "100%",
+          },
+          Object {
+            "borderRadius": 4,
+          },
+        ],
       ]
     }
   >
@@ -348,9 +366,15 @@ exports[`renders disabled button 1`] = `
         Object {
           "overflow": "hidden",
         },
-        Object {
-          "borderRadius": 4,
-        },
+        Array [
+          Object {
+            "flex": 1,
+            "width": "100%",
+          },
+          Object {
+            "borderRadius": 4,
+          },
+        ],
       ]
     }
   >
@@ -438,9 +462,15 @@ exports[`renders loading button 1`] = `
         Object {
           "overflow": "hidden",
         },
-        Object {
-          "borderRadius": 4,
-        },
+        Array [
+          Object {
+            "flex": 1,
+            "width": "100%",
+          },
+          Object {
+            "borderRadius": 4,
+          },
+        ],
       ]
     }
   >
@@ -541,9 +571,15 @@ exports[`renders outlined button with mode 1`] = `
         Object {
           "overflow": "hidden",
         },
-        Object {
-          "borderRadius": 4,
-        },
+        Array [
+          Object {
+            "flex": 1,
+            "width": "100%",
+          },
+          Object {
+            "borderRadius": 4,
+          },
+        ],
       ]
     }
   >
@@ -631,9 +667,15 @@ exports[`renders text button by default 1`] = `
         Object {
           "overflow": "hidden",
         },
-        Object {
-          "borderRadius": 4,
-        },
+        Array [
+          Object {
+            "flex": 1,
+            "width": "100%",
+          },
+          Object {
+            "borderRadius": 4,
+          },
+        ],
       ]
     }
   >
@@ -721,9 +763,15 @@ exports[`renders text button with mode 1`] = `
         Object {
           "overflow": "hidden",
         },
-        Object {
-          "borderRadius": 4,
-        },
+        Array [
+          Object {
+            "flex": 1,
+            "width": "100%",
+          },
+          Object {
+            "borderRadius": 4,
+          },
+        ],
       ]
     }
   >

--- a/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
@@ -175,9 +175,15 @@ exports[`renders snackbar with action button 1`] = `
             Object {
               "overflow": "hidden",
             },
-            Object {
-              "borderRadius": 4,
-            },
+            Array [
+              Object {
+                "flex": 1,
+                "width": "100%",
+              },
+              Object {
+                "borderRadius": 4,
+              },
+            ],
           ]
         }
       >


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Autocomplete was rendered above the input + it was too big so it showed above the outline.
![schermafbeelding 2019-03-02 om 16 47 42](https://user-images.githubusercontent.com/6492229/53684430-98dcff00-3d0d-11e9-94e8-2e6e8aaff8b7.png)

I have changed the height of the input so the auto fill does not overlap the input.
On the web I make use of the fieldset and label the remove border on the outline.
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset#Example
This approach is also used by Material-UI.
https://material-ui.com/

### Test plan

WEB:
![schermafbeelding 2019-03-02 om 17 07 24](https://user-images.githubusercontent.com/6492229/53684442-b14d1980-3d0d-11e9-813b-1ab297ed52f8.png)

ANDROID:
![b9bb3bf1-be37-404d-b9be-4756ddb17686](https://user-images.githubusercontent.com/6492229/53684458-e9ecf300-3d0d-11e9-8607-a0b8805a5f6b.jpeg)

