### PR TITLE
chore: fix babel plugin import

### DIFF
--- a/babel.js
+++ b/babel.js
@@ -1,1 +1,1 @@
-module.exports = require('./src/babel');
+module.exports = require('./lib/module/babel/index.js');

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "lib/module/index.js",
   "types": "lib/typescript/src/index.d.ts",
   "files": [
-    "src",
     "lib",
-    "dist"
+    "dist",
+    "babel.js"
   ],
   "sideEffects": false,
   "repository": {


### PR DESCRIPTION
`babel.js` was removed from the `files` field in package.json. It caused fails in release builds (at least Android #1302 ).

### Test plan

it can be tested with the next alpha release.