### PR TITLE
fix: fix initial label position when value is set on RN 0.61

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -210,7 +210,10 @@ class TextInput extends React.Component<TextInputProps, State> {
   componentDidUpdate(prevProps: TextInputProps, prevState: State) {
     if (
       prevState.focused !== this.state.focused ||
-      prevState.value !== this.state.value
+      prevState.value !== this.state.value ||
+      // workaround for animated regression for react native > 0.61
+      // https://github.com/callstack/react-native-paper/pull/1440
+      prevState.labelLayout !== this.state.labelLayout
     ) {
       // The label should be minimized if the text input is focused, or has text
       // In minimized mode, the label moves up and becomes small


### PR DESCRIPTION
All information is in: 
https://github.com/callstack/react-native-paper/pull/1440

But I don't know how to rebase, so I do another fork.