### PR TITLE
feat: added possibility for transparent input

### DIFF
--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -57,6 +57,10 @@ export type TextInputProps = {|
    */
   multiline?: boolean,
   /**
+   * Whether the input should be transparent.
+   */
+  transparent?: boolean,
+  /**
    * The number of lines to show in the input (Android only).
    */
   numberOfLines?: number,

--- a/src/components/TextInput/TextInputFlat.js
+++ b/src/components/TextInput/TextInputFlat.js
@@ -193,10 +193,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
               style={[
                 styles.placeholder,
                 {
-                  paddingHorizontal:
-                    transparent
-                    ? 0
-                    : LABEL_PADDING_HORIZONTAL,
+                  paddingHorizontal: transparent ? 0 : LABEL_PADDING_HORIZONTAL,
                 },
                 styles.placeholderFlat,
                 labelStyle,
@@ -216,10 +213,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
               style={[
                 styles.placeholder,
                 {
-                  paddingHorizontal:
-                    transparent
-                    ? 0
-                    : LABEL_PADDING_HORIZONTAL,
+                  paddingHorizontal: transparent ? 0 : LABEL_PADDING_HORIZONTAL,
                 },
                 styles.placeholderFlat,
                 labelStyle,

--- a/src/components/TextInput/TextInputFlat.js
+++ b/src/components/TextInput/TextInputFlat.js
@@ -33,6 +33,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
   render() {
     const {
       disabled,
+      transparent,
       label,
       error,
       selectionColor,
@@ -70,19 +71,28 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
       underlineColorCustom = underlineColor || colors.disabled;
     }
 
-    const containerStyle = {
-      backgroundColor: theme.dark
-        ? color(colors.background)
+    let containerStyle = {};
+    let labelHorizontalPadding = 0;
+    if (transparent) {
+      containerStyle = {
+        backgroundColor: 'transparent',
+      };
+      labelHorizontalPadding = RANDOM_VALUE_TO_CENTER_LABEL;
+    } else {
+      containerStyle = {
+        backgroundColor: theme.dark
+          ? color(colors.background)
             .lighten(0.24)
             .rgb()
             .string()
-        : color(colors.background)
+          : color(colors.background)
             .darken(0.06)
             .rgb()
             .string(),
-      borderTopLeftRadius: theme.roundness,
-      borderTopRightRadius: theme.roundness,
-    };
+        borderTopLeftRadius: theme.roundness,
+        borderTopRightRadius: theme.roundness,
+      };
+    }
 
     const labelHalfWidth = parentState.labelLayout.width / 2;
     const baseLabelTranslateX =
@@ -130,16 +140,20 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
               baseLabelTranslateX > 0
                 ? baseLabelTranslateX +
                   labelHalfWidth / LABEL_PADDING_HORIZONTAL -
-                  RANDOM_VALUE_TO_CENTER_LABEL
+                  RANDOM_VALUE_TO_CENTER_LABEL - labelHorizontalPadding
                 : baseLabelTranslateX -
                   labelHalfWidth / LABEL_PADDING_HORIZONTAL +
-                  RANDOM_VALUE_TO_CENTER_LABEL,
+                  RANDOM_VALUE_TO_CENTER_LABEL - labelHorizontalPadding,
               0,
             ],
           }),
         },
       ],
     };
+
+    if (transparent) {
+      labelStyle.paddingHorizontal = 0;
+    }
 
     return (
       <View style={[containerStyle, style]}>
@@ -234,6 +248,9 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
               this.props.label
                 ? styles.inputFlatWithLabel
                 : styles.inputFlatWithoutLabel,
+              {
+                paddingHorizontal: transparent ? 0 : styles.input.paddingHorizontal,
+              },
               {
                 color: inputTextColor,
                 fontFamily,

--- a/src/components/TextInput/TextInputFlat.js
+++ b/src/components/TextInput/TextInputFlat.js
@@ -82,13 +82,13 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
       containerStyle = {
         backgroundColor: theme.dark
           ? color(colors.background)
-            .lighten(0.24)
-            .rgb()
-            .string()
+              .lighten(0.24)
+              .rgb()
+              .string()
           : color(colors.background)
-            .darken(0.06)
-            .rgb()
-            .string(),
+              .darken(0.06)
+              .rgb()
+              .string(),
         borderTopLeftRadius: theme.roundness,
         borderTopRightRadius: theme.roundness,
       };
@@ -140,10 +140,12 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
               baseLabelTranslateX > 0
                 ? baseLabelTranslateX +
                   labelHalfWidth / LABEL_PADDING_HORIZONTAL -
-                  RANDOM_VALUE_TO_CENTER_LABEL - labelHorizontalPadding
+                  RANDOM_VALUE_TO_CENTER_LABEL -
+                  labelHorizontalPadding
                 : baseLabelTranslateX -
                   labelHalfWidth / LABEL_PADDING_HORIZONTAL +
-                  RANDOM_VALUE_TO_CENTER_LABEL - labelHorizontalPadding,
+                  RANDOM_VALUE_TO_CENTER_LABEL -
+                  labelHorizontalPadding,
               0,
             ],
           }),
@@ -249,7 +251,9 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
                 ? styles.inputFlatWithLabel
                 : styles.inputFlatWithoutLabel,
               {
-                paddingHorizontal: transparent ? 0 : styles.input.paddingHorizontal,
+                paddingHorizontal: transparent
+                  ? 0
+                  : styles.input.paddingHorizontal,
               },
               {
                 color: inputTextColor,

--- a/src/components/TextInput/TextInputFlat.js
+++ b/src/components/TextInput/TextInputFlat.js
@@ -153,10 +153,6 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
       ],
     };
 
-    if (transparent) {
-      labelStyle.paddingHorizontal = 0;
-    }
-
     return (
       <View style={[containerStyle, style]}>
         <Animated.View
@@ -196,6 +192,11 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
               onLayout={onLayoutAnimatedText}
               style={[
                 styles.placeholder,
+                {
+                  paddingHorizontal: transparent
+                    ? 0
+                    : style.placeholder.paddingHorizontal,
+                },
                 styles.placeholderFlat,
                 labelStyle,
                 {
@@ -213,6 +214,11 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
             <AnimatedText
               style={[
                 styles.placeholder,
+                {
+                  paddingHorizontal: transparent
+                    ? 0
+                    : style.placeholder.paddingHorizontal,
+                },
                 styles.placeholderFlat,
                 labelStyle,
                 {

--- a/src/components/TextInput/TextInputFlat.js
+++ b/src/components/TextInput/TextInputFlat.js
@@ -193,7 +193,8 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
               style={[
                 styles.placeholder,
                 {
-                  paddingHorizontal: transparent
+                  paddingHorizontal:
+                    transparent
                     ? 0
                     : LABEL_PADDING_HORIZONTAL,
                 },
@@ -215,7 +216,8 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
               style={[
                 styles.placeholder,
                 {
-                  paddingHorizontal: transparent
+                  paddingHorizontal:
+                    transparent
                     ? 0
                     : LABEL_PADDING_HORIZONTAL,
                 },

--- a/src/components/TextInput/TextInputFlat.js
+++ b/src/components/TextInput/TextInputFlat.js
@@ -195,7 +195,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
                 {
                   paddingHorizontal: transparent
                     ? 0
-                    : style.placeholder.paddingHorizontal,
+                    : LABEL_PADDING_HORIZONTAL,
                 },
                 styles.placeholderFlat,
                 labelStyle,
@@ -217,7 +217,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
                 {
                   paddingHorizontal: transparent
                     ? 0
-                    : style.placeholder.paddingHorizontal,
+                    : LABEL_PADDING_HORIZONTAL,
                 },
                 styles.placeholderFlat,
                 labelStyle,


### PR DESCRIPTION
when used with the prop `transparent={true}` the input's background is removed and the label is aligned with the border

### Motivation
When the input is transparent the label is not aligned with the bottom border and there is no way so far to align it.

### Test plan
All original tests should pass, because there are no breaking changes
