### PR TITLE
fix: fix editable disable prop

### DIFF
--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -296,7 +296,7 @@ class TextInput extends React.Component<TextInputProps, State> {
     }).start();
 
   _handleFocus = (...args) => {
-    if (this.props.disabled) {
+    if (this.props.disabled || !this.props.editable) {
       return;
     }
 
@@ -308,7 +308,7 @@ class TextInput extends React.Component<TextInputProps, State> {
   };
 
   _handleBlur = (...args) => {
-    if (this.props.disabled) {
+    if (this.props.disabled || !this.props.editable) {
       return;
     }
 

--- a/src/components/TextInput/TextInputFlat.js
+++ b/src/components/TextInput/TextInputFlat.js
@@ -225,7 +225,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
               ? parentState.placeholder
               : this.props.placeholder,
             placeholderTextColor: placeholderColor,
-            editable: !disabled,
+            editable: !disabled && editable,
             selectionColor:
               typeof selectionColor === 'undefined'
                 ? activeColor

--- a/src/components/TextInput/TextInputFlat.js
+++ b/src/components/TextInput/TextInputFlat.js
@@ -33,6 +33,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
   render() {
     const {
       disabled,
+      editable,
       label,
       error,
       selectionColor,

--- a/src/components/TextInput/TextInputOutlined.js
+++ b/src/components/TextInput/TextInputOutlined.js
@@ -33,6 +33,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps, {}> {
   render() {
     const {
       disabled,
+      editable,
       label,
       error,
       selectionColor,

--- a/src/components/TextInput/TextInputOutlined.js
+++ b/src/components/TextInput/TextInputOutlined.js
@@ -249,7 +249,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps, {}> {
               ? parentState.placeholder
               : this.props.placeholder,
             placeholderTextColor: placeholderColor,
-            editable: !disabled,
+            editable: !disabled && editable,
             selectionColor:
               typeof selectionColor === 'undefined'
                 ? activeColor


### PR DESCRIPTION
### Motivation

Allow to lock control (set editable to false) without gray it out.
fix #986 
fix #737 

### Test plan

1. When you pass disable prop control becomes disabled and grayedOut.
2. When you pass editable prop to false the control behaves the same as disabled but without grayedOut

Passing both above options at once will makes control disabled and grayedOut