### PR TITLE
Add style override to wrapper of Modal component

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -8,6 +8,7 @@ import {
   StyleSheet,
   TouchableWithoutFeedback,
   BackHandler,
+  ViewStyle,
 } from 'react-native';
 import { polyfill } from 'react-lifecycles-compat';
 import Surface from './Surface';
@@ -43,7 +44,7 @@ type Props = {|
    * @optional
    * Overrides Styles for the Wrapper element.
    */
-  wrapperStyle?: StyleSheet.Styles,
+  wrapperStyle?: StyleSheet.NamedStyles<ViewStyle>,
 |};
 
 type State = {

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -43,7 +43,7 @@ type Props = {|
    * @optional
    * Overrides Styles for the Wrapper element.
    */
-  wrapperStyle?: StyleSheet,
+  wrapperStyle?: StyleProp<ViewStyle>,
 |};
 
 type State = {

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -39,6 +39,11 @@ type Props = {|
    * @optional
    */
   theme: Theme,
+  /**
+   * @optional
+   * Overrides Styles for the Wrapper element.
+   */
+  wrapperStyle?: StyleSheet
 |};
 
 type State = {
@@ -168,7 +173,7 @@ class Modal extends React.Component<Props, State> {
             ]}
           />
         </TouchableWithoutFeedback>
-        <View pointerEvents="box-none" style={styles.wrapper}>
+        <View pointerEvents="box-none" style={{...styles.wrapper, ...this.props.wrapperStyle}}>
           <Surface
             style={[
               { opacity: this.state.opacity },

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -8,6 +8,8 @@ import {
   StyleSheet,
   TouchableWithoutFeedback,
   BackHandler,
+  StyleProp,
+  ViewStyle,
 } from 'react-native';
 import { polyfill } from 'react-lifecycles-compat';
 import Surface from './Surface';

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -8,8 +8,6 @@ import {
   StyleSheet,
   TouchableWithoutFeedback,
   BackHandler,
-  StyleProp,
-  ViewStyle,
 } from 'react-native';
 import { polyfill } from 'react-lifecycles-compat';
 import Surface from './Surface';
@@ -45,7 +43,7 @@ type Props = {|
    * @optional
    * Overrides Styles for the Wrapper element.
    */
-  wrapperStyle?: StyleProp<ViewStyle>,
+  wrapperStyle?: StyleSheet.Styles,
 |};
 
 type State = {

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -43,7 +43,7 @@ type Props = {|
    * @optional
    * Overrides Styles for the Wrapper element.
    */
-  wrapperStyle?: StyleSheet
+  wrapperStyle?: StyleSheet,
 |};
 
 type State = {
@@ -173,7 +173,13 @@ class Modal extends React.Component<Props, State> {
             ]}
           />
         </TouchableWithoutFeedback>
-        <View pointerEvents="box-none" style={{...styles.wrapper, ...this.props.wrapperStyle}}>
+        <View
+          pointerEvents="box-none"
+          style={{
+            ...styles.wrapper,
+            ...this.props.wrapperStyle,
+          }}
+        >
           <Surface
             style={[
               { opacity: this.state.opacity },

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -8,6 +8,7 @@ import {
   StyleSheet,
   TouchableWithoutFeedback,
   BackHandler,
+  StyleProp,
   ViewStyle,
 } from 'react-native';
 import { polyfill } from 'react-lifecycles-compat';
@@ -44,7 +45,7 @@ type Props = {|
    * @optional
    * Overrides Styles for the Wrapper element.
    */
-  wrapperStyle?: StyleSheet.NamedStyles<ViewStyle>,
+  wrapperStyle?: StyleProp<ViewStyle>,
 |};
 
 type State = {

--- a/typings/components/Modal.d.ts
+++ b/typings/components/Modal.d.ts
@@ -7,7 +7,7 @@ export interface ModalProps {
   visible: boolean;
   children: React.ReactNode;
   theme?: ThemeShape;
-  wrapperStyle?: StyleSheet;
+  wrapperStyle?: StyleProp<ViewStyle>;
 }
 
 export declare class Modal extends React.Component<ModalProps> {}

--- a/typings/components/Modal.d.ts
+++ b/typings/components/Modal.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, ViewStyle } from 'react-native';
 import { ThemeShape } from '../types';
 
 export interface ModalProps {
@@ -8,7 +8,7 @@ export interface ModalProps {
   visible: boolean;
   children: React.ReactNode;
   theme?: ThemeShape;
-  wrapperStyle?: StyleSheet.Styles;
+  wrapperStyle?: StyleSheet.NamedStyles<ViewStyle>;
 }
 
 export declare class Modal extends React.Component<ModalProps> {}

--- a/typings/components/Modal.d.ts
+++ b/typings/components/Modal.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { StyleProp, ViewStyle } from 'react-native';
 import { ThemeShape } from '../types';
 
 export interface ModalProps {

--- a/typings/components/Modal.d.ts
+++ b/typings/components/Modal.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleProp, ViewStyle } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { ThemeShape } from '../types';
 
 export interface ModalProps {
@@ -8,7 +8,7 @@ export interface ModalProps {
   visible: boolean;
   children: React.ReactNode;
   theme?: ThemeShape;
-  wrapperStyle?: StyleProp<ViewStyle>;
+  wrapperStyle?: StyleSheet.Styles;
 }
 
 export declare class Modal extends React.Component<ModalProps> {}

--- a/typings/components/Modal.d.ts
+++ b/typings/components/Modal.d.ts
@@ -7,6 +7,7 @@ export interface ModalProps {
   visible: boolean;
   children: React.ReactNode;
   theme?: ThemeShape;
+  wrapperStyle?: StyleSheet;
 }
 
 export declare class Modal extends React.Component<ModalProps> {}

--- a/typings/components/Modal.d.ts
+++ b/typings/components/Modal.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleSheet, ViewStyle } from 'react-native';
+import { StyleProp, ViewStyle } from 'react-native';
 import { ThemeShape } from '../types';
 
 export interface ModalProps {
@@ -8,7 +8,7 @@ export interface ModalProps {
   visible: boolean;
   children: React.ReactNode;
   theme?: ThemeShape;
-  wrapperStyle?: StyleSheet.NamedStyles<ViewStyle>;
+  wrapperStyle?: StyleProp<ViewStyle>;
 }
 
 export declare class Modal extends React.Component<ModalProps> {}


### PR DESCRIPTION
### Motivation

The motivation for this PR is to allow style overriding to the wrapper for the Modal. This allows us to do things like justify content to the bottom if we so choose. We could also allow just an override to JustifyContent, but this solution is further extendable should users of the library have other style considerations they want to execute.

### Test plan
```jsx
import * as React from 'react';
import { Modal, Portal, Text, Button, Surface, withTheme, Divider } from 'react-native-paper';
import { View } from 'react-native';

class ModalExampleComponent extends React.Component {
  state = {
    visible: true,
  };

  _showModal = () => this.setState({ visible: true });
  _hideModal = () => this.setState({ visible: false });

  render() {
    const { visible } = this.state;
    return (
      <Portal>
        <Modal wrapperStyle={{ justifyContent:'flex-end'}} visible={visible} onDismiss={this._hideModal}>
          <View>
          <Surface style={{borderRadius:5, margin:10}}>
              <Text style={{textAlign:'center'}}>Select a Photo</Text>
              <Divider />
              <Button>Take Photo...</Button>
              <Divider />
              <Button>Choose from Library...</Button>
            </Surface>
            <Surface style={{borderRadius:5, margin:10}}>
              <Button onPress={this._hideModal}>Cancel</Button>
            </Surface>
          </View>
        </Modal>
      </Portal>
    );
  }
}
```

![image](https://user-images.githubusercontent.com/6373759/54054385-a5e76b80-41af-11e9-9f6e-428b0cb495cc.png)

