### PR TITLE
feat: added keyboardAware prop to Modal and Dialog components

### DIFF
--- a/example/src/Examples/DialogExample.tsx
+++ b/example/src/Examples/DialogExample.tsx
@@ -7,6 +7,7 @@ import {
   DialogWithLongText,
   DialogWithRadioBtns,
   UndismissableDialog,
+  KeyboardAwareDialog,
 } from './Dialogs';
 
 type State = {
@@ -15,6 +16,7 @@ type State = {
   visible3: boolean;
   visible4: boolean;
   visible5: boolean;
+  visible6: boolean;
 };
 
 type Props = {
@@ -30,6 +32,7 @@ class DialogExample extends React.Component<Props, State> {
     visible3: false,
     visible4: false,
     visible5: false,
+    visible6: false,
   };
 
   _openDialog1 = () => this.setState({ visible1: true });
@@ -37,12 +40,14 @@ class DialogExample extends React.Component<Props, State> {
   _openDialog3 = () => this.setState({ visible3: true });
   _openDialog4 = () => this.setState({ visible4: true });
   _openDialog5 = () => this.setState({ visible5: true });
+  _openDialog6 = () => this.setState({ visible6: true });
 
   _closeDialog1 = () => this.setState({ visible1: false });
   _closeDialog2 = () => this.setState({ visible2: false });
   _closeDialog3 = () => this.setState({ visible3: false });
   _closeDialog4 = () => this.setState({ visible4: false });
   _closeDialog5 = () => this.setState({ visible5: false });
+  _closeDialog6 = () => this.setState({ visible6: false });
 
   render() {
     const {
@@ -50,7 +55,14 @@ class DialogExample extends React.Component<Props, State> {
         colors: { background },
       },
     } = this.props;
-    const { visible1, visible2, visible3, visible4, visible5 } = this.state;
+    const {
+      visible1,
+      visible2,
+      visible3,
+      visible4,
+      visible5,
+      visible6,
+    } = this.state;
     return (
       <View style={[styles.container, { backgroundColor: background }]}>
         <Button onPress={this._openDialog1}>Show Dialog with long text</Button>
@@ -64,6 +76,7 @@ class DialogExample extends React.Component<Props, State> {
         <Button onPress={this._openDialog5}>
           Show Dialog with custom colors
         </Button>
+        <Button onPress={this._openDialog6}>Show Keyboard Aware Dialog</Button>
         <DialogWithLongText visible={visible1} close={this._closeDialog1} />
         <DialogWithRadioBtns visible={visible2} close={this._closeDialog2} />
         <DialogWithLoadingIndicator
@@ -72,6 +85,7 @@ class DialogExample extends React.Component<Props, State> {
         />
         <UndismissableDialog visible={visible4} close={this._closeDialog4} />
         <DialogWithCustomColors visible={visible5} close={this._closeDialog5} />
+        <KeyboardAwareDialog visible={visible6} close={this._closeDialog6} />
       </View>
     );
   }

--- a/example/src/Examples/Dialogs/KeyboardAwareDialog.tsx
+++ b/example/src/Examples/Dialogs/KeyboardAwareDialog.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { Button, Dialog, Portal, TextInput } from 'react-native-paper';
+
+const KeyboardAwareDialog = ({
+  visible,
+  close,
+}: {
+  visible: boolean;
+  close: () => void;
+}) => {
+  const [inputVal, setInputVal] = useState('test');
+
+  return (
+    <Portal>
+      <Dialog keyboardAware={true} visible={visible} onDismiss={close}>
+        <Dialog.Title>Username</Dialog.Title>
+        <Dialog.Content>
+          <TextInput
+            value={inputVal}
+            onChangeText={text => setInputVal(text)}
+          />
+        </Dialog.Content>
+        <Dialog.Actions>
+          <Button onPress={close}>Done</Button>
+        </Dialog.Actions>
+      </Dialog>
+    </Portal>
+  );
+};
+
+export default KeyboardAwareDialog;

--- a/example/src/Examples/Dialogs/index.tsx
+++ b/example/src/Examples/Dialogs/index.tsx
@@ -5,3 +5,4 @@ export {
 export { default as DialogWithLongText } from './DialogWithLongText';
 export { default as DialogWithRadioBtns } from './DialogWithRadioBtns';
 export { default as UndismissableDialog } from './UndismissableDialog';
+export { default as KeyboardAwareDialog } from './KeyboardAwareDialog';

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -19,9 +19,13 @@ type Props = {
    */
   onDismiss?: () => void;
   /**
-   * Determines Whether the dialog is visible.
+   * Determines whether the dialog is visible.
    */
   visible: boolean;
+  /**
+   * Determines whether the view resizes when the keyboard is visible.
+   */
+  keyboardAware?: boolean;
   /**
    * Content of the `Dialog`.
    */
@@ -93,6 +97,7 @@ class Dialog extends React.Component<Props> {
   static defaultProps = {
     dismissable: true,
     visible: false,
+    keyboardAware: false,
   };
 
   render() {
@@ -103,6 +108,7 @@ class Dialog extends React.Component<Props> {
       visible,
       style,
       theme,
+      keyboardAware,
     } = this.props;
 
     return (
@@ -110,6 +116,7 @@ class Dialog extends React.Component<Props> {
         dismissable={dismissable}
         onDismiss={onDismiss}
         visible={visible}
+        keyboardAware={keyboardAware}
         contentContainerStyle={[
           {
             borderRadius: theme.roundness,

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -3,12 +3,13 @@ import {
   Animated,
   BackHandler,
   Easing,
+  KeyboardAvoidingView,
   StyleProp,
   StyleSheet,
   TouchableWithoutFeedback,
   ViewStyle,
+  View,
 } from 'react-native';
-import SafeAreaView from 'react-native-safe-area-view';
 import Surface from './Surface';
 import { withTheme } from '../core/theming';
 import { Theme } from '../types';
@@ -26,6 +27,10 @@ type Props = {
    * Determines Whether the modal is visible.
    */
   visible: boolean;
+  /**
+   * Determines whether the view resizes when the keyboard is visible.
+   */
+  keyboardAware?: boolean;
   /**
    * Content of the `Modal`.
    */
@@ -88,6 +93,7 @@ class Modal extends React.Component<Props, State> {
   static defaultProps = {
     dismissable: true,
     visible: false,
+    keyboardAware: false,
   };
 
   static getDerivedStateFromProps(nextProps: Props, prevState: State) {
@@ -176,26 +182,42 @@ class Modal extends React.Component<Props, State> {
   render() {
     if (!this.state.rendered) return null;
 
-    const { children, dismissable, theme, contentContainerStyle } = this.props;
+    const {
+      children,
+      dismissable,
+      keyboardAware,
+      theme,
+      contentContainerStyle,
+    } = this.props;
+
     const { colors } = theme;
+
+    const SurfaceWrapper = keyboardAware ? KeyboardAvoidingView : View;
+
     return (
       <Animated.View
         pointerEvents={this.props.visible ? 'auto' : 'none'}
         accessibilityViewIsModal
         accessibilityLiveRegion="polite"
-        style={StyleSheet.absoluteFill}
+        style={styles.container}
       >
         <TouchableWithoutFeedback
           onPress={dismissable ? this._hideModal : undefined}
         >
-          <Animated.View
+          <View
             style={[
               styles.backdrop,
-              { backgroundColor: colors.backdrop, opacity: this.state.opacity },
+              {
+                backgroundColor: colors.backdrop,
+              },
             ]}
           />
         </TouchableWithoutFeedback>
-        <SafeAreaView style={styles.wrapper}>
+        <SurfaceWrapper
+          style={styles.wrapper}
+          pointerEvents={'box-none'}
+          behavior="padding"
+        >
           <Surface
             style={
               [
@@ -207,7 +229,7 @@ class Modal extends React.Component<Props, State> {
           >
             {children}
           </Surface>
-        </SafeAreaView>
+        </SurfaceWrapper>
       </Animated.View>
     );
   }
@@ -216,6 +238,9 @@ class Modal extends React.Component<Props, State> {
 export default withTheme(Modal);
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
   backdrop: {
     flex: 1,
   },


### PR DESCRIPTION
This PR adds a keyboard awareness prop to `Modal` and `Dialog` components and a `KeyboardAwareDialog` to the example app. It also removes the `SafeAreaView` wrapper from `Modal`. Details below.

### Motivation
When adding a `TextInput` inside a `Modal` or `Dialog` components the input is not keyboard aware and often ends up underneath the keyboard. [Here is a snack example](https://snack.expo.io/@gollyjer/react-native-paper-dialog-with-textinput) of the current behavior.

It would be ideal if a user could simply wrap these themselves in a KeyboardAwareView, but the way `Modal` is structured it can't work.  Once a child of the `KeyboardAwareView`, or any view for that matter, is absolutely positioned it is out of flexbox flow.

From [w3c.org](https://www.w3.org/TR/css-flexbox-1/#abspos-items)
![image](https://user-images.githubusercontent.com/689204/63891324-c68fc180-c999-11e9-9974-72dc025c0ecb.png)

All of that is to say... the `SafeAreaView` (a fix for this should be separate from this PR) in `Modal` and wrapping `KeyboardAwareView` around `Dialog` both have no effect because the `Surface` component has to be wrapped in an absolutely positioned view.

### Test plan
I tested on both iOS and Android with real devices.
- Run the test app.
- Open Dialog > Show Keyboard Aware Dialog
- Tap on the input.
- Keyboard should come up and the view should shrink to fit.
