### PR TITLE
fix: CrossFadeIcon with function-based source

### DIFF
--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -95,7 +95,7 @@ const getIconId = (source: any) => {
 };
 
 export const isValidIcon = (source: any) =>
-  typeof source === 'string' || isImageSource(source);
+  typeof source === 'string' || typeof source == 'function' || isImageSource(source);
 
 export const isEqualIcon = (a: any, b: any) =>
   a === b || getIconId(a) === getIconId(b);


### PR DESCRIPTION
Expand isValidIcon check to include function-based icon source so that CrossFadeIcon will work properly in this case.