### PR TITLE
Add customizable size property for icon in FAB

### DIFF
--- a/example/src/Examples/FABExample.tsx
+++ b/example/src/Examples/FABExample.tsx
@@ -45,6 +45,7 @@ class ButtonExample extends React.Component<Props, State> {
           <FAB
             icon="favorite"
             style={styles.fab}
+            iconSize={40}
             onPress={() => {}}
             visible={this.state.visible}
           />

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -103,6 +103,7 @@ class FAB extends React.Component<Props, State> {
 
   static defaultProps = {
     visible: true,
+    iconSize: 24,
   };
 
   state = {
@@ -133,6 +134,7 @@ class FAB extends React.Component<Props, State> {
     const {
       small,
       icon,
+      iconSize,
       label,
       accessibilityLabel = label,
       color: customColor,
@@ -215,7 +217,7 @@ class FAB extends React.Component<Props, State> {
             pointerEvents="none"
           >
             {icon && loading !== true ? (
-              <CrossFadeIcon source={icon} size={24} color={foregroundColor} />
+              <CrossFadeIcon source={icon} size={iconSize} color={foregroundColor} />
             ) : null}
             {loading && label ? (
               <ActivityIndicator size={18} color={foregroundColor} />

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -19,6 +19,10 @@ type Props = $RemoveChildren<typeof Surface> & {
    */
   icon: IconSource;
   /**
+   * Icon to display for the `FAB`.
+   */
+  iconSize: number,
+  /**
    * Optional label for extended `FAB`.
    */
   label?: string;


### PR DESCRIPTION
Add customizable size property for icon in FAB

### Current behavior

Icons are fixed at size 24 in FAB.

### Proposed

Added a prop (iconSize) to support custom icon sizes similar to color and icon.
