### PR TITLE
fix: add elevation to wrapper style

### DIFF
--- a/src/components/Appbar/AppbarHeader.tsx
+++ b/src/components/Appbar/AppbarHeader.tsx
@@ -129,8 +129,8 @@ class AppbarHeader extends React.Component<Props> {
       <Wrapper
         style={
           [
-            { backgroundColor, zIndex },
-            elevation && shadow(elevation),
+            { backgroundColor, zIndex, elevation },
+            shadow(elevation),
           ] as StyleProp<ViewStyle>
         }
       >


### PR DESCRIPTION
Resolve #1225 
### Motivation

Without property elevation in wrapper style there is no shadow on android.
<img width="310" alt="Screenshot 2019-08-31 at 17 58 37" src="https://user-images.githubusercontent.com/3886886/64066379-14662d00-cc19-11e9-8bf0-7124a1554d6a.png">
<img width="321" alt="Screenshot 2019-08-31 at 17 54 49" src="https://user-images.githubusercontent.com/3886886/64066381-1af4a480-cc19-11e9-82c9-6b8bb6507381.png">

With elevation added to wrapper style
```
<Wrapper
        style={
          [
            { backgroundColor, zIndex, elevation },
            shadow(elevation),
          ] as StyleProp<ViewStyle>
        }
      >
```

<img width="321" alt="Screenshot 2019-08-31 at 17 52 09" src="https://user-images.githubusercontent.com/3886886/64066384-2e077480-cc19-11e9-874e-8b2cddecda2a.png">
<img width="316" alt="Screenshot 2019-08-31 at 17 52 52" src="https://user-images.githubusercontent.com/3886886/64066386-319afb80-cc19-11e9-9e66-41df4a49aaab.png">




Additional
since we have default elevation value 
```
const {
  [..]
  elevation = 4,
  [..]
} = StyleSheet.flatten(style) || {};
```
we don't need to check if it's present
```
elevation &&  shadow(elevation),
```
so
```
shadow(elevation),
```
isn't enough?