### PR TITLE
fix: allow touch events to go through in PortalHost

### DIFF
--- a/src/components/Portal/PortalHost.tsx
+++ b/src/components/Portal/PortalHost.tsx
@@ -125,7 +125,7 @@ export default class PortalHost extends React.Component<Props> {
         }}
       >
         {/* Need collapsable=false here to clip the elevations, otherwise they appear above Portal components */}
-        <View style={styles.container} collapsable={false}>
+        <View style={styles.container} collapsable={false} pointerEvents="box-none">
           {this.props.children}
         </View>
         <PortalManager ref={this.setManager} />

--- a/src/components/Portal/PortalHost.tsx
+++ b/src/components/Portal/PortalHost.tsx
@@ -125,7 +125,11 @@ export default class PortalHost extends React.Component<Props> {
         }}
       >
         {/* Need collapsable=false here to clip the elevations, otherwise they appear above Portal components */}
-        <View style={styles.container} collapsable={false} pointerEvents="box-none">
+        <View
+          style={styles.container}
+          collapsable={false}
+          pointerEvents="box-none"
+        >
           {this.props.children}
         </View>
         <PortalManager ref={this.setManager} />

--- a/src/components/__tests__/__snapshots__/Portal.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Portal.test.js.snap
@@ -4,6 +4,7 @@ exports[`renders portal with siblings 1`] = `
 Array [
   <View
     collapsable={false}
+    pointerEvents="box-none"
     style={
       Object {
         "flex": 1,


### PR DESCRIPTION
### Motivation

I was running into this issue https://github.com/wix/react-native-navigation/issues/5579 earlier.
Turns out that wrapping my screens in a ThemeProvider wasn't allowing my touches to go thru.
This should fix the issue.

