### PR TITLE
fix: adjustsFontSizeToFit does not exist on TextInput

### DIFF
--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -229,7 +229,6 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
               ...rest,
               ref: innerRef,
               onChangeText,
-              adjustsFontSizeToFit: true,
               // @ts-ignore
               placeholder: label
                 ? parentState.placeholder


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

There is a warning:
```
React does not recognize the `adjustsFontSizeToFit` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `adjustsfontsizetofit` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

Checking https://facebook.github.io/react-native/docs/textinput it seems there is no `adjustsFontSizeToFit` on `TextInput`.


### Test plan

n/a
