### PR TITLE
fix: disable interaction when fading out modal

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -180,6 +180,7 @@ class Modal extends React.Component<Props, State> {
     const { colors } = theme;
     return (
       <Animated.View
+        pointerEvents={this.props.visible ? 'auto' : 'none'}
         accessibilityViewIsModal
         accessibilityLiveRegion="polite"
         style={StyleSheet.absoluteFill}


### PR DESCRIPTION
While the animation only last < 300ms, it is still possible for user to interact with the modal during the transition.

This is based on a fix suggested in https://github.com/facebook/react-native/issues/6732
