### PR TITLE
fix: numberOfLines is not working in Android.

### DIFF
--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -321,7 +321,7 @@ const styles = StyleSheet.create({
     height: 2,
   },
   input: {
-    flex: 1,
+    flexGrow: 1,
     margin: 0,
     textAlign: I18nManager.isRTL ? 'right' : 'left',
     zIndex: 1,


### PR DESCRIPTION
### Motivation

Fix for issue:
https://github.com/callstack/react-native-paper/issues/1400

### Test plan

Follow instructions from issue.

### Changes

Replacing `flex: 1` with `flexGrow: 1` in `<TextInputFlat/>` as it is in `<TextInputOutlined/>`.
Probably it was done by a mistake.

With new changes everything work as excepted.
