### PR TITLE
chore: add types for MenuItem Style

### DIFF
--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -1,6 +1,6 @@
 import color from 'color';
 import * as React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, ViewStyle, StyleProp } from 'react-native';
 import Icon, { IconSource } from '../Icon';
 import TouchableRipple from '../TouchableRipple';
 import Text from '../Typography/Text';
@@ -29,7 +29,7 @@ type Props = {
    * @optional
    */
   theme: Theme;
-  style?: any;
+  style?: StyleProp<ViewStyle>;
 };
 
 /**


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
MenuItem Component's style type was set to `any`.
Since the style prop is used for `TouchableRipple` which takes `StyleProp<ViewStyle>`, I've modified the type of style to match that.


### Test plan
yarn
yarn build
yarn test
yarn lint
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
