### PR TITLE
feat: optional key to FAB:Group's actions if the actions order changes

### DIFF
--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -26,6 +26,7 @@ type Props = {
    * - `color`: custom icon color of the action item
    * - `style`: pass additional styles for the fab item, for example, `backgroundColor`
    * - `onPress`: callback that is called when `FAB` is pressed (required)
+   * - `key`: key used by React in case the actions order is not constant
    */
   actions: Array<{
     icon: IconSource;
@@ -34,6 +35,7 @@ type Props = {
     accessibilityLabel?: string;
     style?: StyleProp<ViewStyle>;
     onPress: () => void;
+    key?: string;
   }>;
   /**
    * Icon to display for the `FAB`.
@@ -249,7 +251,7 @@ class FABGroup extends React.Component<Props, State> {
           <View pointerEvents={open ? 'box-none' : 'none'}>
             {actions.map((it, i) => (
               <View
-                key={i} // eslint-disable-line react/no-array-index-key
+                key={it.key ? it.key : i} // eslint-disable-line react/no-array-index-key
                 style={styles.item}
                 pointerEvents="box-none"
               >


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

I'd like to be able to dynamically choose the actions present in the FAB.Group, based on the context of the surrounding application. When I do so, the first batch of actions is rendered properly. However, if the context of the application around changes and the actions provided to the FAB.Group change accordingly, the label are correctly updated, but not the icons. 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

In a FAB.Group, the index of the action in the array is currently used for the React key. That is perfectly fine as long as the actions in the FAB.Group remain constant.
In situations where the actions depend on the context of the application around, you can end up with label-icon mismatches in the FAB.Group.
My proposal is to let the user provide a custom key for the actions in the FAB.Group in case the actions are not constant throughout the application lifetime.

### Test plan

While tested and validated in the example app and the app I am working on, I have not pushed any modification to the example app, as this use case is hard to showcase in an example app.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
