### PR TITLE
refactor: remove pointerEvents from ListItem description

### DIFF
--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -196,7 +196,7 @@ class ListItem extends React.Component<Props> {
                     },
               })
             : null}
-          <View style={[styles.item, styles.content]} pointerEvents="none">
+          <View style={[styles.item, styles.content]}>
             <Text
               ellipsizeMode={titleEllipsizeMode}
               numberOfLines={titleNumberOfLines}

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.js.snap
@@ -147,7 +147,6 @@ exports[`renders expanded accordion 1`] = `
       }
     >
       <View
-        pointerEvents="none"
         style={
           Array [
             Object {

--- a/src/components/__tests__/__snapshots__/ListItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.js.snap
@@ -30,7 +30,6 @@ exports[`renders list item with custom description 1`] = `
     }
   >
     <View
-      pointerEvents="none"
       style={
         Array [
           Object {
@@ -240,7 +239,6 @@ exports[`renders list item with custom title and description styles 1`] = `
     }
   >
     <View
-      pointerEvents="none"
       style={
         Array [
           Object {
@@ -344,7 +342,6 @@ exports[`renders list item with left and right items 1`] = `
       GG
     </Text>
     <View
-      pointerEvents="none"
       style={
         Array [
           Object {
@@ -547,7 +544,6 @@ exports[`renders list item with left item 1`] = `
       </Text>
     </View>
     <View
-      pointerEvents="none"
       style={
         Array [
           Object {
@@ -620,7 +616,6 @@ exports[`renders list item with right item 1`] = `
     }
   >
     <View
-      pointerEvents="none"
       style={
         Array [
           Object {
@@ -696,7 +691,6 @@ exports[`renders list item with title and description 1`] = `
     }
   >
     <View
-      pointerEvents="none"
       style={
         Array [
           Object {
@@ -793,7 +787,6 @@ exports[`renders with a description with typeof number 1`] = `
     }
   >
     <View
-      pointerEvents="none"
       style={
         Array [
           Object {

--- a/src/components/__tests__/__snapshots__/ListSection.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.js.snap
@@ -164,7 +164,6 @@ exports[`renders list section with custom title style 1`] = `
         </Text>
       </View>
       <View
-        pointerEvents="none"
         style={
           Array [
             Object {
@@ -288,7 +287,6 @@ exports[`renders list section with custom title style 1`] = `
         </Text>
       </View>
       <View
-        pointerEvents="none"
         style={
           Array [
             Object {
@@ -494,7 +492,6 @@ exports[`renders list section with subheader 1`] = `
         </Text>
       </View>
       <View
-        pointerEvents="none"
         style={
           Array [
             Object {
@@ -618,7 +615,6 @@ exports[`renders list section with subheader 1`] = `
         </Text>
       </View>
       <View
-        pointerEvents="none"
         style={
           Array [
             Object {
@@ -797,7 +793,6 @@ exports[`renders list section without subheader 1`] = `
         </Text>
       </View>
       <View
-        pointerEvents="none"
         style={
           Array [
             Object {
@@ -921,7 +916,6 @@ exports[`renders list section without subheader 1`] = `
         </Text>
       </View>
       <View
-        pointerEvents="none"
         style={
           Array [
             Object {


### PR DESCRIPTION
### Motivation
Consider the following example from `List.Section` :
![Screenshot from 2019-12-09 22-10-25](https://user-images.githubusercontent.com/6487206/70486487-ce025300-1ad0-11ea-951a-635b0f546274.png)

The description's container can't have `pointerEvents="none"`  in order to make the Chip component able to be pressed.

### Test plan
1. Download this branch
2. Open the `List.Section` example
3. Press on the chip