### PR TITLE
fix: fix borderRadius support for the Chip component

### DIFF
--- a/src/components/Chip.js
+++ b/src/components/Chip.js
@@ -152,6 +152,7 @@ class Chip extends React.Component<Props, State> {
         : dark
           ? '#383838'
           : '#ebebeb',
+      borderRadius = 16,
     } = StyleSheet.flatten(style) || {};
 
     const borderColor =
@@ -214,6 +215,7 @@ class Chip extends React.Component<Props, State> {
               ? selectedBackgroundColor
               : backgroundColor,
             borderColor,
+            borderRadius,
           },
           style,
         ]}
@@ -222,7 +224,7 @@ class Chip extends React.Component<Props, State> {
         <TouchableRipple
           borderless
           delayPressIn={0}
-          style={styles.touchable}
+          style={{ borderRadius }}
           onPress={onPress}
           onPressIn={this._handlePressIn}
           onPressOut={this._handlePressOut}
@@ -296,12 +298,8 @@ class Chip extends React.Component<Props, State> {
 
 const styles = StyleSheet.create({
   container: {
-    borderRadius: 16,
     borderWidth: StyleSheet.hairlineWidth,
     borderStyle: 'solid',
-  },
-  touchable: {
-    borderRadius: 16,
   },
   content: {
     flexDirection: 'row',


### PR DESCRIPTION
### Motivation
Fixes #955 

### Test plan
- Tested in the example app by setting the borderRadius on the chip.
![Mar-29-2019 10-56-38](https://user-images.githubusercontent.com/13083475/55241411-5d9cf580-5211-11e9-893b-fcf392b3fbbe.gif)

