### PR TITLE
refactor: change outline textinput label behaviour

### DIFF
--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Animated, StyleSheet } from 'react-native';
-import AnimatedText from '../Typography/AnimatedText';
+import AnimatedText from '../../Typography/AnimatedText';
 
-import { InputLabelProps } from './types';
+import { InputLabelProps } from '../types';
 
 const InputLabel = (props: InputLabelProps) => {
-  const { parentState } = props;
+  const { parentState, labelBackground } = props;
 
   const {
     label,
@@ -85,6 +85,12 @@ const InputLabel = (props: InputLabelProps) => {
         labelTranslationX,
       ]}
     >
+      {labelBackground &&
+        labelBackground({
+          parentState,
+          labelStyle,
+          labelProps: props.labelProps,
+        })}
       <AnimatedText
         onLayout={onLayoutAnimatedText}
         style={[

--- a/src/components/TextInput/Label/LabelBackground.tsx
+++ b/src/components/TextInput/Label/LabelBackground.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { StyleSheet } from 'react-native';
+
+import AnimatedText from '../../Typography/AnimatedText';
+
+import { LabelBackgroundProps } from '../types';
+
+const LabelBackground = ({
+  parentState,
+  labelProps: {
+    placeholderStyle,
+    topPosition,
+    hasActiveOutline,
+    label,
+    backgroundColor,
+  },
+  labelStyle,
+}: LabelBackgroundProps) =>
+  label ? (
+    <AnimatedText
+      style={[
+        placeholderStyle,
+        labelStyle,
+        {
+          top: topPosition + 1,
+          transform: [
+            ...labelStyle.transform,
+            {
+              scaleY: parentState.labeled.interpolate({
+                inputRange: [0, 1],
+                outputRange: [0.2, 1],
+              }),
+            },
+          ],
+        },
+        styles.outlinedLabel || {},
+        {
+          backgroundColor,
+          opacity: parentState.labeled.interpolate({
+            inputRange: [0, 1],
+            outputRange: [hasActiveOutline || parentState.value ? 1 : 0, 0],
+          }),
+        },
+      ]}
+      numberOfLines={1}
+    >
+      {label}
+    </AnimatedText>
+  ) : null;
+
+export default LabelBackground;
+
+const styles = StyleSheet.create({
+  outlinedLabel: {
+    position: 'absolute',
+    left: 10,
+    paddingHorizontal: 4,
+    color: 'transparent',
+  },
+});

--- a/src/components/TextInput/Label/LabelBackground.tsx
+++ b/src/components/TextInput/Label/LabelBackground.tsx
@@ -54,8 +54,11 @@ const LabelBackground = ({
           style={[
             placeholderStyle,
             labelStyle,
+            styles.outlinedLabel,
             {
               top: topPosition + 1,
+              backgroundColor,
+              opacity,
               transform: [
                 ...labelStyle.transform,
                 {
@@ -65,11 +68,6 @@ const LabelBackground = ({
                   }),
                 },
               ],
-            },
-            styles.outlinedLabel || {},
-            {
-              backgroundColor,
-              opacity,
             },
           ]}
           numberOfLines={1}

--- a/src/components/TextInput/Label/LabelBackground.tsx
+++ b/src/components/TextInput/Label/LabelBackground.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleSheet } from 'react-native';
+import { Animated, StyleSheet } from 'react-native';
 
 import AnimatedText from '../../Typography/AnimatedText';
 
@@ -9,52 +9,91 @@ const LabelBackground = ({
   parentState,
   labelProps: {
     placeholderStyle,
+    baseLabelTranslateX,
     topPosition,
     hasActiveOutline,
     label,
     backgroundColor,
   },
   labelStyle,
-}: LabelBackgroundProps) =>
-  label ? (
-    <AnimatedText
-      style={[
-        placeholderStyle,
-        labelStyle,
-        {
-          top: topPosition + 1,
-          transform: [
-            ...labelStyle.transform,
+}: LabelBackgroundProps) => {
+  const hasFocus = hasActiveOutline || parentState.value;
+  const opacity = parentState.labeled.interpolate({
+    inputRange: [0, 1],
+    outputRange: [hasFocus ? 1 : 0, 0],
+  });
+
+  const labelTranslationX = {
+    transform: [
+      {
+        translateX: parentState.labeled.interpolate({
+          inputRange: [0, 1],
+          outputRange: [-baseLabelTranslateX, 0],
+        }),
+      },
+    ],
+  };
+
+  return label
+    ? [
+        <Animated.View
+          key="labelBackground-view"
+          pointerEvents="none"
+          style={[
+            StyleSheet.absoluteFill,
+            styles.view,
             {
-              scaleY: parentState.labeled.interpolate({
-                inputRange: [0, 1],
-                outputRange: [0.2, 1],
-              }),
+              backgroundColor,
+              opacity,
             },
-          ],
-        },
-        styles.outlinedLabel || {},
-        {
-          backgroundColor,
-          opacity: parentState.labeled.interpolate({
-            inputRange: [0, 1],
-            outputRange: [hasActiveOutline || parentState.value ? 1 : 0, 0],
-          }),
-        },
-      ]}
-      numberOfLines={1}
-    >
-      {label}
-    </AnimatedText>
-  ) : null;
+            labelTranslationX,
+          ]}
+        />,
+        <AnimatedText
+          key="labelBackground-text"
+          style={[
+            placeholderStyle,
+            labelStyle,
+            {
+              top: topPosition + 1,
+              transform: [
+                ...labelStyle.transform,
+                {
+                  scaleY: parentState.labeled.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [0.2, 1],
+                  }),
+                },
+              ],
+            },
+            styles.outlinedLabel || {},
+            {
+              backgroundColor,
+              opacity,
+            },
+          ]}
+          numberOfLines={1}
+        >
+          {label}
+        </AnimatedText>,
+      ]
+    : null;
+};
 
 export default LabelBackground;
 
 const styles = StyleSheet.create({
+  view: {
+    position: 'absolute',
+    top: 6,
+    left: 10,
+    width: 8,
+    height: 2,
+  },
   outlinedLabel: {
     position: 'absolute',
-    left: 10,
-    paddingHorizontal: 4,
+    left: 18,
+    paddingHorizontal: 0,
     color: 'transparent',
   },
 });

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -9,7 +9,7 @@ import {
   TextStyle,
 } from 'react-native';
 import color from 'color';
-import InputLabel from './InputLabel';
+import InputLabel from './Label/InputLabel';
 import { RenderProps, ChildTextInputProps } from './types';
 
 import {

--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -48,10 +48,20 @@ export type LabelProps = {
   topPosition: number;
   paddingOffset?: { paddingHorizontal: number } | null | undefined;
   placeholderColor: string | null | undefined;
+  backgroundColor?: string | null | undefined;
   label?: string | null | undefined;
   hasActiveOutline: boolean | null | undefined;
   activeColor: string;
   error: boolean | null | undefined;
   onLayoutAnimatedText: (args: any) => void;
 };
-export type InputLabelProps = { parentState: State; labelProps: LabelProps };
+export type InputLabelProps = {
+  parentState: State;
+  labelProps: LabelProps;
+  labelBackground?: any;
+};
+export type LabelBackgroundProps = {
+  labelProps: LabelProps;
+  labelStyle: any;
+  parentState: State;
+};


### PR DESCRIPTION
PR makes few things:
1. Refactor outline input label - moves components to separate folder and extract one of the component (LabelBackground)
2. Fix spacing around label in outline input when control has focus or value
3. Adjust label background when backgroundColor is passed in styles to the outline input
4. change input padding from 12 to 14 according to material guidelines [inputs](https://material.io/design/components/text-fields.html#spec)

![image](https://user-images.githubusercontent.com/21242757/61800179-c9dcde00-ae2c-11e9-8c53-16fd09648f3e.png)


### Test plan
**BEFORE**
Note: more white space on right side of the label and gray background outside the outline border

<img width="338" alt="Screenshot 2019-07-24 at 15 57 41" src="https://user-images.githubusercontent.com/21242757/61799713-e298c400-ae2b-11e9-8454-efa9e333935a.png">

<img width="340" alt="Screenshot 2019-07-24 at 15 57 47" src="https://user-images.githubusercontent.com/21242757/61799716-e4fb1e00-ae2b-11e9-8462-d5b14dd1b598.png">

**AFTER**
Note: Equal margin of 4px on both sides of the minimized label, correct spacing and border cutoff view sized properly

![image](https://user-images.githubusercontent.com/21242757/61858498-7cad4a80-aec6-11e9-8c83-3c126d405708.png)

![image](https://user-images.githubusercontent.com/21242757/61858479-70c18880-aec6-11e9-88b6-96bf1f64cc53.png)
