### PR TITLE
fix: use Partial<Props> for type of defaultProps

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -109,8 +109,8 @@ type State = {
  * ```
  */
 class Button extends React.Component<Props, State> {
-  static defaultProps = {
-    mode: 'text' as 'text',
+  static defaultProps: Partial<Props> = {
+    mode: 'text',
     uppercase: true,
   };
 

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -109,8 +109,8 @@ type State = {
  * ```
  */
 class Chip extends React.Component<Props, State> {
-  static defaultProps = {
-    mode: 'flat' as 'flat',
+  static defaultProps: Partial<Props> = {
+    mode: 'flat',
     disabled: false,
     selected: false,
   };

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -164,9 +164,9 @@ export type TextInputProps = React.ComponentProps<typeof NativeTextInput> & {
  */
 
 class TextInput extends React.Component<TextInputProps, State> {
-  static defaultProps = {
-    mode: 'flat' as 'flat',
-    padding: 'normal' as 'normal',
+  static defaultProps: Partial<TextInputProps> = {
+    mode: 'flat',
+    padding: 'normal',
     dense: false,
     disabled: false,
     error: false,


### PR DESCRIPTION
This avoids the following in docs:

```
Default value: 'text' as 'text'
```

![image](https://user-images.githubusercontent.com/1174278/60581300-d66a9b00-9d86-11e9-951a-8c3c26b04603.png)

