### PR TITLE
fix: correct Chip component typings

### DIFF
--- a/__ts-tests__/Chip.test.tsx
+++ b/__ts-tests__/Chip.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Chip } from '..';
 
 const MyComponent = () => (
-  <Chip icon="info" onPress={() => console.log('Pressed')}>Example Chip</Chip>
+  <Chip icon="info" selectedColor="#fff" onPress={() => console.log('Pressed')}>Example Chip</Chip>
 );
 
 export default MyComponent;

--- a/typings/components/Chip.d.ts
+++ b/typings/components/Chip.d.ts
@@ -8,6 +8,7 @@ export interface ChipProps {
   icon?: IconSource;
   avatar?: React.ReactNode;
   selected?: boolean;
+  selectedColor?: string;
   disabled?: boolean;
   accessibilityLabel?: string;
   onPress?: () => any;


### PR DESCRIPTION
### Motivation

As of version 2.15.2 the Chip component accepts the prop `selectedColor`
which it defines as an optional string prop. Though this change was
introduced to the Chip component itself, the typings for the component
were not updated which causes Typescript to complain when using the
`selectedColor` prop. This change adds the missing type to appease
Typescript.

### Test plan

The change to `__ts-tests__/Chip.test.tsx` exposes the issue described in the "Motivation" section. Tests pass with the change to `typings/components/Chip.d.ts` and fail without them. There are no visual changes associated with this change.
