### PR TITLE
refactor: make ListItem accepts a custom description

### DIFF
--- a/example/src/Examples/ListSectionExample.js
+++ b/example/src/Examples/ListSectionExample.js
@@ -1,8 +1,8 @@
 /* @flow */
 
 import * as React from 'react';
-import { ScrollView, StyleSheet, Image } from 'react-native';
-import { List, Divider, withTheme, type Theme } from 'react-native-paper';
+import { ScrollView, StyleSheet, Image, View, Text } from 'react-native';
+import { Chip, List, Divider, withTheme, type Theme } from 'react-native-paper';
 
 type Props = {
   theme: Theme,
@@ -80,6 +80,42 @@ class ListSectionExample extends React.Component<Props> {
             description="Describes item 2. Example of a very very long description."
           />
         </List.Section>
+        <Divider />
+        <List.Section>
+          <List.Subheader>Custom description</List.Subheader>
+          <List.Item
+            left={() => (
+              <Image
+                source={require('../../assets/images/email-icon.png')}
+                style={styles.image}
+              />
+            )}
+            right={props => <List.Icon {...props} icon="star-border" />}
+            title="List Item 1"
+            description={({
+              ellipsizeMode,
+              color: descriptionColor,
+              fontSize,
+            }) => (
+              <View style={[styles.container, styles.column]}>
+                <Text
+                  numberOfLines={2}
+                  ellipsizeMode={ellipsizeMode}
+                  style={{ color: descriptionColor, fontSize }}
+                >
+                  React Native Paper is a high-quality, standard-compliant
+                  Material Design library that has you covered in all major
+                  use-cases.
+                </Text>
+                <View style={[styles.container, styles.row, { paddingTop: 8 }]}>
+                  <Chip icon="picture-as-pdf" onPress={() => {}}>
+                    DOCS.pdf
+                  </Chip>
+                </View>
+              </View>
+            )}
+          />
+        </List.Section>
       </ScrollView>
     );
   }
@@ -93,6 +129,12 @@ const styles = StyleSheet.create({
     height: 40,
     width: 40,
     margin: 8,
+  },
+  row: {
+    flexDirection: 'row',
+  },
+  column: {
+    flexDirection: 'column',
   },
 });
 

--- a/src/components/List/ListItem.js
+++ b/src/components/List/ListItem.js
@@ -87,6 +87,31 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {|
 class ListItem extends React.Component<Props> {
   static displayName = 'List.Item';
 
+  renderDescription(description, descriptionColor) {
+    const { descriptionEllipsizeMode, descriptionStyle } = this.props;
+
+    return typeof description === 'string' ? (
+      <Text
+        numberOfLines={2}
+        ellipsizeMode={descriptionEllipsizeMode}
+        style={[
+          styles.description,
+          { color: descriptionColor },
+          descriptionStyle,
+        ]}
+      >
+        {description}
+      </Text>
+    ) : (
+      description &&
+        description({
+          ellipsizeMode: descriptionEllipsizeMode,
+          color: descriptionColor,
+          fontSize: styles.description.fontSize,
+        })
+    );
+  }
+
   render() {
     const {
       left,
@@ -97,9 +122,7 @@ class ListItem extends React.Component<Props> {
       theme,
       style,
       titleStyle,
-      descriptionStyle,
       titleEllipsizeMode,
-      descriptionEllipsizeMode,
       ...rest
     } = this.props;
     const titleColor = color(theme.colors.text)
@@ -127,21 +150,7 @@ class ListItem extends React.Component<Props> {
             >
               {title}
             </Text>
-            {description ? (
-              <Text
-                ellipsizeMode={descriptionEllipsizeMode}
-                numberOfLines={2}
-                style={[
-                  styles.description,
-                  {
-                    color: descriptionColor,
-                  },
-                  descriptionStyle,
-                ]}
-              >
-                {description}
-              </Text>
-            ) : null}
+            {this.renderDescription(description, descriptionColor)}
           </View>
           {right ? right({ color: descriptionColor }) : null}
         </View>

--- a/src/components/List/ListItem.js
+++ b/src/components/List/ListItem.js
@@ -10,7 +10,7 @@ import type {
 import TouchableRipple from '../TouchableRipple';
 import Text from '../Typography/Text';
 import { withTheme } from '../../core/theming';
-import type { Theme, $RemoveChildren } from '../../types';
+import type { Theme, $RemoveChildren, EllipsizeProp } from '../../types';
 
 type Props = $RemoveChildren<typeof TouchableRipple> & {|
   /**
@@ -18,9 +18,15 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {|
    */
   title: React.Node,
   /**
-   * Description text for the list item.
+   * Description text for the list item or callback which returns a React element to display the description.
    */
-  description?: React.Node,
+  description?:
+    | React.Node
+    | ((props: {
+        ellipsizeMode: EllipsizeProp,
+        color: string,
+        fontSize: number,
+      }) => React.Node),
   /**
    * Callback which returns a React element to display on the left side.
    */
@@ -52,11 +58,11 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {|
   /**
    * Ellipsize Mode for the Title
    */
-  titleEllipsizeMode?: 'head' | 'middle' | 'tail' | 'clip',
+  titleEllipsizeMode?: EllipsizeProp,
   /**
    * Ellipsize Mode for the Description
    */
-  descriptionEllipsizeMode?: 'head' | 'middle' | 'tail' | 'clip',
+  descriptionEllipsizeMode?: EllipsizeProp,
 |};
 
 /**

--- a/src/components/__tests__/ListItem.test.js
+++ b/src/components/__tests__/ListItem.test.js
@@ -2,9 +2,10 @@
 
 import * as React from 'react';
 import renderer from 'react-test-renderer';
-import { Text } from 'react-native';
+import { Text, View } from 'react-native';
 import ListItem from '../List/ListItem';
 import ListIcon from '../List/ListIcon';
+import Chip from '../Chip';
 
 it('renders list item with title and description', () => {
   const tree = renderer
@@ -60,6 +61,35 @@ it('renders list item with custom title and description styles', () => {
         description="Item description"
         titleStyle={{ fontSize: 20 }}
         descriptionStyle={{ color: 'red' }}
+      />
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders list item with custom description', () => {
+  const tree = renderer
+    .create(
+      <ListItem
+        title="List Item with custom description"
+        description={({ ellipsizeMode, color: descriptionColor, fontSize }) => (
+          <View>
+            <Text
+              numberOfLines={2}
+              ellipsizeMode={ellipsizeMode}
+              style={{ color: descriptionColor, fontSize }}
+            >
+              React Native Paper is a high-quality, standard-compliant Design
+              Design library that has you covered in all major use-cases.
+            </Text>
+            <View>
+              <Chip icon="picture-as-pdf" onPress={() => {}}>
+                DOCS.pdf
+              </Chip>
+            </View>
+          </View>
+        )}
       />
     )
     .toJSON();

--- a/src/components/__tests__/__snapshots__/ListItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.js.snap
@@ -1,5 +1,212 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders list item with custom description 1`] = `
+<View
+  accessible={true}
+  isTVSelectable={true}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      false,
+      Array [
+        Object {
+          "padding": 8,
+        },
+        undefined,
+      ],
+    ]
+  }
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View
+      pointerEvents="none"
+      style={
+        Array [
+          Object {
+            "margin": 8,
+          },
+          Object {
+            "flex": 1,
+            "justifyContent": "center",
+          },
+        ]
+      }
+    >
+      <Text
+        numberOfLines={1}
+        style={
+          Array [
+            Object {
+              "color": "#000000",
+              "fontFamily": "Helvetica Neue",
+              "textAlign": "left",
+              "writingDirection": "ltr",
+            },
+            Array [
+              Object {
+                "fontSize": 16,
+              },
+              Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+              },
+              undefined,
+            ],
+          ]
+        }
+      >
+        List Item with custom description
+      </Text>
+      <View>
+        <Text
+          numberOfLines={2}
+          style={
+            Object {
+              "color": "rgba(0, 0, 0, 0.54)",
+              "fontSize": 14,
+            }
+          }
+        >
+          React Native Paper is a high-quality, standard-compliant Design Design library that has you covered in all major use-cases.
+        </Text>
+        <View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "#ebebeb",
+                "borderColor": "#ebebeb",
+                "borderRadius": 16,
+                "borderStyle": "solid",
+                "borderWidth": 0.5,
+                "elevation": 0,
+              }
+            }
+          >
+            <View
+              accessibilityRole="button"
+              accessibilityStates={Array []}
+              accessible={true}
+              isTVSelectable={true}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Array [
+                  Object {
+                    "overflow": "hidden",
+                  },
+                  Object {
+                    "borderRadius": 16,
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "paddingHorizontal": 4,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "padding": 4,
+                      },
+                      null,
+                    ]
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(0, 0, 0, 0.54)",
+                          "fontSize": 18,
+                        },
+                        Array [
+                          Object {
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+                <Text
+                  numberOfLines={1}
+                  style={
+                    Array [
+                      Object {
+                        "color": "#000000",
+                        "fontFamily": "Helvetica Neue",
+                        "textAlign": "left",
+                        "writingDirection": "ltr",
+                      },
+                      Array [
+                        Object {
+                          "lineHeight": 24,
+                          "marginVertical": 4,
+                          "minHeight": 24,
+                          "textAlignVertical": "center",
+                        },
+                        Object {
+                          "color": "rgba(0, 0, 0, 0.87)",
+                          "marginLeft": 4,
+                          "marginRight": 8,
+                        },
+                        undefined,
+                      ],
+                    ]
+                  }
+                >
+                  DOCS.pdf
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
 exports[`renders list item with custom title and description styles 1`] = `
 <View
   accessible={true}

--- a/src/types.js
+++ b/src/types.js
@@ -35,3 +35,5 @@ export type $RemoveChildren<T> = $Diff<
   React.ElementConfig<T>,
   { children: any }
 >;
+
+export type EllipsizeProp = 'head' | 'middle' | 'tail' | 'clip';

--- a/typings/components/List.d.ts
+++ b/typings/components/List.d.ts
@@ -6,7 +6,7 @@ import {
   TextProps,
   TextStyle,
 } from 'react-native';
-import { ThemeShape, IconSource } from '../types';
+import { ThemeShape, IconSource, EllipsizeProp } from '../types';
 import { TouchableRipplePropsWithoutChildren } from './TouchableRipple';
 
 export interface AccordionProps {
@@ -37,8 +37,8 @@ export interface ItemProps extends TouchableRipplePropsWithoutChildren {
   right?: (props: { color: string }) => React.ReactNode;
   titleStyle?: StyleProp<TextStyle>;
   descriptionStyle?: StyleProp<TextStyle>;
-  titleEllipsizeMode?: 'head' | 'middle' | 'tail' | 'clip';
-  descriptionEllipsizeMode?: 'head' | 'middle' | 'tail' | 'clip';
+  titleEllipsizeMode?: EllipsizeProp;
+  descriptionEllipsizeMode?: EllipsizeProp;
 }
 
 export declare class Item extends React.Component<ItemProps> {}

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -50,3 +50,5 @@ export declare class Provider extends React.Component<{
   children: React.ReactNode;
   theme?: ThemeShape;
 }> {}
+
+export type EllipsizeProp = 'head' | 'middle' | 'tail' | 'clip';


### PR DESCRIPTION
### Motivation
Currently, there's no way to customize the description of `List.Item`. In order to make it able to be customized, `List.Item` now accepts a custom node as description.

With these changes we can implement a list item like Gmail app:
![customized-list-description](https://user-images.githubusercontent.com/6487206/57096084-c5e86680-6cea-11e9-8a6c-0068d92ac162.jpeg)

```
<List.Item
  left={() => (
    <Image
      source={require('../../assets/images/email-icon.png')}
      style={styles.image}
    />
  )}
  right={props => <List.Icon {...props} icon="star-border" />}
  title="List Item 1"
  description={({
    ellipsizeMode,
    color: descriptionColor,
    fontSize,
  }) => (
    <View style={[styles.container, styles.column]}>
      <Text
        numberOfLines={2}
        ellipsizeMode={ellipsizeMode}
        style={{ color: descriptionColor, fontSize }}
      >
        React Native Paper is a high-quality, standard-compliant
        Material Design library that has you covered in all major
        use-cases.
      </Text>
      <View style={[styles.container, styles.row, { paddingTop: 8 }]}>
        <Chip icon="picture-as-pdf" onPress={() => {}}>
          DOCS.pdf
        </Chip>
      </View>
    </View>
  )}
/>
```

### Test plan

1. Download this branch
2. Run the example app
3. Open `List.Section` to see the new example.
