### PR TITLE
fix: tests and package.json scripts so they run cross-platform

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,4 @@
-# NOTE: Should match .prettierignore
+# NOTE: Should match .eslintignore
 
 node_modules/
 flow-typed/

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
   ],
   "scripts": {
     "typescript": "tsc --noEmit",
-    "lint": "eslint --ext '.js,.ts,.tsx' .",
+    "lint": "run-script-os",
+    "lint:win32": "eslint **/*.js **/*.ts **/*.tsx",
+    "lint:default": "eslint . --ext .js,.ts,.tsx",
     "test": "jest",
     "prepare": "bob build && node ./scripts/generate-mappings.js",
     "release": "release-it",
@@ -89,6 +91,7 @@
     "react-test-renderer": "16.8.3",
     "release-it": "^12.3.3",
     "rimraf": "^2.6.2",
+    "run-script-os": "^1.0.7",
     "typescript": "^3.5.1"
   },
   "peerDependencies": {

--- a/src/babel/__fixtures-unix__/rewrite-imports/code.js
+++ b/src/babel/__fixtures-unix__/rewrite-imports/code.js
@@ -1,5 +1,3 @@
-/* eslint-disable prettier/prettier */
-
 import { Text } from 'react-native';
 import {
   Provider as PaperProvider,

--- a/src/babel/__fixtures-unix__/rewrite-imports/output.js
+++ b/src/babel/__fixtures-unix__/rewrite-imports/output.js
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 import { Text } from 'react-native';
 import PaperProvider from "react-native-paper/../core/Provider";
 import BottomNavigation from "react-native-paper/../components/BottomNavigation";

--- a/src/babel/__fixtures-windows__/rewrite-imports/code.js
+++ b/src/babel/__fixtures-windows__/rewrite-imports/code.js
@@ -1,0 +1,13 @@
+import { Text } from 'react-native';
+import {
+  Provider as PaperProvider,
+  BottomNavigation,
+  Button,
+  FAB,
+  Appbar,
+  Colors,
+  NonExistent,
+  NonExistentSecond as Stuff,
+  ThemeProvider,
+  withTheme,
+} from 'react-native-paper';

--- a/src/babel/__fixtures-windows__/rewrite-imports/output.js
+++ b/src/babel/__fixtures-windows__/rewrite-imports/output.js
@@ -1,0 +1,10 @@
+import { Text } from 'react-native';
+import PaperProvider from "react-native-paper/..\\core\\Provider";
+import BottomNavigation from "react-native-paper/..\\components\\BottomNavigation";
+import Button from "react-native-paper/..\\components\\Button";
+import FAB from "react-native-paper/..\\components\\FAB\\FAB";
+import Appbar from "react-native-paper/..\\components\\Appbar\\Appbar";
+import * as Colors from "react-native-paper/..\\styles\\colors";
+import { NonExistent, NonExistentSecond as Stuff } from 'react-native-paper';
+import { ThemeProvider } from "react-native-paper/..\\core\\theming";
+import { withTheme } from "react-native-paper/..\\core\\theming";

--- a/src/babel/__tests__/index.js
+++ b/src/babel/__tests__/index.js
@@ -1,3 +1,4 @@
+const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
 const { create } = require('babel-test');
@@ -13,4 +14,10 @@ const { fixtures } = create({
   plugins: [require.resolve('../index')],
 });
 
-fixtures('generate mappings', path.join(__dirname, '..', '__fixtures__'));
+// https://nodejs.org/dist/latest/docs/api/os.html#os_os_platform
+const platform = os.platform() === 'win32' ? 'windows' : 'unix';
+
+fixtures(
+  'generate mappings',
+  path.join(__dirname, '..', `__fixtures-${platform}__`)
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9133,6 +9133,11 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
+run-script-os@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/run-script-os/-/run-script-os-1.0.7.tgz#7cd51144a19c6ca364fe668433f55b47babf4749"
+  integrity sha512-H4NAhP9PiseQQm3Vpen7CHksfKGqC4dmwoVu/9th97r3XyBrMtkg4jIUiy/8dgzuI9MGwmK/7vf13Wncx+Y4bw==
+
 rx-lite-aggregates@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"


### PR DESCRIPTION
This PR does 3 things.

1. Adds a Windows style `fixtures` for the babel plugin tests.
2. Adds an OS based `lint` command in `package.json`.
This kind of sucks. I didn't want to add another package to the repo but I had to use [run-script-os](https://www.npmjs.com/package/run-script-os) to apply platform specific commands.
I was hoping to find a simple cross platform command. You can see [my question here on stackoverflow](https://stackoverflow.com/questions/57750884/cross-platform-eslint-command-to-run-on-current-directory-recursively). (please upvote to get it more traction).

3. Adds a `.prettierignore` file to simplify the `code.js` and `output.js` test files.
Basically, now `.eslintignore` and `.prettierignore` are the same. Generally if you want to ignore with one you want to ignore with the other. In addition I added a pattern to both to ignore the `output.js` files in tests. 
Now `/* eslint-disable prettier/prettier */` isn't needed at the top of every file.

### Motivation
I was unable to commit anything when using a Windows machine do to cross-platform issues.

### Test plan

I have tested on `Windows` and `Ubuntu`.  
**Need someone to test on `macOS`**.

- Create a branch.
- Edit a file and try and commit.
- If the tests all run then we're good to go! 👍
