### PR TITLE
feat: pass underlineHeight prop

### DIFF
--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -53,6 +53,10 @@ export type TextInputProps = {|
    */
   underlineColor?: string,
   /**
+   * Height of the underline in FlatInput.
+   */
+  underlineHeight?: number,
+  /**
    * Whether to apply padding to label and input.
    */
   padding?: 'none' | 'normal',

--- a/src/components/TextInput/TextInputFlat.js
+++ b/src/components/TextInput/TextInputFlat.js
@@ -54,6 +54,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
       error,
       selectionColor,
       underlineColor,
+      underlineHeight,
       padding,
       dense,
       style,
@@ -206,6 +207,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
         <Underline
           parentState={parentState}
           underlineColorCustom={underlineColorCustom}
+          underlineHeight={underlineHeight}
           error={error}
           colors={colors}
           activeColor={activeColor}
@@ -268,6 +270,7 @@ const Underline = ({
   colors,
   activeColor,
   underlineColorCustom,
+  underlineHeight,
 }) => {
   let backgroundColor = parentState.focused
     ? activeColor
@@ -282,6 +285,7 @@ const Underline = ({
           // Underlines is thinner when input is not focused
           transform: [{ scaleY: parentState.focused ? 1 : 0.5 }],
         },
+        underlineHeight !== undefined && { height: underlineHeight },
       ]}
     />
   );

--- a/typings/components/TextInput.d.ts
+++ b/typings/components/TextInput.d.ts
@@ -10,8 +10,9 @@ export interface TextInputProps extends NativeTextInputProps {
   error?: boolean;
   onChangeText?: (text: string) => void;
   underlineColor?: string;
-  padding?: 'none'|'normal',
-  dense?: boolean,
+  underlineHeight?: number;
+  padding?: 'none'|'normal';
+  dense?: boolean;
   multiline?: boolean;
   numberOfLines?: number;
   onFocus?: (e: NativeSyntheticEvent<TextInputFocusEventData>) => void;


### PR DESCRIPTION
Pass underlineHeight prop to allow customize width of underline in FlatInput 

### Motivation

Feature allow to customize underline. 
Fixes #910

### Test plan

Feature affects size of the underline. Default size will remain as current hardcoded style (height = 2)

1.Default **underlineHeight = 2**:

![image](https://user-images.githubusercontent.com/21242757/60009202-c3b0e180-9675-11e9-811f-6c82d26d5058.png)

![image](https://user-images.githubusercontent.com/21242757/60008903-2f467f00-9675-11e9-8604-dbe03c50b87c.png)

2. **underlineHeight = 0**:

![image](https://user-images.githubusercontent.com/21242757/60009176-b1cf3e80-9675-11e9-9ce7-8013c05ea13e.png)

![image](https://user-images.githubusercontent.com/21242757/60008982-54d38880-9675-11e9-9147-5b59335ebdb5.png)

3.  **underlineHeight = 3**:

![image](https://user-images.githubusercontent.com/21242757/60009140-9c5a1480-9675-11e9-88c5-1247bcdd4302.png)

![image](https://user-images.githubusercontent.com/21242757/60009112-8d736200-9675-11e9-84fb-348cb9a3444a.png)
