### PR TITLE
add props `leftStyle` and `rightStyle` to `Card.Title` so devs can style the `left` and `right` independently

### DIFF
--- a/src/components/Card/CardTitle.js
+++ b/src/components/Card/CardTitle.js
@@ -9,7 +9,7 @@ import type { Theme } from '../../types';
 
 type Props = React.ElementConfig<typeof View> & {|
   /**
-   * Text for the title.
+   * Text for the title. Note that this will only accept a `<Text>`-based node.
    */
   title: React.Node,
   /**

--- a/src/components/Card/CardTitle.js
+++ b/src/components/Card/CardTitle.js
@@ -6,6 +6,7 @@ import { withTheme } from '../../core/theming';
 import Caption from './../Typography/Caption';
 import Title from './../Typography/Title';
 import type { Theme } from '../../types';
+import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 type Props = React.ElementConfig<typeof View> & {|
   /**
@@ -29,17 +30,17 @@ type Props = React.ElementConfig<typeof View> & {|
    */
   left?: (props: { size: number }) => React.Node,
   /**
-   * Style for the left.
+   * Style for the left element wrapper.
    */
-  leftStyle?: any,
+  leftStyle?: ViewStyleProp,
   /**
    * Callback which returns a React element to display on the right side.
    */
   right?: (props: { size: number }) => React.Node,
   /**
-   * Style for the right.
+   * Style for the right element wrapper.
    */
-  rightStyle?: any,
+  rightStyle?: ViewStyleProp,
   /**
    * @internal
    */

--- a/src/components/Card/CardTitle.js
+++ b/src/components/Card/CardTitle.js
@@ -29,9 +29,17 @@ type Props = React.ElementConfig<typeof View> & {|
    */
   left?: (props: { size: number }) => React.Node,
   /**
+   * Style for the left.
+   */
+  leftStyle?: any,
+  /**
    * Callback which returns a React element to display on the right side.
    */
   right?: (props: { size: number }) => React.Node,
+  /**
+   * Style for the right.
+   */
+  rightStyle?: any,
   /**
    * @internal
    */
@@ -79,7 +87,9 @@ class CardTitle extends React.Component<Props> {
   render() {
     const {
       left,
+      leftStyle,
       right,
+      rightStyle,
       subtitle,
       subtitleStyle,
       style,
@@ -96,7 +106,7 @@ class CardTitle extends React.Component<Props> {
         ]}
       >
         {left ? (
-          <View style={[styles.left]}>
+          <View style={[styles.left, leftStyle]}>
             {left({
               size: LEFT_SIZE,
             })}
@@ -124,7 +134,7 @@ class CardTitle extends React.Component<Props> {
           ) : null}
         </View>
 
-        <View>{right ? right({ size: 24 }) : null}</View>
+        <View style={rightStyle}>{right ? right({ size: 24 }) : null}</View>
       </View>
     );
   }

--- a/src/components/Card/CardTitle.js
+++ b/src/components/Card/CardTitle.js
@@ -9,7 +9,7 @@ import type { Theme } from '../../types';
 
 type Props = React.ElementConfig<typeof View> & {|
   /**
-   * Text for the title. Note that this will only accept a `<Text>`-based node.
+   * Text for the title. Note that this will only accept a string or `<Text>`-based node.
    */
   title: React.Node,
   /**
@@ -17,7 +17,7 @@ type Props = React.ElementConfig<typeof View> & {|
    */
   titleStyle?: any,
   /**
-   * Text for the subtitle.
+   * Text for the subtitle. Note that this will only accept a string or `<Text>`-based node.
    */
   subtitle?: React.Node,
   /**

--- a/typings/components/Card.d.ts
+++ b/typings/components/Card.d.ts
@@ -22,7 +22,10 @@ export interface CardTitleProps extends ViewProps {
   subtitleStyle?: StyleProp<TextStyle>;
   style?: StyleProp<ViewStyle>;
   left?: (props: { size:number }) => React.ReactNode;
+  leftStyle?: StyleProp<ViewStyle>;
   right?: (props: { size:number }) => React.ReactNode;
+  rightStyle?: StyleProp<ViewStyle>;
+
 }
 
 export interface CardProps {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
This PR adds style APIs for the `left` and `right` of the `Card.Title` component. See also issue #1015. 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
This can be tested by creating a card whose `Card.Title` has `left`, `right`, `leftStyle` and `rightStyle` props. The node passed to `left` should be seen do have the style passed to `leftStyle`, and the node passed to `right` should be seen to have the style passed to `rightStyle`.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
