### PR TITLE
feat: handle fontWeight style-prop

### DIFF
--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -18,6 +18,7 @@ const InputLabel = (props: InputLabelProps) => {
     baseLabelTranslateY,
     font,
     fontSize,
+    fontWeight,
     placeholderOpacity,
     wiggleOffsetX,
     labelScale,
@@ -41,6 +42,7 @@ const InputLabel = (props: InputLabelProps) => {
   const labelStyle = {
     ...font,
     fontSize,
+    fontWeight,
     transform: [
       {
         // Wiggle the label when there's an error

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -77,6 +77,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
 
     const {
       fontSize: fontSizeStyle,
+      fontWeight,
       height,
       ...viewStyle
     } = (StyleSheet.flatten(style) || {}) as TextStyle;
@@ -190,6 +191,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
       baseLabelTranslateX,
       font,
       fontSize,
+      fontWeight,
       labelScale,
       wiggleOffsetX: LABEL_WIGGLE_X_OFFSET,
       topPosition,
@@ -252,9 +254,10 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
                   : {},
                 paddingFlat,
                 {
-                  fontSize,
-                  color: inputTextColor,
                   ...font,
+                  fontSize,
+                  fontWeight,
+                  color: inputTextColor,
                   textAlignVertical: multiline && height ? 'top' : 'center',
                 },
               ],

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -73,6 +73,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps, {}> {
 
     const {
       fontSize: fontSizeStyle,
+      fontWeight,
       height,
       backgroundColor = colors.background,
       ...viewStyle
@@ -168,6 +169,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps, {}> {
       baseLabelTranslateX,
       font,
       fontSize,
+      fontWeight,
       labelScale,
       wiggleOffsetX: LABEL_WIGGLE_X_OFFSET,
       topPosition,
@@ -232,9 +234,10 @@ class TextInputOutlined extends React.Component<ChildTextInputProps, {}> {
                     : {},
                   paddingOut,
                   {
-                    fontSize,
-                    color: inputTextColor,
                     ...font,
+                    fontSize,
+                    fontWeight,
+                    color: inputTextColor,
                     textAlignVertical: multiline && height ? 'top' : 'center',
                   },
                 ],

--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -1,4 +1,8 @@
-import { TextInput as NativeTextInput, Animated } from 'react-native';
+import {
+  TextInput as NativeTextInput,
+  Animated,
+  TextStyle,
+} from 'react-native';
 import { TextInputProps } from './TextInput';
 import { $Omit } from './../../types';
 
@@ -44,6 +48,7 @@ export type LabelProps = {
   wiggleOffsetX: number;
   labelScale: number;
   fontSize: number;
+  fontWeight: TextStyle['fontWeight'];
   font: any;
   topPosition: number;
   paddingOffset?: { paddingHorizontal: number } | null | undefined;


### PR DESCRIPTION
According to #1115 allow to style fontWeight using style prop

### Motivation

Currently it's affects also font of the label and I'm not sure it's behaviour that we really want
@Trancever wdyt ?

### Test plan
Screenshots of the text input flat and outline:
<img width="331" alt="Screenshot 2019-07-31 at 11 44 25" src="https://user-images.githubusercontent.com/21242757/62206312-cf3caa00-b391-11e9-895f-93047147e102.png">

<img width="337" alt="Screenshot 2019-07-31 at 11 44 14" src="https://user-images.githubusercontent.com/21242757/62206339-e24f7a00-b391-11e9-976b-e5dc54df3e01.png">

