### PR TITLE
Feat: dark theme elevation overlay

### DIFF
--- a/docs/pages/2.theming.md
+++ b/docs/pages/2.theming.md
@@ -36,7 +36,7 @@ const theme = {
     ...DefaultTheme.colors,
     primary: '#3498db',
     accent: '#f1c40f',
-  }
+  },
 };
 
 export default function Main() {
@@ -54,6 +54,7 @@ A theme usually contains the following properties:
 
 - `dark` (`boolean`): whether this is a dark theme or light theme.
 - `roundness` (`number`): roundness of common elements, such as buttons.
+- `useSurfaceOverlay` (`boolean`): should surfaces use light overlay to show elevation in dark mode.
 - `colors` (`object`): various colors used throughout different elements.
   - `primary` - primary color for your app, usually your brand color.
   - `accent` - secondary color for your app which complements the primary color.

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -90,10 +90,12 @@ class Appbar extends React.Component<Props> {
   render() {
     const { children, dark, style, theme, primary, ...rest } = this.props;
 
-    const { colors, dark: isDarkTheme } = theme;
+    const { colors, dark: isDarkTheme, useSurfaceOverlay } = theme;
     const {
       backgroundColor = isDarkTheme && !primary
-        ? overlay(4, colors.surface)
+        ? useSurfaceOverlay
+          ? overlay(4, colors.surface)
+          : colors.surface
         : colors.primary,
       ...restStyle
     } = StyleSheet.flatten(style) || {};

--- a/src/components/Appbar/AppbarHeader.tsx
+++ b/src/components/Appbar/AppbarHeader.tsx
@@ -100,12 +100,14 @@ class AppbarHeader extends React.Component<Props> {
       dark,
       ...rest
     } = this.props;
-    const { dark: isDarkTheme, colors } = rest.theme;
+    const { dark: isDarkTheme, colors, useSurfaceOverlay } = rest.theme;
     const {
       height = DEFAULT_APPBAR_HEIGHT,
       elevation = 4,
       backgroundColor = isDarkTheme && !primary
-        ? overlay(4, colors.surface)
+        ? useSurfaceOverlay
+          ? overlay(4, colors.surface)
+          : colors.surface
         : colors.primary,
       zIndex = 0,
       ...restStyle

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -194,6 +194,11 @@ type Props = {
    * @optional
    */
   theme: Theme;
+  /**
+   * Pass `true` if you want BottomNavigation to use theme primary color even in dark mode.
+   * By default in dark mode BottomNavigation use surface color.
+   */
+  primary?: boolean;
 };
 
 type State = {
@@ -575,17 +580,20 @@ class BottomNavigation extends React.Component<Props, State> {
       labeled,
       style,
       theme,
+      primary,
     } = this.props;
 
     const { layout, loaded } = this.state;
     const { routes } = navigationState;
-    const { colors, dark: isDarkTheme } = theme;
+    const { colors, dark: isDarkTheme, useSurfaceOverlay } = theme;
 
     const shifting = this._isShifting();
 
     const {
-      backgroundColor: approxBackgroundColor = isDarkTheme
-        ? overlay(styles.bar.elevation)
+      backgroundColor: approxBackgroundColor = isDarkTheme && !primary
+        ? useSurfaceOverlay
+          ? overlay(styles.bar.elevation, colors.surface)
+          : colors.surface
         : colors.primary,
     } = StyleSheet.flatten(barStyle) || {};
 

--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -64,13 +64,16 @@ class Surface extends React.Component<Props> {
     const { style, theme, ...rest } = this.props;
     const flattenedStyles = StyleSheet.flatten(style) || {};
     const { elevation = 4 }: ViewStyle = flattenedStyles;
-    const { dark: isDarkTheme, colors } = theme;
+    const { dark: isDarkTheme, colors, useSurfaceOverlay } = theme;
     return (
       <Animated.View
         {...rest}
         style={[
           {
-            backgroundColor: isDarkTheme ? overlay(elevation) : colors.surface,
+            backgroundColor:
+              isDarkTheme && useSurfaceOverlay
+                ? overlay(elevation, colors.surface)
+                : colors.surface,
           },
           elevation && shadow(elevation),
           style,

--- a/src/styles/DarkTheme.tsx
+++ b/src/styles/DarkTheme.tsx
@@ -6,6 +6,7 @@ import { Theme } from '../types';
 const DarkTheme: Theme = {
   ...DefaultTheme,
   dark: true,
+  useSurfaceOverlay: true,
   colors: {
     ...DefaultTheme.colors,
     primary: '#BB86FC',

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -24,6 +24,7 @@ export type Fonts = {
 };
 
 export type Theme = {
+  useSurfaceOverlay?: boolean;
   dark: boolean;
   roundness: number;
   colors: {


### PR DESCRIPTION
1. Added possibility for the user to set a custom surface colour on dark theme mode.
2. Added **primary**  prop to bottomNavigation (same as for appbar) It forces component to use primary colour instead of surface one (in new dark theme guideline huge surfaces like appbar or bottom navigation in opposite to light theme use surface instead of primary colour)
3. Added UseSurfaceOverlay boolean property to DarkTheme (true by default) 
In dark theme we use shadow & white overlay with % opacity based on elevation to display elevation differences. (the bigger elevation the lighter surface).
if user set UseSurfaceOverlay to false paper will use only shadow (same as in light theme)