### PR TITLE
Feat: use Material Design Community Icons

### DIFF
--- a/example/src/DrawerItems.js
+++ b/example/src/DrawerItems.js
@@ -29,7 +29,7 @@ const DrawerItemsData = [
   { label: 'Inbox', icon: 'inbox', key: 0 },
   { label: 'Starred', icon: 'star', key: 1 },
   { label: 'Sent mail', icon: 'send', key: 2 },
-  { label: 'Colored label', icon: 'color-lens', key: 3 },
+  { label: 'Colored label', icon: 'palette', key: 3 },
   { label: 'A very long title that will be truncated', icon: 'delete', key: 4 },
 ];
 

--- a/example/src/Examples/ActivityIndicatorExample.js
+++ b/example/src/Examples/ActivityIndicatorExample.js
@@ -37,7 +37,7 @@ class ActivityIndicatorExample extends React.Component<Props, State> {
         <View style={styles.row}>
           <FAB
             small
-            icon={this.state.animating ? 'pause' : 'play-arrow'}
+            icon={this.state.animating ? 'pause' : 'play'}
             style={styles.fab}
             onPress={() => {
               this.setState({

--- a/example/src/Examples/AppbarExample.js
+++ b/example/src/Examples/AppbarExample.js
@@ -24,7 +24,7 @@ const initialParams = {
   showMoreIcon: true,
 };
 
-const MORE_ICON = Platform.OS === 'ios' ? 'more-horiz' : 'more-vert';
+const MORE_ICON = Platform.OS === 'ios' ? 'dots-horizontal' : 'dots-vertical';
 
 class AppbarExample extends React.Component<Props> {
   static title = 'Appbar';
@@ -42,7 +42,7 @@ class AppbarExample extends React.Component<Props> {
             subtitle={params.showSubtitle ? 'Subtitle' : null}
           />
           {params.showSearchIcon && (
-            <Appbar.Action icon="search" onPress={() => {}} />
+            <Appbar.Action icon="magnify" onPress={() => {}} />
           )}
           {params.showMoreIcon && (
             <Appbar.Action icon={MORE_ICON} onPress={() => {}} />
@@ -116,7 +116,7 @@ class AppbarExample extends React.Component<Props> {
         </View>
         <Appbar style={styles.bottom}>
           <Appbar.Action icon="archive" onPress={() => {}} />
-          <Appbar.Action icon="mail" onPress={() => {}} />
+          <Appbar.Action icon="email" onPress={() => {}} />
           <Appbar.Action icon="label" onPress={() => {}} />
           <Appbar.Action icon="delete" onPress={() => {}} />
         </Appbar>

--- a/example/src/Examples/BadgeExample.js
+++ b/example/src/Examples/BadgeExample.js
@@ -47,7 +47,11 @@ class BadgeExample extends React.Component<Props, State> {
         <List.Section title="Text">
           <View style={styles.row}>
             <View style={styles.item}>
-              <IconButton icon="style" size={36} style={styles.button} />
+              <IconButton
+                icon="palette-swatch"
+                size={36}
+                style={styles.button}
+              />
               <Badge visible={this.state.visible} style={styles.badge}>
                 12
               </Badge>
@@ -66,11 +70,7 @@ class BadgeExample extends React.Component<Props, State> {
         <List.Section title="Dot">
           <View style={styles.row}>
             <View style={styles.item}>
-              <IconButton
-                icon="chrome-reader-mode"
-                size={36}
-                style={styles.button}
-              />
+              <IconButton icon="book-open" size={36} style={styles.button} />
               <Badge
                 visible={this.state.visible}
                 style={styles.badge}

--- a/example/src/Examples/BannerExample.js
+++ b/example/src/Examples/BannerExample.js
@@ -81,7 +81,7 @@ class BannerExample extends React.Component<Props, State> {
         <SafeAreaView>
           <View>
             <FAB
-              icon="visibility"
+              icon="eye"
               label={this.state.visible ? 'Hide banner' : 'Show banner'}
               style={styles.fab}
               onPress={() =>

--- a/example/src/Examples/BottomNavigationExample.js
+++ b/example/src/Examples/BottomNavigationExample.js
@@ -47,7 +47,7 @@ export default class BottomNavigationExample extends React.Component<
   state = {
     index: 0,
     routes: [
-      { key: 'album', title: 'Album', icon: 'photo-album', color: '#6200ee' },
+      { key: 'album', title: 'Album', icon: 'image-album', color: '#6200ee' },
       {
         key: 'library',
         title: 'Library',
@@ -58,13 +58,13 @@ export default class BottomNavigationExample extends React.Component<
       {
         key: 'favorites',
         title: 'Favorites',
-        icon: 'favorite',
+        icon: 'heart',
         color: '#00796b',
       },
       {
         key: 'purchased',
         title: 'Purchased',
-        icon: 'shop',
+        icon: 'cart',
         color: '#c51162',
       },
     ],

--- a/example/src/Examples/ButtonExample.js
+++ b/example/src/Examples/ButtonExample.js
@@ -37,7 +37,7 @@ class ButtonExample extends React.Component<Props, State> {
             <Button disabled onPress={() => {}} style={styles.button}>
               Disabled
             </Button>
-            <Button icon="add-a-photo" onPress={() => {}} style={styles.button}>
+            <Button icon="camera" onPress={() => {}} style={styles.button}>
               Icon
             </Button>
             <Button loading onPress={() => {}} style={styles.button}>
@@ -68,7 +68,7 @@ class ButtonExample extends React.Component<Props, State> {
             </Button>
             <Button
               mode="outlined"
-              icon="add-a-photo"
+              icon="camera"
               onPress={() => {}}
               style={styles.button}
             >
@@ -107,7 +107,7 @@ class ButtonExample extends React.Component<Props, State> {
             </Button>
             <Button
               mode="contained"
-              icon="add-a-photo"
+              icon="camera"
               onPress={() => {}}
               style={styles.button}
             >

--- a/example/src/Examples/CardExample.js
+++ b/example/src/Examples/CardExample.js
@@ -57,7 +57,7 @@ class CardExample extends React.Component<Props> {
             subtitle="Omega Ruby"
             left={props => <Avatar.Icon {...props} icon="folder" />}
             right={props => (
-              <IconButton {...props} icon="more-vert" onPress={() => {}} />
+              <IconButton {...props} icon="dots-vertical" onPress={() => {}} />
             )}
           />
           <Card.Content>
@@ -78,7 +78,7 @@ class CardExample extends React.Component<Props> {
             title="Just Strawberries"
             subtitle="... and only Strawberries"
             right={props => (
-              <IconButton {...props} icon="expand-more" onPress={() => {}} />
+              <IconButton {...props} icon="chevron-down" onPress={() => {}} />
             )}
           />
         </Card>
@@ -105,7 +105,7 @@ class CardExample extends React.Component<Props> {
           <Card.Cover source={require('../../assets/images/city.jpg')} />
           <Card.Title
             title="Long Pressable City"
-            left={props => <Avatar.Icon {...props} icon="location-city" />}
+            left={props => <Avatar.Icon {...props} icon="city" />}
           />
           <Card.Content>
             <Paragraph>

--- a/example/src/Examples/ChipExample.js
+++ b/example/src/Examples/ChipExample.js
@@ -32,7 +32,7 @@ class ChipExample extends React.Component<Props> {
               Close button
             </Chip>
             <Chip
-              icon="favorite"
+              icon="heart"
               onPress={() => {}}
               onClose={() => {}}
               style={styles.chip}
@@ -59,12 +59,7 @@ class ChipExample extends React.Component<Props> {
             >
               Avatar (selected)
             </Chip>
-            <Chip
-              disabled
-              icon="favorite"
-              onClose={() => {}}
-              style={styles.chip}
-            >
+            <Chip disabled icon="heart" onClose={() => {}} style={styles.chip}>
               Icon (disabled)
             </Chip>
             <Chip
@@ -93,7 +88,7 @@ class ChipExample extends React.Component<Props> {
             </Chip>
             <Chip
               mode="outlined"
-              icon="favorite"
+              icon="heart"
               onPress={() => {}}
               onClose={() => {}}
               style={styles.chip}
@@ -124,7 +119,7 @@ class ChipExample extends React.Component<Props> {
             <Chip
               disabled
               mode="outlined"
-              icon="favorite"
+              icon="heart"
               onClose={() => {}}
               style={styles.chip}
             >

--- a/example/src/Examples/FABExample.js
+++ b/example/src/Examples/FABExample.js
@@ -33,7 +33,7 @@ class ButtonExample extends React.Component<Props, State> {
         <View style={styles.row}>
           <FAB
             small
-            icon={this.state.visible ? 'visibility-off' : 'visibility'}
+            icon={this.state.visible ? 'eye-off' : 'eye'}
             style={styles.fab}
             onPress={() => {
               this.setState({
@@ -45,20 +45,20 @@ class ButtonExample extends React.Component<Props, State> {
 
         <View style={styles.row}>
           <FAB
-            icon="favorite"
+            icon="heart"
             style={styles.fab}
             onPress={() => {}}
             visible={this.state.visible}
           />
           <FAB
-            icon="done"
+            icon="check"
             label="Extended FAB"
             style={styles.fab}
             onPress={() => {}}
             visible={this.state.visible}
           />
           <FAB
-            icon="cancel"
+            icon="close-circle"
             label="Disabled FAB"
             style={styles.fab}
             onPress={() => {}}
@@ -77,12 +77,12 @@ class ButtonExample extends React.Component<Props, State> {
           <Portal>
             <FAB.Group
               open={this.state.open}
-              icon={this.state.open ? 'today' : 'add'}
+              icon={this.state.open ? 'calendar-today' : 'plus'}
               actions={[
-                { icon: 'add', onPress: () => {} },
+                { icon: 'plus', onPress: () => {} },
                 { icon: 'star', label: 'Star', onPress: () => {} },
                 { icon: 'email', label: 'Email', onPress: () => {} },
-                { icon: 'notifications', label: 'Remind', onPress: () => {} },
+                { icon: 'bell', label: 'Remind', onPress: () => {} },
               ]}
               onStateChange={({ open }) => this.setState({ open })}
               onPress={() => {

--- a/example/src/Examples/IconButtonExample.js
+++ b/example/src/Examples/IconButtonExample.js
@@ -20,9 +20,9 @@ class ButtonExample extends React.Component<Props, State> {
 
     return (
       <View style={[styles.container, { backgroundColor: colors.background }]}>
-        <IconButton icon="add-a-photo" size={24} onPress={() => {}} />
+        <IconButton icon="camera" size={24} onPress={() => {}} />
         <IconButton
-          icon="https"
+          icon="lock"
           size={24}
           color={Colors.green500}
           onPress={() => {}}

--- a/example/src/Examples/ListSectionExample.js
+++ b/example/src/Examples/ListSectionExample.js
@@ -22,17 +22,17 @@ class ListSectionExample extends React.Component<Props> {
         <List.Section>
           <List.Subheader>Single line</List.Subheader>
           <List.Item
-            left={props => <List.Icon {...props} icon="event" />}
+            left={props => <List.Icon {...props} icon="calendar" />}
             title="List item 1"
           />
           <List.Item
-            left={props => <List.Icon {...props} icon="redeem" />}
+            left={props => <List.Icon {...props} icon="wallet-giftcard" />}
             title="List item 2"
           />
           <List.Item
             title="List item 3"
             left={props => <List.Icon {...props} icon="folder" />}
-            right={props => <List.Icon {...props} icon="drag-handle" />}
+            right={props => <List.Icon {...props} icon="reorder-horizontal" />}
           />
         </List.Section>
         <Divider />
@@ -55,7 +55,7 @@ class ListSectionExample extends React.Component<Props> {
                 style={styles.image}
               />
             )}
-            right={props => <List.Icon {...props} icon="info" />}
+            right={props => <List.Icon {...props} icon="information" />}
             title="List item 2"
             description="Describes item 2"
           />
@@ -80,7 +80,7 @@ class ListSectionExample extends React.Component<Props> {
                 style={styles.image}
               />
             )}
-            right={props => <List.Icon {...props} icon="star-border" />}
+            right={props => <List.Icon {...props} icon="star-outline" />}
             title="List item 2"
             description="Describes item 2. Example of a very very long description."
           />

--- a/example/src/Examples/MenuExample.js
+++ b/example/src/Examples/MenuExample.js
@@ -21,7 +21,7 @@ type Props = {
   navigation: any,
 };
 
-const MORE_ICON = Platform.OS === 'ios' ? 'more-horiz' : 'more-vert';
+const MORE_ICON = Platform.OS === 'ios' ? 'dots-horizontal' : 'dots-vertical';
 
 class MenuExample extends React.Component<Props, State> {
   static navigationOptions = {

--- a/example/src/Examples/SearchbarExample.js
+++ b/example/src/Examples/SearchbarExample.js
@@ -50,7 +50,7 @@ class SearchExample extends React.Component<Props, State> {
           onChangeText={query => this.setState({ secondQuery: query })}
           value={this.state.secondQuery}
           onIconPress={() => this.props.navigation.goBack()}
-          icon={{ source: 'arrow-back', direction: 'auto' }}
+          icon={{ source: 'arrow-left', direction: 'auto' }}
           style={styles.searchbar}
         />
         <Searchbar

--- a/example/src/Examples/ToggleButtonExample.js
+++ b/example/src/Examples/ToggleButtonExample.js
@@ -59,7 +59,7 @@ class ToggleButtonExample extends React.Component<Props, State> {
             >
               <ToggleButton disabled icon="format-italic" value="italic" />
               <ToggleButton icon="format-bold" value="bold" />
-              <ToggleButton icon="format-underlined" value="underlined" />
+              <ToggleButton icon="format-underline" value="format-underline" />
               <ToggleButton icon="format-color-text" value="format-color" />
             </ToggleButton.Group>
           </View>
@@ -96,8 +96,8 @@ class ToggleButtonExample extends React.Component<Props, State> {
                   color="white"
                   icon={
                     this.state.fruit === 'watermelon'
-                      ? 'favorite'
-                      : 'favorite-border'
+                      ? 'heart'
+                      : 'heart-outline'
                   }
                 />
               </ImageBackground>
@@ -123,8 +123,8 @@ class ToggleButtonExample extends React.Component<Props, State> {
                   color="white"
                   icon={
                     this.state.fruit === 'strawberries'
-                      ? 'favorite'
-                      : 'favorite-border'
+                      ? 'heart'
+                      : 'heart-outline'
                   }
                 />
               </ImageBackground>

--- a/src/components/Appbar/Appbar.js
+++ b/src/components/Appbar/Appbar.js
@@ -51,8 +51,8 @@ export const DEFAULT_APPBAR_HEIGHT = 56;
  *   render() {
  *     return (
  *       <Appbar style={styles.bottom}>
- *         <Appbar.Action icon="archive" onPress={() => console.log('Pressed archive')} />
- *         <Appbar.Action icon="mail" onPress={() => console.log('Pressed mail')} />
+ *         <Appbar.Action icon="package-down" onPress={() => console.log('Pressed archive')} />
+ *         <Appbar.Action icon="email" onPress={() => console.log('Pressed mail')} />
  *         <Appbar.Action icon="label" onPress={() => console.log('Pressed label')} />
  *         <Appbar.Action icon="delete" onPress={() => console.log('Pressed delete')} />
  *       </Appbar>

--- a/src/components/Appbar/AppbarBackAction.js
+++ b/src/components/Appbar/AppbarBackAction.js
@@ -63,7 +63,7 @@ class AppbarBackAction extends React.Component<Props> {
                   />
                 </View>
               )
-            : { source: 'arrow-back', direction: 'auto' }
+            : { source: 'arrow-left', direction: 'auto' }
         }
       />
     );

--- a/src/components/Appbar/AppbarHeader.js
+++ b/src/components/Appbar/AppbarHeader.js
@@ -78,8 +78,8 @@ const DEFAULT_STATUSBAR_HEIGHT = Platform.select({
  *           title="Title"
  *           subtitle="Subtitle"
  *         />
- *         <Appbar.Action icon="search" onPress={this._onSearch} />
- *         <Appbar.Action icon="more-vert" onPress={this._onMore} />
+ *         <Appbar.Action icon="magnify" onPress={this._onSearch} />
+ *         <Appbar.Action icon="dots-vertical" onPress={this._onMore} />
  *       </Appbar.Header>
  *     );
  *   }

--- a/src/components/BottomNavigation.js
+++ b/src/components/BottomNavigation.js
@@ -73,10 +73,10 @@ type Props<T> = {
    * {
    *   index: 1,
    *   routes: [
-   *     { key: 'music', title: 'Music', icon: 'queue-music', color: '#3F51B5' },
+   *     { key: 'music', title: 'Music', icon: 'playlist-music', color: '#3F51B5' },
    *     { key: 'albums', title: 'Albums', icon: 'album', color: '#009688' },
    *     { key: 'recents', title: 'Recents', icon: 'history', color: '#795548' },
-   *     { key: 'purchased', title: 'Purchased', icon: 'shopping-cart', color: '#607D8B' },
+   *     { key: 'purchased', title: 'Purchased', icon: 'cart', color: '#607D8B' },
    *   ]
    * }
    * ```

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -102,7 +102,7 @@ type State = {
  * import { Button } from 'react-native-paper';
  *
  * const MyComponent = () => (
- *   <Button icon="add-a-photo" mode="contained" onPress={() => console.log('Pressed')}>
+ *   <Button icon="camera" mode="contained" onPress={() => console.log('Pressed')}>
  *     Press me
  *   </Button>
  * );

--- a/src/components/Card/CardTitle.js
+++ b/src/components/Card/CardTitle.js
@@ -78,7 +78,7 @@ const LEFT_SIZE = 40;
  *     title="Card Title"
  *     subtitle="Card Subtitle"
  *     left={(props) => <Avatar.Icon {...props} icon="folder" />}
- *     right={(props) => <IconButton {...props} icon="more-vert" onPress={() => {}} />}
+ *     right={(props) => <IconButton {...props} icon="dots-vertical" onPress={() => {}} />}
  *   />
  * );
  *

--- a/src/components/CheckboxAndroid.js
+++ b/src/components/CheckboxAndroid.js
@@ -113,10 +113,10 @@ class CheckboxAndroid extends React.Component<Props, State> {
     });
 
     const icon = indeterminate
-      ? 'indeterminate-check-box'
+      ? 'minus-box'
       : checked
-        ? 'check-box'
-        : 'check-box-outline-blank';
+        ? 'checkbox-marked'
+        : 'checkbox-blank-outline';
 
     return (
       <TouchableRipple

--- a/src/components/CheckboxIOS.js
+++ b/src/components/CheckboxIOS.js
@@ -72,7 +72,7 @@ class CheckboxIOS extends React.Component<Props> {
         .string();
     }
 
-    const icon = indeterminate ? 'remove' : 'done';
+    const icon = indeterminate ? 'minus' : 'check';
 
     return (
       <TouchableRipple

--- a/src/components/Chip.js
+++ b/src/components/Chip.js
@@ -97,7 +97,7 @@ type State = {
  * import { Chip } from 'react-native-paper';
  *
  * const MyComponent = () => (
- *   <Chip icon="info" onPress={() => console.log('Pressed')}>Example Chip</Chip>
+ *   <Chip icon="information" onPress={() => console.log('Pressed')}>Example Chip</Chip>
  * );
  *
  * export default MyComponent;
@@ -260,7 +260,7 @@ class Chip extends React.Component<Props, State> {
                 ]}
               >
                 <Icon
-                  source={icon || 'done'}
+                  source={icon || 'check'}
                   color={avatar ? white : iconColor}
                   size={18}
                 />
@@ -286,7 +286,7 @@ class Chip extends React.Component<Props, State> {
                 accessibilityComponentType="button"
               >
                 <View style={styles.icon}>
-                  <Icon source="cancel" size={16} color={iconColor} />
+                  <Icon source="close-circle" size={16} color={iconColor} />
                 </View>
               </TouchableWithoutFeedback>
             ) : null}

--- a/src/components/DataTable/DataTableTitle.js
+++ b/src/components/DataTable/DataTableTitle.js
@@ -95,7 +95,7 @@ class DataTableTitle extends React.Component<Props, State> {
 
     const icon = sortDirection ? (
       <Animated.View style={[styles.icon, { transform: [{ rotate: spin }] }]}>
-        <Icon source="arrow-downward" size={16} color={theme.colors.text} />
+        <Icon source="arrow-down" size={16} color={theme.colors.text} />
       </Animated.View>
     ) : null;
 

--- a/src/components/FAB/FAB.js
+++ b/src/components/FAB/FAB.js
@@ -82,7 +82,7 @@ type State = {
  *   <FAB
  *     style={styles.fab}
  *     small
- *     icon="add"
+ *     icon="plus"
  *     onPress={() => console.log('Pressed')}
  *   />
  * );

--- a/src/components/FAB/FABGroup.js
+++ b/src/components/FAB/FABGroup.js
@@ -112,10 +112,10 @@ type State = {
  *           open={this.state.open}
  *           icon={this.state.open ? 'today' : 'add'}
  *           actions={[
- *             { icon: 'add', onPress: () => console.log('Pressed add') },
+ *             { icon: 'plus', onPress: () => console.log('Pressed add') },
  *             { icon: 'star', label: 'Star', onPress: () => console.log('Pressed star')},
  *             { icon: 'email', label: 'Email', onPress: () => console.log('Pressed email') },
- *             { icon: 'notifications', label: 'Remind', onPress: () => console.log('Pressed notifications') },
+ *             { icon: 'bell', label: 'Remind', onPress: () => console.log('Pressed notifications') },
  *           ]}
  *           onStateChange={({ open }) => this.setState({ open })}
  *           onPress={() => {

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -8,12 +8,17 @@ let MaterialIcons;
 
 try {
   // Optionally require vector-icons
-  MaterialIcons = require('react-native-vector-icons/MaterialIcons').default;
+  MaterialIcons = require('react-native-vector-icons/MaterialCommunityIcons')
+    .default;
 } catch (e) {
-  if (global.__expo && global.__expo.Icon && global.__expo.Icon.MaterialIcons) {
+  if (
+    global.__expo &&
+    global.__expo.Icon &&
+    global.__expo.Icon.MaterialCommunityIcons
+  ) {
     // Snack doesn't properly bundle vector icons from subpath
     // Use icons from the __expo global if available
-    MaterialIcons = global.__expo.Icon.MaterialIcons;
+    MaterialIcons = global.__expo.Icon.MaterialCommunityIcons;
   } else {
     let isErrorLogged = false;
 

--- a/src/components/IconButton.js
+++ b/src/components/IconButton.js
@@ -69,7 +69,7 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {|
  *
  * const MyComponent = () => (
  *   <IconButton
- *     icon="add-a-photo"
+ *     icon="camera"
  *     color={Colors.red500}
  *     size={20}
  *     onPress={() => console.log('Pressed')}

--- a/src/components/List/ListAccordion.js
+++ b/src/components/List/ListAccordion.js
@@ -178,7 +178,7 @@ class ListAccordion extends React.Component<Props, State> {
             </View>
             <View style={[styles.item, description && styles.multiline]}>
               <Icon
-                source={expanded ? 'keyboard-arrow-up' : 'keyboard-arrow-down'}
+                source={expanded ? 'chevron-up' : 'chevron-down'}
                 color={titleColor}
                 size={24}
               />

--- a/src/components/RadioButtonIOS.js
+++ b/src/components/RadioButtonIOS.js
@@ -99,7 +99,7 @@ class RadioButtonIOS extends React.Component<Props> {
         <View style={{ opacity: checked ? 1 : 0 }}>
           <Icon
             allowFontScaling={false}
-            source="done"
+            source="check"
             size={24}
             color={checkedColor}
           />

--- a/src/components/Searchbar.js
+++ b/src/components/Searchbar.js
@@ -162,7 +162,7 @@ class Searchbar extends React.Component<Props> {
           rippleColor={rippleColor}
           onPress={onIconPress}
           color={iconColor}
-          icon={icon || 'search'}
+          icon={icon || 'magnify'}
         />
         <TextInput
           style={[styles.input, { color: textColor, ...font }, inputStyle]}

--- a/src/components/__tests__/Avatar.test.js
+++ b/src/components/__tests__/Avatar.test.js
@@ -33,14 +33,14 @@ it('renders avatar with text and custom colors', () => {
 });
 
 it('renders avatar with icon', () => {
-  const tree = renderer.create(<Avatar.Icon icon="info" />).toJSON();
+  const tree = renderer.create(<Avatar.Icon icon="star" />).toJSON();
 
   expect(tree).toMatchSnapshot();
 });
 
 it('renders avatar with icon and custom background color', () => {
   const tree = renderer
-    .create(<Avatar.Icon style={{ backgroundColor: '#FF0000' }} icon="info" />)
+    .create(<Avatar.Icon style={{ backgroundColor: '#FF0000' }} icon="star" />)
     .toJSON();
 
   expect(tree).toMatchSnapshot();

--- a/src/components/__tests__/Button.test.js
+++ b/src/components/__tests__/Button.test.js
@@ -37,7 +37,7 @@ it('renders contained contained with mode', () => {
 
 it('renders button with icon', () => {
   const tree = renderer
-    .create(<Button icon="add-a-photo">Icon Button</Button>)
+    .create(<Button icon="star">Icon Button</Button>)
     .toJSON();
 
   expect(tree).toMatchSnapshot();

--- a/src/components/__tests__/Chip.test.js
+++ b/src/components/__tests__/Chip.test.js
@@ -13,7 +13,7 @@ it('renders chip with onPress', () => {
 });
 
 it('renders chip with icon', () => {
-  const tree = renderer.create(<Chip icon="info">Example Chip</Chip>).toJSON();
+  const tree = renderer.create(<Chip icon="star">Example Chip</Chip>).toJSON();
 
   expect(tree).toMatchSnapshot();
 });
@@ -21,7 +21,7 @@ it('renders chip with icon', () => {
 it('renders chip with close button', () => {
   const tree = renderer
     .create(
-      <Chip icon="info" onClose={() => {}}>
+      <Chip icon="star" onClose={() => {}}>
         Example Chip
       </Chip>
     )

--- a/src/components/__tests__/DrawerItem.test.js
+++ b/src/components/__tests__/DrawerItem.test.js
@@ -14,7 +14,7 @@ it('renders basic DrawerItem', () => {
 
 it('renders DrawerItem with icon', () => {
   const tree = renderer
-    .create(<DrawerItem icon="info" label="Example item" />)
+    .create(<DrawerItem icon="star" label="Example item" />)
     .toJSON();
 
   expect(tree).toMatchSnapshot();
@@ -22,7 +22,7 @@ it('renders DrawerItem with icon', () => {
 
 it('renders active DrawerItem', () => {
   const tree = renderer
-    .create(<DrawerItem icon="info" active label="Example item" />)
+    .create(<DrawerItem icon="star" active label="Example item" />)
     .toJSON();
 
   expect(tree).toMatchSnapshot();

--- a/src/components/__tests__/FAB.test.js
+++ b/src/components/__tests__/FAB.test.js
@@ -5,14 +5,14 @@ import renderer from 'react-test-renderer';
 import FAB from '../FAB/FAB';
 
 it('renders normal FAB', () => {
-  const tree = renderer.create(<FAB onPress={() => {}} icon="add" />).toJSON();
+  const tree = renderer.create(<FAB onPress={() => {}} icon="star" />).toJSON();
 
   expect(tree).toMatchSnapshot();
 });
 
 it('renders small FAB', () => {
   const tree = renderer
-    .create(<FAB small onPress={() => {}} icon="add" />)
+    .create(<FAB small onPress={() => {}} icon="star" />)
     .toJSON();
 
   expect(tree).toMatchSnapshot();
@@ -20,7 +20,7 @@ it('renders small FAB', () => {
 
 it('renders extended FAB', () => {
   const tree = renderer
-    .create(<FAB onPress={() => {}} icon="add" label="Add items" />)
+    .create(<FAB onPress={() => {}} icon="star" label="Add items" />)
     .toJSON();
 
   expect(tree).toMatchSnapshot();

--- a/src/components/__tests__/IconButton.test.js
+++ b/src/components/__tests__/IconButton.test.js
@@ -6,39 +6,33 @@ import IconButton from '../IconButton';
 import { pink500 } from '../../styles/colors';
 
 it('renders icon button by default', () => {
-  const tree = renderer.create(<IconButton icon="add-a-photo" />).toJSON();
+  const tree = renderer.create(<IconButton icon="star" />).toJSON();
 
   expect(tree).toMatchSnapshot();
 });
 
 it('renders icon button with color', () => {
   const tree = renderer
-    .create(<IconButton icon="add-a-photo" color={pink500} />)
+    .create(<IconButton icon="star" color={pink500} />)
     .toJSON();
 
   expect(tree).toMatchSnapshot();
 });
 
 it('renders icon button with size', () => {
-  const tree = renderer
-    .create(<IconButton icon="add-a-photo" size={30} />)
-    .toJSON();
+  const tree = renderer.create(<IconButton icon="star" size={30} />).toJSON();
 
   expect(tree).toMatchSnapshot();
 });
 
 it('renders disabled icon button', () => {
-  const tree = renderer
-    .create(<IconButton icon="add-a-photo" disabled />)
-    .toJSON();
+  const tree = renderer.create(<IconButton icon="star" disabled />).toJSON();
 
   expect(tree).toMatchSnapshot();
 });
 
 it('renders icon change animated', () => {
-  const tree = renderer
-    .create(<IconButton icon="add-a-photo" animated />)
-    .toJSON();
+  const tree = renderer.create(<IconButton icon="star" animated />).toJSON();
 
   expect(tree).toMatchSnapshot();
 });

--- a/src/components/__tests__/ListAccordion.test.js
+++ b/src/components/__tests__/ListAccordion.test.js
@@ -10,7 +10,7 @@ it('renders list accordion with children', () => {
   const tree = renderer
     .create(
       <ListAccordion
-        left={props => <ListIcon {...props} icon="folder" />}
+        left={props => <ListIcon {...props} icon="star" />}
         title="Expandable list item"
       >
         <ListItem title="First Item" />
@@ -44,7 +44,7 @@ it('renders list accordion with left items', () => {
         title="Accordion item 1"
       >
         <ListItem
-          left={props => <ListIcon {...props} icon="thumb-up" />}
+          left={props => <ListIcon {...props} icon="star" />}
           title="List item 1"
         />
       </ListAccordion>

--- a/src/components/__tests__/ListItem.test.js
+++ b/src/components/__tests__/ListItem.test.js
@@ -21,7 +21,7 @@ it('renders list item with left item', () => {
     .create(
       <ListItem
         title="First Item"
-        left={props => <ListIcon {...props} icon="folder" />}
+        left={props => <ListIcon {...props} icon="star" />}
       />
     )
     .toJSON();
@@ -44,7 +44,7 @@ it('renders list item with left and right items', () => {
         title="First Item"
         description="Item description"
         left={() => <Text>GG</Text>}
-        right={props => <ListIcon {...props} icon="folder" />}
+        right={props => <ListIcon {...props} icon="star" />}
       />
     )
     .toJSON();

--- a/src/components/__tests__/ListSection.test.js
+++ b/src/components/__tests__/ListSection.test.js
@@ -13,11 +13,11 @@ it('renders list section without subheader', () => {
       <ListSection>
         <ListItem
           title="First Item"
-          left={props => <ListIcon {...props} icon="folder" />}
+          left={props => <ListIcon {...props} icon="star" />}
         />
         <ListItem
           title="Second Item"
-          left={props => <ListIcon {...props} icon="folder" />}
+          left={props => <ListIcon {...props} icon="star" />}
         />
       </ListSection>
     )
@@ -33,11 +33,11 @@ it('renders list section with subheader', () => {
         <ListSubheader>Some title</ListSubheader>
         <ListItem
           title="First Item"
-          left={props => <ListIcon {...props} icon="folder" />}
+          left={props => <ListIcon {...props} icon="star" />}
         />
         <ListItem
           title="Second Item"
-          left={props => <ListIcon {...props} icon="folder" />}
+          left={props => <ListIcon {...props} icon="star" />}
         />
       </ListSection>
     )

--- a/src/components/__tests__/ToggleButton.test.js
+++ b/src/components/__tests__/ToggleButton.test.js
@@ -6,9 +6,7 @@ import ToggleButton from '../ToggleButton/ToggleButton';
 
 it('renders toggle button', () => {
   const tree = renderer
-    .create(
-      <ToggleButton status="checked" onPress={() => {}} icon="favorite" />
-    )
+    .create(<ToggleButton status="checked" onPress={() => {}} icon="star" />)
     .toJSON();
 
   expect(tree).toMatchSnapshot();
@@ -22,7 +20,7 @@ it('renders disabled toggle button', () => {
         value="toggle"
         status="checked"
         onValueChange={() => {}}
-        icon="favorite"
+        icon="star"
       />
     )
     .toJSON();
@@ -37,7 +35,7 @@ it('renders unchecked toggle button', () => {
         disabled
         status="unchecked"
         onValueChange={() => {}}
-        icon="favorite"
+        icon="star"
       />
     )
     .toJSON();

--- a/src/components/__tests__/__snapshots__/Avatar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Avatar.test.js.snap
@@ -42,7 +42,7 @@ exports[`renders avatar with icon 1`] = `
           },
         ],
         Object {
-          "fontFamily": "Material Icons",
+          "fontFamily": "Material Design Icons",
           "fontStyle": "normal",
           "fontWeight": "normal",
         },
@@ -50,7 +50,7 @@ exports[`renders avatar with icon 1`] = `
       ]
     }
   >
-    
+    
   </Text>
 </View>
 `;
@@ -97,7 +97,7 @@ exports[`renders avatar with icon and custom background color 1`] = `
           },
         ],
         Object {
-          "fontFamily": "Material Icons",
+          "fontFamily": "Material Design Icons",
           "fontStyle": "normal",
           "fontWeight": "normal",
         },
@@ -105,7 +105,7 @@ exports[`renders avatar with icon and custom background color 1`] = `
       ]
     }
   >
-    
+    
   </Text>
 </View>
 `;

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
@@ -188,7 +188,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -196,7 +196,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -236,7 +236,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -244,7 +244,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -374,7 +374,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -382,7 +382,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -422,7 +422,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -430,7 +430,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -560,7 +560,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -568,7 +568,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -608,7 +608,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -616,7 +616,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -881,7 +881,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -889,7 +889,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -929,7 +929,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -937,7 +937,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -1067,7 +1067,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -1075,7 +1075,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -1115,7 +1115,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -1123,7 +1123,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -1253,7 +1253,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -1261,7 +1261,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -1301,7 +1301,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -1309,7 +1309,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -3052,7 +3052,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -3060,7 +3060,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -3100,7 +3100,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -3108,7 +3108,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -3312,7 +3312,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -3320,7 +3320,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -3360,7 +3360,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -3368,7 +3368,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -3572,7 +3572,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -3580,7 +3580,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -3620,7 +3620,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -3628,7 +3628,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -3967,7 +3967,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -3975,7 +3975,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -4015,7 +4015,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -4023,7 +4023,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -4193,7 +4193,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -4201,7 +4201,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -4241,7 +4241,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -4249,7 +4249,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -4419,7 +4419,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -4427,7 +4427,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -4467,7 +4467,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -4475,7 +4475,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -4760,7 +4760,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -4768,7 +4768,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -4808,7 +4808,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -4816,7 +4816,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -5020,7 +5020,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -5028,7 +5028,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -5068,7 +5068,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -5076,7 +5076,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -5280,7 +5280,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -5288,7 +5288,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -5328,7 +5328,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -5336,7 +5336,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -5675,7 +5675,7 @@ exports[`renders shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -5683,7 +5683,7 @@ exports[`renders shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -5723,7 +5723,7 @@ exports[`renders shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -5731,7 +5731,7 @@ exports[`renders shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -5901,7 +5901,7 @@ exports[`renders shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -5909,7 +5909,7 @@ exports[`renders shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -5949,7 +5949,7 @@ exports[`renders shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -5957,7 +5957,7 @@ exports[`renders shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -6127,7 +6127,7 @@ exports[`renders shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -6135,7 +6135,7 @@ exports[`renders shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -6175,7 +6175,7 @@ exports[`renders shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -6183,7 +6183,7 @@ exports[`renders shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -6353,7 +6353,7 @@ exports[`renders shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -6361,7 +6361,7 @@ exports[`renders shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -6401,7 +6401,7 @@ exports[`renders shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -6409,7 +6409,7 @@ exports[`renders shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -6579,7 +6579,7 @@ exports[`renders shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -6587,7 +6587,7 @@ exports[`renders shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View
@@ -6627,7 +6627,7 @@ exports[`renders shifting bottom navigation 1`] = `
                         },
                       ],
                       Object {
-                        "fontFamily": "Material Icons",
+                        "fontFamily": "Material Design Icons",
                         "fontStyle": "normal",
                         "fontWeight": "normal",
                       },
@@ -6635,7 +6635,7 @@ exports[`renders shifting bottom navigation 1`] = `
                     ]
                   }
                 >
-                  
+                  ?
                 </Text>
               </View>
               <View

--- a/src/components/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.js.snap
@@ -166,7 +166,7 @@ exports[`renders button with icon 1`] = `
                 },
               ],
               Object {
-                "fontFamily": "Material Icons",
+                "fontFamily": "Material Design Icons",
                 "fontStyle": "normal",
                 "fontWeight": "normal",
               },
@@ -174,7 +174,7 @@ exports[`renders button with icon 1`] = `
             ]
           }
         >
-          
+          
         </Text>
       </View>
       <Text

--- a/src/components/__tests__/__snapshots__/Checkbox.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Checkbox.test.js.snap
@@ -54,7 +54,7 @@ exports[`renders checked Checkbox with color 1`] = `
             },
           ],
           Object {
-            "fontFamily": "Material Icons",
+            "fontFamily": "Material Design Icons",
             "fontStyle": "normal",
             "fontWeight": "normal",
           },
@@ -62,7 +62,7 @@ exports[`renders checked Checkbox with color 1`] = `
         ]
       }
     >
-      
+      
     </Text>
   </View>
 </View>
@@ -122,7 +122,7 @@ exports[`renders checked Checkbox with onPress 1`] = `
             },
           ],
           Object {
-            "fontFamily": "Material Icons",
+            "fontFamily": "Material Design Icons",
             "fontStyle": "normal",
             "fontWeight": "normal",
           },
@@ -130,7 +130,7 @@ exports[`renders checked Checkbox with onPress 1`] = `
         ]
       }
     >
-      
+      
     </Text>
   </View>
 </View>
@@ -190,7 +190,7 @@ exports[`renders indeterminate Checkbox 1`] = `
             },
           ],
           Object {
-            "fontFamily": "Material Icons",
+            "fontFamily": "Material Design Icons",
             "fontStyle": "normal",
             "fontWeight": "normal",
           },
@@ -198,7 +198,7 @@ exports[`renders indeterminate Checkbox 1`] = `
         ]
       }
     >
-      
+      
     </Text>
   </View>
 </View>
@@ -258,7 +258,7 @@ exports[`renders indeterminate Checkbox with color 1`] = `
             },
           ],
           Object {
-            "fontFamily": "Material Icons",
+            "fontFamily": "Material Design Icons",
             "fontStyle": "normal",
             "fontWeight": "normal",
           },
@@ -266,7 +266,7 @@ exports[`renders indeterminate Checkbox with color 1`] = `
         ]
       }
     >
-      
+      
     </Text>
   </View>
 </View>
@@ -326,7 +326,7 @@ exports[`renders unchecked Checkbox with color 1`] = `
             },
           ],
           Object {
-            "fontFamily": "Material Icons",
+            "fontFamily": "Material Design Icons",
             "fontStyle": "normal",
             "fontWeight": "normal",
           },
@@ -334,7 +334,7 @@ exports[`renders unchecked Checkbox with color 1`] = `
         ]
       }
     >
-      
+      
     </Text>
   </View>
 </View>
@@ -394,7 +394,7 @@ exports[`renders unchecked Checkbox with onPress 1`] = `
             },
           ],
           Object {
-            "fontFamily": "Material Icons",
+            "fontFamily": "Material Design Icons",
             "fontStyle": "normal",
             "fontWeight": "normal",
           },
@@ -402,7 +402,7 @@ exports[`renders unchecked Checkbox with onPress 1`] = `
         ]
       }
     >
-      
+      
     </Text>
   </View>
 </View>

--- a/src/components/__tests__/__snapshots__/Chip.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.js.snap
@@ -78,7 +78,7 @@ exports[`renders chip with close button 1`] = `
                 },
               ],
               Object {
-                "fontFamily": "Material Icons",
+                "fontFamily": "Material Design Icons",
                 "fontStyle": "normal",
                 "fontWeight": "normal",
               },
@@ -86,7 +86,7 @@ exports[`renders chip with close button 1`] = `
             ]
           }
         >
-          
+          
         </Text>
       </View>
       <Text
@@ -158,7 +158,7 @@ exports[`renders chip with close button 1`] = `
                 },
               ],
               Object {
-                "fontFamily": "Material Icons",
+                "fontFamily": "Material Design Icons",
                 "fontStyle": "normal",
                 "fontWeight": "normal",
               },
@@ -166,7 +166,7 @@ exports[`renders chip with close button 1`] = `
             ]
           }
         >
-          
+          
         </Text>
       </View>
     </View>
@@ -252,7 +252,7 @@ exports[`renders chip with icon 1`] = `
                 },
               ],
               Object {
-                "fontFamily": "Material Icons",
+                "fontFamily": "Material Design Icons",
                 "fontStyle": "normal",
                 "fontWeight": "normal",
               },
@@ -260,7 +260,7 @@ exports[`renders chip with icon 1`] = `
             ]
           }
         >
-          
+          
         </Text>
       </View>
       <Text
@@ -539,7 +539,7 @@ exports[`renders selected chip 1`] = `
                 },
               ],
               Object {
-                "fontFamily": "Material Icons",
+                "fontFamily": "Material Design Icons",
                 "fontStyle": "normal",
                 "fontWeight": "normal",
               },
@@ -547,7 +547,7 @@ exports[`renders selected chip 1`] = `
             ]
           }
         >
-          
+          
         </Text>
       </View>
       <Text

--- a/src/components/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.js.snap
@@ -268,7 +268,7 @@ exports[`renders data table pagination 1`] = `
               },
             ],
             Object {
-              "fontFamily": "Material Icons",
+              "fontFamily": "Material Design Icons",
               "fontStyle": "normal",
               "fontWeight": "normal",
             },
@@ -276,7 +276,7 @@ exports[`renders data table pagination 1`] = `
           ]
         }
       >
-        
+        
       </Text>
     </View>
   </View>
@@ -346,7 +346,7 @@ exports[`renders data table pagination 1`] = `
               },
             ],
             Object {
-              "fontFamily": "Material Icons",
+              "fontFamily": "Material Design Icons",
               "fontStyle": "normal",
               "fontWeight": "normal",
             },
@@ -354,7 +354,7 @@ exports[`renders data table pagination 1`] = `
           ]
         }
       >
-        
+        
       </Text>
     </View>
   </View>
@@ -466,7 +466,7 @@ exports[`renders data table pagination with label 1`] = `
               },
             ],
             Object {
-              "fontFamily": "Material Icons",
+              "fontFamily": "Material Design Icons",
               "fontStyle": "normal",
               "fontWeight": "normal",
             },
@@ -474,7 +474,7 @@ exports[`renders data table pagination with label 1`] = `
           ]
         }
       >
-        
+        
       </Text>
     </View>
   </View>
@@ -544,7 +544,7 @@ exports[`renders data table pagination with label 1`] = `
               },
             ],
             Object {
-              "fontFamily": "Material Icons",
+              "fontFamily": "Material Design Icons",
               "fontStyle": "normal",
               "fontWeight": "normal",
             },
@@ -552,7 +552,7 @@ exports[`renders data table pagination with label 1`] = `
           ]
         }
       >
-        
+        
       </Text>
     </View>
   </View>
@@ -618,7 +618,7 @@ exports[`renders data table title with press handler 1`] = `
             },
           ],
           Object {
-            "fontFamily": "Material Icons",
+            "fontFamily": "Material Design Icons",
             "fontStyle": "normal",
             "fontWeight": "normal",
           },
@@ -626,7 +626,7 @@ exports[`renders data table title with press handler 1`] = `
         ]
       }
     >
-      
+      
     </Text>
   </View>
   <Text
@@ -719,7 +719,7 @@ exports[`renders data table title with sort icon 1`] = `
             },
           ],
           Object {
-            "fontFamily": "Material Icons",
+            "fontFamily": "Material Design Icons",
             "fontStyle": "normal",
             "fontWeight": "normal",
           },
@@ -727,7 +727,7 @@ exports[`renders data table title with sort icon 1`] = `
         ]
       }
     >
-      
+      
     </Text>
   </View>
   <Text

--- a/src/components/__tests__/__snapshots__/DrawerItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DrawerItem.test.js.snap
@@ -70,7 +70,7 @@ exports[`renders DrawerItem with icon 1`] = `
               },
             ],
             Object {
-              "fontFamily": "Material Icons",
+              "fontFamily": "Material Design Icons",
               "fontStyle": "normal",
               "fontWeight": "normal",
             },
@@ -78,7 +78,7 @@ exports[`renders DrawerItem with icon 1`] = `
           ]
         }
       >
-        
+        
       </Text>
       <Text
         numberOfLines={1}
@@ -187,7 +187,7 @@ exports[`renders active DrawerItem 1`] = `
               },
             ],
             Object {
-              "fontFamily": "Material Icons",
+              "fontFamily": "Material Design Icons",
               "fontStyle": "normal",
               "fontWeight": "normal",
             },
@@ -195,7 +195,7 @@ exports[`renders active DrawerItem 1`] = `
           ]
         }
       >
-        
+        
       </Text>
       <Text
         numberOfLines={1}

--- a/src/components/__tests__/__snapshots__/FAB.test.js.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.js.snap
@@ -117,7 +117,7 @@ exports[`renders extended FAB 1`] = `
                   },
                 ],
                 Object {
-                  "fontFamily": "Material Icons",
+                  "fontFamily": "Material Design Icons",
                   "fontStyle": "normal",
                   "fontWeight": "normal",
                 },
@@ -125,7 +125,7 @@ exports[`renders extended FAB 1`] = `
               ]
             }
           >
-            
+            
           </Text>
         </View>
       </View>
@@ -275,7 +275,7 @@ exports[`renders normal FAB 1`] = `
                   },
                 ],
                 Object {
-                  "fontFamily": "Material Icons",
+                  "fontFamily": "Material Design Icons",
                   "fontStyle": "normal",
                   "fontWeight": "normal",
                 },
@@ -283,7 +283,7 @@ exports[`renders normal FAB 1`] = `
               ]
             }
           >
-            
+            
           </Text>
         </View>
       </View>
@@ -408,7 +408,7 @@ exports[`renders small FAB 1`] = `
                   },
                 ],
                 Object {
-                  "fontFamily": "Material Icons",
+                  "fontFamily": "Material Design Icons",
                   "fontStyle": "normal",
                   "fontWeight": "normal",
                 },
@@ -416,7 +416,7 @@ exports[`renders small FAB 1`] = `
               ]
             }
           >
-            
+            
           </Text>
         </View>
       </View>

--- a/src/components/__tests__/__snapshots__/IconButton.test.js.snap
+++ b/src/components/__tests__/__snapshots__/IconButton.test.js.snap
@@ -74,7 +74,7 @@ exports[`renders disabled icon button 1`] = `
             },
           ],
           Object {
-            "fontFamily": "Material Icons",
+            "fontFamily": "Material Design Icons",
             "fontStyle": "normal",
             "fontWeight": "normal",
           },
@@ -82,7 +82,7 @@ exports[`renders disabled icon button 1`] = `
         ]
       }
     >
-      
+      
     </Text>
   </View>
 </View>
@@ -155,7 +155,7 @@ exports[`renders icon button by default 1`] = `
             },
           ],
           Object {
-            "fontFamily": "Material Icons",
+            "fontFamily": "Material Design Icons",
             "fontStyle": "normal",
             "fontWeight": "normal",
           },
@@ -163,7 +163,7 @@ exports[`renders icon button by default 1`] = `
         ]
       }
     >
-      
+      
     </Text>
   </View>
 </View>
@@ -236,7 +236,7 @@ exports[`renders icon button with color 1`] = `
             },
           ],
           Object {
-            "fontFamily": "Material Icons",
+            "fontFamily": "Material Design Icons",
             "fontStyle": "normal",
             "fontWeight": "normal",
           },
@@ -244,7 +244,7 @@ exports[`renders icon button with color 1`] = `
         ]
       }
     >
-      
+      
     </Text>
   </View>
 </View>
@@ -317,7 +317,7 @@ exports[`renders icon button with size 1`] = `
             },
           ],
           Object {
-            "fontFamily": "Material Icons",
+            "fontFamily": "Material Design Icons",
             "fontStyle": "normal",
             "fontWeight": "normal",
           },
@@ -325,7 +325,7 @@ exports[`renders icon button with size 1`] = `
         ]
       }
     >
-      
+      
     </Text>
   </View>
 </View>
@@ -429,7 +429,7 @@ exports[`renders icon change animated 1`] = `
                 },
               ],
               Object {
-                "fontFamily": "Material Icons",
+                "fontFamily": "Material Design Icons",
                 "fontStyle": "normal",
                 "fontWeight": "normal",
               },
@@ -437,7 +437,7 @@ exports[`renders icon change animated 1`] = `
             ]
           }
         >
-          
+          
         </Text>
       </View>
     </View>

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.js.snap
@@ -105,7 +105,7 @@ exports[`renders expanded accordion 1`] = `
                 },
               ],
               Object {
-                "fontFamily": "Material Icons",
+                "fontFamily": "Material Design Icons",
                 "fontStyle": "normal",
                 "fontWeight": "normal",
               },
@@ -113,7 +113,7 @@ exports[`renders expanded accordion 1`] = `
             ]
           }
         >
-          
+          
         </Text>
       </View>
     </View>
@@ -264,7 +264,7 @@ exports[`renders list accordion with children 1`] = `
                 },
               ],
               Object {
-                "fontFamily": "Material Icons",
+                "fontFamily": "Material Design Icons",
                 "fontStyle": "normal",
                 "fontWeight": "normal",
               },
@@ -272,7 +272,7 @@ exports[`renders list accordion with children 1`] = `
             ]
           }
         >
-          
+          
         </Text>
       </View>
       <View
@@ -347,7 +347,7 @@ exports[`renders list accordion with children 1`] = `
                 },
               ],
               Object {
-                "fontFamily": "Material Icons",
+                "fontFamily": "Material Design Icons",
                 "fontStyle": "normal",
                 "fontWeight": "normal",
               },
@@ -355,7 +355,7 @@ exports[`renders list accordion with children 1`] = `
             ]
           }
         >
-          
+          
         </Text>
       </View>
     </View>
@@ -435,7 +435,7 @@ exports[`renders list accordion with left items 1`] = `
                 },
               ],
               Object {
-                "fontFamily": "Material Icons",
+                "fontFamily": "Material Design Icons",
                 "fontStyle": "normal",
                 "fontWeight": "normal",
               },
@@ -443,7 +443,7 @@ exports[`renders list accordion with left items 1`] = `
             ]
           }
         >
-          
+          
         </Text>
       </View>
       <View
@@ -518,7 +518,7 @@ exports[`renders list accordion with left items 1`] = `
                 },
               ],
               Object {
-                "fontFamily": "Material Icons",
+                "fontFamily": "Material Design Icons",
                 "fontStyle": "normal",
                 "fontWeight": "normal",
               },
@@ -526,7 +526,7 @@ exports[`renders list accordion with left items 1`] = `
             ]
           }
         >
-          
+          
         </Text>
       </View>
     </View>
@@ -667,7 +667,7 @@ exports[`renders multiline list accordion 1`] = `
                 },
               ],
               Object {
-                "fontFamily": "Material Icons",
+                "fontFamily": "Material Design Icons",
                 "fontStyle": "normal",
                 "fontWeight": "normal",
               },
@@ -675,7 +675,7 @@ exports[`renders multiline list accordion 1`] = `
             ]
           }
         >
-          
+          
         </Text>
       </View>
     </View>

--- a/src/components/__tests__/__snapshots__/ListItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.js.snap
@@ -242,7 +242,7 @@ exports[`renders list item with left and right items 1`] = `
               },
             ],
             Object {
-              "fontFamily": "Material Icons",
+              "fontFamily": "Material Design Icons",
               "fontStyle": "normal",
               "fontWeight": "normal",
             },
@@ -250,7 +250,7 @@ exports[`renders list item with left and right items 1`] = `
           ]
         }
       >
-        
+        
       </Text>
     </View>
   </View>
@@ -329,7 +329,7 @@ exports[`renders list item with left item 1`] = `
               },
             ],
             Object {
-              "fontFamily": "Material Icons",
+              "fontFamily": "Material Design Icons",
               "fontStyle": "normal",
               "fontWeight": "normal",
             },
@@ -337,7 +337,7 @@ exports[`renders list item with left item 1`] = `
           ]
         }
       >
-        
+        
       </Text>
     </View>
     <View

--- a/src/components/__tests__/__snapshots__/ListSection.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.js.snap
@@ -149,7 +149,7 @@ exports[`renders list section with subheader 1`] = `
                 },
               ],
               Object {
-                "fontFamily": "Material Icons",
+                "fontFamily": "Material Design Icons",
                 "fontStyle": "normal",
                 "fontWeight": "normal",
               },
@@ -157,7 +157,7 @@ exports[`renders list section with subheader 1`] = `
             ]
           }
         >
-          
+          
         </Text>
       </View>
       <View
@@ -274,7 +274,7 @@ exports[`renders list section with subheader 1`] = `
                 },
               ],
               Object {
-                "fontFamily": "Material Icons",
+                "fontFamily": "Material Design Icons",
                 "fontStyle": "normal",
                 "fontWeight": "normal",
               },
@@ -282,7 +282,7 @@ exports[`renders list section with subheader 1`] = `
             ]
           }
         >
-          
+          
         </Text>
       </View>
       <View
@@ -452,7 +452,7 @@ exports[`renders list section without subheader 1`] = `
                 },
               ],
               Object {
-                "fontFamily": "Material Icons",
+                "fontFamily": "Material Design Icons",
                 "fontStyle": "normal",
                 "fontWeight": "normal",
               },
@@ -460,7 +460,7 @@ exports[`renders list section without subheader 1`] = `
             ]
           }
         >
-          
+          
         </Text>
       </View>
       <View
@@ -577,7 +577,7 @@ exports[`renders list section without subheader 1`] = `
                 },
               ],
               Object {
-                "fontFamily": "Material Icons",
+                "fontFamily": "Material Design Icons",
                 "fontStyle": "normal",
                 "fontWeight": "normal",
               },
@@ -585,7 +585,7 @@ exports[`renders list section without subheader 1`] = `
             ]
           }
         >
-          
+          
         </Text>
       </View>
       <View

--- a/src/components/__tests__/__snapshots__/RadioButton.test.js.snap
+++ b/src/components/__tests__/__snapshots__/RadioButton.test.js.snap
@@ -91,7 +91,7 @@ exports[`RadioButton on ios platform renders properly 1`] = `
             },
           ],
           Object {
-            "fontFamily": "Material Icons",
+            "fontFamily": "Material Design Icons",
             "fontStyle": "normal",
             "fontWeight": "normal",
           },
@@ -99,7 +99,7 @@ exports[`RadioButton on ios platform renders properly 1`] = `
         ]
       }
     >
-      
+      
     </Text>
   </View>
 </View>
@@ -159,7 +159,7 @@ exports[`RadioButton when RadioButton is wrapped by RadioButtonContext.Provider 
             },
           ],
           Object {
-            "fontFamily": "Material Icons",
+            "fontFamily": "Material Design Icons",
             "fontStyle": "normal",
             "fontWeight": "normal",
           },
@@ -167,7 +167,7 @@ exports[`RadioButton when RadioButton is wrapped by RadioButtonContext.Provider 
         ]
       }
     >
-      
+      
     </Text>
   </View>
 </View>

--- a/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
@@ -85,7 +85,7 @@ exports[`renders with placeholder 1`] = `
               },
             ],
             Object {
-              "fontFamily": "Material Icons",
+              "fontFamily": "Material Design Icons",
               "fontStyle": "normal",
               "fontWeight": "normal",
             },
@@ -93,7 +93,7 @@ exports[`renders with placeholder 1`] = `
           ]
         }
       >
-        
+        
       </Text>
     </View>
   </View>
@@ -199,7 +199,7 @@ exports[`renders with placeholder 1`] = `
               },
             ],
             Object {
-              "fontFamily": "Material Icons",
+              "fontFamily": "Material Design Icons",
               "fontStyle": "normal",
               "fontWeight": "normal",
             },
@@ -207,7 +207,7 @@ exports[`renders with placeholder 1`] = `
           ]
         }
       >
-        
+        
       </Text>
     </View>
   </View>
@@ -299,7 +299,7 @@ exports[`renders with text 1`] = `
               },
             ],
             Object {
-              "fontFamily": "Material Icons",
+              "fontFamily": "Material Design Icons",
               "fontStyle": "normal",
               "fontWeight": "normal",
             },
@@ -307,7 +307,7 @@ exports[`renders with text 1`] = `
           ]
         }
       >
-        
+        
       </Text>
     </View>
   </View>
@@ -407,7 +407,7 @@ exports[`renders with text 1`] = `
               },
             ],
             Object {
-              "fontFamily": "Material Icons",
+              "fontFamily": "Material Design Icons",
               "fontStyle": "normal",
               "fontWeight": "normal",
             },
@@ -415,7 +415,7 @@ exports[`renders with text 1`] = `
           ]
         }
       >
-        
+        
       </Text>
     </View>
   </View>

--- a/src/components/__tests__/__snapshots__/ToggleButton.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ToggleButton.test.js.snap
@@ -84,7 +84,7 @@ exports[`renders disabled toggle button 1`] = `
             },
           ],
           Object {
-            "fontFamily": "Material Icons",
+            "fontFamily": "Material Design Icons",
             "fontStyle": "normal",
             "fontWeight": "normal",
           },
@@ -92,7 +92,7 @@ exports[`renders disabled toggle button 1`] = `
         ]
       }
     >
-      
+      
     </Text>
   </View>
 </View>
@@ -175,7 +175,7 @@ exports[`renders toggle button 1`] = `
             },
           ],
           Object {
-            "fontFamily": "Material Icons",
+            "fontFamily": "Material Design Icons",
             "fontStyle": "normal",
             "fontWeight": "normal",
           },
@@ -183,7 +183,7 @@ exports[`renders toggle button 1`] = `
         ]
       }
     >
-      
+      
     </Text>
   </View>
 </View>
@@ -273,7 +273,7 @@ exports[`renders unchecked toggle button 1`] = `
             },
           ],
           Object {
-            "fontFamily": "Material Icons",
+            "fontFamily": "Material Design Icons",
             "fontStyle": "normal",
             "fontWeight": "normal",
           },
@@ -281,7 +281,7 @@ exports[`renders unchecked toggle button 1`] = `
         ]
       }
     >
-      
+      
     </Text>
   </View>
 </View>


### PR DESCRIPTION
This PR introduces the replacement of Material Icons to Material Community Icons. 
Some of the icons have different names, that's why there are so many changes.

### Motivation
#926 
### Test plan

Unfortunately, it needs to be tested visually. 
1.  Open example app and go through all examples to verify if there is no `?` in place of an icon
2. Open all snacks from the documentation page.

I changed all the icons one-by-one so there shouldn't be anything missing, but it can be double checked.
