### PR TITLE
feat: expose the useTheme React hook (#1127)

### DIFF
--- a/src/core/theming.tsx
+++ b/src/core/theming.tsx
@@ -2,4 +2,4 @@ import { createTheming } from '@callstack/react-theme-provider';
 import DefaultTheme from '../styles/DefaultTheme';
 import { Theme } from '../types';
 
-export const { ThemeProvider, withTheme } = createTheming<Theme>(DefaultTheme);
+export const { useTheme, ThemeProvider, withTheme } = createTheming<Theme>(DefaultTheme);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@ export type Theme = _Theme;
 
 export { Colors };
 
-export { withTheme, ThemeProvider } from './core/theming';
+export { useTheme, withTheme, ThemeProvider } from './core/theming';
 
 export { default as Provider } from './core/Provider';
 export { default as DefaultTheme } from './styles/DefaultTheme';


### PR DESCRIPTION
react-native-paper is now up to date with react-theme-provider (#1085),
but it was still not exposing useTheme.

This patch changes that.

### Motivation

Be able to use this lib with react hooks requires useTheme.

### Test plan

Import useTheme from react-native-paper.
Use the hook in a component.

E.g:
```
function MyComponent() {
  const theme = useTheme();
  const { colors } = theme;
  return <Text style={{ color: colors.primary }}>Yo!</Text>;
}
```
