### PR TITLE
Customize main container style in Snackbar

### DIFF
--- a/src/components/Snackbar.js
+++ b/src/components/Snackbar.js
@@ -38,7 +38,14 @@ type Props = {|
    * Text content of the Snackbar.
    */
   children: React.Node,
+  /**
+   * Snackbar Surface style
+   */
   style?: ViewStyleProp,
+  /**
+   * Snackbar SafeAreaView style
+   */
+  wrapperStyle?: ViewStyleProp,
   /**
    * @optional
    */
@@ -195,7 +202,7 @@ class Snackbar extends React.Component<Props, State> {
   _hideTimeout: TimeoutID;
 
   render() {
-    const { children, visible, action, onDismiss, theme, style } = this.props;
+    const { children, visible, action, onDismiss, theme, style, wrapperStyle } = this.props;
     const { colors, roundness } = theme;
 
     if (this.state.hidden) {
@@ -203,7 +210,7 @@ class Snackbar extends React.Component<Props, State> {
     }
 
     return (
-      <SafeAreaView pointerEvents="box-none" style={styles.wrapper}>
+      <SafeAreaView pointerEvents="box-none" style={[styles.wrapper, wrapperStyle]}>
         <Surface
           pointerEvents="box-none"
           accessibilityLiveRegion="polite"

--- a/typings/components/Snackbar.d.ts
+++ b/typings/components/Snackbar.d.ts
@@ -13,6 +13,7 @@ export interface SnackbarProps {
   duration?: number;
   onDismiss: () => any;
   style?: StyleProp<ViewStyle>;
+  wrapperStyle?: StyleProp<ViewStyle>;
   theme?: ThemeShape;
 }
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

In your case with:
```
  wrapper: {
    position: 'absolute',
    bottom: 0,
    width: '100%',
  },
```

I can't use more than one snackbar at the same time. They overlap each other.
I need to change 'position' to 'relative' inside my components for example.

Keep 'absolute' by default;

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

```jsx
<Fragment>
    <Snackbar />
    <Snackbar />
</Fragment>
```
