### PR TITLE
fix: Multiline aligns text to center in TextInput

### DIFF
--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -321,7 +321,7 @@ const styles = StyleSheet.create({
     height: 2,
   },
   input: {
-    flex: 1,
+    flexGrow: 1,
     margin: 0,
     textAlign: I18nManager.isRTL ? 'right' : 'left',
     zIndex: 1,

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -259,7 +259,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
                   fontSize,
                   fontWeight,
                   color: inputTextColor,
-                  textAlignVertical: multiline && height ? 'top' : 'center',
+                  textAlignVertical: multiline ? "top" : "center"
                 },
               ],
             })}

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -238,7 +238,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps, {}> {
                     fontSize,
                     fontWeight,
                     color: inputTextColor,
-                    textAlignVertical: multiline && height ? 'top' : 'center',
+                    textAlignVertical: multiline ? "top" : "center"
                   },
                 ],
               } as RenderProps)}


### PR DESCRIPTION
### Motivation

Fix for issue:
https://github.com/callstack/react-native-paper/issues/1403

### Test plan

Follow instructions from issue.

### Changes

Replacing check for height to determinate if text should be align top or center.
By default it should be top for multiline text inputs.


