### PR TITLE
fix(ProgressBar): only start/stop animation if visible prop changes

### DIFF
--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -78,7 +78,7 @@ class ProgressBar extends React.Component<Props, State> {
 
   indeterminateAnimation: Animated.CompositeAnimation | null = null;
 
-  componentDidUpdate(prevProps:Props) {
+  componentDidUpdate(prevProps: Props) {
     const { visible } = this.props;
 
     if (visible !== prevProps.visible) {

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -78,13 +78,15 @@ class ProgressBar extends React.Component<Props, State> {
 
   indeterminateAnimation: Animated.CompositeAnimation | null = null;
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps:Props) {
     const { visible } = this.props;
 
-    if (visible) {
-      this._startAnimation();
-    } else {
-      this._stopAnimation();
+    if (visible !== prevProps.visible) {
+      if (visible) {
+        this._startAnimation();
+      } else {
+        this._stopAnimation();
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Currently, the `ProgressBar` restarts in between if any other prop than `visible` changes. This fix only starts/stops the animation if the `visible` prop has change.d

### Test plan

Open `ProgressBar` component in example app.
