### PR TITLE
fix: omit ref in render method of TextInput

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -10,7 +10,7 @@ import TextInputOutlined from './TextInputOutlined';
 import TextInputFlat from './TextInputFlat';
 import { withTheme } from '../../core/theming';
 import { RenderProps, State } from './types';
-import { Theme } from '../../types';
+import { Theme, $Omit } from '../../types';
 
 const BLUR_ANIMATION_DURATION = 180;
 const FOCUS_ANIMATION_DURATION = 150;
@@ -398,8 +398,10 @@ class TextInput extends React.Component<TextInputProps, State> {
   }
 
   render() {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { mode, padding, ref: outerRef, ...rest } = this.props;
+    const { mode, padding, ...rest } = this.props as $Omit<
+      TextInputProps,
+      'ref'
+    >;
 
     return mode === 'outlined' ? (
       <TextInputOutlined


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Currently, the following warning is printed in console when using a `TextInput` on web:
````
TextInput: `ref` is not a prop. Trying to access it will result in `undefined` being returned. If you need to access the same value within the child component, you should pass it as a different prop.
````

This is because the types say there is a `ref` prop but in fact the `ref` prop cannot be accessed at runtime.

### Test plan

Open `TextInput` page in example project for web.
