### PR TITLE
Clear snackbar timeout when content has changed

### DIFF
--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -142,8 +142,21 @@ class Snackbar extends React.Component<Props, State> {
   componentDidUpdate(prevProps: Props) {
     if (prevProps.visible !== this.props.visible) {
       this.toggle();
+    } else if (this.props.visible && prevProps.children !== this.props.children) {
+      if (this.hideTimeout) {
+        clearTimeout(this.hideTimeout);
+        const { duration } = this.props;
+        const isInfinity =
+          duration === Number.POSITIVE_INFINITY ||
+          duration === Number.NEGATIVE_INFINITY;
+
+        if (!isInfinity) {
+          this.hideTimeout = setTimeout(this.props.onDismiss, duration);
+        }
+      }
     }
   }
+
 
   componentWillUnmount() {
     if (this.hideTimeout) {


### PR DESCRIPTION
I don't know if this is intentional but, currently snackbar doesn't reset it's timeout when we change the snackbar's content while it is visible. This causes the second content to show for a short time.

### Motivation

I'm using single snackbar for a page to keep the code much more cleaner. But if user activates snackbar and does something fast, second content shown for a short time.

### Test plan

Use ne snackbar
Create two buttons that sets the snackbar's content to 2 different texts
Press first button
Press second button just before snackbar's timeout ends
