### PR TITLE
added iconColor to searchbar

### DIFF
--- a/src/components/Searchbar.js
+++ b/src/components/Searchbar.js
@@ -137,11 +137,11 @@ class Searchbar extends React.Component<Props> {
     const iconColor =
       customIconColor ||
       (dark
-      ? textColor
-      : color(textColor)
-          .alpha(0.54)
-          .rgb()
-          .string());
+        ? textColor
+        : color(textColor)
+            .alpha(0.54)
+            .rgb()
+            .string());
     const rippleColor = color(textColor)
       .alpha(0.32)
       .rgb()

--- a/src/components/Searchbar.js
+++ b/src/components/Searchbar.js
@@ -40,6 +40,10 @@ type Props = React.ElementConfig<typeof TextInput> & {|
    * @optional
    */
   theme: Theme,
+  /**
+   * Custom color for icon, default will be derived from theme
+   */
+  iconColor?: string,
 |};
 
 /**
@@ -123,18 +127,19 @@ class Searchbar extends React.Component<Props> {
       value,
       theme,
       style,
+      iconColor:customIconColor,
       inputStyle,
       ...rest
     } = this.props;
     const { colors, roundness, dark, fonts } = theme;
     const textColor = colors.text;
     const fontFamily = fonts.regular;
-    const iconColor = dark
+    const iconColor =customIconColor || (dark
       ? textColor
       : color(textColor)
           .alpha(0.54)
           .rgb()
-          .string();
+          .string());
     const rippleColor = color(textColor)
       .alpha(0.32)
       .rgb()

--- a/src/components/Searchbar.js
+++ b/src/components/Searchbar.js
@@ -127,14 +127,16 @@ class Searchbar extends React.Component<Props> {
       value,
       theme,
       style,
-      iconColor:customIconColor,
+      iconColor: customIconColor,
       inputStyle,
       ...rest
     } = this.props;
     const { colors, roundness, dark, fonts } = theme;
     const textColor = colors.text;
     const fontFamily = fonts.regular;
-    const iconColor =customIconColor || (dark
+    const iconColor =
+      customIconColor ||
+      (dark
       ? textColor
       : color(textColor)
           .alpha(0.54)


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
I used the searchbar inside the Appbar. But I wanted to change the background color when it's not active. the porblem was that changing background caused the icons to look awkward, and the color didn't match the other components in Appbar. so I decided to add this prop.

I resized the search bar when it was not active. so the other components in the Appbar will be visible.
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
```<Searchbar iconColor="black"  {...otherProps} />```

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/25160928/54033506-bd335280-41c9-11e9-88d8-8355175f2ee0.gif)

