### PR TITLE
feat: add prop textStyle to Chip

### DIFF
--- a/example/src/Examples/ChipExample.js
+++ b/example/src/Examples/ChipExample.js
@@ -176,6 +176,13 @@ class ChipExample extends React.Component<Props> {
             >
               Outlined unselected chip with custom color
             </Chip>
+            <Chip
+              onPress={() => {}}
+              style={styles.chip}
+              textStyle={styles.tiny}
+            >
+              With custom size
+            </Chip>
           </View>
         </List.Section>
       </ScrollView>
@@ -194,6 +201,13 @@ const styles = StyleSheet.create({
   },
   chip: {
     margin: 4,
+  },
+  tiny: {
+    marginVertical: 2,
+    marginRight: 2,
+    marginLeft: 2,
+    minHeight: 19,
+    lineHeight: 19,
   },
 });
 

--- a/src/components/Chip.js
+++ b/src/components/Chip.js
@@ -61,6 +61,10 @@ type Props = React.ElementConfig<typeof Surface> & {|
    * Function to execute on close button press. The close button appears only when this prop is specified.
    */
   onClose?: () => mixed,
+  /**
+   * Style of chip's text
+   */
+  textStyle?: any,
   style?: any,
   /**
    * @optional
@@ -138,6 +142,7 @@ class Chip extends React.Component<Props, State> {
       accessibilityLabel,
       onPress,
       onClose,
+      textStyle,
       style,
       theme,
       testID,
@@ -272,6 +277,7 @@ class Chip extends React.Component<Props, State> {
                   marginRight: onClose ? 4 : 8,
                   marginLeft: avatar || icon || selected ? 4 : 8,
                 },
+                textStyle,
               ]}
             >
               {(children: any)}

--- a/src/components/__tests__/__snapshots__/Chip.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.js.snap
@@ -111,6 +111,7 @@ exports[`renders chip with close button 1`] = `
                 "marginLeft": 4,
                 "marginRight": 4,
               },
+              undefined,
             ],
           ]
         }
@@ -284,6 +285,7 @@ exports[`renders chip with icon 1`] = `
                 "marginLeft": 4,
                 "marginRight": 8,
               },
+              undefined,
             ],
           ]
         }
@@ -361,6 +363,7 @@ exports[`renders chip with onPress 1`] = `
                 "marginLeft": 8,
                 "marginRight": 8,
               },
+              undefined,
             ],
           ]
         }
@@ -442,6 +445,7 @@ exports[`renders outlined disabled chip 1`] = `
                 "marginLeft": 8,
                 "marginRight": 8,
               },
+              undefined,
             ],
           ]
         }
@@ -568,6 +572,7 @@ exports[`renders selected chip 1`] = `
                 "marginLeft": 4,
                 "marginRight": 8,
               },
+              undefined,
             ],
           ]
         }

--- a/typings/components/Chip.d.ts
+++ b/typings/components/Chip.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { StyleProp, TextStyle } from 'react-native';
 import { ThemeShape, IconSource } from '../types';
 
 export interface ChipProps {
@@ -11,6 +12,7 @@ export interface ChipProps {
   accessibilityLabel?: string;
   onPress?: () => any;
   onClose?: () => any;
+  textStyle?: StyleProp<TextStyle>;
   style?: any;
   theme?: ThemeShape;
   testID?: string;


### PR DESCRIPTION
### Motivation
It would be nice to be able to customize the style of chip's content .

![example](https://user-images.githubusercontent.com/6487206/55094738-b778b080-5095-11e9-8f61-079208e0b687.jpeg)
