### PR TITLE
fix typo

### DIFF
--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -24,7 +24,7 @@ type Props = {
    */
   visible: boolean,
   /**
-   * The anchor to open the menu from. In most cases, it will be a button that opens the manu.
+   * The anchor to open the menu from. In most cases, it will be a button that opens the menu.
    */
   anchor: React.Node,
   /**


### PR DESCRIPTION
I'm assuming the docs are generated from source; if so, this should fix the typo in docs https://callstack.github.io/react-native-paper/menu.html