### PR TITLE
docs: Adding <Text> to avoid errors

### DIFF
--- a/src/components/Dialog/DialogScrollArea.js
+++ b/src/components/Dialog/DialogScrollArea.js
@@ -19,8 +19,8 @@ type Props = React.ElementConfig<typeof View> & {
  * ## Usage
  * ```js
  * import * as React from 'react';
- * import { ScrollView, Text } from 'react-native';
- * import { Dialog, Portal } from 'react-native-paper';
+ * import { ScrollView } from 'react-native';
+ * import { Dialog, Portal, Text } from 'react-native-paper';
  *
  * export default class MyComponent extends React.Component {
  *   state = {

--- a/src/components/Dialog/DialogScrollArea.js
+++ b/src/components/Dialog/DialogScrollArea.js
@@ -19,7 +19,7 @@ type Props = React.ElementConfig<typeof View> & {
  * ## Usage
  * ```js
  * import * as React from 'react';
- * import { ScrollView } from 'react-native';
+ * import { ScrollView, Text } from 'react-native';
  * import { Dialog, Portal } from 'react-native-paper';
  *
  * export default class MyComponent extends React.Component {
@@ -37,7 +37,7 @@ type Props = React.ElementConfig<typeof View> & {
  *           onDismiss={this._hideDialog}>
  *           <Dialog.ScrollArea>
  *             <ScrollView contentContainerStyle={{ paddingHorizontal: 24 }}>
- *               This is a scrollable area
+ *               <Text>This is a scrollable area</Text>
  *             </ScrollView>
  *           </Dialog.ScrollArea>
  *         </Dialog>


### PR DESCRIPTION
## The change

Add a `<Text>` in the documentation of the `Dialog.ScrollArea` to avoid errors while copying without making changes.

When copying the code and trying it in the editor, an error is returned, demanding that the "This is a scrollable area" text be wrapped in a `<Text>` component.

Although in most cases the scrollable content won't be a `<Text>` component, I think it would nice to do something to avoid the error. As an alternative, a `<View>` with a few `<Text>` inside could be added.

## Motivation

By fixing this, it'll avoid errors by beginners or by someone who's just copying the code and trying to check things out, avoiding the unnecessary trouble.