### PR TITLE
feat: Multiple line for card title and subtitle

### DIFF
--- a/src/components/Card/CardTitle.tsx
+++ b/src/components/Card/CardTitle.tsx
@@ -22,10 +22,6 @@ type Props = React.ComponentProps<typeof View> & {
    */
   titleStyle?: StyleProp<TextStyle>;
   /**
-   * Number of line for the title.
-   */
-  titleNumberOfLines?: number;
-  /**
    * Text for the subtitle. Note that this will only accept a string or `<Text>`-based node.
    */
   subtitle?: React.ReactNode;
@@ -98,7 +94,6 @@ class CardTitle extends React.Component<Props> {
   static displayName = 'Card.Title';
 
   static defaultProps = {
-    titleNumberOfLines: 1,
     subtitleNumberOfLines: 1,
   };
 
@@ -114,7 +109,6 @@ class CardTitle extends React.Component<Props> {
       style,
       title,
       titleStyle,
-      titleNumberOfLines,
     } = this.props;
 
     return (
@@ -141,7 +135,6 @@ class CardTitle extends React.Component<Props> {
                 { marginBottom: subtitle ? 0 : 2 },
                 titleStyle,
               ]}
-              numberOfLines={titleNumberOfLines}
             >
               {title}
             </Title>


### PR DESCRIPTION
The title property of a card would wrap lines
The subtitle property of a card would wrap lines

### Motivation

<img width="361" alt="58108975-fb75c680-7ba9-11e9-9c36-851042827d08" src="https://user-images.githubusercontent.com/20625911/72412826-e9800e00-37a0-11ea-883e-6ab7989c1206.png">
