### PR TITLE
feat: add ability to change padding between FAB group items

### DIFF
--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -78,6 +78,10 @@ type Props = {
    * @optional
    */
   theme: Theme;
+  /**
+   * Space between FAB group items
+   */
+  itemMargin?: number;
 };
 
 type State = {
@@ -205,6 +209,7 @@ class FABGroup extends React.Component<Props, State> {
       style,
       fabStyle,
       visible,
+      itemMargin,
     } = this.props;
     const { colors } = theme;
 
@@ -250,7 +255,7 @@ class FABGroup extends React.Component<Props, State> {
             {actions.map((it, i) => (
               <View
                 key={i} // eslint-disable-line react/no-array-index-key
-                style={styles.item}
+                style={[styles.item, { marginBottom: itemMargin || 16 }]}
                 pointerEvents="box-none"
               >
                 {it.label && (
@@ -361,7 +366,6 @@ const styles = StyleSheet.create({
   },
   item: {
     marginHorizontal: 24,
-    marginBottom: 16,
     flexDirection: 'row',
     justifyContent: 'flex-end',
     alignItems: 'center',


### PR DESCRIPTION
### Motivation

This pull requests introduces a feature proposed in [Add ability to change padding between fab group children #1274](https://github.com/callstack/react-native-paper/issues/1274)

### Test plan

- Go to `FABExample` component
- Add `itemMargin` with numeric value to the rendered `FAB.Group` component
- Run the app and in the example the spaces between the items should change