### PR TITLE
docs: update font section according to v3.0

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -51,7 +51,7 @@ a:hover {
 }
 
 @font-face {
-  font-family: 'MaterialIcons';
-  src: url('../../node_modules/react-native-vector-icons/Fonts/MaterialIcons.ttf')
+  font-family: 'MaterialCommunityIcons';
+  src: url('../../node_modules/react-native-vector-icons/Fonts/MaterialCommunityIcons.ttf')
     format('truetype');
 }

--- a/docs/pages/3.icons.mdx
+++ b/docs/pages/3.icons.mdx
@@ -83,7 +83,7 @@ import AwesomeIcon from 'react-native-vector-icons/FontAwesome';
 
       <PaperProvider
         settings={{
-          icon: ({ ...props }) => <AwesomeIcon {...props} />,
+          icon: props => <AwesomeIcon {...props} />,
         }}
         theme={this.state.theme}
       >

--- a/docs/pages/3.icons.mdx
+++ b/docs/pages/3.icons.mdx
@@ -18,12 +18,12 @@ Many components such as `Button` accept an `icon` prop which is used to display 
 
 ### 1. An icon name
 
-You can pass the name of an icon from [`MaterialIcon`](https://material.io/icons/). This will use the [`react-native-vector-icons`](https://github.com/oblador/react-native-vector-icons) library to display the icon.
+You can pass the name of an icon from [`MaterialCommunityIcons`](https://materialdesignicons.com). This will use the [`react-native-vector-icons`](https://github.com/oblador/react-native-vector-icons) library to display the icon.
 
 Example:
 
 ```js
-<Button icon="add-a-photo">
+<Button icon="camera">
   Press me
 </Button>
 ```

--- a/docs/pages/3.icons.mdx
+++ b/docs/pages/3.icons.mdx
@@ -71,6 +71,26 @@ Example:
 </Button>
 ```
 
+### 4. Use custom icons
+
+If you want to use other icons than `MaterialCommunityIcons` you need to import your icons and pass it to `settings` prop within `PaperProvider`.
+
+Example:
+
+```js
+import AwesomeIcon from 'react-native-vector-icons/FontAwesome';
+// ...
+
+      <PaperProvider
+        settings={{
+          icon: ({ ...props }) => <AwesomeIcon {...props} />,
+        }}
+        theme={this.state.theme}
+      >
+        // ...
+      </PaperProvider>
+```
+
 ## RTL support
 
 If you want your icon to behave properly in a RTL environment, you can pass an object to the `icon` prop with shape: `{ source: { uri: 'https://path.to' }, direction : 'rtl' }`. `source` can be any of the values that the `icon` prop accepts in [option 1](#1.-an-icon-name) and [option 2](#2.-an-image-source). For `direction` you have few options:

--- a/docs/pages/5.react-native-web.md
+++ b/docs/pages/5.react-native-web.md
@@ -215,7 +215,7 @@ To configure it, add the following in the `module.rules` array in your webpack c
 }
 ```
 
-## Load the Material icons
+## Load the Material Community Icons
 
 If you followed the getting started guide, you should have the following code in your root component:
 
@@ -225,7 +225,7 @@ If you followed the getting started guide, you should have the following code in
 </PaperProvider>
 ```
 
-Now we need tweak this section to load the Material icons from the [`react-native-vector-icons`](https://github.com/oblador/react-native-vector-icons) library:
+Now we need tweak this section to load the Material Community Icons from the [`react-native-vector-icons`](https://github.com/oblador/react-native-vector-icons) library:
 
 ```js
 <PaperProvider>
@@ -233,8 +233,8 @@ Now we need tweak this section to load the Material icons from the [`react-nativ
     {Platform.OS === 'web' ? (
       <style type="text/css">{`
         @font-face {
-          font-family: 'MaterialIcons';
-          src: url(${require('react-native-vector-icons/Fonts/MaterialIcons.ttf')}) format('truetype');
+          font-family: 'MaterialCommunityIcons';
+          src: url(${require('react-native-vector-icons/Fonts/MaterialCommunityIcons.ttf')}) format('truetype');
         }
       `}</style>
     ) : null}

--- a/docs/pages/src/components/IconsList.js
+++ b/docs/pages/src/components/IconsList.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { styled } from 'linaria/react';
-import icons from 'react-native-vector-icons/glyphmaps/MaterialIcons.json';
+import icons from 'react-native-vector-icons/glyphmaps/MaterialCommunityIcons.json';
 
 type State = {
   query: string,
@@ -97,7 +97,7 @@ const IconContainer = styled.button`
 const Icon = styled.span`
   display: block;
   margin: 16px;
-  font-family: 'MaterialIcons';
+  font-family: 'MaterialCommunityIcons';
   font-size: 48px;
 `;
 


### PR DESCRIPTION
Since v3.0 is using Material Community Icons we need to update section `Icon` in the documentation.

Closes: #687
### Motivation

Current `Icons` section is outdated.

### Test plan

![image](https://user-images.githubusercontent.com/22746080/63252124-8b8ddf80-c26f-11e9-867a-1d979a78b34b.png)

