### PR TITLE
fix: appbar shadow on web

### DIFF
--- a/src/components/Appbar/AppbarHeader.js
+++ b/src/components/Appbar/AppbarHeader.js
@@ -100,7 +100,7 @@ class AppbarHeader extends React.Component<Props> {
     const {
       height = DEFAULT_APPBAR_HEIGHT,
       elevation = 4,
-      zIndex = 0,
+      zIndex = 1,
       backgroundColor = colors.primary,
       ...restStyle
     } = StyleSheet.flatten(style) || {};


### PR DESCRIPTION
Issue: https://github.com/callstack/react-native-paper/issues/781

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Shadow wasn't visible for the Appbar component on web.
Without increasing the z-index, the shadow wasn't visible. Another way could be adding space between the sibling component (the one rendered below), but the space may or may not be required. So z-index will fix the issue.
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

<img width="1440" alt="Screen Shot 2019-03-15 at 12 02 46 AM" src="https://user-images.githubusercontent.com/3988398/54382297-bd45bd80-46b5-11e9-9138-bc2eef85b243.png">
