### PR TITLE
feat: config animation duration

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -147,15 +147,17 @@ class Banner extends React.Component<Props, State> {
   };
 
   private show = () => {
+    const { animation } = this.props.theme;
     Animated.timing(this.state.position, {
-      duration: 250,
+      duration: 250 * animation.scale,
       toValue: 1,
     }).start();
   };
 
   private hide = () => {
+    const { animation } = this.props.theme;
     Animated.timing(this.state.position, {
-      duration: 200,
+      duration: 200 * animation.scale,
       toValue: 0,
     }).start();
   };

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -147,17 +147,17 @@ class Banner extends React.Component<Props, State> {
   };
 
   private show = () => {
-    const { animation } = this.props.theme;
+    const { scale } = this.props.theme.animation;
     Animated.timing(this.state.position, {
-      duration: 250 * animation.scale,
+      duration: 250 * scale,
       toValue: 1,
     }).start();
   };
 
   private hide = () => {
-    const { animation } = this.props.theme;
+    const { scale } = this.props.theme.animation;
     Animated.timing(this.state.position, {
-      duration: 200 * animation.scale,
+      duration: 200 * scale,
       toValue: 0,
     }).start();
   };

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -110,6 +110,7 @@ class FAB extends React.Component<Props, State> {
   };
 
   componentDidUpdate(prevProps: Props) {
+    const { animation } = this.props.theme;
     if (this.props.visible === prevProps.visible) {
       return;
     }
@@ -117,13 +118,13 @@ class FAB extends React.Component<Props, State> {
     if (this.props.visible) {
       Animated.timing(this.state.visibility, {
         toValue: 1,
-        duration: 200,
+        duration: 200 * animation.scale,
         useNativeDriver: true,
       }).start();
     } else {
       Animated.timing(this.state.visibility, {
         toValue: 0,
-        duration: 150,
+        duration: 150 * animation.scale,
         useNativeDriver: true,
       }).start();
     }

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -110,7 +110,7 @@ class FAB extends React.Component<Props, State> {
   };
 
   componentDidUpdate(prevProps: Props) {
-    const { animation } = this.props.theme;
+    const { scale } = this.props.theme.animation;
     if (this.props.visible === prevProps.visible) {
       return;
     }
@@ -118,13 +118,13 @@ class FAB extends React.Component<Props, State> {
     if (this.props.visible) {
       Animated.timing(this.state.visibility, {
         toValue: 1,
-        duration: 200 * animation.scale,
+        duration: 200 * scale,
         useNativeDriver: true,
       }).start();
     } else {
       Animated.timing(this.state.visibility, {
         toValue: 0,
-        duration: 150 * animation.scale,
+        duration: 150 * scale,
         useNativeDriver: true,
       }).start();
     }

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -152,20 +152,21 @@ class FABGroup extends React.Component<Props, State> {
       return;
     }
 
+    const { animation: themeAnimation } = this.props.theme;
     if (this.props.open) {
       Animated.parallel([
         Animated.timing(this.state.backdrop, {
           toValue: 1,
-          duration: 250,
+          duration: 250 * themeAnimation.scale,
           useNativeDriver: true,
         }),
         Animated.stagger(
-          50,
+          50 * themeAnimation.scale,
           this.state.animations
             .map(animation =>
               Animated.timing(animation, {
                 toValue: 1,
-                duration: 150,
+                duration: 150 * themeAnimation.scale,
                 useNativeDriver: true,
               })
             )
@@ -176,13 +177,13 @@ class FABGroup extends React.Component<Props, State> {
       Animated.parallel([
         Animated.timing(this.state.backdrop, {
           toValue: 0,
-          duration: 200,
+          duration: 200 * themeAnimation.scale,
           useNativeDriver: true,
         }),
         ...this.state.animations.map(animation =>
           Animated.timing(animation, {
             toValue: 0,
-            duration: 150,
+            duration: 150 * themeAnimation.scale,
             useNativeDriver: true,
           })
         ),

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -152,21 +152,21 @@ class FABGroup extends React.Component<Props, State> {
       return;
     }
 
-    const { animation: themeAnimation } = this.props.theme;
+    const { scale } = this.props.theme.animation;
     if (this.props.open) {
       Animated.parallel([
         Animated.timing(this.state.backdrop, {
           toValue: 1,
-          duration: 250 * themeAnimation.scale,
+          duration: 250 * scale,
           useNativeDriver: true,
         }),
         Animated.stagger(
-          50 * themeAnimation.scale,
+          50 * scale,
           this.state.animations
             .map(animation =>
               Animated.timing(animation, {
                 toValue: 1,
-                duration: 150 * themeAnimation.scale,
+                duration: 150 * scale,
                 useNativeDriver: true,
               })
             )
@@ -177,13 +177,13 @@ class FABGroup extends React.Component<Props, State> {
       Animated.parallel([
         Animated.timing(this.state.backdrop, {
           toValue: 0,
-          duration: 200 * themeAnimation.scale,
+          duration: 200 * scale,
           useNativeDriver: true,
         }),
         ...this.state.animations.map(animation =>
           Animated.timing(animation, {
             toValue: 0,
-            duration: 150 * themeAnimation.scale,
+            duration: 150 * scale,
             useNativeDriver: true,
           })
         ),

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -166,9 +166,10 @@ class Snackbar extends React.Component<Props, State> {
     this.setState({
       hidden: false,
     });
+    const { animation } = this.props.theme;
     Animated.timing(this.state.opacity, {
       toValue: 1,
-      duration: 200,
+      duration: 200 * animation.scale,
       useNativeDriver: true,
     }).start(({ finished }) => {
       if (finished) {
@@ -188,10 +189,10 @@ class Snackbar extends React.Component<Props, State> {
     if (this.hideTimeout) {
       clearTimeout(this.hideTimeout);
     }
-
+    const { animation } = this.props.theme;
     Animated.timing(this.state.opacity, {
       toValue: 0,
-      duration: 100,
+      duration: 100 * animation.scale,
       useNativeDriver: true,
     }).start(({ finished }) => {
       if (finished) {

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -166,10 +166,10 @@ class Snackbar extends React.Component<Props, State> {
     this.setState({
       hidden: false,
     });
-    const { animation } = this.props.theme;
+    const { scale } = this.props.theme.animation;
     Animated.timing(this.state.opacity, {
       toValue: 1,
-      duration: 200 * animation.scale,
+      duration: 200 * scale,
       useNativeDriver: true,
     }).start(({ finished }) => {
       if (finished) {
@@ -189,10 +189,10 @@ class Snackbar extends React.Component<Props, State> {
     if (this.hideTimeout) {
       clearTimeout(this.hideTimeout);
     }
-    const { animation } = this.props.theme;
+    const { scale } = this.props.theme.animation;
     Animated.timing(this.state.opacity, {
       toValue: 0,
-      duration: 100 * animation.scale,
+      duration: 100 * scale,
       useNativeDriver: true,
     }).start(({ finished }) => {
       if (finished) {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Following components are using `theme.animation.scale` prop for the animations duration: 
- Header
- FAB 
- Snackbar

### Test plan

All changes were tested in the example app.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
