### PR TITLE
RNW setup: only transpile node_modules

### DIFF
--- a/docs/pages/4.react-native-web.md
+++ b/docs/pages/4.react-native-web.md
@@ -30,6 +30,7 @@ yarn add --dev react-app-rewired
 module.exports = function override(config, env) {
   config.module.rules.push({
     test: /\.js$/,
+    include: /node_modules/,
     exclude: /node_modules[/\\](?!react-native-paper|react-native-vector-icons|react-native-safe-area-view)/,
     use: {
       loader: "babel-loader",
@@ -175,6 +176,7 @@ Now, add the following in the `module.rules` array in your webpack config:
 ```js
 {
   test: /\.js$/,
+  include: /node_modules/,
   exclude: /node_modules[/\\](?!react-native-paper|react-native-vector-icons|react-native-safe-area-view)/,
   use: {
     loader: 'babel-loader',


### PR DESCRIPTION
I think the newly added rule should not apply to files outside of node modules, to avoid messing up with another js loader that may already be present

This is for example required for my Gatsby plugin setup to work, because Gatsby already has its own babel loader for app sources:
https://github.com/slorber/gatsby-plugin-react-native-web/blob/master/examples/todos/gatsby-node.js
https://gatsby-rnw-todos.netlify.com/
