### PR TITLE
refactor: declare typography colors into theme file

### DIFF
--- a/src/components/Appbar/AppbarAction.js
+++ b/src/components/Appbar/AppbarAction.js
@@ -1,10 +1,10 @@
 /* @flow */
 
 import * as React from 'react';
-import color from 'color';
-import { black } from '../../styles/colors';
 import IconButton from '../IconButton';
 import type { IconSource } from '../Icon';
+import type { Theme } from '../../types';
+import { withTheme } from '../../core/theming';
 
 type Props = React.ElementConfig<typeof IconButton> & {|
   /**
@@ -32,12 +32,16 @@ type Props = React.ElementConfig<typeof IconButton> & {|
    */
   onPress?: () => mixed,
   style?: any,
+  /**
+   * @optional
+   */
+  theme: Theme,
 |};
 
 /**
  * A component used to display an action item in the appbar.
  */
-export default class AppbarAction extends React.Component<Props> {
+class AppbarAction extends React.Component<Props> {
   static displayName = 'Appbar.Action';
 
   static defaultProps = {
@@ -46,21 +50,19 @@ export default class AppbarAction extends React.Component<Props> {
 
   render() {
     const {
-      color: iconColor = color(black)
-        .alpha(0.54)
-        .rgb()
-        .string(),
+      color: iconColor,
       icon,
       disabled,
       onPress,
       accessibilityLabel,
+      theme: { colors },
       ...rest
     } = this.props;
 
     return (
       <IconButton
         onPress={onPress}
-        color={iconColor}
+        color={iconColor || colors.typography.secondary}
         icon={icon}
         disabled={disabled}
         accessibilityLabel={accessibilityLabel}
@@ -70,3 +72,5 @@ export default class AppbarAction extends React.Component<Props> {
     );
   }
 }
+
+export default withTheme(AppbarAction);

--- a/src/components/Drawer/DrawerSection.js
+++ b/src/components/Drawer/DrawerSection.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-import color from 'color';
 import * as React from 'react';
 import { View } from 'react-native';
 import Text from '../Typography/Text';
@@ -63,10 +62,6 @@ class DrawerSection extends React.Component<Props> {
   render() {
     const { children, title, theme, ...rest } = this.props;
     const { colors, fonts } = theme;
-    const titleColor = color(colors.text)
-      .alpha(0.54)
-      .rgb()
-      .string();
     const fontFamily = fonts.medium;
 
     return (
@@ -75,7 +70,11 @@ class DrawerSection extends React.Component<Props> {
           <View style={{ height: 40, justifyContent: 'center' }}>
             <Text
               numberOfLines={1}
-              style={{ color: titleColor, fontFamily, marginLeft: 16 }}
+              style={{
+                color: colors.typography.secondary,
+                fontFamily,
+                marginLeft: 16,
+              }}
             >
               {title}
             </Text>

--- a/src/components/List/ListAccordion.js
+++ b/src/components/List/ListAccordion.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-import color from 'color';
 import * as React from 'react';
 import { View, StyleSheet } from 'react-native';
 import TouchableRipple from '../TouchableRipple';
@@ -119,15 +118,14 @@ class ListAccordion extends React.Component<Props, State> {
   };
 
   render() {
-    const { left, title, description, children, theme, style } = this.props;
-    const titleColor = color(theme.colors.text)
-      .alpha(0.87)
-      .rgb()
-      .string();
-    const descriptionColor = color(theme.colors.text)
-      .alpha(0.54)
-      .rgb()
-      .string();
+    const {
+      left,
+      title,
+      description,
+      children,
+      theme: { colors },
+      style,
+    } = this.props;
 
     const expanded =
       this.props.expanded !== undefined
@@ -146,7 +144,9 @@ class ListAccordion extends React.Component<Props, State> {
           <View style={styles.row} pointerEvents="none">
             {left
               ? left({
-                  color: expanded ? theme.colors.primary : descriptionColor,
+                  color: expanded
+                    ? colors.primary
+                    : colors.typography.secondary,
                 })
               : null}
             <View style={[styles.item, styles.content]}>
@@ -155,7 +155,9 @@ class ListAccordion extends React.Component<Props, State> {
                 style={[
                   styles.title,
                   {
-                    color: expanded ? theme.colors.primary : titleColor,
+                    color: expanded
+                      ? colors.primary
+                      : colors.typography.primary,
                   },
                 ]}
               >
@@ -167,7 +169,7 @@ class ListAccordion extends React.Component<Props, State> {
                   style={[
                     styles.description,
                     {
-                      color: descriptionColor,
+                      color: colors.typography.secondary,
                     },
                   ]}
                 >
@@ -178,7 +180,7 @@ class ListAccordion extends React.Component<Props, State> {
             <View style={[styles.item, description && styles.multiline]}>
               <Icon
                 source={expanded ? 'keyboard-arrow-up' : 'keyboard-arrow-down'}
-                color={titleColor}
+                color={colors.typography.primary}
                 size={24}
               />
             </View>

--- a/src/components/List/ListItem.js
+++ b/src/components/List/ListItem.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-import color from 'color';
 import * as React from 'react';
 import { View, StyleSheet } from 'react-native';
 import type {
@@ -94,7 +93,7 @@ class ListItem extends React.Component<Props> {
       title,
       description,
       onPress,
-      theme,
+      theme: { colors },
       style,
       titleStyle,
       descriptionStyle,
@@ -102,14 +101,6 @@ class ListItem extends React.Component<Props> {
       descriptionEllipsizeMode,
       ...rest
     } = this.props;
-    const titleColor = color(theme.colors.text)
-      .alpha(0.87)
-      .rgb()
-      .string();
-    const descriptionColor = color(theme.colors.text)
-      .alpha(0.54)
-      .rgb()
-      .string();
 
     return (
       <TouchableRipple
@@ -118,12 +109,16 @@ class ListItem extends React.Component<Props> {
         onPress={onPress}
       >
         <View style={styles.row}>
-          {left ? left({ color: descriptionColor }) : null}
+          {left ? left({ color: colors.typography.secondary }) : null}
           <View style={[styles.item, styles.content]} pointerEvents="none">
             <Text
               ellipsizeMode={titleEllipsizeMode}
               numberOfLines={1}
-              style={[styles.title, { color: titleColor }, titleStyle]}
+              style={[
+                styles.title,
+                { color: colors.typography.primary },
+                titleStyle,
+              ]}
             >
               {title}
             </Text>
@@ -134,7 +129,7 @@ class ListItem extends React.Component<Props> {
                 style={[
                   styles.description,
                   {
-                    color: descriptionColor,
+                    color: colors.typography.secondary,
                   },
                   descriptionStyle,
                 ]}
@@ -143,7 +138,7 @@ class ListItem extends React.Component<Props> {
               </Text>
             ) : null}
           </View>
-          {right ? right({ color: descriptionColor }) : null}
+          {right ? right({ color: colors.typography.secondary }) : null}
         </View>
       </TouchableRipple>
     );

--- a/src/components/List/ListSubheader.js
+++ b/src/components/List/ListSubheader.js
@@ -2,7 +2,6 @@
 
 import * as React from 'react';
 import { StyleSheet } from 'react-native';
-import color from 'color';
 import Text from '../Typography/Text';
 import { withTheme } from '../../core/theming';
 import type { Theme } from '../../types';
@@ -39,16 +38,16 @@ class ListSubheader extends React.Component<Props> {
     const { style, theme, ...rest } = this.props;
     const { colors, fonts } = theme;
     const fontFamily = fonts.medium;
-    const textColor = color(colors.text)
-      .alpha(0.54)
-      .rgb()
-      .string();
 
     return (
       <Text
         numberOfLines={1}
         {...rest}
-        style={[styles.container, { color: textColor, fontFamily }, style]}
+        style={[
+          styles.container,
+          { color: colors.typography.secondary, fontFamily },
+          style,
+        ]}
       />
     );
   }

--- a/src/components/Menu/MenuItem.js
+++ b/src/components/Menu/MenuItem.js
@@ -44,26 +44,23 @@ class MenuItem extends React.Component<Props> {
   static displayName = 'Menu.Item';
 
   render() {
-    const { icon, title, disabled, onPress, theme, style } = this.props;
+    const {
+      icon,
+      title,
+      disabled,
+      onPress,
+      theme: { colors, dark },
+      style,
+    } = this.props;
 
-    const disabledColor = color(theme.dark ? white : black)
+    const disabledColor = color(dark ? white : black)
       .alpha(0.32)
       .rgb()
       .string();
 
-    const titleColor = disabled
-      ? disabledColor
-      : color(theme.colors.text)
-          .alpha(0.87)
-          .rgb()
-          .string();
+    const titleColor = disabled ? disabledColor : colors.typography.primary;
 
-    const iconColor = disabled
-      ? disabledColor
-      : color(theme.colors.text)
-          .alpha(0.54)
-          .rgb()
-          .string();
+    const iconColor = disabled ? disabledColor : colors.typography.secondary;
 
     return (
       <TouchableRipple

--- a/src/components/Searchbar.js
+++ b/src/components/Searchbar.js
@@ -140,13 +140,7 @@ class Searchbar extends React.Component<Props> {
     const textColor = colors.text;
     const fontFamily = fonts.regular;
     const iconColor =
-      customIconColor ||
-      (dark
-        ? textColor
-        : color(textColor)
-            .alpha(0.54)
-            .rgb()
-            .string());
+      customIconColor || (dark ? textColor : colors.typography.secondary);
     const rippleColor = color(textColor)
       .alpha(0.32)
       .rgb()
@@ -170,7 +164,7 @@ class Searchbar extends React.Component<Props> {
         <TextInput
           style={[styles.input, { color: textColor, fontFamily }, inputStyle]}
           placeholder={placeholder || ''}
-          placeholderTextColor={colors.placeholder}
+          placeholderTextColor={colors.typography.secondary}
           selectionColor={colors.primary}
           underlineColorAndroid="transparent"
           returnKeyType="search"

--- a/src/components/TextInput/TextInputFlat.js
+++ b/src/components/TextInput/TextInputFlat.js
@@ -57,16 +57,13 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
     let inputTextColor, activeColor, underlineColorCustom, placeholderColor;
 
     if (disabled) {
-      inputTextColor = activeColor = color(colors.text)
-        .alpha(0.54)
-        .rgb()
-        .string();
+      inputTextColor = activeColor = colors.typography.secondary;
       placeholderColor = colors.disabled;
       underlineColorCustom = 'transparent';
     } else {
       inputTextColor = colors.text;
       activeColor = error ? colors.error : colors.primary;
-      placeholderColor = colors.placeholder;
+      placeholderColor = colors.typography.secondary;
       underlineColorCustom = underlineColor || colors.disabled;
     }
 

--- a/src/components/TextInput/TextInputOutlined.js
+++ b/src/components/TextInput/TextInputOutlined.js
@@ -8,7 +8,6 @@ import {
   StyleSheet,
   I18nManager,
 } from 'react-native';
-import color from 'color';
 import Text from '../Typography/Text';
 import type { ChildTextInputProps, RenderProps } from './types';
 
@@ -63,15 +62,12 @@ class TextInputOutlined extends React.Component<ChildTextInputProps, {}> {
       containerStyle;
 
     if (disabled) {
-      inputTextColor = activeColor = color(colors.text)
-        .alpha(0.54)
-        .rgb()
-        .string();
+      inputTextColor = activeColor = colors.typography.secondary;
       placeholderColor = outlineColor = colors.disabled;
     } else {
       inputTextColor = colors.text;
       activeColor = error ? colors.error : colors.primary;
-      placeholderColor = outlineColor = colors.placeholder;
+      placeholderColor = outlineColor = colors.typography.secondary;
     }
 
     const labelHalfWidth = parentState.labelLayout.width / 2;
@@ -133,10 +129,10 @@ class TextInputOutlined extends React.Component<ChildTextInputProps, {}> {
 
     return (
       <View style={[containerStyle, style]}>
-        {/* 
+        {/*
           Render the outline separately from the container
           This is so that the label can overlap the outline
-          Otherwise the border will cut off the label on Android 
+          Otherwise the border will cut off the label on Android
           */}
         <View
           pointerEvents="none"

--- a/src/components/__tests__/Appbar/AppbarAction.test.js
+++ b/src/components/__tests__/Appbar/AppbarAction.test.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import AppbarAction from '../../Appbar/AppbarAction';
+
+describe('ApAppbarActionpbar', () => {
+  it('defaults its colors to colors.typography.secondary', () => {
+    const tree = renderer.create(<AppbarAction icon="add-a-photo" />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('accepts a color as props', () => {
+    const tree = renderer
+      .create(<AppbarAction icon="add-a-photo" color="#fff" />)
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/__tests__/Appbar/__snapshots__/AppbarAction.test.js.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/AppbarAction.test.js.snap
@@ -1,0 +1,229 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ApAppbarActionpbar accepts a color as props 1`] = `
+<View
+  accessibilityRole="button"
+  accessible={true}
+  hitSlop={
+    Object {
+      "bottom": 6,
+      "left": 6,
+      "right": 6,
+      "top": 6,
+    }
+  }
+  isTVSelectable={true}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "overflow": "hidden",
+      },
+      Array [
+        Object {
+          "alignItems": "center",
+          "borderRadius": 18,
+          "height": 36,
+          "justifyContent": "center",
+          "margin": 6,
+          "overflow": "visible",
+          "width": 36,
+        },
+        undefined,
+        undefined,
+      ],
+    ]
+  }
+>
+  <View
+    style={null}
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "justifyContent": "center",
+          },
+          Object {
+            "height": 24,
+            "width": 24,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Object {
+            "bottom": 0,
+            "left": 0,
+            "opacity": 1,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "transform": Array [
+              Object {
+                "rotate": "0deg",
+              },
+            ],
+          }
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          allowFontScaling={false}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          style={
+            Array [
+              Object {
+                "color": "#fff",
+                "fontSize": 24,
+              },
+              Array [
+                Object {
+                  "transform": Array [
+                    Object {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                Object {
+                  "backgroundColor": "transparent",
+                },
+              ],
+              Object {
+                "fontFamily": "Material Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`ApAppbarActionpbar defaults its colors to colors.typography.secondary 1`] = `
+<View
+  accessibilityRole="button"
+  accessible={true}
+  hitSlop={
+    Object {
+      "bottom": 6,
+      "left": 6,
+      "right": 6,
+      "top": 6,
+    }
+  }
+  isTVSelectable={true}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "overflow": "hidden",
+      },
+      Array [
+        Object {
+          "alignItems": "center",
+          "borderRadius": 18,
+          "height": 36,
+          "justifyContent": "center",
+          "margin": 6,
+          "overflow": "visible",
+          "width": 36,
+        },
+        undefined,
+        undefined,
+      ],
+    ]
+  }
+>
+  <View
+    style={null}
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "justifyContent": "center",
+          },
+          Object {
+            "height": 24,
+            "width": 24,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Object {
+            "bottom": 0,
+            "left": 0,
+            "opacity": 1,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "transform": Array [
+              Object {
+                "rotate": "0deg",
+              },
+            ],
+          }
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          allowFontScaling={false}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          style={
+            Array [
+              Object {
+                "color": "rgba(0, 0, 0, 0.54)",
+                "fontSize": 24,
+              },
+              Array [
+                Object {
+                  "transform": Array [
+                    Object {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                Object {
+                  "backgroundColor": "transparent",
+                },
+              ],
+              Object {
+                "fontFamily": "Material Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/src/components/__tests__/__snapshots__/ListSection.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.js.snap
@@ -19,10 +19,13 @@ exports[`renders list section with subheader 1`] = `
         "disabled": "rgba(0, 0, 0, 0.26)",
         "error": "#B00020",
         "notification": "#f50057",
-        "placeholder": "rgba(0, 0, 0, 0.54)",
         "primary": "#6200ee",
         "surface": "#ffffff",
         "text": "#000000",
+        "typography": Object {
+          "primary": "rgba(0, 0, 0, 0.87)",
+          "secondary": "rgba(0, 0, 0, 0.54)",
+        },
       },
       "dark": false,
       "fonts": Object {
@@ -321,10 +324,13 @@ exports[`renders list section without subheader 1`] = `
         "disabled": "rgba(0, 0, 0, 0.26)",
         "error": "#B00020",
         "notification": "#f50057",
-        "placeholder": "rgba(0, 0, 0, 0.54)",
         "primary": "#6200ee",
         "surface": "#ffffff",
         "text": "#000000",
+        "typography": Object {
+          "primary": "rgba(0, 0, 0, 0.87)",
+          "secondary": "rgba(0, 0, 0, 0.54)",
+        },
       },
       "dark": false,
       "fonts": Object {

--- a/src/styles/DarkTheme.js
+++ b/src/styles/DarkTheme.js
@@ -22,12 +22,12 @@ const DarkTheme: Theme = {
     surface: grey800,
     error: redA400,
     text: white,
+    typography: {
+      primary: 'rgba(255, 255, 255, 0.87)',
+      secondary: 'rgba(255, 255, 255, 0.54)',
+    },
     disabled: color(white)
       .alpha(0.3)
-      .rgb()
-      .string(),
-    placeholder: color(white)
-      .alpha(0.54)
       .rgb()
       .string(),
     backdrop: color(black)

--- a/src/styles/DefaultTheme.js
+++ b/src/styles/DefaultTheme.js
@@ -14,12 +14,12 @@ export default {
     surface: white,
     error: '#B00020',
     text: black,
+    typography: {
+      primary: 'rgba(0, 0, 0, 0.87)',
+      secondary: 'rgba(0, 0, 0, 0.54)',
+    },
     disabled: color(black)
       .alpha(0.26)
-      .rgb()
-      .string(),
-    placeholder: color(black)
-      .alpha(0.54)
       .rgb()
       .string(),
     backdrop: color(black)

--- a/src/types.js
+++ b/src/types.js
@@ -12,8 +12,11 @@ export type Theme = {
     accent: string,
     error: string,
     text: string,
+    typography: {
+      primary: string,
+      secondary: string,
+    },
     disabled: string,
-    placeholder: string,
     backdrop: string,
     notification: string,
   },


### PR DESCRIPTION
### Motivation
This PR inserts a new node in the theme file containing the default style of typography in order to avoid the need of declaring variables with the title and description style in each component.

DefaultTheme.js
```
typography: {
  primary: 'rgba(0, 0, 0, 0.87)',
  secondary: 'rgba(0, 0, 0, 0.54)',
},
```

DarkTheme.js
```
typography: {
  primary: 'rgba(255, 255, 255, 0.87)',
  secondary: 'rgba(255, 255, 255, 0.54)',
},
```