### PR TITLE
ci: cache jest tests and fix flaky tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,10 +65,19 @@ jobs:
       steps:
         - attach_workspace:
             at: ~/react-native-paper
-        - run: yarn test -- --coverage
+        - restore_cache:
+            name: Restoring Jest Cache
+            keys:
+            - jest-cache-{{ .Branch }}
+            - jest-cache
+        - run: yarn test --maxWorkers=2 --coverage
         - store_artifacts:
             path: coverage
             destination: coverage
+        - save_cache:
+            paths:
+            - ./cache/jest
+            key: jest-cache-{{ .Branch }}
   build-docs:
       <<: *defaults
       steps:

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ yarn-error.log
 # jest
 #
 coverage/
+cache/jest/
 
 # BUCK
 #

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
   },
   "jest": {
     "preset": "react-native",
+    "cacheDirectory": "./cache/jest",
     "modulePathIgnorePatterns": [
       "<rootDir>/example/node_modules"
     ],


### PR DESCRIPTION
### Motivation
Sometimes CircleCI is running out of memory when running the job `unit-tests` .

```
Test Suites: 26 passed, 26 total
Tests:       106 passed, 106 total
Snapshots:   105 passed, 105 total
Time:        4.133s, estimated 8s
Ran all test suites.
Done in 5.67s.
```