### PR TITLE
fix: use "active" instead of "text" for ripple color

### DIFF
--- a/src/components/BottomNavigation.js
+++ b/src/components/BottomNavigation.js
@@ -595,7 +595,7 @@ class BottomNavigation<T: *> extends React.Component<Props<T>, State> {
             .rgb()
             .string();
 
-    const touchColor = color(textColor)
+    const touchColor = color(activeColor)
       .alpha(0.12)
       .rgb()
       .string();


### PR DESCRIPTION
…with Material Design
