### PR TITLE
fix(BREAKING): remove padding prop from TextInput

### DIFF
--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -227,8 +227,7 @@ class TextInputExample extends React.Component<Props, State> {
           <View style={styles.inputContainerStyle}>
             <TextInput
               label="Input with no padding"
-              style={{ backgroundColor: 'transparent' }}
-              padding="none"
+              style={{ backgroundColor: 'transparent', paddingHorizontal: 0 }}
               placeholder="Enter username, only letters"
               value={this.state.nameNoPadding}
               error={!this._isUsernameValid(this.state.nameNoPadding)}

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -56,10 +56,6 @@ export type TextInputProps = React.ComponentPropsWithRef<
    */
   underlineColor?: string;
   /**
-   * Whether to apply padding to label and input.
-   */
-  padding?: 'none' | 'normal';
-  /**
    * Sets min height with densed layout. For `TextInput` in `flat` mode
    * height is `64dp` or in dense layout - `52dp` with label or `40dp` without label.
    * For `TextInput` in `outlined` mode
@@ -168,7 +164,6 @@ export type TextInputProps = React.ComponentPropsWithRef<
 class TextInput extends React.Component<TextInputProps, State> {
   static defaultProps: Partial<TextInputProps> = {
     mode: 'flat',
-    padding: 'normal',
     dense: false,
     disabled: false,
     error: false,
@@ -398,10 +393,7 @@ class TextInput extends React.Component<TextInputProps, State> {
   }
 
   render() {
-    const { mode, padding, ...rest } = this.props as $Omit<
-      TextInputProps,
-      'ref'
-    >;
+    const { mode, ...rest } = this.props as $Omit<TextInputProps, 'ref'>;
 
     return mode === 'outlined' ? (
       <TextInputOutlined
@@ -422,7 +414,6 @@ class TextInput extends React.Component<TextInputProps, State> {
         innerRef={ref => {
           this._root = ref;
         }}
-        padding={padding}
         onFocus={this._handleFocus}
         onBlur={this._handleBlur}
         onChangeText={this._handleChangeText}

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -106,6 +106,8 @@ export type TextInputProps = React.ComponentPropsWithRef<
    * Pass `fontSize` prop to modify the font size inside `TextInput`.
    * Pass `height` prop to set `TextInput` height. When `height` is passed,
    * `dense` prop will affect only input's `paddingVertical`.
+   * Pass `paddingHorizontal` to modify horizontal padding.
+   * This can be used to get MD Guidelines v1 TextInput look.
    */
   style?: any;
   /**

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -55,7 +55,6 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
       error,
       selectionColor,
       underlineColor,
-      padding,
       dense,
       style,
       theme,
@@ -73,15 +72,19 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
     const { colors, fonts } = theme;
     const font = fonts.regular;
     const hasActiveOutline = parentState.focused || error;
-    const paddingOffset = padding !== 'none' ? styles.paddingOffset : null;
 
     const {
       fontSize: fontSizeStyle,
       fontWeight,
       height,
+      paddingHorizontal,
       ...viewStyle
     } = (StyleSheet.flatten(style) || {}) as TextStyle;
     const fontSize = fontSizeStyle || MAXIMIZED_LABEL_FONT_SIZE;
+    const paddingOffset = (paddingHorizontal !== undefined &&
+    typeof paddingHorizontal === 'number'
+      ? { paddingHorizontal }
+      : styles.paddingOffset) as { paddingHorizontal: number };
 
     let inputTextColor, activeColor, underlineColorCustom, placeholderColor;
 
@@ -123,10 +126,8 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
 
     const baseLabelTranslateX =
       (I18nManager.isRTL ? 1 : -1) *
-      (labelHalfWidth -
-        (labelScale * labelWidth) / 2 -
-        (fontSize - MINIMIZED_LABEL_FONT_SIZE) * labelScale +
-        (!paddingOffset ? (1 - labelScale) * LABEL_PADDING_HORIZONTAL : 0));
+        (labelHalfWidth - (labelScale * labelWidth) / 2) +
+      (1 - labelScale) * paddingOffset.paddingHorizontal;
 
     const minInputHeight = dense
       ? (label ? MIN_DENSE_HEIGHT_WL : MIN_DENSE_HEIGHT) -


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

We don't like the `padding` prop in TextInput and that's why we are removing it. Instead it will be possible to pass `paddingHorizontal` via style prop. 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
