### PR TITLE
feat: add accessibilityLabel to DrawerItem

### DIFF
--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -24,6 +24,10 @@ type Props = {
    * Function to execute on press.
    */
   onPress?: () => void;
+  /**
+   * Accessibility label for the button. This is read by the screen reader when the user taps the button.
+   */
+  accessibilityLabel?: string;
   style?: StyleProp<ViewStyle>;
   /**
    * @optional
@@ -50,7 +54,16 @@ class DrawerItem extends React.Component<Props> {
   static displayName = 'Drawer.Item';
 
   render() {
-    const { icon, label, active, theme, style, onPress, ...rest } = this.props;
+    const {
+      icon,
+      label,
+      active,
+      theme,
+      style,
+      onPress,
+      accessibilityLabel,
+      ...rest
+    } = this.props;
     const { colors, roundness } = theme;
     const backgroundColor = active
       ? color(colors.primary)
@@ -85,6 +98,7 @@ class DrawerItem extends React.Component<Props> {
           accessibilityComponentType="button"
           accessibilityRole="button"
           accessibilityStates={active ? ['selected'] : []}
+          accessibilityLabel={accessibilityLabel}
         >
           <View style={styles.wrapper}>
             {icon ? (


### PR DESCRIPTION
### Motivation
It's not possible to press on a `DrawerItem` using appium without passing an `accessibilityLabel` to the touchable.