### PR TITLE
feat: support loading indicator for FAB

### DIFF
--- a/example/src/Examples/FABExample.js
+++ b/example/src/Examples/FABExample.js
@@ -65,6 +65,15 @@ class ButtonExample extends React.Component<Props, State> {
             visible={this.state.visible}
             disabled
           />
+
+          <FAB
+            icon="cancel"
+            label="Loading FAB"
+            style={styles.fab}
+            onPress={() => {}}
+            visible={this.state.visible}
+            loading
+          />
           <Portal>
             <FAB.Group
               open={this.state.open}

--- a/src/components/FAB/FAB.js
+++ b/src/components/FAB/FAB.js
@@ -2,7 +2,7 @@
 
 import color from 'color';
 import * as React from 'react';
-import { Animated, View, StyleSheet } from 'react-native';
+import { Animated, View, StyleSheet, ActivityIndicator } from 'react-native';
 import FABGroup from './FABGroup';
 import Surface from '../Surface';
 import CrossFadeIcon from '../CrossFadeIcon';
@@ -13,7 +13,7 @@ import { withTheme } from '../../core/theming';
 import type { Theme, $RemoveChildren } from '../../types';
 import type { IconSource } from './../Icon';
 
-type Props = $RemoveChildren<typeof Surface> & {|
+type Props = $RemoveChildren<typeof Surface> & {
   /**
    * Icon to display for the `FAB`.
    */
@@ -43,6 +43,10 @@ type Props = $RemoveChildren<typeof Surface> & {|
    * Whether `FAB` is currently visible.
    */
   visible: boolean,
+  /**
+   * Whether to show a loading indicator.
+   */
+  loading ?: boolean,
   /**
    * Function to execute on press.
    */
@@ -137,6 +141,7 @@ class FAB extends React.Component<Props, State> {
       theme,
       style,
       visible,
+      loading,
       ...rest
     } = this.props;
     const { visibility } = this.state;
@@ -207,7 +212,16 @@ class FAB extends React.Component<Props, State> {
             ]}
             pointerEvents="none"
           >
-            <CrossFadeIcon source={icon} size={24} color={foregroundColor} />
+            {icon && loading !== true ? (
+              <CrossFadeIcon source={icon} size={24} color={foregroundColor} />
+            ) : null}
+            {loading ? (
+              <ActivityIndicator
+                size="small"
+                color={foregroundColor}
+                style={styles.icon}
+              />
+            ) : null}
             {label ? (
               <Text
                 style={[
@@ -255,6 +269,10 @@ const styles = StyleSheet.create({
   },
   disabled: {
     elevation: 0,
+  },
+  icon: {
+    width: 16,
+    marginLeft: 12,
   },
 });
 

--- a/src/components/FAB/FAB.js
+++ b/src/components/FAB/FAB.js
@@ -42,7 +42,7 @@ type Props = $RemoveChildren<typeof Surface> & {|
   /**
    * Whether `FAB` is currently visible.
    */
-  visible?: boolean,
+  visible: boolean,
   /**
    * Whether to show a loading indicator.
    */

--- a/src/components/FAB/FAB.js
+++ b/src/components/FAB/FAB.js
@@ -2,7 +2,8 @@
 
 import color from 'color';
 import * as React from 'react';
-import { Animated, View, StyleSheet, ActivityIndicator } from 'react-native';
+import { Animated, View, StyleSheet } from 'react-native';
+import ActivityIndicator from '../ActivityIndicator';
 import FABGroup from './FABGroup';
 import Surface from '../Surface';
 import CrossFadeIcon from '../CrossFadeIcon';
@@ -215,12 +216,8 @@ class FAB extends React.Component<Props, State> {
             {icon && loading !== true ? (
               <CrossFadeIcon source={icon} size={24} color={foregroundColor} />
             ) : null}
-            {loading ? (
-              <ActivityIndicator
-                size="small"
-                color={foregroundColor}
-                style={styles.icon}
-              />
+            {loading && label ? (
+              <ActivityIndicator size={18} color={foregroundColor} />
             ) : null}
             {label ? (
               <Text
@@ -269,10 +266,6 @@ const styles = StyleSheet.create({
   },
   disabled: {
     elevation: 0,
-  },
-  icon: {
-    width: 16,
-    marginLeft: 12,
   },
 });
 

--- a/src/components/FAB/FAB.js
+++ b/src/components/FAB/FAB.js
@@ -13,7 +13,7 @@ import { withTheme } from '../../core/theming';
 import type { Theme, $RemoveChildren } from '../../types';
 import type { IconSource } from './../Icon';
 
-type Props = $RemoveChildren<typeof Surface> & {
+type Props = $RemoveChildren<typeof Surface> & {|
   /**
    * Icon to display for the `FAB`.
    */
@@ -42,11 +42,11 @@ type Props = $RemoveChildren<typeof Surface> & {
   /**
    * Whether `FAB` is currently visible.
    */
-  visible: boolean,
+  visible?: boolean,
   /**
    * Whether to show a loading indicator.
    */
-  loading ?: boolean,
+  loading?: boolean,
   /**
    * Function to execute on press.
    */

--- a/typings/components/FAB.d.ts
+++ b/typings/components/FAB.d.ts
@@ -33,6 +33,7 @@ export interface FABProps extends ViewProps {
   color?: string;
   disabled?: boolean;
   visible?: boolean;
+  loading?: boolean;
   onPress?: () => any;
   theme?: ThemeShape;
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
It is nice to have a loading indicator for a fab button 
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
1 - open example app in expo
2 -click on FAB example
3 -you can see the example of FAB with loading indicator as similar to a normal button
4 - try out -> 
```
<FAB
    icon="cancel"
    label="Loading FAB"
    loading
    style={styles.fab}
    onPress={() => {}}
     visible={this.state.visible}
  />
```


<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
