### PR TITLE
fix: correct FlatTextInput padding on web

### DIFF
--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -84,7 +84,9 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
     const paddingOffset = (paddingHorizontal !== undefined &&
     typeof paddingHorizontal === 'number'
       ? { paddingHorizontal }
-      : styles.paddingOffset) as { paddingHorizontal: number };
+      : StyleSheet.flatten(styles.paddingOffset)) as {
+      paddingHorizontal: number;
+    };
 
     let inputTextColor, activeColor, underlineColorCustom, placeholderColor;
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Fix https://github.com/callstack/react-native-paper/issues/1404

### Test plan

Open `FlatTextInput` example on web.
