### PR TITLE
refactor: use textTransform to upperCase Button

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -268,15 +268,12 @@ class Button extends React.Component<Props, State> {
               style={[
                 styles.label,
                 compact && styles.compactLabel,
+                uppercase && styles.uppercaseLabel,
                 textStyle,
                 font,
               ]}
             >
-              {React.Children.map(children, child =>
-                typeof child === 'string' && uppercase
-                  ? child.toUpperCase()
-                  : child
-              )}
+              {children}
             </Text>
           </View>
         </TouchableRipple>
@@ -311,6 +308,9 @@ const styles = StyleSheet.create({
   },
   compactLabel: {
     marginHorizontal: 8,
+  },
+  uppercaseLabel: {
+    textTransform: 'uppercase',
   },
 });
 

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -257,7 +257,7 @@ class Snackbar extends React.Component<Props, State> {
               compact
               mode="text"
             >
-              {action.label.toUpperCase()}
+              {action.label}
             </Button>
           ) : null}
         </Surface>

--- a/src/components/__tests__/__snapshots__/Banner.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.js.snap
@@ -268,6 +268,9 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                         "marginHorizontal": 8,
                       },
                       Object {
+                        "textTransform": "uppercase",
+                      },
+                      Object {
                         "color": "#6200ee",
                         "fontFamily": "System",
                         "fontWeight": "500",
@@ -280,7 +283,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                   ]
                 }
               >
-                FIRST
+                first
               </Text>
             </View>
           </View>
@@ -441,6 +444,9 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                         "marginHorizontal": 8,
                       },
                       Object {
+                        "textTransform": "uppercase",
+                      },
+                      Object {
                         "color": "#6200ee",
                         "fontFamily": "System",
                         "fontWeight": "500",
@@ -453,7 +459,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   ]
                 }
               >
-                FIRST
+                first
               </Text>
             </View>
           </View>
@@ -528,6 +534,9 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                         "marginHorizontal": 8,
                       },
                       Object {
+                        "textTransform": "uppercase",
+                      },
+                      Object {
                         "color": "#6200ee",
                         "fontFamily": "System",
                         "fontWeight": "500",
@@ -540,7 +549,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   ]
                 }
               >
-                SECOND
+                second
               </Text>
             </View>
           </View>

--- a/src/components/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.js.snap
@@ -68,6 +68,9 @@ exports[`renders button with color 1`] = `
               },
               undefined,
               Object {
+                "textTransform": "uppercase",
+              },
+              Object {
                 "color": "#e91e63",
                 "fontFamily": "System",
                 "fontWeight": "500",
@@ -80,7 +83,7 @@ exports[`renders button with color 1`] = `
           ]
         }
       >
-        CUSTOM BUTTON
+        Custom Button
       </Text>
     </View>
   </View>
@@ -199,6 +202,9 @@ exports[`renders button with icon 1`] = `
               },
               undefined,
               Object {
+                "textTransform": "uppercase",
+              },
+              Object {
                 "color": "#6200ee",
                 "fontFamily": "System",
                 "fontWeight": "500",
@@ -211,7 +217,7 @@ exports[`renders button with icon 1`] = `
           ]
         }
       >
-        ICON BUTTON
+        Icon Button
       </Text>
     </View>
   </View>
@@ -293,6 +299,9 @@ exports[`renders contained contained with mode 1`] = `
               },
               undefined,
               Object {
+                "textTransform": "uppercase",
+              },
+              Object {
                 "color": "#ffffff",
                 "fontFamily": "System",
                 "fontWeight": "500",
@@ -305,7 +314,7 @@ exports[`renders contained contained with mode 1`] = `
           ]
         }
       >
-        CONTAINED BUTTON
+        Contained Button
       </Text>
     </View>
   </View>
@@ -384,6 +393,9 @@ exports[`renders disabled button 1`] = `
               },
               undefined,
               Object {
+                "textTransform": "uppercase",
+              },
+              Object {
                 "color": "rgba(0, 0, 0, 0.32)",
                 "fontFamily": "System",
                 "fontWeight": "500",
@@ -396,7 +408,7 @@ exports[`renders disabled button 1`] = `
           ]
         }
       >
-        DISABLED BUTTON
+        Disabled Button
       </Text>
     </View>
   </View>
@@ -654,6 +666,9 @@ exports[`renders loading button 1`] = `
               },
               undefined,
               Object {
+                "textTransform": "uppercase",
+              },
+              Object {
                 "color": "#6200ee",
                 "fontFamily": "System",
                 "fontWeight": "500",
@@ -666,7 +681,7 @@ exports[`renders loading button 1`] = `
           ]
         }
       >
-        LOADING BUTTON
+        Loading Button
       </Text>
     </View>
   </View>
@@ -741,6 +756,9 @@ exports[`renders outlined button with mode 1`] = `
               },
               undefined,
               Object {
+                "textTransform": "uppercase",
+              },
+              Object {
                 "color": "#6200ee",
                 "fontFamily": "System",
                 "fontWeight": "500",
@@ -753,7 +771,7 @@ exports[`renders outlined button with mode 1`] = `
           ]
         }
       >
-        OUTLINED BUTTON
+        Outlined Button
       </Text>
     </View>
   </View>
@@ -828,6 +846,9 @@ exports[`renders text button by default 1`] = `
               },
               undefined,
               Object {
+                "textTransform": "uppercase",
+              },
+              Object {
                 "color": "#6200ee",
                 "fontFamily": "System",
                 "fontWeight": "500",
@@ -840,7 +861,7 @@ exports[`renders text button by default 1`] = `
           ]
         }
       >
-        TEXT BUTTON
+        Text Button
       </Text>
     </View>
   </View>
@@ -915,6 +936,9 @@ exports[`renders text button with mode 1`] = `
               },
               undefined,
               Object {
+                "textTransform": "uppercase",
+              },
+              Object {
                 "color": "#6200ee",
                 "fontFamily": "System",
                 "fontWeight": "500",
@@ -927,7 +951,7 @@ exports[`renders text button with mode 1`] = `
           ]
         }
       >
-        TEXT BUTTON
+        Text Button
       </Text>
     </View>
   </View>

--- a/src/components/__tests__/__snapshots__/Menu.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.js.snap
@@ -71,6 +71,9 @@ exports[`renders menu with content styles 1`] = `
                 },
                 undefined,
                 Object {
+                  "textTransform": "uppercase",
+                },
+                Object {
                   "color": "#6200ee",
                   "fontFamily": "System",
                   "fontWeight": "500",
@@ -83,7 +86,7 @@ exports[`renders menu with content styles 1`] = `
             ]
           }
         >
-          OPEN MENU
+          Open menu
         </Text>
       </View>
     </View>
@@ -162,6 +165,9 @@ exports[`renders not visible menu 1`] = `
                 },
                 undefined,
                 Object {
+                  "textTransform": "uppercase",
+                },
+                Object {
                   "color": "#6200ee",
                   "fontFamily": "System",
                   "fontWeight": "500",
@@ -174,7 +180,7 @@ exports[`renders not visible menu 1`] = `
             ]
           }
         >
-          OPEN MENU
+          Open menu
         </Text>
       </View>
     </View>
@@ -253,6 +259,9 @@ exports[`renders visible menu 1`] = `
                 },
                 undefined,
                 Object {
+                  "textTransform": "uppercase",
+                },
+                Object {
                   "color": "#6200ee",
                   "fontFamily": "System",
                   "fontWeight": "500",
@@ -265,7 +274,7 @@ exports[`renders visible menu 1`] = `
             ]
           }
         >
-          OPEN MENU
+          Open menu
         </Text>
       </View>
     </View>

--- a/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
@@ -213,6 +213,9 @@ exports[`renders snackbar with action button 1`] = `
                     "marginHorizontal": 8,
                   },
                   Object {
+                    "textTransform": "uppercase",
+                  },
+                  Object {
                     "color": "#03dac4",
                     "fontFamily": "System",
                     "fontWeight": "500",
@@ -225,7 +228,7 @@ exports[`renders snackbar with action button 1`] = `
               ]
             }
           >
-            UNDO
+            Undo
           </Text>
         </View>
       </View>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

When testing with `@testing-library/react-native` I want to find buttons by text. However, `Button` component uses `toUpperCase` explicitly, so I have to upprecase all my search strings. This is annoying, especially since I use react-i18next. With this change, I can use the same string in my tests (you can see this from snapshots)

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

I tested it in example app visually on iOS and Android simulators and web version. Everything looks properly uppercased.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
