### PR TITLE
feat: RadioButton.Item add labelStyle prop & support themes

### DIFF
--- a/example/src/Examples/RadioButtonGroupExample.tsx
+++ b/example/src/Examples/RadioButtonGroupExample.tsx
@@ -29,7 +29,7 @@ class RadioButtonGroupExample extends React.Component<Props, State> {
   render() {
     const {
       theme: {
-        colors: { background },
+        colors: { background, primary },
       },
     } = this.props;
     return (
@@ -67,6 +67,11 @@ class RadioButtonGroupExample extends React.Component<Props, State> {
           >
             <RadioButton.Item label="First item" value="first" />
             <RadioButton.Item label="Second item" value="second" />
+            <RadioButton.Item
+              label="Third item"
+              value="third"
+              labelStyle={{ color: primary }}
+            />
           </RadioButton.Group>
         </List.Section>
       </View>

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -102,7 +102,7 @@ class RadioButton extends React.Component<Props> {
   // @component ./RadioButtonIOS.tsx
   static IOS = RadioButtonIOS;
 
-  // @component = ./RadioButtonItem.tsx
+  // @component ./RadioButtonItem.tsx
   static Item = RadioButtonItem;
 
   render() {

--- a/src/components/RadioButton/RadioButtonItem.tsx
+++ b/src/components/RadioButton/RadioButtonItem.tsx
@@ -1,9 +1,16 @@
 import * as React from 'react';
-import { View, Text, StyleSheet, StyleProp, ViewStyle } from 'react-native';
+import {
+  View,
+  StyleSheet,
+  StyleProp,
+  ViewStyle,
+  TextStyle,
+} from 'react-native';
 import { RadioButtonContext, RadioButtonContextType } from './RadioButtonGroup';
 import { handlePress } from './utils';
 import TouchableRipple from '../TouchableRipple';
 import RadioButton from './RadioButton';
+import Text from '../Typography/Text';
 
 export type Props = {
   /**
@@ -23,9 +30,13 @@ export type Props = {
    */
   status?: 'checked' | 'unchecked';
   /**
-   * Additional styles for container View
+   * Additional styles for container View.
    */
   style?: StyleProp<ViewStyle>;
+  /**
+   * Style that is passed to Label element.
+   */
+  labelStyle?: StyleProp<TextStyle>;
 };
 
 /**
@@ -60,7 +71,7 @@ class RadioButtonItem extends React.Component<Props> {
   static displayName = 'RadioButton.Item';
 
   render() {
-    const { value, label, style, onPress, status } = this.props;
+    const { value, label, style, labelStyle, onPress, status } = this.props;
 
     return (
       <RadioButtonContext.Consumer>
@@ -76,7 +87,7 @@ class RadioButtonItem extends React.Component<Props> {
               }
             >
               <View style={[styles.container, style]} pointerEvents="none">
-                <Text>{label}</Text>
+                <Text style={[styles.label, labelStyle]}>{label}</Text>
                 <RadioButton value={value} status={status}></RadioButton>
               </View>
             </TouchableRipple>
@@ -96,5 +107,8 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     paddingVertical: 8,
     paddingHorizontal: 16,
+  },
+  label: {
+    fontSize: 16,
   },
 });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

`RadioButton.Item`:

- fix: Label element using `./Typography/Text` instead of `react-native/Text` (to support themes).
- feat: add `labelStyle` prop.
- docs: fix link.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Screenshots from examples.

![RadioButton Item issue@2x](https://user-images.githubusercontent.com/157338/74600495-85b57180-50cd-11ea-9854-7d9cb1632ce8.png)
