### PR TITLE
autolinking works fine in react-native-cli || vanilla app

### DIFF
--- a/docs/pages/1.getting-started.md
+++ b/docs/pages/1.getting-started.md
@@ -12,12 +12,14 @@ Open a Terminal in your project's folder and run,
 yarn add react-native-paper
 ```
 
-If you're on a vanilla React Native project, you also need to install [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons). This will allow auto link your package.
+If you're on a vanilla React Native project, you also need to install and link [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons).
 
 ```sh
 yarn add react-native-vector-icons
-
+react-native link react-native-vector-icons
 ```
+Note: If you are using react-native version 0.60 or higher you don't need to link [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons). This will [autolink](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons).
+
 
 If you don't want to install vector icons, you can use [babel-plugin-optional-require](https://github.com/satya164/babel-plugin-optional-require) to opt-out.
 

--- a/docs/pages/1.getting-started.md
+++ b/docs/pages/1.getting-started.md
@@ -18,7 +18,7 @@ If you're on a vanilla React Native project, you also need to install and link [
 yarn add react-native-vector-icons
 react-native link react-native-vector-icons
 ```
-Note: If you are using react-native version 0.60 or higher you don't need to link [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons). This will [autolink](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons).
+Note: If you are using react-native version 0.60 or higher you don't need to link [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons).
 
 
 If you don't want to install vector icons, you can use [babel-plugin-optional-require](https://github.com/satya164/babel-plugin-optional-require) to opt-out.

--- a/docs/pages/1.getting-started.md
+++ b/docs/pages/1.getting-started.md
@@ -12,11 +12,11 @@ Open a Terminal in your project's folder and run,
 yarn add react-native-paper
 ```
 
-If you're on a vanilla React Native project, you also need to install and link [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons).
+If you're on a vanilla React Native project, you also need to install [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons). This will allow auto link your package.
 
 ```sh
 yarn add react-native-vector-icons
-react-native link react-native-vector-icons
+
 ```
 
 If you don't want to install vector icons, you can use [babel-plugin-optional-require](https://github.com/satya164/babel-plugin-optional-require) to opt-out.


### PR DESCRIPTION
[react-native-cli](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) package by default allow us auto link any packages.

@satya164 thanks. Please review this PR 🎉 that's my first PR  🙌 

🙌Happy to contribute with your team🙌