### PR TITLE
fix: set forceInset in Appbar.Header by default

### DIFF
--- a/src/components/Appbar/AppbarHeader.js
+++ b/src/components/Appbar/AppbarHeader.js
@@ -1,7 +1,8 @@
 /* @flow */
 
 import * as React from 'react';
-import { View, SafeAreaView, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
+import SafeAreaView from 'react-native-safe-area-view';
 
 import Appbar, { DEFAULT_APPBAR_HEIGHT } from './Appbar';
 import shadow from '../../styles/shadow';
@@ -96,13 +97,11 @@ class AppbarHeader extends React.Component<Props> {
       backgroundColor = colors.primary,
       ...restStyle
     } = StyleSheet.flatten(style) || {};
-
-    // Let the user override the behaviour
-    const Wrapper =
-      typeof this.props.statusBarHeight === 'number' ? View : SafeAreaView;
+    const useView = typeof this.props.statusBarHeight === 'number';
 
     return (
       <Wrapper
+        useView={useView}
         style={[{ backgroundColor, zIndex }, elevation && shadow(elevation)]}
       >
         {/* $FlowFixMe: There seems to be conflict between Appbar's props and Header's props */}
@@ -117,6 +116,14 @@ class AppbarHeader extends React.Component<Props> {
       </Wrapper>
     );
   }
+}
+
+function Wrapper({ useView, ...props }) {
+  if (useView) return <View {...props} />;
+
+  return (
+    <SafeAreaView forceInset={{ top: 'always', bottom: 'never' }} {...props} />
+  );
 }
 
 const styles = StyleSheet.create({

--- a/src/components/__tests__/Appbar/Appbar.Header.test.js
+++ b/src/components/__tests__/Appbar/Appbar.Header.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Appbar from '../../Appbar/Appbar';
+
+describe('AppbarHeader', () => {
+  it('Uses a SafeAreaView wrapper if statusBarHeight is not given', () => {
+    const tree = renderer
+      .create(
+        <Appbar.Header>
+          <Appbar.Content title="Examples" />
+        </Appbar.Header>
+      )
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('Uses a View wrapper if statusBarHeight is given a number', () => {
+    const tree = renderer
+      .create(
+        <Appbar.Header statusBarHeight={100}>
+          <Appbar.Content title="Examples" />
+        </Appbar.Header>
+      )
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.Header.test.js.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.Header.test.js.snap
@@ -1,0 +1,209 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AppbarHeader Uses a SafeAreaView wrapper if statusBarHeight is not given 1`] = `
+<View
+  onLayout={[Function]}
+  pointerEvents="box-none"
+  style={
+    Object {
+      "backgroundColor": "#6200ee",
+      "paddingBottom": 0,
+      "paddingLeft": 0,
+      "paddingRight": 0,
+      "paddingTop": 20,
+      "shadowColor": "#000000",
+      "shadowOffset": Object {
+        "height": 3,
+        "width": 0,
+      },
+      "shadowOpacity": 0.24,
+      "shadowRadius": 4,
+      "zIndex": 0,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#6200ee",
+        "elevation": 0,
+        "flexDirection": "row",
+        "height": 56,
+        "marginTop": 0,
+        "paddingHorizontal": 4,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "width": 48,
+        }
+      }
+    />
+    <View
+      accessible={true}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "flex": 1,
+            "paddingHorizontal": 12,
+          },
+          Array [
+            false,
+            Object {
+              "alignItems": "center",
+            },
+            undefined,
+          ],
+        ]
+      }
+    >
+      <Text
+        accessibilityRole="header"
+        accessibilityTraits="header"
+        numberOfLines={1}
+        style={
+          Array [
+            Object {
+              "color": "#000000",
+              "fontFamily": "Helvetica Neue",
+              "textAlign": "left",
+              "writingDirection": "ltr",
+            },
+            Array [
+              Object {
+                "color": "#ffffff",
+                "fontFamily": "Helvetica Neue",
+              },
+              Object {
+                "fontSize": 17,
+              },
+              undefined,
+            ],
+          ]
+        }
+      >
+        Examples
+      </Text>
+    </View>
+    <View
+      style={
+        Object {
+          "width": 48,
+        }
+      }
+    />
+  </View>
+</View>
+`;
+
+exports[`AppbarHeader Uses a View wrapper if statusBarHeight is given a number 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#6200ee",
+        "zIndex": 0,
+      },
+      Object {
+        "shadowColor": "#000000",
+        "shadowOffset": Object {
+          "height": 3,
+          "width": 0,
+        },
+        "shadowOpacity": 0.24,
+        "shadowRadius": 4,
+      },
+    ]
+  }
+>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#6200ee",
+        "elevation": 0,
+        "flexDirection": "row",
+        "height": 56,
+        "marginTop": 100,
+        "paddingHorizontal": 4,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "width": 48,
+        }
+      }
+    />
+    <View
+      accessible={true}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "flex": 1,
+            "paddingHorizontal": 12,
+          },
+          Array [
+            false,
+            Object {
+              "alignItems": "center",
+            },
+            undefined,
+          ],
+        ]
+      }
+    >
+      <Text
+        accessibilityRole="header"
+        accessibilityTraits="header"
+        numberOfLines={1}
+        style={
+          Array [
+            Object {
+              "color": "#000000",
+              "fontFamily": "Helvetica Neue",
+              "textAlign": "left",
+              "writingDirection": "ltr",
+            },
+            Array [
+              Object {
+                "color": "#ffffff",
+                "fontFamily": "Helvetica Neue",
+              },
+              Object {
+                "fontSize": 17,
+              },
+              undefined,
+            ],
+          ]
+        }
+      >
+        Examples
+      </Text>
+    </View>
+    <View
+      style={
+        Object {
+          "width": 48,
+        }
+      }
+    />
+  </View>
+</View>
+`;


### PR DESCRIPTION
Follows a similar fix made on the BottomNavigation where we explicitly tell `SafeAreaView` that the Header is placed on the top, so it does not have to calculate using `onLayout`.

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

The SafeAreaView component uses `onLayout` to calculate the insets. It would sometimes cause some visual flickering as the layout is being calculated. They also mention about this on their [documentation](https://github.com/react-native-community/react-native-safe-area-view#forceinset).

### Test plan

- [x] Unit tests (snapshots)
- [x] Tested on simulator and real device, the problem is gone
