### PR TITLE
fix: Searchbar TS

### DIFF
--- a/typings/components/Searchbar.d.ts
+++ b/typings/components/Searchbar.d.ts
@@ -9,4 +9,9 @@ export interface SearchbarProps extends TextInputProps {
   onChangeText?: (query: string) => void;
 }
 
-export declare class Searchbar extends React.Component<SearchbarProps> {}
+export declare class Searchbar extends React.Component<SearchbarProps> {
+  isFocused: () => boolean;
+  clear: () => void;
+  focus(): void;
+  blur(): void;
+}

--- a/typings/components/Searchbar.d.ts
+++ b/typings/components/Searchbar.d.ts
@@ -12,6 +12,6 @@ export interface SearchbarProps extends TextInputProps {
 export declare class Searchbar extends React.Component<SearchbarProps> {
   isFocused: () => boolean;
   clear: () => void;
-  focus(): void;
-  blur(): void;
+  focus: () => void;
+  blur: () => void;
 }

--- a/typings/components/TextInput.d.ts
+++ b/typings/components/TextInput.d.ts
@@ -39,6 +39,6 @@ export interface RenderProps extends NativeTextInputProps {
 export declare class TextInput extends React.Component<TextInputProps> {
   isFocused: () => boolean;
   clear: () => void;
-  focus(): void;
-  blur(): void;
+  focus: () => void;
+  blur: () => void;
 }


### PR DESCRIPTION
Missing TS typings for Searchbar methods

<img width="664" alt="Screen Shot 2019-03-21 at 15 12 50" src="https://user-images.githubusercontent.com/7827311/54758388-5f046780-4bec-11e9-8c0f-9c75e9c189b4.png">
