### PR TITLE
Elevation applied after mode changes

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -221,7 +221,7 @@ class Button extends React.Component<Props, State> {
     };
     const touchableStyle = { borderRadius: roundness };
     const textStyle = { color: textColor, fontFamily };
-    const elevation = disabled ? 0 : this.state.elevation;
+    const elevation = disabled || mode !== 'contained' ? 0 : this.state.elevation;
 
     return (
       <Surface

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -221,7 +221,10 @@ class Button extends React.Component<Props, State> {
     };
     const touchableStyle = { borderRadius: roundness };
     const textStyle = { color: textColor, fontFamily };
-    const elevation = disabled || mode !== 'contained' ? 0 : this.state.elevation;
+    const elevation = 
+      disabled || mode !== 'contained' 
+      ? 0 : 
+      this.state.elevation;
 
     return (
       <Surface

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -221,8 +221,11 @@ class Button extends React.Component<Props, State> {
     };
     const touchableStyle = { borderRadius: roundness };
     const textStyle = { color: textColor, fontFamily };
-    const elevation =
-      disabled || mode !== 'contained' ? 0 : this.state.elevation;
+    const elevation = disabled
+      ? 0
+      : mode !== 'contained'
+        ? new Animated.Value(0)
+        : this.state.elevation;
 
     return (
       <Surface

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -222,9 +222,7 @@ class Button extends React.Component<Props, State> {
     const touchableStyle = { borderRadius: roundness };
     const textStyle = { color: textColor, fontFamily };
     const elevation = 
-      disabled || mode !== 'contained' 
-      ? 0 : 
-      this.state.elevation;
+      disabled || mode !== 'contained' ? 0 : this.state.elevation;
 
     return (
       <Surface

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -221,7 +221,7 @@ class Button extends React.Component<Props, State> {
     };
     const touchableStyle = { borderRadius: roundness };
     const textStyle = { color: textColor, fontFamily };
-    const elevation = 
+    const elevation =
       disabled || mode !== 'contained' ? 0 : this.state.elevation;
 
     return (


### PR DESCRIPTION
### Motivation
The wrong elevation is being applied to an outlined button when it is first being rendered as a contained button.

Reproduce steps:
1. Render a button using `mode={this.propsIsContained ? 'contained' : 'outline'}` and set `propsIsContained = 'true'`.
2. Change the property in the component to false during runtime `propsIsContained = false`
3. Observe that elevation is applied on the outlined button while it shouldn't.

**WRONG**
![image](https://user-images.githubusercontent.com/18186115/56661857-e5f0a800-66a2-11e9-968c-480b168c3c29.png)

**GOOD**
![image](https://user-images.githubusercontent.com/18186115/56661889-f6a11e00-66a2-11e9-90b6-5a5165730a9b.png)

