### PR TITLE
feat: added prefixes to text inputs

### DIFF
--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -187,6 +187,12 @@ class TextInputExample extends React.Component<Props, State> {
             style={styles.inputContainerStyle}
             label="Disabled outlined input"
           />
+          <TextInput label="Flat input with prefix text" prefixText="Tip: $" />
+          <TextInput
+            label="Outline input with prefix text"
+            mode="outlined"
+            prefixText="Tip: $"
+          />
           <View style={styles.inputContainerStyle}>
             <TextInput
               label="Input with helper text"

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -36,6 +36,10 @@ export type TextInputProps = React.ComponentPropsWithRef<
    */
   label?: string;
   /**
+   * The uneditable text prepended to the input
+   */
+  prefixText?: string;
+  /**
    * Placeholder for the input.
    */
   placeholder?: string;

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -12,6 +12,8 @@ import color from 'color';
 import InputLabel from './Label/InputLabel';
 import { RenderProps, ChildTextInputProps } from './types';
 
+import Text from '../Typography/Text';
+
 import {
   MAXIMIZED_LABEL_FONT_SIZE,
   MINIMIZED_LABEL_FONT_SIZE,
@@ -52,6 +54,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
       disabled,
       editable,
       label,
+      prefixText,
       error,
       selectionColor,
       underlineColor,
@@ -66,6 +69,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
       onBlur,
       onChangeText,
       onLayoutAnimatedText,
+      value,
       ...rest
     } = this.props;
 
@@ -236,38 +240,60 @@ class TextInputFlat extends React.Component<ChildTextInputProps, {}> {
         >
           <InputLabel parentState={parentState} labelProps={labelProps} />
 
-          {render?.({
-            ...rest,
-            ref: innerRef,
-            onChangeText,
-            // @ts-ignore
-            placeholder: label
-              ? parentState.placeholder
-              : this.props.placeholder,
-            placeholderTextColor: placeholderColor,
-            editable: !disabled && editable,
-            selectionColor:
-              typeof selectionColor === 'undefined'
-                ? activeColor
-                : selectionColor,
-            onFocus,
-            onBlur,
-            underlineColorAndroid: 'transparent',
-            multiline,
-            style: [
-              styles.input,
-              paddingOffset,
-              !multiline || (multiline && height) ? { height: flatHeight } : {},
-              paddingFlat,
-              {
-                ...font,
-                fontSize,
-                fontWeight,
-                color: inputTextColor,
-                textAlignVertical: multiline ? 'top' : 'center',
-              },
-            ],
-          })}
+          <View style={styles.inputContainer}>
+            {prefixText &&
+              (parentState.focused === true ||
+                (typeof value === 'string' && value.length > 0)) && (
+                <Text
+                  style={{
+                    ...styles.prefixLabel,
+                    ...paddingFlat,
+                    paddingLeft: LABEL_PADDING_HORIZONTAL,
+                    fontSize,
+                    fontWeight,
+                    color: placeholderColor,
+                  }}
+                >
+                  {prefixText}
+                </Text>
+              )}
+
+            {render?.({
+              ...rest,
+              ref: innerRef,
+              onChangeText,
+              // @ts-ignore
+              placeholder: label
+                ? parentState.placeholder
+                : this.props.placeholder,
+              placeholderTextColor: placeholderColor,
+              editable: !disabled && editable,
+              selectionColor:
+                typeof selectionColor === 'undefined'
+                  ? activeColor
+                  : selectionColor,
+              onFocus,
+              onBlur,
+              underlineColorAndroid: 'transparent',
+              multiline,
+              style: [
+                styles.input,
+                paddingOffset,
+                !multiline || (multiline && height)
+                  ? { height: flatHeight }
+                  : {},
+                paddingFlat,
+                {
+                  ...font,
+                  fontSize,
+                  fontWeight,
+                  color: inputTextColor,
+                  textAlignVertical: multiline ? 'top' : 'center',
+                  paddingLeft: prefixText ? 0 : paddingOffset.paddingHorizontal,
+                },
+              ],
+            })}
+          </View>
         </View>
       </View>
     );
@@ -341,5 +367,11 @@ const styles = StyleSheet.create({
   },
   paddingOffset: {
     paddingHorizontal: LABEL_PADDING_HORIZONTAL,
+  },
+  inputContainer: {
+    flexDirection: 'row',
+  },
+  prefixLabel: {
+    alignSelf: 'center',
   },
 });

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -13,6 +13,7 @@ import InputLabel from './Label/InputLabel';
 import LabelBackground from './Label/LabelBackground';
 import { RenderProps, ChildTextInputProps } from './types';
 import { Theme } from '../../types';
+import Text from '../Typography/Text';
 
 import {
   MAXIMIZED_LABEL_FONT_SIZE,
@@ -49,6 +50,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps, {}> {
       disabled,
       editable,
       label,
+      prefixText,
       error,
       selectionColor,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -64,6 +66,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps, {}> {
       onBlur,
       onChangeText,
       onLayoutAnimatedText,
+      value,
       ...rest
     } = this.props;
 
@@ -212,38 +215,58 @@ class TextInputOutlined extends React.Component<ChildTextInputProps, {}> {
               labelBackground={LabelBackground}
             />
 
-            {render?.({
-              ...rest,
-              ref: innerRef,
-              onChangeText,
-              placeholder: label
-                ? parentState.placeholder
-                : this.props.placeholder,
-              placeholderTextColor: placeholderColor,
-              editable: !disabled && editable,
-              selectionColor:
-                typeof selectionColor === 'undefined'
-                  ? activeColor
-                  : selectionColor,
-              onFocus,
-              onBlur,
-              underlineColorAndroid: 'transparent',
-              multiline,
-              style: [
-                styles.input,
-                !multiline || (multiline && height)
-                  ? { height: inputHeight }
-                  : {},
-                paddingOut,
-                {
-                  ...font,
-                  fontSize,
-                  fontWeight,
-                  color: inputTextColor,
-                  textAlignVertical: multiline ? 'top' : 'center',
-                },
-              ],
-            } as RenderProps)}
+            <View style={styles.inputContainer}>
+              {prefixText &&
+                (parentState.focused === true ||
+                  (typeof value === 'string' && value.length > 0)) && (
+                  <Text
+                    style={{
+                      ...styles.prefixLabel,
+                      paddingLeft: INPUT_PADDING_HORIZONTAL,
+                      fontSize,
+                      fontWeight,
+                      color: placeholderColor,
+                    }}
+                  >
+                    {prefixText}
+                  </Text>
+                )}
+
+              {render?.({
+                ...rest,
+                value,
+                ref: innerRef,
+                onChangeText,
+                placeholder: label
+                  ? parentState.placeholder
+                  : this.props.placeholder,
+                placeholderTextColor: placeholderColor,
+                editable: !disabled && editable,
+                selectionColor:
+                  typeof selectionColor === 'undefined'
+                    ? activeColor
+                    : selectionColor,
+                onFocus,
+                onBlur,
+                underlineColorAndroid: 'transparent',
+                multiline,
+                style: [
+                  styles.input,
+                  !multiline || (multiline && height)
+                    ? { height: inputHeight }
+                    : {},
+                  paddingOut,
+                  {
+                    ...font,
+                    fontSize,
+                    fontWeight,
+                    color: inputTextColor,
+                    textAlignVertical: multiline ? 'top' : 'center',
+                    paddingLeft: prefixText ? 0 : INPUT_PADDING_HORIZONTAL,
+                  },
+                ],
+              } as RenderProps)}
+            </View>
           </View>
         </View>
       </View>
@@ -310,5 +333,12 @@ const styles = StyleSheet.create({
   inputOutlinedDense: {
     paddingTop: 4,
     paddingBottom: 4,
+  },
+  inputContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+  },
+  prefixLabel: {
+    alignSelf: 'center',
   },
 });


### PR DESCRIPTION
### Motivation
To allow users to specify prefixes to text inputs as specified in the [material ui documentation](https://material.io/components/text-fields/)

### Test plan

If the proposed approach is good, I'll add snapshot tests for various combinations of input type, size etc.
