### PR TITLE
refactor: banner - icon prop instead of image

### DIFF
--- a/example/src/Examples/BannerExample.tsx
+++ b/example/src/Examples/BannerExample.tsx
@@ -54,15 +54,7 @@ class BannerExample extends React.Component<Props, State> {
                 },
               },
             ]}
-            image={({ size }) => (
-              <Image
-                source={require('../../assets/images/email-icon.png')}
-                style={{
-                  width: size,
-                  height: size,
-                }}
-              />
-            )}
+            icon={require('../../assets/images/email-icon.png')}
             visible={this.state.visible}
           >
             Two line text string with two actions. One to two lines is

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -3,6 +3,7 @@ import { View, ViewStyle, StyleSheet, StyleProp, Animated } from 'react-native';
 import Surface from './Surface';
 import Text from './Typography/Text';
 import Button from './Button';
+import Icon, { IconSource } from './Icon';
 import { withTheme } from '../core/theming';
 import { Theme, $RemoveChildren } from '../types';
 import shadow from '../styles/shadow';
@@ -20,9 +21,9 @@ type Props = $RemoveChildren<typeof Surface> & {
    */
   children: string;
   /**
-   * Callback that returns an image to display inside banner.
+   * Icon to display for the `Banner`. Can be an image.
    */
-  image?: (props: { size: number }) => React.ReactNode;
+  icon?: IconSource;
   /**
    * Action items to shown in the banner.
    * An action item should contain the following properties:
@@ -162,7 +163,7 @@ class Banner extends React.Component<Props, State> {
   render() {
     const {
       visible,
-      image,
+      icon,
       children,
       actions,
       contentStyle,
@@ -186,7 +187,6 @@ class Banner extends React.Component<Props, State> {
       Animated.add(position, -1),
       layout.height
     );
-
     return (
       <Surface
         {...rest}
@@ -211,8 +211,12 @@ class Banner extends React.Component<Props, State> {
             ]}
           >
             <View style={styles.content}>
-              {image ? (
-                <View style={styles.image}>{image({ size: 40 })}</View>
+              {icon ? (
+                <View style={styles.icon}>
+                  {/* 
+                  // @ts-ignore */}
+                  <Icon source={icon} size={40} />
+                </View>
               ) : null}
               <Text style={styles.message}>{children}</Text>
             </View>
@@ -258,7 +262,7 @@ const styles = StyleSheet.create({
     marginTop: 16,
     marginBottom: 0,
   },
-  image: {
+  icon: {
     margin: 8,
   },
   message: {

--- a/src/components/__tests__/__snapshots__/Banner.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.js.snap
@@ -99,6 +99,7 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
 
 exports[`renders visible banner, with action buttons and with image 1`] = `
 <View
+  image={[Function]}
   style={
     Object {
       "backgroundColor": "#ffffff",
@@ -148,27 +149,6 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
           }
         }
       >
-        <View
-          style={
-            Object {
-              "margin": 8,
-            }
-          }
-        >
-          <Image
-            source={
-              Object {
-                "uri": "https://callstack.com/images/team/Satya.png",
-              }
-            }
-            style={
-              Object {
-                "height": 40,
-                "width": 40,
-              }
-            }
-          />
-        </View>
         <Text
           style={
             Array [
@@ -553,6 +533,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
 
 exports[`renders visible banner, without action buttons and with image 1`] = `
 <View
+  image={[Function]}
   style={
     Object {
       "backgroundColor": "#ffffff",
@@ -602,27 +583,6 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
           }
         }
       >
-        <View
-          style={
-            Object {
-              "margin": 8,
-            }
-          }
-        >
-          <Image
-            source={
-              Object {
-                "uri": "https://callstack.com/images/team/Satya.png",
-              }
-            }
-            style={
-              Object {
-                "height": 40,
-                "width": 40,
-              }
-            }
-          />
-        </View>
         <Text
           style={
             Array [


### PR DESCRIPTION
I changed the banner's prop `image` to `icon` to make the component more reusable

### Motivation

@Trancever motivated me.

### Test plan

The current solution can be reviewed using an example app.
