### PR TITLE
fix: warning in console when running tests

### DIFF
--- a/src/components/__tests__/BottomNavigation.test.js
+++ b/src/components/__tests__/BottomNavigation.test.js
@@ -4,6 +4,8 @@ import * as React from 'react';
 import renderer from 'react-test-renderer';
 import BottomNavigation from '../BottomNavigation';
 
+jest.useFakeTimers();
+
 jest.mock('Animated', () => {
   const ActualAnimated = jest.requireActual('Animated');
 


### PR DESCRIPTION
### Motivation
Jest was throwing the following warning when running tests:
```
console.warn node_modules/react-native/jest/MockNativeMethods.js:19
      Calling .measureInWindow() in the test renderer environment is not supported. Instead, mock out your components that use findNodeHandle with replacements that don't rely on the native environment.
```

### Test plan
1. Run `yarn test`
2. Check if jest will threw any warning