### PR TITLE
Feat: style inner TextInput and closes #877

### DIFF
--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -93,6 +93,10 @@ export type TextInputProps = {|
   value?: string,
   style?: any,
   /**
+   * Style for the inner TextInput.
+   */
+  childStyle?: string,
+  /**
    * @optional
    */
   theme: Theme,

--- a/src/components/TextInput/TextInputFlat.js
+++ b/src/components/TextInput/TextInputFlat.js
@@ -239,6 +239,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
                 fontFamily,
                 textAlignVertical: multiline ? 'top' : 'center',
               },
+              this.props.childStyle,
             ],
           }: RenderProps)
         )}

--- a/src/components/TextInput/TextInputOutlined.js
+++ b/src/components/TextInput/TextInputOutlined.js
@@ -265,6 +265,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps, {}> {
                 fontFamily,
                 textAlignVertical: multiline ? 'top' : 'center',
               },
+              this.props.childStyle,
             ],
           }: RenderProps)
         )}

--- a/src/components/TextInput/types.js
+++ b/src/components/TextInput/types.js
@@ -13,7 +13,6 @@ export type RenderProps = {
   onBlur: ?() => mixed,
   underlineColorAndroid: ?string,
   style: any,
-  childStyle: any,
   multiline: ?boolean,
   numberOfLines: ?number,
   value: ?string,

--- a/src/components/TextInput/types.js
+++ b/src/components/TextInput/types.js
@@ -13,6 +13,7 @@ export type RenderProps = {
   onBlur: ?() => mixed,
   underlineColorAndroid: ?string,
   style: any,
+  childStyle: any,
   multiline: ?boolean,
   numberOfLines: ?number,
   value: ?string,


### PR DESCRIPTION
### Motivation

With this pull request you can style the inner TextInput of a `TextInputFlat` or `TextInputOutlined`. Without this, now you can't change the height of the TextInput.

Also, closes #877 .

### Test plan

Pass `{ minHeight: 0, paddingVertical: 0 }` as `childStyle` and see the height of the TextInput changing.