### PR TITLE
feat: (title|description)numberOfLines prop to ListItem and ListAccordion

### DIFF
--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -127,6 +127,11 @@ type State = {
 class ListAccordion extends React.Component<Props, State> {
   static displayName = 'List.Accordion';
 
+  static defaultProps: Partial<Props> = {
+    titleNumberOfLines: 1,
+    descriptionNumberOfLines: 2,
+  };
+
   state = {
     expanded: this.props.expanded || false,
   };
@@ -187,7 +192,7 @@ class ListAccordion extends React.Component<Props, State> {
               : null}
             <View style={[styles.item, styles.content]}>
               <Text
-                numberOfLines={titleNumberOfLines ? titleNumberOfLines : 1}
+                numberOfLines={titleNumberOfLines}
                 style={[
                   styles.title,
                   {
@@ -200,9 +205,7 @@ class ListAccordion extends React.Component<Props, State> {
               </Text>
               {description && (
                 <Text
-                  numberOfLines={
-                    descriptionNumberOfLines ? descriptionNumberOfLines : 2
-                  }
+                  numberOfLines={descriptionNumberOfLines}
                   style={[
                     styles.description,
                     {

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -57,6 +57,11 @@ type Props = {
    */
   descriptionStyle?: StyleProp<TextStyle>;
   /**
+   * Truncate title text such that the total number of lines does not
+   * exceed this number.
+   */
+  titleNumberOfLines?: number;
+  /**
    * Truncate description text such that the total number of lines does not
    * exceed this number.
    */
@@ -147,6 +152,7 @@ class ListAccordion extends React.Component<Props, State> {
       theme,
       titleStyle,
       descriptionStyle,
+      titleNumberOfLines,
       descriptionNumberOfLines,
       style,
     } = this.props;
@@ -181,7 +187,7 @@ class ListAccordion extends React.Component<Props, State> {
               : null}
             <View style={[styles.item, styles.content]}>
               <Text
-                numberOfLines={1}
+                numberOfLines={titleNumberOfLines ? titleNumberOfLines : 1}
                 style={[
                   styles.title,
                   {

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -57,12 +57,12 @@ type Props = {
    */
   descriptionStyle?: StyleProp<TextStyle>;
   /**
-   * Truncate title text such that the total number of lines does not
+   * Truncate Title text such that the total number of lines does not
    * exceed this number.
    */
   titleNumberOfLines?: number;
   /**
-   * Truncate description text such that the total number of lines does not
+   * Truncate Description text such that the total number of lines does not
    * exceed this number.
    */
   descriptionNumberOfLines?: number;

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -56,6 +56,11 @@ type Props = {
    * Style that is passed to Description element.
    */
   descriptionStyle?: StyleProp<TextStyle>;
+  /**
+   * Truncate description text such that the total number of lines does not
+   * exceed this number.
+   */
+  descriptionNumberOfLines?: number;
 };
 
 type State = {
@@ -142,6 +147,7 @@ class ListAccordion extends React.Component<Props, State> {
       theme,
       titleStyle,
       descriptionStyle,
+      descriptionNumberOfLines,
       style,
     } = this.props;
     const titleColor = color(theme.colors.text)
@@ -188,7 +194,9 @@ class ListAccordion extends React.Component<Props, State> {
               </Text>
               {description && (
                 <Text
-                  numberOfLines={2}
+                  numberOfLines={
+                    descriptionNumberOfLines ? descriptionNumberOfLines : 2
+                  }
                   style={[
                     styles.description,
                     {

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -72,12 +72,12 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
    */
   descriptionStyle?: StyleProp<TextStyle>;
   /**
-   * Truncate title text such that the total number of lines does not
+   * Truncate Title text such that the total number of lines does not
    * exceed this number.
    */
   titleNumberOfLines?: number;
   /**
-   * Truncate description text such that the total number of lines does not
+   * Truncate Description text such that the total number of lines does not
    * exceed this number.
    */
   descriptionNumberOfLines?: number;

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -72,6 +72,11 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
    */
   descriptionStyle?: StyleProp<TextStyle>;
   /**
+   * Truncate title text such that the total number of lines does not
+   * exceed this number.
+   */
+  titleNumberOfLines?: number;
+  /**
    * Truncate description text such that the total number of lines does not
    * exceed this number.
    */
@@ -155,6 +160,7 @@ class ListItem extends React.Component<Props> {
       theme,
       style,
       titleStyle,
+      titleNumberOfLines,
       titleEllipsizeMode,
       ...rest
     } = this.props;
@@ -188,7 +194,7 @@ class ListItem extends React.Component<Props> {
           <View style={[styles.item, styles.content]} pointerEvents="none">
             <Text
               ellipsizeMode={titleEllipsizeMode}
-              numberOfLines={1}
+              numberOfLines={titleNumberOfLines ? titleNumberOfLines : 1}
               style={[styles.title, { color: titleColor }, titleStyle]}
             >
               {title}

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -119,6 +119,11 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
 class ListItem extends React.Component<Props> {
   static displayName = 'List.Item';
 
+  static defaultProps: Partial<Props> = {
+    titleNumberOfLines: 1,
+    descriptionNumberOfLines: 2,
+  };
+
   renderDescription(
     descriptionColor: string,
     description?: Description | null
@@ -137,7 +142,7 @@ class ListItem extends React.Component<Props> {
       })
     ) : (
       <Text
-        numberOfLines={descriptionNumberOfLines ? descriptionNumberOfLines : 2}
+        numberOfLines={descriptionNumberOfLines}
         ellipsizeMode={descriptionEllipsizeMode}
         style={[
           styles.description,
@@ -194,7 +199,7 @@ class ListItem extends React.Component<Props> {
           <View style={[styles.item, styles.content]} pointerEvents="none">
             <Text
               ellipsizeMode={titleEllipsizeMode}
-              numberOfLines={titleNumberOfLines ? titleNumberOfLines : 1}
+              numberOfLines={titleNumberOfLines}
               style={[styles.title, { color: titleColor }, titleStyle]}
             >
               {title}

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -72,9 +72,13 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
    */
   descriptionStyle?: StyleProp<TextStyle>;
   /**
+   * Truncate description text such that the total number of lines does not
+   * exceed this number.
+   */
+  descriptionNumberOfLines?: number;
+  /**
    * Ellipsize Mode for the Title
    */
-
   titleEllipsizeMode?: EllipsizeProp;
   /**
    * Ellipsize Mode for the Description
@@ -114,7 +118,11 @@ class ListItem extends React.Component<Props> {
     descriptionColor: string,
     description?: Description | null
   ) {
-    const { descriptionEllipsizeMode, descriptionStyle } = this.props;
+    const {
+      descriptionEllipsizeMode,
+      descriptionStyle,
+      descriptionNumberOfLines,
+    } = this.props;
 
     return typeof description === 'function' ? (
       description({
@@ -124,7 +132,7 @@ class ListItem extends React.Component<Props> {
       })
     ) : (
       <Text
-        numberOfLines={2}
+        numberOfLines={descriptionNumberOfLines ? descriptionNumberOfLines : 2}
         ellipsizeMode={descriptionEllipsizeMode}
         style={[
           styles.description,


### PR DESCRIPTION
### Motivation

To address #1242, this PR adds optional `titleNumberOfLines` and `descriptionNumberOfLines` props to the `ListItem` and `ListAccordion` components, keeping the default values as before (1 and 2, respectively). Also, see #1096 for a related feature.

### Test plan

Tested `List.Section` and `List.Accordion` examples using
```
titleNumberOfLines={3}
descriptionNumberOfLines={3}
```

#### ListItem
![ListItem](https://user-images.githubusercontent.com/4244379/61876130-10414400-aee4-11e9-8a4a-cd4ca419321b.png)

#### ListAccordion
![ListAccordion](https://user-images.githubusercontent.com/4244379/61876122-0c152680-aee4-11e9-8433-1c73beec7746.png)