### PR TITLE
fix: add contentStyle prop to Menu

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -47,6 +47,10 @@ type Props = {
    * Content of the `Menu`.
    */
   children: React.ReactNode;
+  /**
+   * Style of menu's inner content.
+   */
+  contentStyle?: StyleProp<ViewStyle>;
   style?: StyleProp<ViewStyle>;
   /**
    * @optional
@@ -330,6 +334,7 @@ class Menu extends React.Component<Props, State> {
     const {
       visible,
       anchor,
+      contentStyle,
       style,
       children,
       theme,
@@ -481,6 +486,7 @@ class Menu extends React.Component<Props, State> {
                     [
                       styles.shadowMenuContainer,
                       shadowMenuContainerStyle,
+                      contentStyle,
                     ] as StyleProp<ViewStyle>
                   }
                 >


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

This will allow us to apply inner styles which could be useful if you want to have a Menu for a TextInput and don't want to have rounded corners at the top for example.

### Test plan

n/a
