### PR TITLE
fix: use theme font in TextInputFlat

### DIFF
--- a/src/components/TextInput/TextInputFlat.js
+++ b/src/components/TextInput/TextInputFlat.js
@@ -51,7 +51,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
     } = this.props;
 
     const { colors, fonts } = theme;
-    const fontFamily = fonts.regular;
+    const font = fonts.regular;
     const hasActiveOutline = parentState.focused || error;
 
     let inputTextColor, activeColor, underlineColorCustom, placeholderColor;
@@ -91,7 +91,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
       labelHalfWidth;
 
     const labelStyle = {
-      fontFamily,
+      ...font,
       fontSize: MAXIMIZED_LABEL_FONT_SIZE,
       transform: [
         {
@@ -236,7 +236,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
                 : styles.inputFlatWithoutLabel,
               {
                 color: inputTextColor,
-                fontFamily,
+                ...font,
                 textAlignVertical: multiline ? 'top' : 'center',
               },
             ],

--- a/src/components/TextInput/TextInputOutlined.js
+++ b/src/components/TextInput/TextInputOutlined.js
@@ -262,7 +262,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps, {}> {
               styles.inputOutlined,
               {
                 color: inputTextColor,
-                fontFamily,
+                ...font,
                 textAlignVertical: multiline ? 'top' : 'center',
               },
             ],

--- a/src/components/TextInput/TextInputOutlined.js
+++ b/src/components/TextInput/TextInputOutlined.js
@@ -51,7 +51,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps, {}> {
     } = this.props;
 
     const { colors, fonts } = theme;
-    const fontFamily = fonts.regular;
+    const font = fonts.regular;
     const hasActiveOutline = parentState.focused || error;
     const { backgroundColor = colors.background } =
       StyleSheet.flatten(style) || {};
@@ -81,7 +81,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps, {}> {
       labelHalfWidth;
 
     const labelStyle = {
-      fontFamily,
+      ...font,
       fontSize: MAXIMIZED_LABEL_FONT_SIZE,
       transform: [
         {
@@ -161,7 +161,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps, {}> {
               styles.outlinedLabelBackground,
               {
                 backgroundColor,
-                fontFamily,
+                ...font,
                 fontSize: MINIMIZED_LABEL_FONT_SIZE,
                 // Hide the background when scale will be 0
                 // There's a bug in RN which makes scale: 0 act weird


### PR DESCRIPTION
### Motivation

`TextInput` did not use the new types of font definition.

### Test plan

n/a