### PR TITLE
fix: fix text input disappearing value on blur when in uncontrolled mode

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -398,6 +398,7 @@ class TextInput extends React.Component<TextInputProps, State> {
     return mode === 'outlined' ? (
       <TextInputOutlined
         {...rest}
+        value={this.state.value}
         parentState={this.state}
         innerRef={ref => {
           this.root = ref;
@@ -410,6 +411,7 @@ class TextInput extends React.Component<TextInputProps, State> {
     ) : (
       <TextInputFlat
         {...rest}
+        value={this.state.value}
         parentState={this.state}
         innerRef={ref => {
           this.root = ref;


### PR DESCRIPTION
### Motivation

This pull request fixes the issue mentioned in [Passing TextInput props dynamically hides text input field Value #1346](https://github.com/callstack/react-native-paper/issues/1346). When TextInput is in uncontrolled mode it's text value disappears when blurred. 

### Test plan

- Go to `TextInputExample` component
- Remove `value` and `onChangeText` props from any text input
- Run the example 
- Type something to this input, then focus another one. The value of the blurred input should not disappear