### PR TITLE
feat(searchbar): add search and clear accessibility labels

### DIFF
--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -96,6 +96,10 @@ type Props = React.ComponentProps<typeof TextInput> & {
  * ```
  */
 class Searchbar extends React.Component<Props> {
+  static defaultProps = {
+    searchAccessibilityLabel: 'search',
+    clearAccessibilityLabel: 'clear',
+  };
   private handleClearPress = () => {
     this.clear();
     this.props.onChangeText && this.props.onChangeText('');

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -18,6 +18,14 @@ import MaterialCommunityIcon from './MaterialCommunityIcon';
 
 type Props = React.ComponentProps<typeof TextInput> & {
   /**
+   * Accessibility label for the button. This is read by the screen reader when the user taps the button.
+   */
+  clearAccessibilityLabel?: string;
+  /**
+   * Accessibility label for the button. This is read by the screen reader when the user taps the button.
+   */
+  searchAccessibilityLabel?: string;
+  /**
    * Hint text shown when the input is empty.
    */
   placeholder?: string;
@@ -131,15 +139,17 @@ class Searchbar extends React.Component<Props> {
 
   render() {
     const {
-      placeholder,
-      onIconPress,
-      icon,
-      value,
-      theme,
-      style,
-      iconColor: customIconColor,
+      clearAccessibilityLabel,
       clearIcon,
+      icon,
+      iconColor: customIconColor,
       inputStyle,
+      onIconPress,
+      placeholder,
+      searchAccessibilityLabel,
+      style,
+      theme,
+      value,
       ...rest
     } = this.props;
     const { colors, roundness, dark, fonts } = theme;
@@ -167,6 +177,9 @@ class Searchbar extends React.Component<Props> {
         ]}
       >
         <IconButton
+          accessibilityTraits="button"
+          accessibilityComponentType="button"
+          accessibilityRole="button"
           borderless
           rippleColor={rippleColor}
           onPress={onIconPress}
@@ -182,6 +195,7 @@ class Searchbar extends React.Component<Props> {
               />
             ))
           }
+          accessibilityLabel={searchAccessibilityLabel}
         />
         <TextInput
           style={[styles.input, { color: textColor, ...font }, inputStyle]}
@@ -202,6 +216,7 @@ class Searchbar extends React.Component<Props> {
         <IconButton
           borderless
           disabled={!value}
+          accessibilityLabel={clearAccessibilityLabel}
           color={value ? iconColor : 'rgba(255, 255, 255, 0)'}
           rippleColor={rippleColor}
           onPress={this.handleClearPress}

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
@@ -39,6 +39,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
     }
   >
     <View
+      accessibilityLabel="search"
       accessibilityRole="button"
       accessibilityStates={Array []}
       accessible={true}
@@ -152,6 +153,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
       underlineColorAndroid="transparent"
     />
     <View
+      accessibilityLabel="clear"
       accessibilityRole="button"
       accessibilityStates={
         Array [

--- a/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
@@ -20,6 +20,7 @@ exports[`renders with placeholder 1`] = `
   }
 >
   <View
+    accessibilityLabel="search"
     accessibilityRole="button"
     accessibilityStates={Array []}
     accessible={true}
@@ -133,6 +134,7 @@ exports[`renders with placeholder 1`] = `
     underlineColorAndroid="transparent"
   />
   <View
+    accessibilityLabel="clear"
     accessibilityRole="button"
     accessibilityStates={
       Array [
@@ -244,6 +246,7 @@ exports[`renders with text 1`] = `
   }
 >
   <View
+    accessibilityLabel="search"
     accessibilityRole="button"
     accessibilityStates={Array []}
     accessible={true}
@@ -358,6 +361,7 @@ exports[`renders with text 1`] = `
     value="query"
   />
   <View
+    accessibilityLabel="clear"
     accessibilityRole="button"
     accessibilityStates={Array []}
     accessible={true}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

We need a way to add a generated accessibility label to the search and clear buttons. The copy changes based on a user's locale settings.

### Test plan

As long as the typescript and eslint checks pass this should be good to go.
