### PR TITLE
fix: animation speed for checkbox on Android

### DIFF
--- a/src/components/CheckboxAndroid.tsx
+++ b/src/components/CheckboxAndroid.tsx
@@ -37,6 +37,9 @@ type State = {
   scaleAnim: Animated.Value;
 };
 
+// From https://material.io/design/motion/speed.html#duration
+const ANIMATION_DURATION = 100;
+
 /**
  * Checkboxes allow the selection of multiple options from a set.
  * This component follows platform guidelines for Android.
@@ -65,14 +68,18 @@ class CheckboxAndroid extends React.Component<Props, State> {
     }
 
     const checked = this.props.status === 'checked';
+    const { animation } = this.props.theme;
+
     Animated.sequence([
       Animated.timing(this.state.scaleAnim, {
         toValue: 0.85,
-        duration: checked ? 200 : 0,
+        duration: checked ? ANIMATION_DURATION * animation.scale : 0,
       }),
       Animated.timing(this.state.scaleAnim, {
         toValue: 1,
-        duration: checked ? 200 : 350,
+        duration: checked
+          ? ANIMATION_DURATION * animation.scale
+          : ANIMATION_DURATION * animation.scale * 1.75,
       }),
     ]).start();
   }


### PR DESCRIPTION
Checkbox.android now has a faster animation in accordance with the material docs https://material.io/design/motion/speed.html#duration (lowered from 200 to 100).

The animation speed is now also scaled by `theme.animation.scale`

Fixes issue #1467 

### Motivation

- Checkbox.android had too slow animations (200ms instead of 100ms as per material docs)
- Checkbox.android did not use theme.animation.scale for adjusting animation speed

### Test plan

Set `theme.animation.scale = 10` to se a really slow Checkbox.android in action