### PR TITLE
Give user the option to change input style in searchbar

### DIFF
--- a/src/components/Searchbar.js
+++ b/src/components/Searchbar.js
@@ -30,7 +30,12 @@ type Props = React.ElementConfig<typeof TextInput> & {|
    * Callback to execute if we want the left icon to act as button.
    */
   onIconPress?: () => mixed,
+  /**
+   * Set style of the TextInput component inside the searchbar
+   */
+  inputStyle?: any,
   style?: any,
+
   /**
    * @optional
    */
@@ -118,6 +123,7 @@ class Searchbar extends React.Component<Props> {
       value,
       theme,
       style,
+      inputStyle,
       ...rest
     } = this.props;
     const { colors, roundness, dark, fonts } = theme;
@@ -150,7 +156,7 @@ class Searchbar extends React.Component<Props> {
           icon={icon || 'search'}
         />
         <TextInput
-          style={[styles.input, { color: textColor, fontFamily }]}
+          style={[styles.input, { color: textColor, fontFamily }, inputStyle]}
           placeholder={placeholder || ''}
           placeholderTextColor={colors.placeholder}
           selectionColor={colors.primary}

--- a/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
@@ -120,6 +120,7 @@ exports[`renders with placeholder 1`] = `
           "color": "#000000",
           "fontFamily": "Helvetica Neue",
         },
+        undefined,
       ]
     }
     underlineColorAndroid="transparent"
@@ -332,6 +333,7 @@ exports[`renders with text 1`] = `
           "color": "#000000",
           "fontFamily": "Helvetica Neue",
         },
+        undefined,
       ]
     }
     underlineColorAndroid="transparent"


### PR DESCRIPTION
https://www.slashgear.com/gmail-app-android-ios-material-design-update-released-21566652/
```
<Searchbar
  placeholder={'Zoeken'}
  onChangeText={this.props.onSearch}
  style={{
    shadowOpacity: 0.07,
    elevation: 2,
  }}
  inputStyle={{
    fontSize: 16,
  }}
  value={value}
  icon={icon}
  onIconPress={this._onMenu}
/>
```


Before:
![9219e44b-52f7-4f5a-b017-62d0b578d9c5](https://user-images.githubusercontent.com/6492229/53686058-f62f7b00-3d22-11e9-9ee3-6c21005e75e1.jpeg)

After:
![e77f1c71-b3af-451a-af15-b9a43992c1be](https://user-images.githubusercontent.com/6492229/53686050-dbf59d00-3d22-11e9-9b82-3718cde31b51.jpeg)


Related pull request:
https://github.com/callstack/react-native-paper/pull/861