### PR TITLE
chore: remove TS test generation from CI, fix ts gen script, add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,6 @@ android/keystores/debug.keystore
 # Build
 #
 dist/
-__ts-tests__/
 
 # Release
 #

--- a/__ts-tests__/ActivityIndicator.test.tsx
+++ b/__ts-tests__/ActivityIndicator.test.tsx
@@ -1,0 +1,9 @@
+
+import * as React from 'react';
+import { ActivityIndicator, Colors } from '..';
+
+const MyComponent = () => (
+  <ActivityIndicator animating={true} color={Colors.red800} />
+);
+
+export default MyComponent;

--- a/__ts-tests__/Appbar.test.tsx
+++ b/__ts-tests__/Appbar.test.tsx
@@ -1,0 +1,26 @@
+
+import * as React from 'react';
+import { Appbar } from '..';
+import { StyleSheet } from 'react-native';
+
+export default class MyComponent extends React.Component {
+  render() {
+    return (
+      <Appbar style={styles.bottom}>
+        <Appbar.Action icon="archive" onPress={() => console.log('Pressed archive')} />
+        <Appbar.Action icon="mail" onPress={() => console.log('Pressed mail')} />
+        <Appbar.Action icon="label" onPress={() => console.log('Pressed label')} />
+        <Appbar.Action icon="delete" onPress={() => console.log('Pressed delete')} />
+      </Appbar>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  bottom: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
+});

--- a/__ts-tests__/AppbarHeader.test.tsx
+++ b/__ts-tests__/AppbarHeader.test.tsx
@@ -1,0 +1,27 @@
+
+import * as React from 'react';
+import { Appbar } from '..';
+
+export default class MyComponent extends React.Component {
+  _goBack = () => console.log('Went back');
+
+  _onSearch = () => console.log('Searching');
+
+  _onMore = () => console.log('Shown more');
+
+  render() {
+    return (
+      <Appbar.Header>
+        <Appbar.BackAction
+          onPress={this._goBack}
+        />
+        <Appbar.Content
+          title="Title"
+          subtitle="Subtitle"
+        />
+        <Appbar.Action icon="search" onPress={this._onSearch} />
+        <Appbar.Action icon="more-vert" onPress={this._onMore} />
+      </Appbar.Header>
+    );
+  }
+}

--- a/__ts-tests__/AvatarIcon.test.tsx
+++ b/__ts-tests__/AvatarIcon.test.tsx
@@ -1,0 +1,7 @@
+
+import * as React from 'react';
+import { Avatar } from '..';
+
+const MyComponent = () => (
+  <Avatar.Icon size={24} icon="folder" />
+);

--- a/__ts-tests__/AvatarImage.test.tsx
+++ b/__ts-tests__/AvatarImage.test.tsx
@@ -1,0 +1,7 @@
+
+import * as React from 'react';
+import { Avatar } from '..';
+
+const MyComponent = () => (
+  <Avatar.Image size={24} source={require('../assets/avatar.png')} />
+);

--- a/__ts-tests__/AvatarText.test.tsx
+++ b/__ts-tests__/AvatarText.test.tsx
@@ -1,0 +1,7 @@
+
+import * as React from 'react';
+import { Avatar } from '..';
+
+const MyComponent = () => (
+  <Avatar.Text size={24} label="XD" />
+);

--- a/__ts-tests__/Badge.test.tsx
+++ b/__ts-tests__/Badge.test.tsx
@@ -1,0 +1,9 @@
+
+import * as React from 'react';
+import { Badge } from '..';
+
+const MyComponent = () => (
+  <Badge>3</Badge>
+);
+
+export default MyComponent;

--- a/__ts-tests__/Banner.test.tsx
+++ b/__ts-tests__/Banner.test.tsx
@@ -1,0 +1,39 @@
+
+import * as React from 'react';
+import { Image } from 'react-native';
+import { Banner } from '..';
+
+export default class MyComponent extends React.Component {
+  state = {
+    visible: true,
+  };
+
+  render() {
+    return (
+      <Banner
+        visible={this.state.visible}
+        actions={[
+          {
+            label: 'Fix it',
+            onPress: () => this.setState({ visible: false }),
+          },
+          {
+            label: 'Learn more',
+            onPress: () => this.setState({ visible: false }),
+          },
+        ]}
+        image={({ size }) =>
+          <Image
+            source={{ uri: 'https://avatars3.githubusercontent.com/u/17571969?s=400&v=4' }}
+            style={{
+              width: size,
+              height: size,
+            }}
+          />
+        }
+      >
+        There was a problem processing a transaction on your credit card.
+      </Banner>
+    );
+  }
+}

--- a/__ts-tests__/BottomNavigation.test.tsx
+++ b/__ts-tests__/BottomNavigation.test.tsx
@@ -1,0 +1,38 @@
+
+import * as React from 'react';
+import { BottomNavigation, Text } from '..';
+
+const MusicRoute = () => <Text>Music</Text>;
+
+const AlbumsRoute = () => <Text>Albums</Text>;
+
+const RecentsRoute = () => <Text>Recents</Text>;
+
+export default class MyComponent extends React.Component {
+  state = {
+    index: 0,
+    routes: [
+      { key: 'music', title: 'Music', icon: 'queue-music' },
+      { key: 'albums', title: 'Albums', icon: 'album' },
+      { key: 'recents', title: 'Recents', icon: 'history' },
+    ],
+  };
+
+  _handleIndexChange = index => this.setState({ index });
+
+  _renderScene = BottomNavigation.SceneMap({
+    music: MusicRoute,
+    albums: AlbumsRoute,
+    recents: RecentsRoute,
+  });
+
+  render() {
+    return (
+      <BottomNavigation
+        navigationState={this.state}
+        onIndexChange={this._handleIndexChange}
+        renderScene={this._renderScene}
+      />
+    );
+  }
+}

--- a/__ts-tests__/Button.test.tsx
+++ b/__ts-tests__/Button.test.tsx
@@ -1,0 +1,11 @@
+
+import * as React from 'react';
+import { Button } from '..';
+
+const MyComponent = () => (
+  <Button icon="add-a-photo" mode="contained" onPress={() => console.log('Pressed')}>
+    Press me
+  </Button>
+);
+
+export default MyComponent;

--- a/__ts-tests__/Caption.test.tsx
+++ b/__ts-tests__/Caption.test.tsx
@@ -1,0 +1,9 @@
+
+import * as React from 'react';
+import { Caption } from '..';
+
+const MyComponent = () => (
+  <Caption>Caption</Caption>
+);
+
+export default MyComponent;

--- a/__ts-tests__/Card.test.tsx
+++ b/__ts-tests__/Card.test.tsx
@@ -1,0 +1,20 @@
+
+import * as React from 'react';
+import { Avatar, Button, Card, Title, Paragraph } from '..';
+
+const MyComponent = () => (
+  <Card>
+    <Card.Title title="Card Title" subtitle="Card Subtitle" left={(props) => <Avatar.Icon {...props} icon="folder" />} />
+    <Card.Content>
+      <Title>Card title</Title>
+      <Paragraph>Card content</Paragraph>
+    </Card.Content>
+    <Card.Cover source={{ uri: 'https://picsum.photos/700' }} />
+    <Card.Actions>
+      <Button>Cancel</Button>
+      <Button>Ok</Button>
+    </Card.Actions>
+  </Card>
+);
+
+export default MyComponent;

--- a/__ts-tests__/CardActions.test.tsx
+++ b/__ts-tests__/CardActions.test.tsx
@@ -1,0 +1,14 @@
+
+import * as React from 'react';
+import { Button, Card } from '..';
+
+const MyComponent = () => (
+  <Card>
+    <Card.Actions>
+      <Button>Cancel</Button>
+      <Button>Ok</Button>
+    </Card.Actions>
+  </Card>
+);
+
+export default MyComponent;

--- a/__ts-tests__/CardContent.test.tsx
+++ b/__ts-tests__/CardContent.test.tsx
@@ -1,0 +1,14 @@
+
+import * as React from 'react';
+import { Card, Title, Paragraph } from '..';
+
+const MyComponent = () => (
+  <Card>
+    <Card.Content>
+      <Title>Card title</Title>
+      <Paragraph>Card content</Paragraph>
+    </Card.Content>
+  </Card>
+);
+
+export default MyComponent;

--- a/__ts-tests__/CardCover.test.tsx
+++ b/__ts-tests__/CardCover.test.tsx
@@ -1,0 +1,11 @@
+
+import * as React from 'react';
+import { Card } from '..';
+
+const MyComponent = () => (
+  <Card>
+    <Card.Cover source={{ uri: 'https://picsum.photos/700' }} />
+  </Card>
+);
+
+export default MyComponent;

--- a/__ts-tests__/CardTitle.test.tsx
+++ b/__ts-tests__/CardTitle.test.tsx
@@ -1,0 +1,14 @@
+
+import * as React from 'react';
+import { Avatar, Card, IconButton } from '..';
+
+const MyComponent = () => (
+  <Card.Title
+    title="Card Title"
+    subtitle="Card Subtitle"
+    left={(props) => <Avatar.Icon {...props} icon="folder" />}
+    right={(props) => <IconButton {...props} icon="more-vert" onPress={() => {}} />}
+  />
+);
+
+export default MyComponent;

--- a/__ts-tests__/Checkbox.test.tsx
+++ b/__ts-tests__/Checkbox.test.tsx
@@ -1,0 +1,19 @@
+
+import * as React from 'react';
+import { Checkbox } from '..';
+
+export default class MyComponent extends React.Component {
+  state = {
+    checked: false,
+  };
+
+  render() {
+    const { checked } = this.state;
+    return (
+      <Checkbox
+        status={checked ? 'checked' : 'unchecked'}
+        onPress={() => { this.setState({ checked: !checked }); }}
+      />
+    );
+  }
+}

--- a/__ts-tests__/Chip.test.tsx
+++ b/__ts-tests__/Chip.test.tsx
@@ -1,0 +1,9 @@
+
+import * as React from 'react';
+import { Chip } from '..';
+
+const MyComponent = () => (
+  <Chip icon="info" onPress={() => console.log('Pressed')}>Example Chip</Chip>
+);
+
+export default MyComponent;

--- a/__ts-tests__/DataTable.test.tsx
+++ b/__ts-tests__/DataTable.test.tsx
@@ -1,0 +1,36 @@
+
+import * as React from 'react';
+import { DataTable } from '..';
+
+export default class MyComponent extends React.Component {
+  render() {
+    return (
+      <DataTable>
+        <DataTable.Header>
+          <DataTable.Title>Dessert</DataTable.Title>
+          <DataTable.Title numeric>Calories</DataTable.Title>
+          <DataTable.Title numeric>Fat</DataTable.Title>
+        </DataTable.Header>
+
+        <DataTable.Row>
+          <DataTable.Cell>Frozen yogurt</DataTable.Cell>
+          <DataTable.Cell numeric>159</DataTable.Cell>
+          <DataTable.Cell numeric>6.0</DataTable.Cell>
+        </DataTable.Row>
+
+        <DataTable.Row>
+          <DataTable.Cell>Ice cream sandwich</DataTable.Cell>
+          <DataTable.Cell numeric>237</DataTable.Cell>
+          <DataTable.Cell numeric>8.0</DataTable.Cell>
+        </DataTable.Row>
+
+        <DataTable.Pagination
+          page={1}
+          numberOfPages={3}
+          onPageChange={(page) => { console.log(page); }}
+          label="1-2 of 6"
+        />
+      </DataTable>
+    );
+  }
+}

--- a/__ts-tests__/Dialog.test.tsx
+++ b/__ts-tests__/Dialog.test.tsx
@@ -1,0 +1,35 @@
+
+import * as React from 'react';
+import { View } from 'react-native';
+import { Button, Paragraph, Dialog, Portal } from '..';
+
+export default class MyComponent extends React.Component {
+  state = {
+    visible: false,
+  };
+
+  _showDialog = () => this.setState({ visible: true });
+
+  _hideDialog = () => this.setState({ visible: false });
+
+  render() {
+    return (
+      <View>
+        <Button onPress={this._showDialog}>Show Dialog</Button>
+        <Portal>
+          <Dialog
+             visible={this.state.visible}
+             onDismiss={this._hideDialog}>
+            <Dialog.Title>Alert</Dialog.Title>
+            <Dialog.Content>
+              <Paragraph>This is simple dialog</Paragraph>
+            </Dialog.Content>
+            <Dialog.Actions>
+              <Button onPress={this._hideDialog}>Done</Button>
+            </Dialog.Actions>
+          </Dialog>
+        </Portal>
+      </View>
+    );
+  }
+}

--- a/__ts-tests__/DialogActions.test.tsx
+++ b/__ts-tests__/DialogActions.test.tsx
@@ -1,0 +1,26 @@
+
+import * as React from 'react';
+import { Button, Dialog, Portal } from '..';
+
+export default class MyComponent extends React.Component {
+  state = {
+    visible: false,
+  };
+
+  _hideDialog = () => this.setState({ visible: false });
+
+  render() {
+    return (
+      <Portal>
+        <Dialog
+          visible={this.state.visible}
+          onDismiss={this._hideDialog}>
+          <Dialog.Actions>
+            <Button onPress={() => console.log("Cancel")}>Cancel</Button>
+            <Button onPress={() => console.log("Ok")}>Ok</Button>
+          </Dialog.Actions>
+        </Dialog>
+      </Portal>
+    );
+  }
+}

--- a/__ts-tests__/DialogContent.test.tsx
+++ b/__ts-tests__/DialogContent.test.tsx
@@ -1,0 +1,25 @@
+
+import * as React from 'react';
+import { Paragraph, Dialog, Portal } from '..';
+
+export default class MyComponent extends React.Component {
+  state = {
+    visible: false,
+  };
+
+  _hideDialog = () => this.setState({ visible: false });
+
+  render() {
+    return (
+      <Portal>
+        <Dialog
+          visible={this.state.visible}
+          onDismiss={this._hideDialog}>
+          <Dialog.Content>
+            <Paragraph>This is simple dialog</Paragraph>
+          </Dialog.Content>
+        </Dialog>
+      </Portal>
+    );
+  }
+}

--- a/__ts-tests__/DialogScrollArea.test.tsx
+++ b/__ts-tests__/DialogScrollArea.test.tsx
@@ -1,0 +1,28 @@
+
+import * as React from 'react';
+import { ScrollView } from 'react-native';
+import { Dialog, Portal } from '..';
+
+export default class MyComponent extends React.Component {
+  state = {
+    visible: false,
+  };
+
+  _hideDialog = () => this.setState({ visible: false });
+
+  render() {
+    return (
+      <Portal>
+        <Dialog
+          visible={this.state.visible}
+          onDismiss={this._hideDialog}>
+          <Dialog.ScrollArea>
+            <ScrollView contentContainerStyle={{ paddingHorizontal: 24 }}>
+              This is a scrollable area
+            </ScrollView>
+          </Dialog.ScrollArea>
+        </Dialog>
+      </Portal>
+    );
+  }
+}

--- a/__ts-tests__/DialogTitle.test.tsx
+++ b/__ts-tests__/DialogTitle.test.tsx
@@ -1,0 +1,26 @@
+
+import * as React from 'react';
+import { Paragraph, Dialog, Portal } from '..';
+
+export default class MyComponent extends React.Component {
+  state = {
+    visible: false,
+  };
+
+  _hideDialog = () => this.setState({ visible: false });
+
+  render() {
+    return (
+      <Portal>
+        <Dialog
+          visible={this.state.visible}
+          onDismiss={this._hideDialog}>
+          <Dialog.Title>This is a title</Dialog.Title>
+          <Dialog.Content>
+            <Paragraph>This is simple dialog</Paragraph>
+          </Dialog.Content>
+        </Dialog>
+      </Portal>
+    );
+  }
+}

--- a/__ts-tests__/Divider.test.tsx
+++ b/__ts-tests__/Divider.test.tsx
@@ -1,0 +1,15 @@
+
+import * as React from 'react';
+import { View } from 'react-native';
+import { Divider, Text } from '..';
+
+const MyComponent = () => (
+  <View>
+    <Text>Apple</Text>
+    <Divider />
+    <Text>Orange</Text>
+    <Divider />
+  </View>
+);
+
+export default MyComponent;

--- a/__ts-tests__/DrawerItem.test.tsx
+++ b/__ts-tests__/DrawerItem.test.tsx
@@ -1,0 +1,9 @@
+
+import * as React from 'react';
+import { Drawer } from '..';
+
+const MyComponent = () => (
+  <Drawer.Item label="First Item" />
+);
+
+export default MyComponent;

--- a/__ts-tests__/DrawerSection.test.tsx
+++ b/__ts-tests__/DrawerSection.test.tsx
@@ -1,0 +1,28 @@
+
+import * as React from 'react';
+import { Drawer } from '..';
+
+export default class MyComponent extends React.Component {
+  state = {
+    active: 'first',
+  };
+
+  render() {
+    const { active } = this.state;
+
+    return (
+      <Drawer.Section title="Some title">
+        <Drawer.Item
+          label="First Item"
+          active={active === 'first'}
+          onPress={() => { this.setState({ active: 'first' }); }}
+        />
+        <Drawer.Item
+          label="Second Item"
+          active={active === 'second'}
+          onPress={() => { this.setState({ active: 'second' }); }}
+        />
+     </Drawer.Section>
+    );
+  }
+}

--- a/__ts-tests__/FAB.test.tsx
+++ b/__ts-tests__/FAB.test.tsx
@@ -1,0 +1,24 @@
+
+import * as React from 'react';
+import { StyleSheet } from 'react-native';
+import { FAB } from '..';
+
+const MyComponent = () => (
+  <FAB
+    style={styles.fab}
+    small
+    icon="add"
+    onPress={() => console.log('Pressed')}
+  />
+);
+
+const styles = StyleSheet.create({
+  fab: {
+    position: 'absolute',
+    margin: 16,
+    right: 0,
+    bottom: 0,
+  },
+})
+
+export default MyComponent;

--- a/__ts-tests__/FABGroup.test.tsx
+++ b/__ts-tests__/FABGroup.test.tsx
@@ -1,0 +1,32 @@
+
+import * as React from 'react';
+import { FAB, Portal } from '..';
+
+export default class MyComponent extends React.Component {
+  state = {
+    open: false,
+  };
+
+  render() {
+    return (
+      <Portal>
+        <FAB.Group
+          open={this.state.open}
+          icon={this.state.open ? 'today' : 'add'}
+          actions={[
+            { icon: 'add', onPress: () => console.log('Pressed add') },
+            { icon: 'star', label: 'Star', onPress: () => console.log('Pressed star')},
+            { icon: 'email', label: 'Email', onPress: () => console.log('Pressed email') },
+            { icon: 'notifications', label: 'Remind', onPress: () => console.log('Pressed notifications') },
+          ]}
+          onStateChange={({ open }) => this.setState({ open })}
+          onPress={() => {
+            if (this.state.open) {
+              // do something if the speed dial is open
+            }
+          }}
+        />
+      </Portal>
+    );
+  }
+}

--- a/__ts-tests__/Headline.test.tsx
+++ b/__ts-tests__/Headline.test.tsx
@@ -1,0 +1,9 @@
+
+import * as React from 'react';
+import { Headline } from '..';
+
+const MyComponent = () => (
+  <Headline>Headline</Headline>
+);
+
+export default MyComponent;

--- a/__ts-tests__/HelperText.test.tsx
+++ b/__ts-tests__/HelperText.test.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { HelperText, TextInput } from '..';
+import { View } from 'react-native';
+export default class MyComponent extends React.Component {
+  state = {
+    text: ''
+  };
+
+  render(){
+    return (
+      <View>
+        <TextInput
+          label="Email"
+          value={this.state.text}
+          onChangeText={text => this.setState({ text })}
+        />
+        <HelperText
+          type="error"
+          visible={this.state.text.indexOf('@')!==-1}
+        >
+          Email address is invalid!
+        </HelperText>
+      </View>
+    );
+  }
+}

--- a/__ts-tests__/IconButton.test.tsx
+++ b/__ts-tests__/IconButton.test.tsx
@@ -1,0 +1,14 @@
+
+import * as React from 'react';
+import { IconButton, Colors } from '..';
+
+const MyComponent = () => (
+  <IconButton
+    icon="add-a-photo"
+    color={Colors.red500}
+    size={20}
+    onPress={() => console.log('Pressed')}
+  />
+);
+
+export default MyComponent;

--- a/__ts-tests__/ListAccordion.test.tsx
+++ b/__ts-tests__/ListAccordion.test.tsx
@@ -1,0 +1,40 @@
+
+import * as React from 'react';
+import { List, Checkbox } from '..';
+
+class MyComponent extends React.Component {
+  state = {
+    expanded: true
+  }
+
+  _handlePress = () =>
+    this.setState({
+      expanded: !this.state.expanded
+    });
+
+  render() {
+    return (
+      <List.Section title="Accordions">
+        <List.Accordion
+          title="Uncontrolled Accordion"
+          left={props => <List.Icon {...props} icon="folder" />}
+        >
+          <List.Item title="First item" />
+          <List.Item title="Second item" />
+        </List.Accordion>
+
+        <List.Accordion
+          title="Controlled Accordion"
+          left={props => <List.Icon {...props} icon="folder" />}
+          expanded={this.state.expanded}
+          onPress={this._handlePress}
+        >
+          <List.Item title="First item" />
+          <List.Item title="Second item" />
+        </List.Accordion>
+      </List.Section>
+    );
+  }
+}
+
+export default MyComponent;

--- a/__ts-tests__/ListIcon.test.tsx
+++ b/__ts-tests__/ListIcon.test.tsx
@@ -1,0 +1,9 @@
+
+import * as React from 'react';
+import { List, Colors } from '..';
+
+const MyComponent = () => (
+  <List.Icon color={Colors.blue500} icon="folder" />
+);
+
+export default MyComponent;

--- a/__ts-tests__/ListItem.test.tsx
+++ b/__ts-tests__/ListItem.test.tsx
@@ -1,0 +1,13 @@
+
+import * as React from 'react';
+import { List } from '..';
+
+const MyComponent = () => (
+  <List.Item
+    title="First Item"
+    description="Item description"
+    left={props => <List.Icon {...props} icon="folder" />}
+  />
+);
+
+export default MyComponent;

--- a/__ts-tests__/ListSection.test.tsx
+++ b/__ts-tests__/ListSection.test.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { List } from '..';
+
+class MyComponent extends React.Component {
+  render() {
+    return (
+      <List.Section>
+        <List.Subheader>Some title</List.Subheader>
+        <List.Item
+          title="First Item"
+          left={() => <List.Icon color="#000" icon="folder" />}
+        />
+        <List.Item
+          title="Second Item"
+          left={() => <List.Icon color="#000" icon="folder" />}
+        />
+      </List.Section>
+    );
+  }
+}
+
+export default MyComponent;

--- a/__ts-tests__/ListSubheader.test.tsx
+++ b/__ts-tests__/ListSubheader.test.tsx
@@ -1,0 +1,11 @@
+
+import * as React from 'react';
+import { List } from '..';
+
+class MyComponent extends React.Component {
+ render () {
+   return <List.Subheader>My List Title</List.Subheader>;
+ }
+}
+
+export default MyComponent;

--- a/__ts-tests__/Modal.test.tsx
+++ b/__ts-tests__/Modal.test.tsx
@@ -1,0 +1,29 @@
+
+import * as React from 'react';
+import { Modal, Portal, Text, Button, Provider } from '..';
+
+export default class MyComponent extends React.Component {
+  state = {
+    visible: false,
+  };
+
+  _showModal = () => this.setState({ visible: true });
+  _hideModal = () => this.setState({ visible: false });
+
+  render() {
+    const { visible } = this.state;
+    return (
+      <Portal>
+        <Modal visible={visible} onDismiss={this._hideModal}>
+          <Text>Example Modal</Text>
+        </Modal>
+        <Button
+          style={{ marginTop: 30 }}
+          onPress={this._showModal}
+        >
+          Show
+        </Button>
+      </Portal>
+    );
+  }
+}

--- a/__ts-tests__/Paragraph.test.tsx
+++ b/__ts-tests__/Paragraph.test.tsx
@@ -1,0 +1,9 @@
+
+import * as React from 'react';
+import { Paragraph } from '..';
+
+const MyComponent = () => (
+  <Paragraph>Paragraph</Paragraph>
+);
+
+export default MyComponent;

--- a/__ts-tests__/Portal.test.tsx
+++ b/__ts-tests__/Portal.test.tsx
@@ -1,0 +1,13 @@
+
+import * as React from 'react';
+import { Portal, Text } from '..';
+
+export default class MyComponent extends React.Component {
+  render() {
+    return (
+      <Portal>
+        <Text>This is rendered at a different place</Text>
+      </Portal>
+    );
+  }
+}

--- a/__ts-tests__/PortalHost.test.tsx
+++ b/__ts-tests__/PortalHost.test.tsx
@@ -1,0 +1,14 @@
+
+import * as React from 'react';
+import { Text } from 'react-native';
+import { Portal } from '..';
+
+export default class MyComponent extends React.Component {
+  render() {
+    return (
+      <Portal.Host>
+        <Text>Content of the app</Text>
+      </Portal.Host>
+    );
+  }
+}

--- a/__ts-tests__/ProgressBar.test.tsx
+++ b/__ts-tests__/ProgressBar.test.tsx
@@ -1,0 +1,9 @@
+
+import * as React from 'react';
+import { ProgressBar, Colors } from '..';
+
+const MyComponent = () => (
+  <ProgressBar progress={0.5} color={Colors.red800} />
+);
+
+export default MyComponent;

--- a/__ts-tests__/RadioButton.test.tsx
+++ b/__ts-tests__/RadioButton.test.tsx
@@ -1,0 +1,29 @@
+
+import * as React from 'react';
+import { View } from 'react-native';
+import { RadioButton } from '..';
+
+export default class MyComponent extends React.Component {
+  state = {
+    checked: 'first',
+  };
+
+  render() {
+    const { checked } = this.state;
+
+    return (
+      <View>
+        <RadioButton
+          value="first"
+          status={checked === 'first' ? 'checked' : 'unchecked'}
+          onPress={() => { this.setState({ checked: 'first' }); }}
+        />
+        <RadioButton
+          value="second"
+          status={checked === 'second' ? 'checked' : 'unchecked'}
+          onPress={() => { this.setState({ checked: 'second' }); }}
+        />
+      </View>
+    );
+  }
+}

--- a/__ts-tests__/RadioButtonGroup.test.tsx
+++ b/__ts-tests__/RadioButtonGroup.test.tsx
@@ -1,0 +1,28 @@
+
+import * as React from 'react';
+import { View } from 'react-native';
+import { RadioButton, Text } from '..';
+
+export default class MyComponent extends React.Component {
+  state = {
+    value: 'first',
+  };
+
+  render() {
+    return(
+      <RadioButton.Group
+        onValueChange={value => this.setState({ value })}
+        value={this.state.value}
+      >
+        <View>
+          <Text>First</Text>
+          <RadioButton value="first" />
+        </View>
+        <View>
+          <Text>Second</Text>
+          <RadioButton value="second" />
+        </View>
+      </RadioButton.Group>
+    )
+  }
+}

--- a/__ts-tests__/Searchbar.test.tsx
+++ b/__ts-tests__/Searchbar.test.tsx
@@ -1,0 +1,20 @@
+
+import * as React from 'react';
+import { Searchbar } from '..';
+
+export default class MyComponent extends React.Component {
+  state = {
+    firstQuery: '',
+  };
+
+  render() {
+    const { firstQuery } = this.state;
+    return (
+      <Searchbar
+        placeholder="Search"
+        onChangeText={query => { this.setState({ firstQuery: query }); }}
+        value={firstQuery}
+      />
+    );
+  }
+}

--- a/__ts-tests__/Snackbar.test.tsx
+++ b/__ts-tests__/Snackbar.test.tsx
@@ -1,0 +1,46 @@
+
+import * as React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Snackbar, Button } from '..';
+
+interface MyComponentState {
+  visible: boolean  
+}
+
+export default class MyComponent extends React.Component<{}, MyComponentState> {
+  state = {
+    visible: false,
+  };
+
+  render() {
+    const { visible } = this.state;
+    return (
+      <View style={styles.container}>
+        <Button
+          onPress={() => this.setState(state => ({ visible: !state.visible }))}
+        >
+          {this.state.visible ? 'Hide' : 'Show'}
+        </Button>
+        <Snackbar
+          visible={this.state.visible}
+          onDismiss={() => this.setState({ visible: false })}
+          action={{
+            label: 'Undo',
+            onPress: () => {
+              // Do something
+            },
+          }}
+        >
+          Hey there! I'm a Snackbar.
+        </Snackbar>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'space-between',
+  },
+});

--- a/__ts-tests__/Subheading.test.tsx
+++ b/__ts-tests__/Subheading.test.tsx
@@ -1,0 +1,9 @@
+
+import * as React from 'react';
+import { Subheading } from '..';
+
+const MyComponent = () => (
+  <Subheading>Subheading</Subheading>
+);
+
+export default MyComponent;

--- a/__ts-tests__/Surface.test.tsx
+++ b/__ts-tests__/Surface.test.tsx
@@ -1,0 +1,23 @@
+
+import * as React from 'react';
+import { Surface, Text } from '..';
+import { StyleSheet } from 'react-native';
+
+const MyComponent = () => (
+  <Surface style={styles.surface}>
+     <Text>Surface</Text>
+  </Surface>
+);
+
+export default MyComponent;
+
+const styles = StyleSheet.create({
+  surface: {
+    padding: 8,
+    height: 80,
+    width: 80,
+    alignItems: 'center',
+    justifyContent: 'center',
+    elevation: 4,
+  },
+});

--- a/__ts-tests__/Switch.test.tsx
+++ b/__ts-tests__/Switch.test.tsx
@@ -1,0 +1,21 @@
+
+import * as React from 'react';
+import { Switch } from '..';
+
+export default class MyComponent extends React.Component {
+  state = {
+    isSwitchOn: false,
+  };
+
+  render() {
+    const { isSwitchOn } = this.state;
+    return (
+      <Switch
+        value={isSwitchOn}
+        onValueChange={() =>
+          { this.setState({ isSwitchOn: !isSwitchOn }); }
+        }
+      />
+    );
+  }
+}

--- a/__ts-tests__/TextInput.test.tsx
+++ b/__ts-tests__/TextInput.test.tsx
@@ -1,0 +1,19 @@
+
+import * as React from 'react';
+import { TextInput } from '..';
+
+export default class MyComponent extends React.Component {
+  state = {
+    text: ''
+  };
+
+  render(){
+    return (
+      <TextInput
+        label='Email'
+        value={this.state.text}
+        onChangeText={text => this.setState({ text })}
+      />
+    );
+  }
+}

--- a/__ts-tests__/Title.test.tsx
+++ b/__ts-tests__/Title.test.tsx
@@ -1,0 +1,9 @@
+
+import * as React from 'react';
+import { Title } from '..';
+
+const MyComponent = () => (
+  <Title>Title</Title>
+);
+
+export default MyComponent;

--- a/__ts-tests__/ToggleButton.test.tsx
+++ b/__ts-tests__/ToggleButton.test.tsx
@@ -1,0 +1,26 @@
+
+import * as React from 'react';
+import { ToggleButton } from '..';
+
+class ToggleButtonExample extends React.Component {
+  state = {
+    status: 'checked',
+  };
+
+  render() {
+    return (
+      <ToggleButton
+        icon="bluetooth"
+        value="bluetooth"
+        // @ts-ignore
+        status={this.state.status}
+        onPress={value =>
+          this.setState({
+            // @ts-ignore
+            status: value === 'checked' ? 'unchecked' : 'checked',
+          })
+        }
+      />
+    );
+  }
+}

--- a/__ts-tests__/ToggleButtonGroup.test.tsx
+++ b/__ts-tests__/ToggleButtonGroup.test.tsx
@@ -1,0 +1,22 @@
+
+import * as React from 'react';
+import { View } from 'react-native';
+import { ToggleButton } from '..';
+
+export default class MyComponent extends React.Component {
+  state = {
+    value: 'left',
+  };
+
+  render() {
+    return(
+      <ToggleButton.Group
+        onValueChange={value => this.setState({ value })}
+        value={this.state.value}
+      >
+          <ToggleButton icon="format-align-left" value="left" />
+          <ToggleButton icon="format-align-right" value="right" />
+      </ToggleButton.Group>
+    )
+  }
+}

--- a/__ts-tests__/index.test.tsx
+++ b/__ts-tests__/index.test.tsx
@@ -1,0 +1,15 @@
+
+import * as React from 'react';
+import { View } from 'react-native';
+import { Text, TouchableRipple } from '..';
+
+const MyComponent = () => (
+  <TouchableRipple
+    onPress={() => console.log('Pressed')}
+    rippleColor="rgba(0, 0, 0, .32)"
+  >
+    <Text>Press me</Text>
+  </TouchableRipple>
+);
+
+export default MyComponent;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   ],
   "scripts": {
     "flow": "flow",
-    "typescript": "node ./scripts/generate-ts-tests.js && tsc --noEmit --skipLibCheck --jsx react ./__ts-tests__/*",
+    "typescript": "tsc --noEmit --skipLibCheck --jsx react ./__ts-tests__/*",
+    "typescript:generate": "node ./scripts/generate-ts-tests.js",
     "lint": "eslint .",
     "test": "jest",
     "prepare": "node ./scripts/generate-mappings",

--- a/scripts/generate-ts-tests.js
+++ b/scripts/generate-ts-tests.js
@@ -22,6 +22,8 @@ const getFiles = () =>
     .map(filePath => {
       const content = readFileSync(filePath, 'utf-8');
       const match = EXAMPLE_REGEX.exec(content);
+      // JS regexp is stateful, you need to reset lastIndex each time
+      EXAMPLE_REGEX.lastIndex = 0;
       return match
         ? {
             path: filePath,

--- a/src/components/HelperText.js
+++ b/src/components/HelperText.js
@@ -44,6 +44,7 @@ type State = {
  * ## Usage
  * ```js
  * import * as React from 'react';
+ * import { View } from 'react-native';
  * import { HelperText, TextInput } from 'react-native-paper';
  *
  * export default class MyComponent extends React.Component {

--- a/src/components/List/ListSection.js
+++ b/src/components/List/ListSection.js
@@ -34,7 +34,7 @@ type Props = React.ElementConfig<typeof View> & {
  * import * as React from 'react';
  * import { List } from 'react-native-paper';
  *
- * export default class MyComponent extends React.Component {
+ * class MyComponent extends React.Component {
  *   render() {
  *     return (
  *       <List.Section>
@@ -45,7 +45,7 @@ type Props = React.ElementConfig<typeof View> & {
  *        />
  *         <List.Item
  *           title="Second Item"
- *           left={() => <List.Icon icon="folder" />}
+ *           left={() => <List.Icon color="#000" icon="folder" />}
  *        />
  *      </List.Section>
  *     );

--- a/src/components/Portal/Portal.js
+++ b/src/components/Portal/Portal.js
@@ -30,7 +30,6 @@ type Props = {|
  *
  * export default class MyComponent extends React.Component {
  *   render() {
- *     const { visible } = this.state;
  *     return (
  *       <Portal>
  *         <Text>This is rendered at a different place</Text>


### PR DESCRIPTION
- remove TS generation script from CI checks (leave only testing, not generation - script will remain in repo as utility),
- generate all TS tests, fix them and commit,
- fix broken example usages.

I propose to remove TS generation script from CI checks. After fixing script that extract TS tests from example usage I commited all tests and fixed them (also fixed couple of broken examples). Squash and merge please, we need to move forward with this TS madness. 

### Motivation

Tests shouldn't be generated at runtime. 

### Test plan

run `yarn typescript`