### PR TITLE
fix: reduce delay of Menu

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -262,7 +262,7 @@ class Menu extends React.Component<Props, State> {
       !anchorLayout.width ||
       !anchorLayout.height
     ) {
-      setImmediate(this._show);
+      requestAnimationFrame(this._show);
       return;
     }
 

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -262,7 +262,7 @@ class Menu extends React.Component<Props, State> {
       !anchorLayout.width ||
       !anchorLayout.height
     ) {
-      setTimeout(this._show, ANIMATION_DURATION);
+      setImmediate(this._show);
       return;
     }
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

The menu does only appear after half a second on iOS and Android. This fix will reduce the delay to milliseconds and was tested on all devices.

### Test plan

Open Menu examples.