### PR TITLE
refactor: add ThemeColors type

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -23,24 +23,26 @@ export type Fonts = {
   thin: Font;
 };
 
+export type ThemeColors = {
+  primary: string;
+  background: string;
+  surface: string;
+  accent: string;
+  error: string;
+  text: string;
+  onSurface: string;
+  onBackground: string;
+  disabled: string;
+  placeholder: string;
+  backdrop: string;
+  notification: string;
+};
+
 export type Theme = {
   dark: boolean;
   mode?: 'adaptive' | 'exact';
   roundness: number;
-  colors: {
-    primary: string;
-    background: string;
-    surface: string;
-    accent: string;
-    error: string;
-    text: string;
-    onSurface: string;
-    onBackground: string;
-    disabled: string;
-    placeholder: string;
-    backdrop: string;
-    notification: string;
-  };
+  colors: ThemeColors;
   fonts: Fonts;
   animation: {
     scale: number;


### PR DESCRIPTION
### Motivation

My team is using `react-native-paper` in a React Native project that is written in TypeScript. I wanted to extend the Theme type and add my own variables to its `colors` object. In this way, I could pass in a custom theme that fit the Theme type, but also include extra `colors` variables to be used in the same way as the default `colors` variables.

However, I wasn't able to do this without adding every existing color from Theme.colors. Which works, but by having `colors` be its own type (like Fonts) it allows for more robust theming. For example, if there are ever changes to Theme.colors, it would not break a theme customized in this fashion.

### Test plan

Creating a custom theme type could be done by doing something similar to this:

```
export const CUSTOM_THEME: CustomTheme = {
  ...DefaultTheme,
  colors: {
    ...DefaultTheme.colors,
    primary: COLORS.PRIMARY,
    secondary: COLORS.SECONDARY,
    accent: COLORS.ACCENT,
    accentAlt: COLORS.ACCENT_ALT, 
    exampleCustomColor: COLORS.EXAMPLE_CUSTOM_COLOR
  },
};

export interface CustomTheme extends Theme {
  colors: CustomColors;
}

declare interface CustomColors extends ThemeColors {
    secondary: string;
    accentAlt: string;
    exampleCustomColor: string;
}
```