### PR TITLE
refactor: remove unused variable in TextInputOutlined

### DIFF
--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -80,12 +80,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps, {}> {
     } = (StyleSheet.flatten(style) || {}) as TextStyle;
     const fontSize = fontSizeStyle || MAXIMIZED_LABEL_FONT_SIZE;
 
-    let inputTextColor,
-      activeColor,
-      outlineColor,
-      placeholderColor,
-      errorColor,
-      containerStyle;
+    let inputTextColor, activeColor, outlineColor, placeholderColor, errorColor;
 
     if (disabled) {
       inputTextColor = activeColor = color(colors.text)
@@ -185,11 +180,11 @@ class TextInputOutlined extends React.Component<ChildTextInputProps, {}> {
     const minHeight = height || (dense ? MIN_DENSE_HEIGHT : MIN_HEIGHT);
 
     return (
-      <View style={[containerStyle, viewStyle]}>
-        {/* 
+      <View style={viewStyle}>
+        {/*
           Render the outline separately from the container
           This is so that the label can overlap the outline
-          Otherwise the border will cut off the label on Android 
+          Otherwise the border will cut off the label on Android
           */}
         <View>
           <Outline


### PR DESCRIPTION
### Motivation
I was just looking over the code and found that `containerStyle` is not been used.