### PR TITLE
Fix banner doc comment

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -100,7 +100,7 @@ type NativeEvent = {
  *             onPress: () => this.setState({ visible: false }),
  *           },
  *         ]}
- *         image={({ size }) =>
+ *         icon={({ size }) =>
  *           <Image
  *             source={{ uri: 'https://avatars3.githubusercontent.com/u/17571969?s=400&v=4' }}
  *             style={{


### PR DESCRIPTION
The doc comment says "image", but "icon" is correct.