### PR TITLE
feat: Export useTheme hook from react-theme-provider

### DIFF
--- a/src/core/theming.tsx
+++ b/src/core/theming.tsx
@@ -2,4 +2,6 @@ import { createTheming } from '@callstack/react-theme-provider';
 import DefaultTheme from '../styles/DefaultTheme';
 import { Theme } from '../types';
 
-export const { ThemeProvider, withTheme, useTheme } = createTheming<Theme>(DefaultTheme);
+export const { ThemeProvider, withTheme, useTheme } = createTheming<Theme>(
+  DefaultTheme
+);

--- a/src/core/theming.tsx
+++ b/src/core/theming.tsx
@@ -2,4 +2,4 @@ import { createTheming } from '@callstack/react-theme-provider';
 import DefaultTheme from '../styles/DefaultTheme';
 import { Theme } from '../types';
 
-export const { ThemeProvider, withTheme } = createTheming<Theme>(DefaultTheme);
+export const { ThemeProvider, withTheme, useTheme } = createTheming<Theme>(DefaultTheme);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@ export type Theme = _Theme;
 
 export { Colors };
 
-export { withTheme, ThemeProvider } from './core/theming';
+export { useTheme, withTheme, ThemeProvider } from './core/theming';
 
 export { default as Provider } from './core/Provider';
 export { default as DefaultTheme } from './styles/DefaultTheme';


### PR DESCRIPTION
### Motivation
Instead of wrapping every component that needs the theme with `withTheme`, in React 16.8+ and RN 0.59+ you can use `useTheme()` as a hook to get the theme with much less hassle.

This would close #994.

### Test plan

I don't believe this would break any tests.