### PR TITLE
fix: paper babel plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "types": "lib/typescript/src/index.d.ts",
   "files": [
     "lib",
-    "dist",
     "babel.js"
   ],
   "sideEffects": false,

--- a/scripts/generate-mappings.js
+++ b/scripts/generate-mappings.js
@@ -6,7 +6,7 @@ const types = require('babel-types');
 const parser = require('@babel/parser');
 
 const root = path.resolve(__dirname, '..');
-const output = path.join(root, 'dist/mappings.json');
+const output = path.join(root, 'lib/mappings.json');
 const source = fs.readFileSync(path.resolve(root, 'src', 'index.tsx'), 'utf8');
 const ast = parser.parse(source, {
   sourceType: 'module',
@@ -20,7 +20,7 @@ const ast = parser.parse(source, {
 });
 
 const relative = (value /* : string */) =>
-  path.relative(root, path.resolve(path.dirname(root, 'lib', 'module'), value));
+  path.relative(root, path.resolve(path.dirname(require.resolve('..')), value));
 
 const mappings = ast.program.body.reduce((acc, declaration, index, self) => {
   if (types.isExportNamedDeclaration(declaration)) {

--- a/src/babel/__fixtures__/rewrite-imports/output.js
+++ b/src/babel/__fixtures__/rewrite-imports/output.js
@@ -1,11 +1,11 @@
 /* eslint-disable prettier/prettier */
 import { Text } from 'react-native';
-import PaperProvider from "react-native-paper/../core/Provider";
-import BottomNavigation from "react-native-paper/../components/BottomNavigation";
-import Button from "react-native-paper/../components/Button";
-import FAB from "react-native-paper/../components/FAB/FAB";
-import Appbar from "react-native-paper/../components/Appbar/Appbar";
-import * as Colors from "react-native-paper/../styles/colors";
+import PaperProvider from "react-native-paper/lib/module/core/Provider";
+import BottomNavigation from "react-native-paper/lib/module/components/BottomNavigation";
+import Button from "react-native-paper/lib/module/components/Button";
+import FAB from "react-native-paper/lib/module/components/FAB/FAB";
+import Appbar from "react-native-paper/lib/module/components/Appbar/Appbar";
+import * as Colors from "react-native-paper/lib/module/styles/colors";
 import { NonExistent, NonExistentSecond as Stuff } from 'react-native-paper';
-import { ThemeProvider } from "react-native-paper/../core/theming";
-import { withTheme } from "react-native-paper/../core/theming";
+import { ThemeProvider } from "react-native-paper/lib/module/core/theming";
+import { withTheme } from "react-native-paper/lib/module/core/theming";

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -1,10 +1,13 @@
-const mappings = require('../../dist/mappings.json');
+const mappingsPath =
+  process.env.NODE_ENV === 'test'
+    ? `../../lib/mappings.json`
+    : `../../mappings.json`;
+const mappings = require(mappingsPath);
 
 const SKIP = Symbol('SKIP');
 
 module.exports = function rewire(babel) {
   const t = babel.types;
-
   return {
     visitor: {
       ImportDeclaration(path) {


### PR DESCRIPTION
This PR changes destination of generated mappings from `dist/mappings.json` to `lib/mappings.json` and fixes mapping generation script that generated mappings with incorrect paths.
Also removes `dist` from `files` in `package.json` since dir is empty after changes.

### Motivation

This PR resolves #1302 

### Test plan

Install paper from `fix/babel-plugin` and run `cd android && ./gradlew assembleRelease` inside root of react native app
