### PR TITLE
fix: make ListIcon color optional

### DIFF
--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -7,22 +7,28 @@ import {
 } from 'react-native';
 import { Consumer as SettingsConsumer } from '../core/settings';
 import { accessibilityProps } from './MaterialCommunityIcon';
+import { withTheme } from '../core/theming';
+import { Theme } from '../types';
 
 type IconSourceBase = string | ImageSourcePropType;
 
 export type IconSource =
   | IconSourceBase
   | Readonly<{ source: IconSourceBase; direction: 'rtl' | 'ltr' | 'auto' }>
-  | ((props: IconProps) => React.ReactNode);
+  | ((props: IconProps & { color: string }) => React.ReactNode);
 
 type IconProps = {
-  color: string;
   size: number;
   allowFontScaling?: boolean;
 };
 
 type Props = IconProps & {
+  color?: string;
   source: any;
+  /**
+   * @optional
+   */
+  theme: Theme;
 };
 
 const isImageSource = (source: any) =>
@@ -58,7 +64,7 @@ export const isValidIcon = (source: any) =>
 export const isEqualIcon = (a: any, b: any) =>
   a === b || getIconId(a) === getIconId(b);
 
-const Icon = ({ source, color, size, ...rest }: Props) => {
+const Icon = ({ source, color, size, theme, ...rest }: Props) => {
   const direction =
     // @ts-ignore
     typeof source === 'object' && source.direction && source.source
@@ -73,6 +79,7 @@ const Icon = ({ source, color, size, ...rest }: Props) => {
     typeof source === 'object' && source.direction && source.source
       ? source.source
       : source;
+  const iconColor = color || theme.colors.text;
 
   if (isImageSource(s)) {
     return (
@@ -100,7 +107,7 @@ const Icon = ({ source, color, size, ...rest }: Props) => {
         {({ icon }) => {
           return icon({
             name: s,
-            color,
+            color: iconColor,
             size,
             direction,
           });
@@ -108,10 +115,10 @@ const Icon = ({ source, color, size, ...rest }: Props) => {
       </SettingsConsumer>
     );
   } else if (typeof s === 'function') {
-    return s({ color, size, direction });
+    return s({ color: iconColor, size, direction });
   }
 
   return null;
 };
 
-export default Icon;
+export default withTheme(Icon);

--- a/src/components/List/ListIcon.tsx
+++ b/src/components/List/ListIcon.tsx
@@ -10,7 +10,7 @@ type Props = {
   /**
    * Color for the icon.
    */
-  color: string;
+  color?: string;
   style?: StyleProp<ViewStyle>;
 };
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

If I want to use images instead of icons in the `ListIcon` a color prop causes the image to have a tint (i.e. all the non-alpha pixels will be converted to the tint color) and thus it appears completely black on web. However, excluding the color would solve the issue:
```
                      left={props => {
                        const { color, ...rest } = props

                        return <List.Icon {...rest} icon={{
                          uri: providerType.icon || ''
                        }} />
                      }}
```

Currently, the color prop is required but this PR makes it optional.

### Test plan

This is just a prop type change.
