### PR TITLE
feat: add character counter to text input example

### DIFF
--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -7,6 +7,8 @@ import {
 } from 'react-native';
 import { TextInput, HelperText, withTheme, Theme } from 'react-native-paper';
 
+const MAX_LENGTH = 20;
+
 type Props = {
   theme: Theme;
 };
@@ -26,6 +28,7 @@ type State = {
   flatTextArea: string;
   outlinedMultiline: string;
   outlinedTextArea: string;
+  maxLengthName: string;
 };
 
 class TextInputExample extends React.Component<Props, State> {
@@ -46,6 +49,7 @@ class TextInputExample extends React.Component<Props, State> {
     flatTextArea: '',
     outlinedMultiline: '',
     outlinedTextArea: '',
+    maxLengthName: '',
   };
 
   _isUsernameValid = (name: string) => /^[a-zA-Z]*$/.test(name);
@@ -200,6 +204,28 @@ class TextInputExample extends React.Component<Props, State> {
           </View>
           <View style={styles.inputContainerStyle}>
             <TextInput
+              label="Input with helper text and character counter"
+              placeholder="Enter username, only letters"
+              value={this.state.maxLengthName}
+              error={!this._isUsernameValid(this.state.maxLengthName)}
+              onChangeText={maxLengthName => this.setState({ maxLengthName })}
+              maxLength={MAX_LENGTH}
+            />
+            <View style={styles.helpersWrapper}>
+              <HelperText
+                type="error"
+                visible={!this._isUsernameValid(this.state.maxLengthName)}
+                style={styles.helper}
+              >
+                Error: Numbers and special characters are not allowed
+              </HelperText>
+              <HelperText visible style={styles.counterHelper}>
+                {this.state.maxLengthName.length} / {MAX_LENGTH}
+              </HelperText>
+            </View>
+          </View>
+          <View style={styles.inputContainerStyle}>
+            <TextInput
               label="Input with no padding"
               style={{ backgroundColor: 'transparent' }}
               padding="none"
@@ -227,8 +253,18 @@ const styles = StyleSheet.create({
     flex: 1,
     padding: 8,
   },
+  helpersWrapper: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
   wrapper: {
     flex: 1,
+  },
+  helper: {
+    flexShrink: 1,
+  },
+  counterHelper: {
+    textAlign: 'right',
   },
   inputContainerStyle: {
     margin: 8,


### PR DESCRIPTION
### Motivation
Fixes: #1212 

Following the MD guidelines I've added character counter example.
![image](https://user-images.githubusercontent.com/22746080/61215499-5b509f80-a70b-11e9-855c-29ff2c3990a4.png)


### Test plan

<img width="300" src="https://user-images.githubusercontent.com/22746080/61215512-673c6180-a70b-11e9-9c7c-c86693fce91d.gif" />

with longer message | RTL
--- | ---
<img width="510" alt="Screenshot 2019-07-15 at 14 15 13" src="https://user-images.githubusercontent.com/22746080/61215548-8dfa9800-a70b-11e9-8062-2cec916d918f.png"> | <img width="510" alt="Screenshot 2019-07-15 at 14 15 29" src="https://user-images.githubusercontent.com/22746080/61215570-99e65a00-a70b-11e9-97e9-f108477ef6d0.png">


