### PR TITLE
Improve outlined input on the web

### DIFF
--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -655,8 +655,11 @@ class TextInput extends React.Component<Props, State> {
           multiline,
           style: [
             styles.input,
-            mode === 'outlined' && {
+            mode === 'outlined' ? {
               borderRadius: theme.roundness,
+            } : {
+              borderTopLeftRadius: theme.roundness,
+              borderTopRightRadius: theme.roundness,        
             },
             mode === 'outlined'
               ? styles.inputOutlined

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -528,6 +528,7 @@ class TextInput extends React.Component<Props, State> {
             style={[
               styles.outlinedLabelBackground,
               {
+                height: hasActiveOutline ? 2 : 1,
                 backgroundColor,
                 fontFamily,
                 fontSize: MINIMIZED_LABEL_FONT_SIZE,
@@ -655,6 +656,9 @@ class TextInput extends React.Component<Props, State> {
           multiline,
           style: [
             styles.input,
+            mode === 'outlined' && {
+              borderRadius: theme.roundness,
+            },
             mode === 'outlined'
               ? styles.inputOutlined
               : this.props.label
@@ -704,8 +708,9 @@ const styles = StyleSheet.create({
     bottom: 0,
   },
   outlinedLabelBackground: {
+    overflow: 'hidden',
     position: 'absolute',
-    top: 0,
+    top: 6,
     left: 8,
     paddingHorizontal: 4,
     color: 'transparent',
@@ -717,12 +722,12 @@ const styles = StyleSheet.create({
     margin: 0,
     minHeight: 58,
     textAlign: I18nManager.isRTL ? 'right' : 'left',
-    zIndex: 1,
   },
   inputOutlined: {
     paddingTop: 20,
     paddingBottom: 16,
-    minHeight: 64,
+    minHeight: 58,
+    marginTop: 6,
   },
   inputFlatWithLabel: {
     paddingTop: 24,

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -712,6 +712,7 @@ const styles = StyleSheet.create({
     left: 8,
     paddingHorizontal: 4,
     color: 'transparent',
+    borderRadius: 5,
   },
   input: {
     flexGrow: 1,

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -528,7 +528,6 @@ class TextInput extends React.Component<Props, State> {
             style={[
               styles.outlinedLabelBackground,
               {
-                height: hasActiveOutline ? 2 : 1,
                 backgroundColor,
                 fontFamily,
                 fontSize: MINIMIZED_LABEL_FONT_SIZE,
@@ -708,9 +707,8 @@ const styles = StyleSheet.create({
     bottom: 0,
   },
   outlinedLabelBackground: {
-    overflow: 'hidden',
     position: 'absolute',
-    top: 6,
+    top: 0,
     left: 8,
     paddingHorizontal: 4,
     color: 'transparent',


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Autocomplete was rendered above the input + it was too big so it showed above the outline.
![schermafbeelding 2019-03-02 om 16 47 42](https://user-images.githubusercontent.com/6492229/53684430-98dcff00-3d0d-11e9-94e8-2e6e8aaff8b7.png)


### Test plan

WEB:
![schermafbeelding 2019-03-02 om 19 26 13](https://user-images.githubusercontent.com/6492229/53685901-18c09480-3d21-11e9-88b6-987ed18c3ba8.png)

ANDROID:
![8f1024f1-eaff-4f5f-ba4a-d6cc0cad215f](https://user-images.githubusercontent.com/6492229/53685822-fc702800-3d1f-11e9-9ee0-44df41a1aa1c.jpeg)


PS: I did another pull request which was more changes but did have support for backgroundless labels. This creates even better effect for the label on the web because it uses fieldset en legend to remove the border: https://github.com/callstack/react-native-paper/pull/883