### PR TITLE
fix: appBar Accessibility Focus

### DIFF
--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -31,6 +31,10 @@ type Props = $RemoveChildren<typeof View> & {
    */
   titleStyle?: StyleProp<TextStyle>;
   /**
+   * Reference for the title.
+   */
+  titleRef?: React.RefObject<Text>;
+  /**
    * Text for the subtitle.
    */
   subtitle?: React.ReactNode;
@@ -62,6 +66,7 @@ class AppbarContent extends React.Component<Props> {
       subtitleStyle,
       onPress,
       style,
+      titleRef,
       titleStyle,
       theme,
       title,
@@ -78,6 +83,7 @@ class AppbarContent extends React.Component<Props> {
       <TouchableWithoutFeedback onPress={onPress}>
         <View style={[styles.container, style]} {...rest}>
           <Text
+            ref={titleRef}
             style={[
               {
                 color: titleColor,
@@ -87,6 +93,7 @@ class AppbarContent extends React.Component<Props> {
               titleStyle,
             ]}
             numberOfLines={1}
+            accessible
             accessibilityTraits="header"
             // @ts-ignore
             accessibilityRole={Platform.OS === 'web' ? 'heading' : 'header'}

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
@@ -417,6 +417,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
     <Text
       accessibilityRole="header"
       accessibilityTraits="header"
+      accessible={true}
       numberOfLines={1}
       style={
         Array [


### PR DESCRIPTION
### Motivation
Increase accessibility of `Appbar.Content` by adding support for [Accessibilityinfo.setaccessibilityfocus](https://facebook.github.io/react-native/docs/0.48/accessibilityinfo#setaccessibilityfocus) allowing apps to focus screen readers on the `Appbar.Content` title when a screen is initially rendered.

Notes: Android requires the focused component to have `accessible` set in order to focus.

Example:
```
const FocusedHeader = () => {
  const ref = useRef<Text>(null);

  useEffect(() => {
    const handle = findNodeHandle(ref.current);
    AccessibilityInfo.setAccessibilityFocus(handle);
  });

  return (
    <Appbar.Header>
      <Appbar.Content
        titleRef={ref}
        title="Screen Title"
      />
    </Appbar.Header>
  );
};
```

### Test plan
`yarn flow && yarn typescript && yarn lint && yarn test`
