### PR TITLE
feat FastImage support in CardCover component

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "create-react-context": "^0.2.3",
     "hoist-non-react-statics": "^3.1.0",
     "react-lifecycles-compat": "^3.0.4",
+    "react-native-fast-image": "^5.2.0",
     "react-native-safe-area-view": "^0.12.0"
   },
   "devDependencies": {

--- a/src/components/Card/CardCover.js
+++ b/src/components/Card/CardCover.js
@@ -21,6 +21,10 @@ type Props = React.ElementConfig<typeof Image> & {|
    * @optional
    */
   theme: Theme,
+  /**
+   * @optional
+   */
+  fastImage: boolean,
 |};
 
 /**

--- a/src/components/Card/CardCover.js
+++ b/src/components/Card/CardCover.js
@@ -84,21 +84,20 @@ class CardCover extends React.Component<Props> {
         borderBottomLeftRadius: roundness,
       };
     }
+
     if (fastImage) {
-      console.log('FASTIMAGE');
       return (
         <View style={[styles.container, coverStyle, style]}>
           <FastImage {...rest} style={[styles.fastImage, coverStyle]} />
         </View>
       );
-    } else {
-      console.log('IMAGE');
-      return (
-        <View style={[styles.container, coverStyle, style]}>
-          <Image {...rest} style={[styles.image, coverStyle]} />
-        </View>
-      );
     }
+
+    return (
+      <View style={[styles.container, coverStyle, style]}>
+        <Image {...rest} style={[styles.image, coverStyle]} />
+      </View>
+    );
   }
 }
 

--- a/src/components/Card/CardCover.js
+++ b/src/components/Card/CardCover.js
@@ -7,25 +7,26 @@ import { grey200 } from '../../styles/colors';
 import FastImage from 'react-native-fast-image';
 import type { Theme } from '../../types';
 
-type Props = React.ElementConfig<typeof Image> & {|
-  /**
-   * @internal
-   */
-  index?: number,
-  /**
-   * @internal
-   */
-  total?: number,
-  style?: any,
-  /**
-   * @optional
-   */
-  theme: Theme,
-  /**
-   * @optional
-   */
-  fastImage: boolean,
-|};
+type Props = React.ElementConfig<typeof Image> &
+  React.ElementConfig<typeof FastImage> & {|
+    /**
+     * @internal
+     */
+    index?: number,
+    /**
+     * @internal
+     */
+    total?: number,
+    style?: any,
+    /**
+     * @optional
+     */
+    theme: Theme,
+    /**
+     * @optional
+     */
+    fastImage: boolean,
+  |};
 
 /**
  * A component to show a cover image inside a Card.

--- a/src/components/Card/CardCover.js
+++ b/src/components/Card/CardCover.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { StyleSheet, View, Image } from 'react-native';
 import { withTheme } from '../../core/theming';
 import { grey200 } from '../../styles/colors';
+import FastImage from 'react-native-fast-image';
 import type { Theme } from '../../types';
 
 type Props = React.ElementConfig<typeof Image> & {|
@@ -40,12 +41,29 @@ type Props = React.ElementConfig<typeof Image> & {|
  * ```
  *
  * @extends Image props https://facebook.github.io/react-native/docs/image.html#props
+ *
+ * ## Usage with FastImage library
+ * Make sure that you have ```react-native-fast-image``` library installed and linked
+ * https://github.com/DylanVann/react-native-fast-image#usage
+ *
+ * ```js
+ * import * as React from 'react';
+ * import { Card } from 'react-native-paper';
+ *
+ * const MyComponent = () => (
+ *   <Card>
+ *     <Card.Cover fastImage source={{ uri: 'https://picsum.photos/700' }} />
+ *   </Card>
+ * );
+ *
+ * export default MyComponent;
+ * ```
  */
 class CardCover extends React.Component<Props> {
   static displayName = 'Card.Cover';
 
   render() {
-    const { index, total, style, theme, ...rest } = this.props;
+    const { index, total, style, theme, fastImage, ...rest } = this.props;
     const { roundness } = theme;
 
     let coverStyle;
@@ -66,12 +84,21 @@ class CardCover extends React.Component<Props> {
         borderBottomLeftRadius: roundness,
       };
     }
-
-    return (
-      <View style={[styles.container, coverStyle, style]}>
-        <Image {...rest} style={[styles.image, coverStyle]} />
-      </View>
-    );
+    if (fastImage) {
+      console.log('FASTIMAGE');
+      return (
+        <View style={[styles.container, coverStyle, style]}>
+          <FastImage {...rest} style={[styles.fastImage, coverStyle]} />
+        </View>
+      );
+    } else {
+      console.log('IMAGE');
+      return (
+        <View style={[styles.container, coverStyle, style]}>
+          <Image {...rest} style={[styles.image, coverStyle]} />
+        </View>
+      );
+    }
   }
 }
 
@@ -88,6 +115,13 @@ const styles = StyleSheet.create({
     padding: 16,
     justifyContent: 'flex-end',
     resizeMode: 'cover',
+  },
+  fastImage: {
+    flex: 1,
+    height: null,
+    width: null,
+    padding: 16,
+    justifyContent: 'flex-end',
   },
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7832,6 +7832,11 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-native-fast-image@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-fast-image/-/react-native-fast-image-5.2.0.tgz#6730eb06951ea6f9a79abe02a733bc05b7a73412"
+  integrity sha512-S+2gmv9HfLc7CGjjnQ3kO/QoZD9BJnjfwWhsJWgjEvaeOPbpHZaXSUkINSqLcHD5KIHcYidu+U2lgXdEv4Jamg==
+
 react-native-safe-area-view@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.12.0.tgz#5c312f087300ecf82e8541c3eac25d560e147f22"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

I discovered `react-native-fast-image` library some days ago and I believe that it improves the performance when loading big amount of images, I wanted to use it in a Card.Cover component yesterday but I wasn't able as it is hard coupled with the Image component. This changes I believe will not strongly affect the use of Card.Cover as it is now but will add the feature for those who want to use FastImages.

#### Features

-   [x] Aggressively cache images.
-   [x] Add authorization headers.
-   [x] Prioritize images.
-   [x] Preload images.
-   [x] GIF support.
-   [x] Border radius.

[FastImage repository on GitHub](https://github.com/DylanVann/react-native-fast-image)

### Test plan

Documentation has been added to show the usage, the only change is adding the prop fastImage when you feel that you want to use it:
 ```js
 import * as React from 'react';
 import { Card } from 'react-native-paper';
 
 const MyComponent = () => (
   <Card>
     <Card.Cover fastImage source={{ uri: 'https://picsum.photos/700' }} />
   </Card>
 );

 export default MyComponent;
 ```


