### PR TITLE
feat: use animation scale on minor animations

### DIFF
--- a/src/components/ActivityIndicator.tsx
+++ b/src/components/ActivityIndicator.tsx
@@ -98,7 +98,13 @@ class ActivityIndicator extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    const { animating, hidesWhenStopped } = this.props;
+    const {
+      animating,
+      hidesWhenStopped,
+      theme: {
+        animation: { scale },
+      },
+    } = this.props;
     const { fade } = this.state;
 
     if (animating !== prevProps.animating) {
@@ -107,7 +113,7 @@ class ActivityIndicator extends React.Component<Props, State> {
       } else if (hidesWhenStopped) {
         // Hide indicator first and then stop rotation
         Animated.timing(fade, {
-          duration: 200,
+          duration: 200 * scale,
           toValue: 0,
           useNativeDriver: true,
           isInteraction: false,
@@ -120,10 +126,11 @@ class ActivityIndicator extends React.Component<Props, State> {
 
   private startRotation = () => {
     const { fade, timer } = this.state;
+    const { scale } = this.props.theme.animation;
 
     // Show indicator
     Animated.timing(fade, {
-      duration: 200,
+      duration: 200 * scale,
       toValue: 1,
       isInteraction: false,
       useNativeDriver: true,

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -64,12 +64,17 @@ class Badge extends React.Component<Props, State> {
   };
 
   componentDidUpdate(prevProps: Props) {
-    const { visible } = this.props;
+    const {
+      visible,
+      theme: {
+        animation: { scale },
+      },
+    } = this.props;
 
     if (visible !== prevProps.visible) {
       Animated.timing(this.state.opacity, {
         toValue: visible ? 1 : 0,
-        duration: 150,
+        duration: 150 * scale,
         useNativeDriver: true,
       }).start();
     }

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -461,27 +461,36 @@ class BottomNavigation extends React.Component<Props, State> {
     }
   }
 
-  private handleKeyboardShow = () =>
+  private handleKeyboardShow = () => {
+    const { scale } = this.props.theme.animation;
     this.setState({ keyboard: true }, () =>
       Animated.timing(this.state.visible, {
         toValue: 0,
-        duration: 150,
+        duration: 150 * scale,
         useNativeDriver: true,
       }).start()
     );
+  };
 
-  private handleKeyboardHide = () =>
+  private handleKeyboardHide = () => {
+    const { scale } = this.props.theme.animation;
     Animated.timing(this.state.visible, {
       toValue: 1,
-      duration: 100,
+      duration: 100 * scale,
       useNativeDriver: true,
     }).start(() => {
       this.setState({ keyboard: false });
     });
+  };
 
   private animateToCurrentIndex = () => {
     const shifting = this.isShifting();
-    const { navigationState } = this.props;
+    const {
+      navigationState,
+      theme: {
+        animation: { scale },
+      },
+    } = this.props;
     const { routes, index } = navigationState;
 
     // Reset the ripple to avoid glitch if it's currently animating
@@ -490,13 +499,13 @@ class BottomNavigation extends React.Component<Props, State> {
     Animated.parallel([
       Animated.timing(this.state.ripple, {
         toValue: 1,
-        duration: shifting ? 400 : 0,
+        duration: shifting ? 400 * scale : 0,
         useNativeDriver: true,
       }),
       ...routes.map((_, i) =>
         Animated.timing(this.state.tabs[i], {
           toValue: i === index ? 1 : 0,
-          duration: shifting ? 150 : 0,
+          duration: shifting ? 150 * scale : 0,
           useNativeDriver: true,
         })
       ),

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -131,18 +131,20 @@ class Button extends React.Component<Props, State> {
 
   private handlePressIn = () => {
     if (this.props.mode === 'contained') {
+      const { scale } = this.props.theme.animation;
       Animated.timing(this.state.elevation, {
         toValue: 8,
-        duration: 200,
+        duration: 200 * scale,
       }).start();
     }
   };
 
   private handlePressOut = () => {
     if (this.props.mode === 'contained') {
+      const { scale } = this.props.theme.animation;
       Animated.timing(this.state.elevation, {
         toValue: 2,
-        duration: 150,
+        duration: 150 * scale,
       }).start();
     }
   };

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -104,17 +104,19 @@ class Card extends React.Component<Props, State> {
   };
 
   private handlePressIn = () => {
+    const { scale } = this.props.theme.animation;
     Animated.timing(this.state.elevation, {
       toValue: 8,
-      duration: 150,
+      duration: 150 * scale,
     }).start();
   };
 
   private handlePressOut = () => {
+    const { scale } = this.props.theme.animation;
     Animated.timing(this.state.elevation, {
       // @ts-ignore
       toValue: this.props.elevation,
-      duration: 150,
+      duration: 150 * scale,
     }).start();
   };
 

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -124,16 +124,18 @@ class Chip extends React.Component<Props, State> {
   };
 
   private handlePressIn = () => {
+    const { scale } = this.props.theme.animation;
     Animated.timing(this.state.elevation, {
       toValue: 4,
-      duration: 200,
+      duration: 200 * scale,
     }).start();
   };
 
   private handlePressOut = () => {
+    const { scale } = this.props.theme.animation;
     Animated.timing(this.state.elevation, {
       toValue: 0,
-      duration: 150,
+      duration: 150 * scale,
     }).start();
   };
 

--- a/src/components/HelperText.tsx
+++ b/src/components/HelperText.tsx
@@ -111,17 +111,19 @@ class HelperText extends React.PureComponent<Props, State> {
   }
 
   private showText = () => {
+    const { scale } = this.props.theme.animation;
     Animated.timing(this.state.shown, {
       toValue: 1,
-      duration: 150,
+      duration: 150 * scale,
       useNativeDriver: true,
     }).start();
   };
 
   private hideText = () => {
+    const { scale } = this.props.theme.animation;
     Animated.timing(this.state.shown, {
       toValue: 0,
-      duration: 180,
+      duration: 180 * scale,
       useNativeDriver: true,
     }).start();
   };

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -105,12 +105,18 @@ class ProgressBar extends React.Component<Props, State> {
   };
 
   private startAnimation = () => {
-    const { indeterminate, progress } = this.props;
+    const {
+      indeterminate,
+      progress,
+      theme: {
+        animation: { scale },
+      },
+    } = this.props;
     const { fade, timer } = this.state;
 
     // Show progress bar
     Animated.timing(fade, {
-      duration: 200,
+      duration: 200 * scale,
       toValue: 1,
       useNativeDriver: true,
       isInteraction: false,
@@ -134,7 +140,7 @@ class ProgressBar extends React.Component<Props, State> {
       Animated.loop(this.indeterminateAnimation).start();
     } else {
       Animated.timing(timer, {
-        duration: 200,
+        duration: 200 * scale,
         toValue: progress ? progress : 0,
         useNativeDriver: true,
         isInteraction: false,
@@ -144,6 +150,7 @@ class ProgressBar extends React.Component<Props, State> {
 
   private stopAnimation = () => {
     const { fade } = this.state;
+    const { scale } = this.props.theme.animation;
 
     // Stop indeterminate animation
     if (this.indeterminateAnimation) {
@@ -151,7 +158,7 @@ class ProgressBar extends React.Component<Props, State> {
     }
 
     Animated.timing(fade, {
-      duration: 200,
+      duration: 200 * scale,
       toValue: 0,
       useNativeDriver: true,
       isInteraction: false,

--- a/src/components/RadioButton/RadioButtonAndroid.tsx
+++ b/src/components/RadioButton/RadioButtonAndroid.tsx
@@ -72,20 +72,20 @@ class RadioButtonAndroid extends React.Component<Props, State> {
     if (prevProps.status === this.props.status) {
       return;
     }
-
+    const { scale } = this.props.theme.animation;
     if (this.props.status === 'checked') {
       this.state.radioAnim.setValue(1.2);
 
       Animated.timing(this.state.radioAnim, {
         toValue: 1,
-        duration: 150,
+        duration: 150 * scale,
       }).start();
     } else {
       this.state.borderAnim.setValue(10);
 
       Animated.timing(this.state.borderAnim, {
         toValue: BORDER_WIDTH,
-        duration: 150,
+        duration: 150 * scale,
       }).start();
     }
   }

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -280,9 +280,10 @@ class TextInput extends React.Component<TextInputProps, State> {
   private root: NativeTextInput | undefined | null;
 
   private showError = () => {
+    const { scale } = this.props.theme.animation;
     Animated.timing(this.state.error, {
       toValue: 1,
-      duration: FOCUS_ANIMATION_DURATION,
+      duration: FOCUS_ANIMATION_DURATION * scale,
       // To prevent this - https://github.com/callstack/react-native-paper/issues/941
       useNativeDriver: Platform.select({
         ios: false,
@@ -292,9 +293,10 @@ class TextInput extends React.Component<TextInputProps, State> {
   };
 
   private hideError = () => {
+    const { scale } = this.props.theme.animation;
     Animated.timing(this.state.error, {
       toValue: 0,
-      duration: BLUR_ANIMATION_DURATION,
+      duration: BLUR_ANIMATION_DURATION * scale,
       // To prevent this - https://github.com/callstack/react-native-paper/issues/941
       useNativeDriver: Platform.select({
         ios: false,
@@ -303,27 +305,31 @@ class TextInput extends React.Component<TextInputProps, State> {
     }).start();
   };
 
-  private restoreLabel = () =>
+  private restoreLabel = () => {
+    const { scale } = this.props.theme.animation;
     Animated.timing(this.state.labeled, {
       toValue: 1,
-      duration: FOCUS_ANIMATION_DURATION,
+      duration: FOCUS_ANIMATION_DURATION * scale,
       // To prevent this - https://github.com/callstack/react-native-paper/issues/941
       useNativeDriver: Platform.select({
         ios: false,
         default: true,
       }),
     }).start();
+  };
 
-  private minimizeLabel = () =>
+  private minimizeLabel = () => {
+    const { scale } = this.props.theme.animation;
     Animated.timing(this.state.labeled, {
       toValue: 0,
-      duration: BLUR_ANIMATION_DURATION,
+      duration: BLUR_ANIMATION_DURATION * scale,
       // To prevent this - https://github.com/callstack/react-native-paper/issues/941
       useNativeDriver: Platform.select({
         ios: false,
         default: true,
       }),
     }).start();
+  };
 
   private handleFocus = (args: any) => {
     if (this.props.disabled || !this.props.editable) {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

`this.props.theme.animation.scale` applied to the following components: 
- Button
- Card
- Chip
- HelperText
- ProgressBar
- RadioButtonAndroid
- TextInput

The animations were scaled mainly for the touch effects and fading in and -out components. This feature will be helpful for disabling all animations using one prop.
