### PR TITLE
fix: Added optional prop theme in typescript format for TextInput

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -111,9 +111,9 @@ export type TextInputProps = React.ComponentPropsWithRef<
    */
   style?: any;
   /**
-   * @optional
+   * Pass a `Theme` to set the Theme Styling of this component
    */
-  theme: Theme;
+  theme?: Theme;
 };
 
 /**

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -112,6 +112,7 @@ export type TextInputProps = React.ComponentPropsWithRef<
   style?: any;
   /**
    * Pass a `Theme` to set the Theme Styling of this component
+   * @optional
    */
   theme?: Theme;
 };


### PR DESCRIPTION
### Motivation

The current typescript interface make the theme prop to be mandatory but there's a comment over it stating that it is in fact optional. This fix will add more consistancy.
