### PR TITLE
docs: font configuration

### DIFF
--- a/docs/pages/4.fonts.md
+++ b/docs/pages/4.fonts.md
@@ -40,23 +40,41 @@ The easiest way to install custom fonts to your RN project is do as follows:
 
 ## Configuring fonts in ThemeProvider
 
-After you configure the fonts you need to pass them as font object in a custom theme with the `Provider` component. Check the [default theme](https://github.com/callstack/react-native-paper/blob/master/src/styles/DefaultTheme.tsx) to see what customization options are supported.
+To create a custom font you need to prepare `fontConfig` where fonts are divided by platforms. 
+After you have to pass the `fontConfig` into `configureFont` method in a custom theme. 
+Note: To override font on all platforms use `deafult` key.
 
-Example:
+Check the [default theme](https://github.com/callstack/react-native-paper/blob/master/src/styles/DefaultTheme.tsx) to see what customization options are supported.
 
 ```js
 import * as React from 'react';
-import { DefaultTheme, Provider as PaperProvider } from 'react-native-paper';
+import { DefaultTheme, Provider as PaperProvider, configureFont } from 'react-native-paper';
 import App from './src/App';
+
+const fontConfig = {
+  default: {
+    regular: {
+      fontFamily: 'sans-serif',
+      fontWeight: 'normal',
+    },
+    medium: {
+      fontFamily: 'sans-serif-medium',
+      fontWeight: 'normal',
+    },
+    light: {
+      fontFamily: 'sans-serif-light',
+      fontWeight: 'normal',
+    },
+    thin: {
+      fontFamily: 'sans-serif-thin',
+      fontWeight: 'normal',
+    },
+  },
+};
 
 const theme = {
   ...DefaultTheme,
-  fonts: {
-      regular: 'Roboto',
-      medium: 'Roboto',
-      light: 'Roboto Light',
-      thin: 'Roboto Thin',
-    },
+  fonts: configureFont(fontConfig),
 };
 
 export default function Main() {

--- a/docs/pages/4.fonts.md
+++ b/docs/pages/4.fonts.md
@@ -41,7 +41,7 @@ The easiest way to install custom fonts to your RN project is do as follows:
 ## Configuring fonts in ThemeProvider
 
 To create a custom font you need to prepare `fontConfig` where fonts are divided by platforms. 
-After you have to pass the `fontConfig` into `configureFont` method in a custom theme. 
+After you have to pass the `fontConfig` into `configureFonts` method in a custom theme. 
 
 Note: To override font on all platforms use `deafult` key.
 
@@ -49,7 +49,7 @@ Check the [default theme](https://github.com/callstack/react-native-paper/blob/m
 
 ```js
 import * as React from 'react';
-import { configureFont, DefaultTheme, Provider as PaperProvider } from 'react-native-paper';
+import { configureFonts, DefaultTheme, Provider as PaperProvider } from 'react-native-paper';
 import App from './src/App';
 
 const fontConfig = {
@@ -75,7 +75,7 @@ const fontConfig = {
 
 const theme = {
   ...DefaultTheme,
-  fonts: configureFont(fontConfig),
+  fonts: configureFonts(fontConfig),
 };
 
 export default function Main() {

--- a/docs/pages/4.fonts.md
+++ b/docs/pages/4.fonts.md
@@ -42,13 +42,14 @@ The easiest way to install custom fonts to your RN project is do as follows:
 
 To create a custom font you need to prepare `fontConfig` where fonts are divided by platforms. 
 After you have to pass the `fontConfig` into `configureFont` method in a custom theme. 
+
 Note: To override font on all platforms use `deafult` key.
 
 Check the [default theme](https://github.com/callstack/react-native-paper/blob/master/src/styles/DefaultTheme.tsx) to see what customization options are supported.
 
 ```js
 import * as React from 'react';
-import { DefaultTheme, Provider as PaperProvider, configureFont } from 'react-native-paper';
+import { configureFont, DefaultTheme, Provider as PaperProvider } from 'react-native-paper';
 import App from './src/App';
 
 const fontConfig = {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,7 @@ export { default as Provider } from './core/Provider';
 export { default as DefaultTheme } from './styles/DefaultTheme';
 export { default as DarkTheme } from './styles/DarkTheme';
 export { default as shadow } from './styles/shadow';
+export { default as configureFont } from './styles/fonts';
 
 import * as Avatar from './components/Avatar/Avatar';
 import * as List from './components/List/List';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ export { default as Provider } from './core/Provider';
 export { default as DefaultTheme } from './styles/DefaultTheme';
 export { default as DarkTheme } from './styles/DarkTheme';
 export { default as shadow } from './styles/shadow';
-export { default as configureFont } from './styles/fonts';
+export { default as configureFonts } from './styles/fonts';
 
 import * as Avatar from './components/Avatar/Avatar';
 import * as List from './components/List/List';

--- a/src/styles/DefaultTheme.tsx
+++ b/src/styles/DefaultTheme.tsx
@@ -1,8 +1,8 @@
 import color from 'color';
 import { black, white, pinkA400 } from './colors';
-import fonts from './fonts';
+import configureFont from './fonts';
 
-import { Theme, Fonts } from '../types';
+import { Theme } from '../types';
 
 const DefaultTheme: Theme = {
   dark: false,
@@ -30,7 +30,7 @@ const DefaultTheme: Theme = {
       .string(),
     notification: pinkA400,
   },
-  fonts: fonts as Fonts,
+  fonts: configureFont(),
   animation: {
     scale: 1.0,
   },

--- a/src/styles/DefaultTheme.tsx
+++ b/src/styles/DefaultTheme.tsx
@@ -1,6 +1,6 @@
 import color from 'color';
 import { black, white, pinkA400 } from './colors';
-import configureFont from './fonts';
+import configureFonts from './fonts';
 
 import { Theme } from '../types';
 
@@ -30,7 +30,7 @@ const DefaultTheme: Theme = {
       .string(),
     notification: pinkA400,
   },
-  fonts: configureFont(),
+  fonts: configureFonts(),
   animation: {
     scale: 1.0,
   },

--- a/src/styles/fonts.tsx
+++ b/src/styles/fonts.tsx
@@ -58,7 +58,7 @@ const fontConfig = {
   },
 };
 
-export default function configureFont(
+export default function configureFonts(
   config?: { [platform in PlatformOSType | 'default']?: Fonts }
 ): Fonts {
   const fonts = Platform.select({ ...fontConfig, ...config }) as Fonts;

--- a/src/styles/fonts.tsx
+++ b/src/styles/fonts.tsx
@@ -1,60 +1,66 @@
-import { Platform } from 'react-native';
+import { Platform, PlatformOSType } from 'react-native';
+import { Fonts } from '../types';
 
-const fonts = Platform.select({
+const fontConfig = {
   web: {
     regular: {
       fontFamily: 'Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif',
-      fontWeight: '400',
+      fontWeight: '400' as '400',
     },
     medium: {
       fontFamily: 'Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif',
-      fontWeight: '500',
+      fontWeight: '500' as '500',
     },
     light: {
       fontFamily: 'Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif',
-      fontWeight: '300',
+      fontWeight: '300' as '300',
     },
     thin: {
       fontFamily: 'Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif',
-      fontWeight: '100',
+      fontWeight: '100' as '100',
     },
   },
   ios: {
     regular: {
       fontFamily: 'System',
-      fontWeight: '400',
+      fontWeight: '400' as '400',
     },
     medium: {
       fontFamily: 'System',
-      fontWeight: '500',
+      fontWeight: '500' as '500',
     },
     light: {
       fontFamily: 'System',
-      fontWeight: '300',
+      fontWeight: '300' as '300',
     },
     thin: {
       fontFamily: 'System',
-      fontWeight: '100',
+      fontWeight: '100' as '100',
     },
   },
   default: {
     regular: {
       fontFamily: 'sans-serif',
-      fontWeight: 'normal',
+      fontWeight: 'normal' as 'normal',
     },
     medium: {
       fontFamily: 'sans-serif-medium',
-      fontWeight: 'normal',
+      fontWeight: 'normal' as 'normal',
     },
     light: {
       fontFamily: 'sans-serif-light',
-      fontWeight: 'normal',
+      fontWeight: 'normal' as 'normal',
     },
     thin: {
       fontFamily: 'sans-serif-thin',
-      fontWeight: 'normal',
+      fontWeight: 'normal' as 'normal',
     },
   },
-});
+};
 
-export default fonts;
+export default function configureFont(
+  config?: { [platform in PlatformOSType | 'default']?: Fonts }
+): Fonts {
+  const fonts = Platform.select({ ...fontConfig, ...config }) as Fonts;
+  return fonts;
+}


### PR DESCRIPTION
### Motivation

Updated docs for fonts configuration.

Add `configureFonts` method to be able to set fonts on certain platforms and do not override default ones.

### Test plan

No plan.
