### PR TITLE
feat: allow to make inputs uncontrolled with defaultValue

### DIFF
--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -174,7 +174,7 @@ class TextInput extends React.Component<TextInputProps, State> {
     error: new Animated.Value(this.props.error ? 1 : 0),
     focused: false,
     placeholder: this.props.error ? this.props.placeholder : '',
-    value: this.props.value,
+    value: this.props.value || this.props.defaultValue,
     labelLayout: {
       measured: false,
       width: 0,
@@ -187,7 +187,8 @@ class TextInput extends React.Component<TextInputProps, State> {
     if (
       prevState.focused !== this.state.focused ||
       prevState.value !== this.state.value ||
-      prevProps.error !== this.props.error
+      prevProps.error !== this.props.error ||
+      this.props.defaultValue
     ) {
       // The label should be minimized if the text input is focused, or has text
       // In minimized mode, the label moves up and becomes small


### PR DESCRIPTION
Use defaultValue prop to make the TextInputs uncontrolled

Please see #154

### Motivation

Passing defaultValue does not make effects on minimize label in textInputs.
Passing value as const it does not became 'uncontrolled'

### Test plan

If you pass value the control stays in controlled mode. If you ommit the value props the input becomes uncontrolled. You can also pass defaultValue to show it at first render 
