### PR TITLE
feat: Allow Override of Button Label Text Styles

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -65,6 +65,11 @@ type Props = React.ElementConfig<typeof Surface> & {|
    * Use this prop to apply custom height and width.
    */
   contentStyle?: any,
+  /**
+   * Style of button's text component.
+   * Use this prop to apply custom fontSize.
+   */
+  textStyles?: any,
   style?: any,
   /**
    * @optional

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -152,6 +152,7 @@ class Button extends React.Component<Props, State> {
       style,
       theme,
       contentStyle,
+      textStyles,
       ...rest
     } = this.props;
     const { colors, roundness } = theme;
@@ -220,7 +221,7 @@ class Button extends React.Component<Props, State> {
       borderRadius: roundness,
     };
     const touchableStyle = { borderRadius: roundness };
-    const textStyle = { color: textColor, fontFamily };
+    const textStyle = { ...textStyles, color: textColor, fontFamily };
     const elevation =
       disabled || mode !== 'contained' ? 0 : this.state.elevation;
 

--- a/typings/components/Button.d.ts
+++ b/typings/components/Button.d.ts
@@ -12,6 +12,7 @@ export interface ButtonProps extends TouchableRippleProps {
   icon?: IconSource;
   uppercase?: boolean;
   contentStyle?: StyleProp<ViewStyle>;
+  textStyle?: StyleProp<ViewStyle>;
   style?: StyleProp<ViewStyle>;
   theme?: ThemeShape;
 }


### PR DESCRIPTION
### Motivation

I wanted to be able to increase the font size of the text displayed within the Button component

### Test plan

- Add an optional `textStyles` object parameter to your react-native-paper Button component as displayed below:

```javascript
<Button
  {...props}
  mode="contained"
  textStyles={{ fontSize: 25 }}
/>
```