### PR TITLE
fix(Card): add onLongPress prop to types

### DIFF
--- a/typings/components/Card.d.ts
+++ b/typings/components/Card.d.ts
@@ -28,6 +28,7 @@ export interface CardTitleProps extends ViewProps {
 export interface CardProps {
   elevation?: number;
   onPress?: () => any;
+  onLongPress?: () => any;
   children: React.ReactNode;
   style?: any;
   theme?: ThemeShape;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

`onLongPress` was missing in Typescript types.

### Test plan

n/a
