### PR TITLE
feat: support RadioGroup & RadioButton clicking row with children

### DIFF
--- a/example/src/Examples/RadioButtonGroupExample.tsx
+++ b/example/src/Examples/RadioButtonGroupExample.tsx
@@ -42,14 +42,12 @@ class RadioButtonGroupExample extends React.Component<Props, State> {
           value={this.state.value}
           onValueChange={(value: string) => this.setState({ value })}
         >
-          <View style={styles.row}>
+          <RadioButton value="first">
             <Paragraph>First</Paragraph>
-            <RadioButton value="first" />
-          </View>
-          <View style={styles.row}>
+          </RadioButton>
+          <RadioButton value="second">
             <Paragraph>Second</Paragraph>
-            <RadioButton value="second" />
-          </View>
+          </RadioButton>
         </RadioButton.Group>
       </View>
     );
@@ -61,13 +59,6 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: Colors.white,
     padding: 8,
-  },
-  row: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingVertical: 8,
-    paddingHorizontal: 16,
   },
 });
 

--- a/src/components/RadioButton.tsx
+++ b/src/components/RadioButton.tsx
@@ -43,7 +43,7 @@ type Props = {
    */
   color?: string;
   /**
-   * React elements containing radio buttons.
+   * React elements containing radio button children.
    */
   children?: React.ReactNode;
   /**

--- a/src/components/RadioButtonGroup.tsx
+++ b/src/components/RadioButtonGroup.tsx
@@ -44,14 +44,12 @@ export const RadioButtonContext = React.createContext<RadioButtonContextType>(
  *         onValueChange={value => this.setState({ value })}
  *         value={this.state.value}
  *       >
- *         <View>
+ *         <RadioButton value="first">
  *           <Text>First</Text>
- *           <RadioButton value="first" />
- *         </View>
- *         <View>
+ *         </RadioButton>
+ *         <RadioButton value="second">
  *           <Text>Second</Text>
- *           <RadioButton value="second" />
- *         </View>
+ *         </RadioButton>
  *       </RadioButton.Group>
  *     )
  *   }


### PR DESCRIPTION
Refs #808

### Motivation
Add support for clicking children to RadioButton especially in RadioGroup:

```jsx
          <RadioButton value="second">
            <Paragraph>Second</Paragraph>
          </RadioButton>
```

```jsx
        <RadioButton.Group
          value={this.state.value}
          onValueChange={(value: string) => this.setState({ value })}
        >
          <RadioButton value="first">
            <Paragraph>First</Paragraph>
          </RadioButton>
          <RadioButton value="second">
            <Paragraph>Second</Paragraph>
          </RadioButton>
        </RadioButton.Group>
```

### Test plan

RadioGroup examples.
