### PR TITLE
add ability to pass custom style for FAB labels in a FAB.Group

### DIFF
--- a/src/components/FAB/FABGroup.js
+++ b/src/components/FAB/FABGroup.js
@@ -24,6 +24,7 @@ type Props = {|
    * An action item should contain the following properties:
    * - `icon`: icon to display (required)
    * - `label`: optional label text
+   * - `labelStyle`: pass additional styles for the fab label, for example `backgroundColor`
    * - `accessibilityLabel`: accessibility label for the action, uses label by default if specified
    * - `color`: custom icon color of the action item
    * - `style`: pass additional styles for the fab item, for example, `backgroundColor`
@@ -32,6 +33,7 @@ type Props = {|
   actions: Array<{
     icon: IconSource,
     label?: string,
+    labelStyle?: WiewStyleProp,
     color?: string,
     accessibilityLabel?: string,
     style?: ViewStyleProp,
@@ -262,6 +264,7 @@ class FABGroup extends React.Component<Props, State> {
                         transform: [{ scale: scales[i] }],
                         opacity: opacities[i],
                       },
+                      it.labelStyle,
                     ]}
                     onPress={() => {
                       it.onPress();

--- a/src/components/FAB/FABGroup.js
+++ b/src/components/FAB/FABGroup.js
@@ -33,7 +33,7 @@ type Props = {|
   actions: Array<{
     icon: IconSource,
     label?: string,
-    labelStyle?: WiewStyleProp,
+    labelStyle?: ViewStyleProp,
     color?: string,
     accessibilityLabel?: string,
     style?: ViewStyleProp,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

I'd like to be able to style the labels of the FAB.Group's FABs. 

### Test plan

`actions={[`
`{ icon: 'add', label: 'New FooBar' onPress: () => console.log('Pressed add') },`
`{ icon: 'star', label: 'Star', onPress: () => console.log('Pressed star')},`
`]}`

can now become : 

`actions={[`
`{ labelStyle: { backgroundColor: 'red' }, icon: 'add', label: 'New FooBar', onPress: () => console.log('Pressed add') },`
`{ icon: 'star', label: 'Star', onPress: () => console.log('Pressed star')},`
`]}`

allowing every fab label in the fab group to be styled independently.
