### PR TITLE
fix: add inputStyle prop tying to Searchbar

### DIFF
--- a/typings/components/Searchbar.d.ts
+++ b/typings/components/Searchbar.d.ts
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { TextInputProps } from 'react-native';
+import { StyleProp, TextInputProps, TextStyle } from 'react-native';
 import { ThemeShape, IconSource } from '../types';
 
 export interface SearchbarProps extends TextInputProps {
+  inputStyle?: StyleProp<TextStyle>;
   icon?: IconSource;
   theme?: ThemeShape;
   clearIcon?: IconSource;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

According to official [docs](https://callstack.github.io/react-native-paper/searchbar.html#inputStyle), `inputStyle` should be in `SearchbarProps`. The current typing apparently misses it.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

Very minor typing change, could be tested straight away by vscode code intellisense.
