### PR TITLE
docs: theming.md

### DIFF
--- a/docs/pages/2.theming.md
+++ b/docs/pages/2.theming.md
@@ -22,7 +22,7 @@ export default function Main() {
 }
 ```
 
-If no prop is specified, this will apply the [default theme](https://github.com/callstack/react-native-paper/blob/master/src/styles/DefaultTheme.js) to the components. You can also provide a `theme` prop with a theme object with same properties as the default theme:
+If no prop is specified, this will apply the [default theme](https://github.com/callstack/react-native-paper/blob/master/src/styles/DefaultTheme.tsx) to the components. You can also provide a `theme` prop with a theme object with same properties as the default theme:
 
 ```js
 import * as React from 'react';


### PR DESCRIPTION
docs: missing link (404 Not found) of `default theme` in theming pages.

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
Just help for new `user` use this library (like me 🙇🏻‍♂️) can't visit theming default pages.
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
I've read theming from the docs here https://callstack.github.io/react-native-paper/theming.html & visit `default theme` link, but 404 not found.
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
