### PR TITLE
fix: use TouchableRipple for Card

### DIFF
--- a/__ts-tests__/TouchableRipple.test.tsx
+++ b/__ts-tests__/TouchableRipple.test.tsx
@@ -1,0 +1,15 @@
+
+import * as React from 'react';
+import { View } from 'react-native';
+import { Text, TouchableRipple } from '..';
+
+const MyComponent = () => (
+  <TouchableRipple
+    onPress={() => console.log('Pressed')}
+    rippleColor="rgba(0, 0, 0, .32)"
+  >
+    <Text>Press me</Text>
+  </TouchableRipple>
+);
+
+export default MyComponent;

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -1,17 +1,13 @@
 /* @flow */
 
 import * as React from 'react';
-import {
-  Animated,
-  View,
-  TouchableWithoutFeedback,
-  StyleSheet,
-} from 'react-native';
+import { Animated, View, StyleSheet } from 'react-native';
 import CardContent from './CardContent';
 import CardActions from './CardActions';
 import CardCover from './CardCover';
 import CardTitle from './CardTitle';
 import Surface from '../Surface';
+import TouchableRipple from '../TouchableRipple/';
 import { withTheme } from '../../core/theming';
 import type { Theme } from '../../types';
 
@@ -143,15 +139,15 @@ class Card extends React.Component<Props, State> {
         style={[{ borderRadius: roundness, elevation }, style]}
         {...rest}
       >
-        <TouchableWithoutFeedback
+        <TouchableRipple
           delayPressIn={0}
-          disabled={!(onPress || onLongPress)}
           onLongPress={onLongPress}
           onPress={onPress}
           onPressIn={onPress ? this._handlePressIn : undefined}
           onPressOut={onPress ? this._handlePressOut : undefined}
           testID={testID}
           accessible={accessible}
+          style={{ borderRadius: roundness }}
         >
           <View style={styles.innerContainer}>
             {React.Children.map(
@@ -166,7 +162,7 @@ class Card extends React.Component<Props, State> {
                   : child
             )}
           </View>
-        </TouchableWithoutFeedback>
+        </TouchableRipple>
       </Surface>
     );
   }

--- a/src/components/TouchableRipple/index.js
+++ b/src/components/TouchableRipple/index.js
@@ -229,7 +229,8 @@ class TouchableRipple extends React.Component<Props, void> {
       ...rest
     } = this.props;
 
-    const disabled = disabledProp || !this.props.onPress;
+    const disabled =
+      disabledProp || !(this.props.onPress || this.props.onLongPress);
 
     return (
       <TouchableWithoutFeedback


### PR DESCRIPTION
### Motivation

Replaces `TouchableWithoutFeedback` with `TouchableRipple` in Cards.

### Test plan

- Open example app
- Open `Card` examples
- Press "Pressable Chameleon" card