### PR TITLE
fix: disable Modal background when not dismissable

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -188,6 +188,7 @@ class Modal extends React.Component<Props, State> {
         style={StyleSheet.absoluteFill}
       >
         <TouchableWithoutFeedback
+          disabled={!dismissable}
           onPress={dismissable ? this.hideModal : undefined}
         >
           <Animated.View


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Currently, even if not `dismissable` the Modal background is clickable on web (i.e. pointer is cursor). This change disables the background view so it does not get a focus index and the cursor is the default one.

### Test plan

Open Modal with `dismissable={false}` on web and ensure that no pointer cursor is used on the background.
