### PR TITLE
fix: add default touchable style to always fill parent container with…

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -246,7 +246,7 @@ class Button extends React.Component<Props, State> {
           accessibilityStates={disabled ? ['disabled'] : undefined}
           disabled={disabled}
           rippleColor={rippleColor}
-          style={touchableStyle}
+          style={[styles.touchable, touchableStyle]}
         >
           <View style={[styles.content, contentStyle]}>
             {icon && loading !== true ? (
@@ -289,6 +289,10 @@ const styles = StyleSheet.create({
   button: {
     minWidth: 64,
     borderStyle: 'solid',
+  },
+  touchable: {
+    width: '100%',
+    flex: 1,
   },
   compact: {
     minWidth: 'auto',

--- a/src/components/__tests__/__snapshots__/Banner.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.js.snap
@@ -205,9 +205,15 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              Object {
-                "borderRadius": 4,
-              },
+              Array [
+                Object {
+                  "flex": 1,
+                  "width": "100%",
+                },
+                Object {
+                  "borderRadius": 4,
+                },
+              ],
             ]
           }
         >
@@ -366,9 +372,15 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              Object {
-                "borderRadius": 4,
-              },
+              Array [
+                Object {
+                  "flex": 1,
+                  "width": "100%",
+                },
+                Object {
+                  "borderRadius": 4,
+                },
+              ],
             ]
           }
         >
@@ -456,9 +468,15 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              Object {
-                "borderRadius": 4,
-              },
+              Array [
+                Object {
+                  "flex": 1,
+                  "width": "100%",
+                },
+                Object {
+                  "borderRadius": 4,
+                },
+              ],
             ]
           }
         >

--- a/src/components/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.js.snap
@@ -36,9 +36,15 @@ exports[`renders button with color 1`] = `
         Object {
           "overflow": "hidden",
         },
-        Object {
-          "borderRadius": 4,
-        },
+        Array [
+          Object {
+            "flex": 1,
+            "width": "100%",
+          },
+          Object {
+            "borderRadius": 4,
+          },
+        ],
       ]
     }
   >
@@ -126,9 +132,15 @@ exports[`renders button with icon 1`] = `
         Object {
           "overflow": "hidden",
         },
-        Object {
-          "borderRadius": 4,
-        },
+        Array [
+          Object {
+            "flex": 1,
+            "width": "100%",
+          },
+          Object {
+            "borderRadius": 4,
+          },
+        ],
       ]
     }
   >
@@ -260,9 +272,15 @@ exports[`renders contained contained with mode 1`] = `
         Object {
           "overflow": "hidden",
         },
-        Object {
-          "borderRadius": 4,
-        },
+        Array [
+          Object {
+            "flex": 1,
+            "width": "100%",
+          },
+          Object {
+            "borderRadius": 4,
+          },
+        ],
       ]
     }
   >
@@ -348,9 +366,15 @@ exports[`renders disabled button 1`] = `
         Object {
           "overflow": "hidden",
         },
-        Object {
-          "borderRadius": 4,
-        },
+        Array [
+          Object {
+            "flex": 1,
+            "width": "100%",
+          },
+          Object {
+            "borderRadius": 4,
+          },
+        ],
       ]
     }
   >
@@ -438,9 +462,15 @@ exports[`renders loading button 1`] = `
         Object {
           "overflow": "hidden",
         },
-        Object {
-          "borderRadius": 4,
-        },
+        Array [
+          Object {
+            "flex": 1,
+            "width": "100%",
+          },
+          Object {
+            "borderRadius": 4,
+          },
+        ],
       ]
     }
   >
@@ -541,9 +571,15 @@ exports[`renders outlined button with mode 1`] = `
         Object {
           "overflow": "hidden",
         },
-        Object {
-          "borderRadius": 4,
-        },
+        Array [
+          Object {
+            "flex": 1,
+            "width": "100%",
+          },
+          Object {
+            "borderRadius": 4,
+          },
+        ],
       ]
     }
   >
@@ -631,9 +667,15 @@ exports[`renders text button by default 1`] = `
         Object {
           "overflow": "hidden",
         },
-        Object {
-          "borderRadius": 4,
-        },
+        Array [
+          Object {
+            "flex": 1,
+            "width": "100%",
+          },
+          Object {
+            "borderRadius": 4,
+          },
+        ],
       ]
     }
   >
@@ -721,9 +763,15 @@ exports[`renders text button with mode 1`] = `
         Object {
           "overflow": "hidden",
         },
-        Object {
-          "borderRadius": 4,
-        },
+        Array [
+          Object {
+            "flex": 1,
+            "width": "100%",
+          },
+          Object {
+            "borderRadius": 4,
+          },
+        ],
       ]
     }
   >

--- a/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
@@ -175,9 +175,15 @@ exports[`renders snackbar with action button 1`] = `
             Object {
               "overflow": "hidden",
             },
-            Object {
-              "borderRadius": 4,
-            },
+            Array [
+              Object {
+                "flex": 1,
+                "width": "100%",
+              },
+              Object {
+                "borderRadius": 4,
+              },
+            ],
           ]
         }
       >


### PR DESCRIPTION
Motivation:
Only small part of a custom button was clickable (in web and native apps)

Before:
![schermafbeelding 2019-03-02 om 18 38 09](https://user-images.githubusercontent.com/6492229/53685407-7b626200-3d1a-11e9-88be-28fce6cd281d.png)

After:
![schermafbeelding 2019-03-02 om 18 41 45](https://user-images.githubusercontent.com/6492229/53685430-d98f4500-3d1a-11e9-91e4-194f9219b827.png)


It's a different app so colors are a bit different ;)