### PR TITLE
fix: make appbarcontentprops extend touchableripple props

### DIFF
--- a/typings/components/Appbar.d.ts
+++ b/typings/components/Appbar.d.ts
@@ -3,7 +3,7 @@ import { StyleProp, TextStyle, ViewStyle, ViewProps, TouchableNativeFeedbackProp
 import { IconSource, ThemeShape } from '../types';
 import { TouchableRipplePropsWithoutChildren } from './TouchableRipple';
 
-export interface AppbarContentProps {
+export interface AppbarContentProps extends TouchableRipplePropsWithoutChildren {
   color?: string;
   title: React.ReactNode;
   titleStyle?: StyleProp<TextStyle>;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

In a typescript project, I am attempting to add an onPress property as it is listed in the react-native-paper api https://callstack.github.io/react-native-paper/appbar-content.html but it is not listed in the AppBar.Content 
```
export interface AppbarContentProps {
  color?: string;
  title: React.ReactNode;
  titleStyle?: StyleProp<TextStyle>;
  subtitle?: React.ReactNode;
  subtitleStyle?: StyleProp<TextStyle>;
  style?: StyleProp<ViewStyle>;
  theme?: ThemeShape;
}
```

### Test plan

Import Appbar component from react-native-paper and add an onPress property to Appbar.content
