### PR TITLE
fix: FAB - always display activity indicator if loading property is set to true

### DIFF
--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -217,7 +217,7 @@ class FAB extends React.Component<Props, State> {
             {icon && loading !== true ? (
               <CrossFadeIcon source={icon} size={24} color={foregroundColor} />
             ) : null}
-            {loading && label ? (
+            {loading ? (
               <ActivityIndicator size={18} color={foregroundColor} />
             ) : null}
             {label ? (


### PR DESCRIPTION
Displaying activity indicator if loading property is set to true. activity indicator was not displaying if label is not set. 
Removed condition to check for label is loading property is set true.

### Motivation
Pull request to address callstack#1130

### Test plan

Testing different combination like
Icon and Loading 
Label and Loading
No Label and Icon
