### PR TITLE
fix: add animation scale to Menu

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -286,6 +286,7 @@ class Menu extends React.Component<Props, State> {
       () => {
         this._attachListeners();
 
+        const { animation } = props.theme;
         Animated.parallel([
           Animated.timing(this.state.scaleAnimation, {
             toValue: { x: menuLayout.width, y: menuLayout.height },
@@ -295,7 +296,7 @@ class Menu extends React.Component<Props, State> {
           }),
           Animated.timing(this.state.opacityAnimation, {
             toValue: 1,
-            duration: ANIMATION_DURATION,
+            duration: ANIMATION_DURATION * animation.scale,
             easing: EASING,
             useNativeDriver: true,
           }),
@@ -311,9 +312,10 @@ class Menu extends React.Component<Props, State> {
   _hide = () => {
     this._removeListeners();
 
+    const { animation } = props.theme;
     Animated.timing(this.state.opacityAnimation, {
       toValue: 0,
-      duration: ANIMATION_DURATION,
+      duration: ANIMATION_DURATION * animation.scale,
       easing: EASING,
       useNativeDriver: true,
     }).start(finished => {

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -286,11 +286,11 @@ class Menu extends React.Component<Props, State> {
       () => {
         this._attachListeners();
 
-        const { animation } = props.theme;
+        const { animation } = this.props.theme;
         Animated.parallel([
           Animated.timing(this.state.scaleAnimation, {
             toValue: { x: menuLayout.width, y: menuLayout.height },
-            duration: ANIMATION_DURATION,
+            duration: ANIMATION_DURATION * animation.scale,
             easing: EASING,
             useNativeDriver: true,
           }),
@@ -312,7 +312,7 @@ class Menu extends React.Component<Props, State> {
   _hide = () => {
     this._removeListeners();
 
-    const { animation } = props.theme;
+    const { animation } = this.props.theme;
     Animated.timing(this.state.opacityAnimation, {
       toValue: 0,
       duration: ANIMATION_DURATION * animation.scale,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Adds animation scale from theme to animations in Menu.

### Test plan

Change animation scale in theme temporary to 0 and see how the Menu will pop up immediately.
