### PR TITLE
fix: disable Appbar Content when not pressable

### DIFF
--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -80,7 +80,7 @@ class AppbarContent extends React.Component<Props> {
       .string();
 
     return (
-      <TouchableWithoutFeedback onPress={onPress}>
+      <TouchableWithoutFeedback onPress={onPress} disabled={!!onPress}>
         <View style={[styles.container, style]} {...rest}>
           <Text
             ref={titleRef}

--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -80,7 +80,7 @@ class AppbarContent extends React.Component<Props> {
       .string();
 
     return (
-      <TouchableWithoutFeedback onPress={onPress} disabled={!!onPress}>
+      <TouchableWithoutFeedback onPress={onPress} disabled={!onPress}>
         <View style={[styles.container, style]} {...rest}>
           <Text
             ref={titleRef}


### PR DESCRIPTION
### Motivation

Similar to https://github.com/callstack/react-native-paper/pull/1599 the Appbar Content is clickable on web (i.e. pointer is cursor). This change disables the touchable part so it does not get a focus index and the cursor is the default one.

### Test plan

Hover the Appbar Content view and you should not see a pointer cursor.
