### PR TITLE
fix: expose ref in text input

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -395,7 +395,7 @@ class TextInput extends React.Component<TextInputProps, State> {
   }
 
   render() {
-    const { mode, padding, ...rest } = this.props;
+    const { mode, padding, ref: outerRef, ...rest } = this.props;
 
     return mode === 'outlined' ? (
       <TextInputOutlined

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -15,7 +15,7 @@ import { Theme } from '../../types';
 const BLUR_ANIMATION_DURATION = 180;
 const FOCUS_ANIMATION_DURATION = 150;
 
-export type TextInputProps = React.ComponentProps<typeof NativeTextInput> & {
+export type TextInputProps = React.ComponentPropsWithRef<typeof NativeTextInput> & {
   /**
    * Mode of the TextInput.
    * - `flat` - flat input with an underline.

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -15,7 +15,9 @@ import { Theme } from '../../types';
 const BLUR_ANIMATION_DURATION = 180;
 const FOCUS_ANIMATION_DURATION = 150;
 
-export type TextInputProps = React.ComponentPropsWithRef<typeof NativeTextInput> & {
+export type TextInputProps = React.ComponentPropsWithRef<
+  typeof NativeTextInput
+> & {
   /**
    * Mode of the TextInput.
    * - `flat` - flat input with an underline.
@@ -395,6 +397,7 @@ class TextInput extends React.Component<TextInputProps, State> {
   }
 
   render() {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { mode, padding, ref: outerRef, ...rest } = this.props;
 
     return mode === 'outlined' ? (


### PR DESCRIPTION

### Motivation

Currently, it is not possible to pass a `ref` prop to the `TextInput`.

### Test plan

Use `TextInput` with `ref` prop.