### PR TITLE
fix: text input defaultValue collision with label. fixes #1072

### DIFF
--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -178,15 +178,27 @@ class TextInput extends React.Component<TextInputProps, State> {
 
   ref: ?NativeTextInput;
 
+  componentDidMount() {
+    if (this.props.defaultValue) {
+      this._minmizeLabel();
+    }
+  }
+
   componentDidUpdate(prevProps, prevState) {
     if (
       prevState.focused !== this.state.focused ||
       prevState.value !== this.state.value ||
-      prevProps.error !== this.props.error
+      prevProps.error !== this.props.error ||
+      this.props.defaultValue
     ) {
       // The label should be minimized if the text input is focused, or has text
       // In minimized mode, the label moves up and becomes small
-      if (this.state.value || this.state.focused || this.props.error) {
+      if (
+        this.state.value ||
+        this.state.focused ||
+        this.props.error ||
+        this.props.defaultValue
+      ) {
         this._minmizeLabel();
       } else {
         this._restoreLabel();

--- a/src/components/TextInput/TextInputOutlined.js
+++ b/src/components/TextInput/TextInputOutlined.js
@@ -133,10 +133,10 @@ class TextInputOutlined extends React.Component<ChildTextInputProps, {}> {
 
     return (
       <View style={[containerStyle, style]}>
-        {/* 
+        {/*
           Render the outline separately from the container
           This is so that the label can overlap the outline
-          Otherwise the border will cut off the label on Android 
+          Otherwise the border will cut off the label on Android
           */}
         <View
           pointerEvents="none"


### PR DESCRIPTION
This resolves #1072 by checking for a `defaultValue` prop in `componentDidMount` and minimizing the label immediately.

### Motivation

#1072

### Test plan

```
<TextInput
    style={{ flex: 1 }}
    label='Name'
    defaultValue={'21535278'}
    onChangeText={name => {
        // do something
    }}
    mode={'outlined'}
/>
```
<img width="323" alt="Screen Shot 2019-05-17 at 4 00 24 PM" src="https://user-images.githubusercontent.com/8162417/57958396-ee608b00-78bc-11e9-8ed1-8275b5ec94c3.png">
