### PR TITLE
fix: touchable ripple toggling disable prop

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -245,7 +245,7 @@ class Button extends React.Component<Props, State> {
           accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
           accessibilityComponentType="button"
           accessibilityRole="button"
-          accessibilityStates={disabled ? ['disabled'] : undefined}
+          accessibilityStates={disabled ? ['disabled'] : []}
           disabled={disabled}
           rippleColor={rippleColor}
           style={touchableStyle}

--- a/src/components/CheckboxAndroid.tsx
+++ b/src/components/CheckboxAndroid.tsx
@@ -126,7 +126,7 @@ class CheckboxAndroid extends React.Component<Props, State> {
         accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
         accessibilityComponentType="button"
         accessibilityRole="button"
-        accessibilityStates={disabled ? ['disabled'] : undefined}
+        accessibilityStates={disabled ? ['disabled'] : []}
         accessibilityLiveRegion="polite"
         style={styles.container}
       >

--- a/src/components/CheckboxIOS.tsx
+++ b/src/components/CheckboxIOS.tsx
@@ -82,7 +82,7 @@ class CheckboxIOS extends React.Component<Props> {
         accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
         accessibilityComponentType="button"
         accessibilityRole="button"
-        accessibilityStates={disabled ? ['disabled'] : undefined}
+        accessibilityStates={disabled ? ['disabled'] : []}
         accessibilityLiveRegion="polite"
         style={styles.container}
       >

--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -84,7 +84,7 @@ class DrawerItem extends React.Component<Props> {
           accessibilityTraits={active ? ['button', 'selected'] : 'button'}
           accessibilityComponentType="button"
           accessibilityRole="button"
-          accessibilityStates={active ? ['selected'] : undefined}
+          accessibilityStates={active ? ['selected'] : []}
         >
           <View style={styles.wrapper}>
             {icon ? (

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -204,7 +204,7 @@ class FAB extends React.Component<Props, State> {
           accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
           accessibilityComponentType="button"
           accessibilityRole="button"
-          accessibilityStates={disabled ? ['disabled'] : undefined}
+          accessibilityStates={disabled ? ['disabled'] : []}
           style={styles.touchable}
         >
           <View

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -119,7 +119,7 @@ const IconButton = ({
       accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
       accessibilityComponentType="button"
       accessibilityRole="button"
-      accessibilityStates={disabled ? ['disabled'] : undefined}
+      accessibilityStates={disabled ? ['disabled'] : []}
       disabled={disabled}
       hitSlop={
         // @ts-ignore - this should be fixed in react-theme-providersince withTheme() is not forwarding static property types

--- a/src/components/RadioButtonAndroid.tsx
+++ b/src/components/RadioButtonAndroid.tsx
@@ -133,7 +133,7 @@ class RadioButtonAndroid extends React.Component<Props, State> {
           checked ? 'radiobutton_checked' : 'radiobutton_unchecked'
         }
         accessibilityRole="button"
-        accessibilityStates={disabled ? ['disabled'] : undefined}
+        accessibilityStates={disabled ? ['disabled'] : []}
         accessibilityLiveRegion="polite"
         style={styles.container}
       >

--- a/src/components/RadioButtonIOS.tsx
+++ b/src/components/RadioButtonIOS.tsx
@@ -90,7 +90,7 @@ class RadioButtonIOS extends React.Component<Props> {
           checked ? 'radiobutton_checked' : 'radiobutton_unchecked'
         }
         accessibilityRole="button"
-        accessibilityStates={disabled ? ['disabled'] : undefined}
+        accessibilityStates={disabled ? ['disabled'] : []}
         accessibilityLiveRegion="polite"
         style={styles.container}
       >

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
@@ -40,6 +40,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
   >
     <View
       accessibilityRole="button"
+      accessibilityStates={Array []}
       accessible={true}
       hitSlop={
         Object {

--- a/src/components/__tests__/__snapshots__/Banner.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.js.snap
@@ -214,6 +214,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
         >
           <View
             accessibilityRole="button"
+            accessibilityStates={Array []}
             accessible={true}
             isTVSelectable={true}
             onResponderGrant={[Function]}
@@ -386,6 +387,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
         >
           <View
             accessibilityRole="button"
+            accessibilityStates={Array []}
             accessible={true}
             isTVSelectable={true}
             onResponderGrant={[Function]}
@@ -472,6 +474,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
         >
           <View
             accessibilityRole="button"
+            accessibilityStates={Array []}
             accessible={true}
             isTVSelectable={true}
             onResponderGrant={[Function]}

--- a/src/components/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.js.snap
@@ -16,6 +16,7 @@ exports[`renders button with color 1`] = `
 >
   <View
     accessibilityRole="button"
+    accessibilityStates={Array []}
     accessible={true}
     isTVSelectable={true}
     onResponderGrant={[Function]}
@@ -102,6 +103,7 @@ exports[`renders button with icon 1`] = `
 >
   <View
     accessibilityRole="button"
+    accessibilityStates={Array []}
     accessible={true}
     isTVSelectable={true}
     onResponderGrant={[Function]}
@@ -239,6 +241,7 @@ exports[`renders contained contained with mode 1`] = `
 >
   <View
     accessibilityRole="button"
+    accessibilityStates={Array []}
     accessible={true}
     isTVSelectable={true}
     onResponderGrant={[Function]}
@@ -416,6 +419,7 @@ exports[`renders loading button 1`] = `
 >
   <View
     accessibilityRole="button"
+    accessibilityStates={Array []}
     accessible={true}
     isTVSelectable={true}
     onResponderGrant={[Function]}
@@ -685,6 +689,7 @@ exports[`renders outlined button with mode 1`] = `
 >
   <View
     accessibilityRole="button"
+    accessibilityStates={Array []}
     accessible={true}
     isTVSelectable={true}
     onResponderGrant={[Function]}
@@ -771,6 +776,7 @@ exports[`renders text button by default 1`] = `
 >
   <View
     accessibilityRole="button"
+    accessibilityStates={Array []}
     accessible={true}
     isTVSelectable={true}
     onResponderGrant={[Function]}
@@ -857,6 +863,7 @@ exports[`renders text button with mode 1`] = `
 >
   <View
     accessibilityRole="button"
+    accessibilityStates={Array []}
     accessible={true}
     isTVSelectable={true}
     onResponderGrant={[Function]}

--- a/src/components/__tests__/__snapshots__/Checkbox.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Checkbox.test.js.snap
@@ -3,6 +3,7 @@
 exports[`renders checked Checkbox with color 1`] = `
 <View
   accessibilityRole="button"
+  accessibilityStates={Array []}
   accessible={true}
   isTVSelectable={true}
   onResponderGrant={[Function]}
@@ -71,6 +72,7 @@ exports[`renders checked Checkbox with color 1`] = `
 exports[`renders checked Checkbox with onPress 1`] = `
 <View
   accessibilityRole="button"
+  accessibilityStates={Array []}
   accessible={true}
   isTVSelectable={true}
   onResponderGrant={[Function]}
@@ -139,6 +141,7 @@ exports[`renders checked Checkbox with onPress 1`] = `
 exports[`renders indeterminate Checkbox 1`] = `
 <View
   accessibilityRole="button"
+  accessibilityStates={Array []}
   accessible={true}
   isTVSelectable={true}
   onResponderGrant={[Function]}
@@ -207,6 +210,7 @@ exports[`renders indeterminate Checkbox 1`] = `
 exports[`renders indeterminate Checkbox with color 1`] = `
 <View
   accessibilityRole="button"
+  accessibilityStates={Array []}
   accessible={true}
   isTVSelectable={true}
   onResponderGrant={[Function]}
@@ -275,6 +279,7 @@ exports[`renders indeterminate Checkbox with color 1`] = `
 exports[`renders unchecked Checkbox with color 1`] = `
 <View
   accessibilityRole="button"
+  accessibilityStates={Array []}
   accessible={true}
   isTVSelectable={true}
   onResponderGrant={[Function]}
@@ -343,6 +348,7 @@ exports[`renders unchecked Checkbox with color 1`] = `
 exports[`renders unchecked Checkbox with onPress 1`] = `
 <View
   accessibilityRole="button"
+  accessibilityStates={Array []}
   accessible={true}
   isTVSelectable={true}
   onResponderGrant={[Function]}

--- a/src/components/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.js.snap
@@ -204,6 +204,7 @@ exports[`renders data table pagination 1`] = `
   />
   <View
     accessibilityRole="button"
+    accessibilityStates={Array []}
     accessible={true}
     hitSlop={
       Object {
@@ -284,6 +285,7 @@ exports[`renders data table pagination 1`] = `
   </View>
   <View
     accessibilityRole="button"
+    accessibilityStates={Array []}
     accessible={true}
     hitSlop={
       Object {
@@ -406,6 +408,7 @@ exports[`renders data table pagination with label 1`] = `
   </Text>
   <View
     accessibilityRole="button"
+    accessibilityStates={Array []}
     accessible={true}
     hitSlop={
       Object {
@@ -486,6 +489,7 @@ exports[`renders data table pagination with label 1`] = `
   </View>
   <View
     accessibilityRole="button"
+    accessibilityStates={Array []}
     accessible={true}
     hitSlop={
       Object {

--- a/src/components/__tests__/__snapshots__/DrawerItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DrawerItem.test.js.snap
@@ -18,6 +18,7 @@ exports[`renders DrawerItem with icon 1`] = `
 >
   <View
     accessibilityRole="button"
+    accessibilityStates={Array []}
     accessible={true}
     isTVSelectable={true}
     onResponderGrant={[Function]}
@@ -247,6 +248,7 @@ exports[`renders basic DrawerItem 1`] = `
 >
   <View
     accessibilityRole="button"
+    accessibilityStates={Array []}
     accessible={true}
     isTVSelectable={true}
     onResponderGrant={[Function]}

--- a/src/components/__tests__/__snapshots__/FAB.test.js.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.js.snap
@@ -27,6 +27,7 @@ exports[`renders extended FAB 1`] = `
   <View
     accessibilityLabel="Add items"
     accessibilityRole="button"
+    accessibilityStates={Array []}
     accessible={true}
     isTVSelectable={true}
     onResponderGrant={[Function]}
@@ -185,6 +186,7 @@ exports[`renders normal FAB 1`] = `
 >
   <View
     accessibilityRole="button"
+    accessibilityStates={Array []}
     accessible={true}
     isTVSelectable={true}
     onResponderGrant={[Function]}
@@ -318,6 +320,7 @@ exports[`renders small FAB 1`] = `
 >
   <View
     accessibilityRole="button"
+    accessibilityStates={Array []}
     accessible={true}
     isTVSelectable={true}
     onResponderGrant={[Function]}

--- a/src/components/__tests__/__snapshots__/IconButton.test.js.snap
+++ b/src/components/__tests__/__snapshots__/IconButton.test.js.snap
@@ -93,6 +93,7 @@ exports[`renders disabled icon button 1`] = `
 exports[`renders icon button by default 1`] = `
 <View
   accessibilityRole="button"
+  accessibilityStates={Array []}
   accessible={true}
   hitSlop={
     Object {
@@ -176,6 +177,7 @@ exports[`renders icon button by default 1`] = `
 exports[`renders icon button with color 1`] = `
 <View
   accessibilityRole="button"
+  accessibilityStates={Array []}
   accessible={true}
   hitSlop={
     Object {
@@ -259,6 +261,7 @@ exports[`renders icon button with color 1`] = `
 exports[`renders icon button with size 1`] = `
 <View
   accessibilityRole="button"
+  accessibilityStates={Array []}
   accessible={true}
   hitSlop={
     Object {
@@ -342,6 +345,7 @@ exports[`renders icon button with size 1`] = `
 exports[`renders icon change animated 1`] = `
 <View
   accessibilityRole="button"
+  accessibilityStates={Array []}
   accessible={true}
   hitSlop={
     Object {

--- a/src/components/__tests__/__snapshots__/Menu.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.js.snap
@@ -19,6 +19,7 @@ exports[`renders not visible menu 1`] = `
   >
     <View
       accessibilityRole="button"
+      accessibilityStates={Array []}
       accessible={true}
       isTVSelectable={true}
       onResponderGrant={[Function]}
@@ -109,6 +110,7 @@ exports[`renders visible menu 1`] = `
   >
     <View
       accessibilityRole="button"
+      accessibilityStates={Array []}
       accessible={true}
       isTVSelectable={true}
       onResponderGrant={[Function]}

--- a/src/components/__tests__/__snapshots__/RadioButton.test.js.snap
+++ b/src/components/__tests__/__snapshots__/RadioButton.test.js.snap
@@ -3,6 +3,7 @@
 exports[`RadioButton on default platform renders properly 1`] = `
 <View
   accessibilityRole="button"
+  accessibilityStates={Array []}
   accessible={true}
   isTVSelectable={true}
   onResponderGrant={[Function]}
@@ -40,6 +41,7 @@ exports[`RadioButton on default platform renders properly 1`] = `
 exports[`RadioButton on ios platform renders properly 1`] = `
 <View
   accessibilityRole="button"
+  accessibilityStates={Array []}
   accessible={true}
   isTVSelectable={true}
   onResponderGrant={[Function]}
@@ -108,6 +110,7 @@ exports[`RadioButton on ios platform renders properly 1`] = `
 exports[`RadioButton when RadioButton is wrapped by RadioButtonContext.Provider renders properly 1`] = `
 <View
   accessibilityRole="button"
+  accessibilityStates={Array []}
   accessible={true}
   isTVSelectable={true}
   onResponderGrant={[Function]}

--- a/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
@@ -21,6 +21,7 @@ exports[`renders with placeholder 1`] = `
 >
   <View
     accessibilityRole="button"
+    accessibilityStates={Array []}
     accessible={true}
     hitSlop={
       Object {
@@ -240,6 +241,7 @@ exports[`renders with text 1`] = `
 >
   <View
     accessibilityRole="button"
+    accessibilityStates={Array []}
     accessible={true}
     hitSlop={
       Object {
@@ -351,6 +353,7 @@ exports[`renders with text 1`] = `
   />
   <View
     accessibilityRole="button"
+    accessibilityStates={Array []}
     accessible={true}
     hitSlop={
       Object {

--- a/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
@@ -159,6 +159,7 @@ exports[`renders snackbar with action button 1`] = `
     >
       <View
         accessibilityRole="button"
+        accessibilityStates={Array []}
         accessible={true}
         isTVSelectable={true}
         onResponderGrant={[Function]}

--- a/src/components/__tests__/__snapshots__/ToggleButton.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ToggleButton.test.js.snap
@@ -103,6 +103,7 @@ exports[`renders disabled toggle button 1`] = `
 exports[`renders toggle button 1`] = `
 <View
   accessibilityRole="button"
+  accessibilityStates={Array []}
   accessible={true}
   hitSlop={
     Object {


### PR DESCRIPTION
Resolves #1188 
### Motivation
Passing `undefined` to `accessibilityStates` 
https://github.com/callstack/react-native-paper/blob/4fc1eb9b0e4bf418d6262d011e28fe215243aa3f/src/components/Button.tsx#L248
causes unexpecting behaviour that if you switch button or any similar component to disabled and then back to normal it loses ripple effect and a possibility to be clicked.
Problem occurs on android devices with `react-native >= 0.6`
![ezgif com-optimize](https://user-images.githubusercontent.com/3886886/61450108-a3173700-a956-11e9-99c0-2c83ee5d8d31.gif)

https://facebook.github.io/react-native/docs/view#accessibilitystates
AccessibilityStates accept array of values, so if we don't want to pass anything there we should pass empty array instead of undefined