### PR TITLE
fix: move paddingHorizontal out from content style

### DIFF
--- a/src/components/DataTable/DataTableRow.js
+++ b/src/components/DataTable/DataTableRow.js
@@ -40,7 +40,7 @@ class DataTableRow extends React.Component<Props> {
         onPress={onPress}
         style={[styles.container, { borderBottomColor }, style]}
       >
-        <View style={styles.content}>{this.props.children}</View>
+        <View style={[styles.content, style]}>{this.props.children}</View>
       </TouchableRipple>
     );
   }

--- a/src/components/DataTable/DataTableRow.js
+++ b/src/components/DataTable/DataTableRow.js
@@ -40,7 +40,7 @@ class DataTableRow extends React.Component<Props> {
         onPress={onPress}
         style={[styles.container, { borderBottomColor }, style]}
       >
-        <View style={[styles.content, style]}>{this.props.children}</View>
+        <View style={ styles.content }>{this.props.children}</View>
       </TouchableRipple>
     );
   }
@@ -51,11 +51,11 @@ const styles = StyleSheet.create({
     borderStyle: 'solid',
     borderBottomWidth: StyleSheet.hairlineWidth,
     minHeight: 48,
+    paddingHorizontal: 16,
   },
   content: {
     flex: 1,
     flexDirection: 'row',
-    paddingHorizontal: 16,
   },
 });
 

--- a/src/components/DataTable/DataTableRow.js
+++ b/src/components/DataTable/DataTableRow.js
@@ -40,7 +40,7 @@ class DataTableRow extends React.Component<Props> {
         onPress={onPress}
         style={[styles.container, { borderBottomColor }, style]}
       >
-        <View style={ styles.content }>{this.props.children}</View>
+        <View style={styles.content}>{this.props.children}</View>
       </TouchableRipple>
     );
   }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

The ability of overriding style properties makes things more flexible. In order to achieve this within DataTableRow,  we have moved paddingHorizontal out from content style which can't be overridden, and put it in container style which can be overridden with the style class property.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
