### PR TITLE
fix: omit theme prop in DataTable.Cell

### DIFF
--- a/src/components/DataTable/DataTableCell.tsx
+++ b/src/components/DataTable/DataTableCell.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import { StyleSheet, StyleProp, ViewStyle } from 'react-native';
 import Text from '../Typography/Text';
 import TouchableRipple from '../TouchableRipple';
-import { $RemoveChildren } from '../../types';
+import { $RemoveChildren, $Omit } from '../../types';
 
-type Props = $RemoveChildren<typeof TouchableRipple> & {
+type Props = $Omit<$RemoveChildren<typeof TouchableRipple>, 'children'> & {
   /**
    * Content of the `DataTableCell`.
    */


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Currently, the theme property is required because `DataTable.Cell` uses the props of `TouchableRipple` and TypeScript generates a warning. However, `DataTable.Cell` does not use the `withTheme` HOC and thus it's not omitted automatically. I'm not sure why it's not complaining the examples.

### Test plan

Use `DataTable.Cell` without `theme` prop in a project
