### PR TITLE
feat: data table cell text style

### DIFF
--- a/src/components/DataTable/DataTableCell.tsx
+++ b/src/components/DataTable/DataTableCell.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleSheet, StyleProp, ViewStyle } from 'react-native';
+import { StyleSheet, StyleProp, ViewStyle, TextStyle } from 'react-native';
 import Text from '../Typography/Text';
 import TouchableRipple from '../TouchableRipple';
 import { $RemoveChildren } from '../../types';
@@ -18,20 +18,26 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
    */
   onPress?: () => void;
   style?: StyleProp<ViewStyle>;
+  /**
+   * Style of the text inside the cell
+   */
+  textStyle?: StyleProp<TextStyle>;
 };
 
 class DataTableCell extends React.Component<Props> {
   static displayName = 'DataTable.Cell';
 
   render() {
-    const { children, style, numeric, ...rest } = this.props;
+    const { children, style, numeric, textStyle, ...rest } = this.props;
 
     return (
-      <TouchableRipple
-        {...rest}
-        style={[styles.container, numeric && styles.right, style]}
-      >
-        <Text numberOfLines={1}>{children}</Text>
+      <TouchableRipple {...rest} style={[styles.container, style]}>
+        <Text
+          numberOfLines={1}
+          style={[styles.text, textStyle, numeric && styles.numeric]}
+        >
+          {children}
+        </Text>
       </TouchableRipple>
     );
   }
@@ -44,8 +50,12 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 
-  right: {
-    justifyContent: 'flex-end',
+  numeric: {
+    textAlign: 'right',
+  },
+
+  text: {
+    flex: 1,
   },
 });
 

--- a/src/components/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.js.snap
@@ -20,7 +20,6 @@ exports[`renders data table cell 1`] = `
           "flexDirection": "row",
         },
         undefined,
-        undefined,
       ],
     ]
   }
@@ -35,7 +34,13 @@ exports[`renders data table cell 1`] = `
           "fontWeight": "400",
           "textAlign": "left",
         },
-        null,
+        Array [
+          Object {
+            "flex": 1,
+          },
+          undefined,
+          undefined,
+        ],
       ]
     }
   >
@@ -785,9 +790,6 @@ exports[`renders right aligned data table cell 1`] = `
           "flex": 1,
           "flexDirection": "row",
         },
-        Object {
-          "justifyContent": "flex-end",
-        },
         undefined,
       ],
     ]
@@ -803,7 +805,15 @@ exports[`renders right aligned data table cell 1`] = `
           "fontWeight": "400",
           "textAlign": "left",
         },
-        null,
+        Array [
+          Object {
+            "flex": 1,
+          },
+          undefined,
+          Object {
+            "textAlign": "right",
+          },
+        ],
       ]
     }
   >


### PR DESCRIPTION
### Motivation

This pull request introduces feature proposed in [[New Features] Datatable column width and text style for title and cell. #1150](https://github.com/callstack/react-native-paper/issues/1150)

### Test plan

- Go to DataTable component in examples
- Where rendering cells add `textStyle` prop to the cell with some text style properties
- Run the example
