### PR TITLE
feat: added testID to FAB and FAB.Group

### DIFF
--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -56,6 +56,7 @@ type Props = $RemoveChildren<typeof Surface> & {
    * @optional
    */
   theme: Theme;
+  testID?: string;
 };
 
 type State = {
@@ -142,6 +143,7 @@ class FAB extends React.Component<Props, State> {
       style,
       visible,
       loading,
+      testID,
       ...rest
     } = this.props;
     const { visibility } = this.state;
@@ -206,6 +208,7 @@ class FAB extends React.Component<Props, State> {
           accessibilityRole="button"
           accessibilityStates={disabled ? ['disabled'] : []}
           style={styles.touchable}
+          testID={testID}
         >
           <View
             style={[

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -78,6 +78,10 @@ type Props = {
    * @optional
    */
   theme: Theme;
+  /**
+   * Pass down testID from Group props to FAB and child FABs with indices.
+   */
+  testID?: string;
 };
 
 type State = {
@@ -205,6 +209,7 @@ class FABGroup extends React.Component<Props, State> {
       style,
       fabStyle,
       visible,
+      testID,
     } = this.props;
     const { colors } = theme;
 
@@ -306,6 +311,7 @@ class FABGroup extends React.Component<Props, State> {
                   accessibilityTraits="button"
                   accessibilityComponentType="button"
                   accessibilityRole="button"
+                  testID={`${testID}-${i}`}
                 />
               </View>
             ))}
@@ -323,6 +329,7 @@ class FABGroup extends React.Component<Props, State> {
             accessibilityRole="button"
             style={[styles.fab, fabStyle]}
             visible={visible}
+            testID={testID}
           />
         </SafeAreaView>
       </View>

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -34,6 +34,7 @@ type Props = {
     accessibilityLabel?: string;
     style?: StyleProp<ViewStyle>;
     onPress: () => void;
+    testID?: string;
   }>;
   /**
    * Icon to display for the `FAB`.
@@ -79,7 +80,7 @@ type Props = {
    */
   theme: Theme;
   /**
-   * Pass down testID from Group props to FAB and child FABs with indices.
+   * Pass down testID from Group props to FAB.
    */
   testID?: string;
 };
@@ -311,7 +312,7 @@ class FABGroup extends React.Component<Props, State> {
                   accessibilityTraits="button"
                   accessibilityComponentType="button"
                   accessibilityRole="button"
-                  testID={`${testID}-${i}`}
+                  testID={it.testID}
                 />
               </View>
             ))}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
Added a testID to enable testing with detox. You can now add a testID as it is done for other components to the FAB and the FAB.Group.
Additionally the you can hand in testIDs to any action provided to a FAB.Group.
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
Check, if the way that the testIDs of the FAB children of the FAB.Group are generated in a reasonable way (especially in respect to naming conventions)

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
