### PR TITLE
feat: add labelStyle prop to FAB.Groups's item

### DIFF
--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -25,6 +25,7 @@ type Props = {
    * - `accessibilityLabel`: accessibility label for the action, uses label by default if specified
    * - `color`: custom icon color of the action item
    * - `style`: pass additional styles for the fab item, for example, `backgroundColor`
+   * - `labelStyle`: pass additional styles for the fab item's label, for example `backgroundColor`
    * - `onPress`: callback that is called when `FAB` is pressed (required)
    */
   actions: Array<{
@@ -33,6 +34,7 @@ type Props = {
     color?: string;
     accessibilityLabel?: string;
     style?: StyleProp<ViewStyle>;
+    labelStyle?: StyleProp<ViewStyle>;
     onPress: () => void;
   }>;
   /**
@@ -262,6 +264,7 @@ class FABGroup extends React.Component<Props, State> {
                           transform: [{ scale: scales[i] }],
                           opacity: opacities[i],
                         },
+                        it.labelStyle,
                       ] as StyleProp<ViewStyle>
                     }
                     onPress={() => {

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -25,7 +25,7 @@ type Props = {
    * - `accessibilityLabel`: accessibility label for the action, uses label by default if specified
    * - `color`: custom icon color of the action item
    * - `style`: pass additional styles for the fab item, for example, `backgroundColor`
-   * - `labelStyle`: pass additional styles for the fab item's label, for example `backgroundColor`
+   * - `labelViewStyle`: pass additional styles for the view containing the fab item's label, for example `backgroundColor`
    * - `onPress`: callback that is called when `FAB` is pressed (required)
    */
   actions: Array<{
@@ -34,7 +34,7 @@ type Props = {
     color?: string;
     accessibilityLabel?: string;
     style?: StyleProp<ViewStyle>;
-    labelStyle?: StyleProp<ViewStyle>;
+    labelViewStyle?: StyleProp<ViewStyle>;
     onPress: () => void;
   }>;
   /**
@@ -264,7 +264,7 @@ class FABGroup extends React.Component<Props, State> {
                           transform: [{ scale: scales[i] }],
                           opacity: opacities[i],
                         },
-                        it.labelStyle,
+                        it.labelViewStyle,
                       ] as StyleProp<ViewStyle>
                     }
                     onPress={() => {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

I'd like to be able to pass a custom style to the item's label in a FAB.Group.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
