### PR TITLE
Fix typo in accessibilityRole in DialogTitle

### DIFF
--- a/src/components/Dialog/DialogTitle.js
+++ b/src/components/Dialog/DialogTitle.js
@@ -59,7 +59,7 @@ class DialogTitle extends React.Component<Props> {
     return (
       <Title
         accessibilityTraits="header"
-        accessibilityRole="header"
+        accessibilityRole="heading"
         style={[styles.text, { color: theme.colors.text }, style]}
         {...rest}
       >


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
This solves the following error when using this library on web:
<img width="712" alt="Screen Shot 2019-05-17 at 15 02 21" src="https://user-images.githubusercontent.com/369384/57958752-bb66c900-78b5-11e9-80f7-61248a8088c3.png">

See [documentation here](https://github.com/necolas/react-native-web/blob/master/docs/guides/accessibility.md#accessibilityrole).

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
Manually opened in a web browser and confirmed the error is gone.
