### PR TITLE
fix: remove unused prop from Appbar.Header

### DIFF
--- a/src/components/Appbar/AppbarHeader.tsx
+++ b/src/components/Appbar/AppbarHeader.tsx
@@ -34,7 +34,6 @@ type Props = React.ComponentProps<typeof Appbar> & {
    */
   theme: Theme;
   style?: StyleProp<ViewStyle>;
-  __expo?: any;
 };
 
 /**


### PR DESCRIPTION
Closes #1186
Remove "__expo" prop from Appbar.Header