### PR TITLE
feat: add `elevation` to Theme type

### DIFF
--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -26,6 +26,10 @@ type Props = Partial<React.ComponentProps<typeof View>> & {
    */
   children: React.ReactNode;
   /**
+   * Resting elevation of the app bar which controls the drop shadow.
+   */
+  elevation?: number;
+  /**
    * @optional
    */
   theme: Theme;
@@ -86,14 +90,25 @@ class Appbar extends React.Component<Props> {
   static Header = AppbarHeader;
 
   render() {
-    const { children, dark, style, theme, ...rest } = this.props;
-
-    const { colors, dark: isDarkTheme, mode } = theme;
     const {
-      backgroundColor: customBackground,
-      elevation = 4,
-      ...restStyle
-    }: ViewStyle = StyleSheet.flatten(style) || {};
+      children,
+      dark,
+      style,
+      theme,
+      elevation: propsElevation,
+      ...rest
+    } = this.props;
+
+    const {
+      colors,
+      dark: isDarkTheme,
+      mode,
+      elevation: themeElevation = 4,
+    } = theme;
+    const { backgroundColor: customBackground, ...restStyle }: ViewStyle =
+      StyleSheet.flatten(style) || {};
+
+    const elevation = propsElevation || themeElevation;
 
     let isDark: boolean;
 
@@ -139,7 +154,12 @@ class Appbar extends React.Component<Props> {
     return (
       <Surface
         //@ts-ignore
-        style={[{ backgroundColor }, styles.appbar, { elevation }, restStyle]}
+        style={[
+          { backgroundColor },
+          styles.appbar,
+          elevation && { elevation },
+          restStyle,
+        ]}
         {...rest}
       >
         {shouldAddLeftSpacing ? <View style={styles.spacing} /> : null}
@@ -189,7 +209,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     paddingHorizontal: 4,
-    elevation: 4,
   },
   spacing: {
     width: 48,

--- a/src/components/Appbar/AppbarHeader.tsx
+++ b/src/components/Appbar/AppbarHeader.tsx
@@ -28,6 +28,10 @@ type Props = React.ComponentProps<typeof Appbar> & {
    */
   statusBarHeight?: number;
   /**
+   * Resting elevation of the app bar header which controls the drop shadow.
+   */
+  elevation?: number;
+  /**
    * Content of the header.
    */
   children: React.ReactNode;
@@ -92,16 +96,25 @@ class AppbarHeader extends React.Component<Props> {
       statusBarHeight = APPROX_STATUSBAR_HEIGHT,
       style,
       dark,
+      elevation: propsElevation,
+      theme,
       ...rest
     } = this.props;
-    const { dark: isDarkTheme, colors, mode } = rest.theme;
+    const {
+      dark: isDarkTheme,
+      colors,
+      mode,
+      elevation: themeElevation,
+    } = theme;
     const {
       height = DEFAULT_APPBAR_HEIGHT,
-      elevation = 4,
       backgroundColor: customBackground,
       zIndex = 0,
       ...restStyle
     }: ViewStyle = StyleSheet.flatten(style) || {};
+
+    const elevation = propsElevation || themeElevation;
+
     const backgroundColor = customBackground
       ? customBackground
       : isDarkTheme && mode === 'adaptive'
@@ -125,7 +138,8 @@ class AppbarHeader extends React.Component<Props> {
       <Wrapper
         style={
           [
-            { backgroundColor, zIndex, elevation },
+            { backgroundColor, zIndex },
+            elevation && { elevation },
             shadow(elevation),
           ] as StyleProp<ViewStyle>
         }

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -100,22 +100,30 @@ class Card extends React.Component<Props, State> {
 
   state = {
     // @ts-ignore
-    elevation: new Animated.Value(this.props.elevation),
+    elevation: new Animated.Value(
+      this.props.elevation || this.props.theme.elevation || 1
+    ),
   };
 
   private handlePressIn = () => {
     const { scale } = this.props.theme.animation;
+    const { elevation: propsElevation } = this.props;
+    const { elevation: themeElevation = 1 } = this.props.theme;
+    const elevation = propsElevation || themeElevation;
     Animated.timing(this.state.elevation, {
-      toValue: 8,
+      toValue: elevation + 8,
       duration: 150 * scale,
     }).start();
   };
 
   private handlePressOut = () => {
     const { scale } = this.props.theme.animation;
+    const { elevation: propsElevation } = this.props;
+    const { elevation: themeElevation = 1 } = this.props.theme;
+    const elevation = propsElevation || themeElevation;
     Animated.timing(this.state.elevation, {
       // @ts-ignore
-      toValue: this.props.elevation,
+      toValue: elevation,
       duration: 150 * scale,
     }).start();
   };
@@ -143,7 +151,11 @@ class Card extends React.Component<Props, State> {
     );
     return (
       <Surface
-        style={[{ borderRadius: roundness, elevation }, style]}
+        style={
+          [{ borderRadius: roundness, elevation }, style] as StyleProp<
+            ViewStyle
+          >
+        }
         {...rest}
       >
         <TouchableWithoutFeedback

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -23,6 +23,10 @@ type Props = $RemoveChildren<typeof Surface> & {
    */
   label?: string;
   /**
+   * Resting elevation of the FAB which controls the drop shadow.
+   */
+  elevation?: number;
+  /**
    * Accessibility label for the FAB. This is read by the screen reader when the user taps the FAB.
    * Uses `label` by default if specified.
    */
@@ -143,9 +147,14 @@ class FAB extends React.Component<Props, State> {
       style,
       visible,
       loading,
+      elevation: propsElevation,
       ...rest
     } = this.props;
     const { visibility } = this.state;
+
+    const { elevation: themeElevation = 6 } = theme;
+
+    const elevation = propsElevation || themeElevation;
 
     const disabledColor = color(theme.dark ? white : black)
       .alpha(0.12)
@@ -190,6 +199,7 @@ class FAB extends React.Component<Props, State> {
               ],
             },
             styles.container,
+            elevation && { elevation },
             disabled && styles.disabled,
             style,
           ] as StyleProp<ViewStyle>

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -49,6 +49,10 @@ type Props = {
    */
   color?: string;
   /**
+   * Resting elevation of the FAB Group which controls the drop shadow.
+   */
+  elevation?: number;
+  /**
    * Function to execute on pressing the `FAB`.
    */
   onPress?: () => void;
@@ -203,11 +207,14 @@ class FABGroup extends React.Component<Props, State> {
       onPress,
       accessibilityLabel,
       theme,
+      elevation: propsElevation,
       style,
       fabStyle,
       visible,
     } = this.props;
-    const { colors } = theme;
+    const { colors, elevation: themeElevation = 6 } = theme;
+
+    const elevation = propsElevation || themeElevation;
 
     const labelColor = theme.dark
       ? colors.text
@@ -269,6 +276,7 @@ class FABGroup extends React.Component<Props, State> {
                       it.onPress();
                       this.close();
                     }}
+                    elevation={elevation}
                     accessibilityLabel={
                       it.accessibilityLabel !== 'undefined'
                         ? it.accessibilityLabel
@@ -299,6 +307,7 @@ class FABGroup extends React.Component<Props, State> {
                     it.onPress();
                     this.close();
                   }}
+                  elevation={elevation}
                   accessibilityLabel={
                     typeof it.accessibilityLabel !== 'undefined'
                       ? it.accessibilityLabel
@@ -318,6 +327,7 @@ class FABGroup extends React.Component<Props, State> {
             }}
             icon={icon}
             color={this.props.color}
+            elevation={elevation}
             accessibilityLabel={accessibilityLabel}
             accessibilityTraits="button"
             accessibilityComponentType="button"

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -30,6 +30,10 @@ type Props = React.ComponentProps<typeof TextInput> & {
    */
   icon?: IconSource;
   /**
+   * Resting elevation of the search bar which controls the drop shadow.
+   */
+  elevation?: number;
+  /**
    * Callback that is called when the text input's text changes.
    */
   onChangeText?: (query: string) => void;
@@ -137,12 +141,21 @@ class Searchbar extends React.Component<Props> {
       value,
       theme,
       style,
+      elevation: propsElevation,
       iconColor: customIconColor,
       clearIcon,
       inputStyle,
       ...rest
     } = this.props;
-    const { colors, roundness, dark, fonts } = theme;
+    const {
+      colors,
+      roundness,
+      dark,
+      fonts,
+      elevation: themeElevation = 4,
+    } = theme;
+
+    const elevation = propsElevation || themeElevation;
     const textColor = colors.text;
     const font = fonts.regular;
     const iconColor =
@@ -160,11 +173,14 @@ class Searchbar extends React.Component<Props> {
 
     return (
       <Surface
-        style={[
-          { borderRadius: roundness, elevation: 4 },
-          styles.container,
-          style,
-        ]}
+        style={
+          [
+            { borderRadius: roundness },
+            styles.container,
+            elevation && { elevation },
+            style,
+          ] as StyleProp<ViewStyle>
+        }
       >
         <IconButton
           borderless

--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -64,8 +64,14 @@ class Surface extends React.Component<Props> {
   render() {
     const { style, theme, ...rest } = this.props;
     const flattenedStyles = StyleSheet.flatten(style) || {};
-    const { elevation = 4 }: ViewStyle = flattenedStyles;
-    const { dark: isDarkTheme, mode, colors } = theme;
+    const { elevation: styleElevation }: ViewStyle = flattenedStyles;
+    const {
+      dark: isDarkTheme,
+      mode,
+      colors,
+      elevation: themeElevation,
+    } = theme;
+    const elevation = styleElevation || themeElevation;
     return (
       <Animated.View
         {...rest}

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -27,6 +27,7 @@ export type Theme = {
   dark: boolean;
   mode?: 'adaptive' | 'exact';
   roundness: number;
+  elevation?: number;
   colors: {
     primary: string;
     background: string;


### PR DESCRIPTION
feat: add `elevation` to Theme type
elevation could be used to apply custom elevation to following components
- Appbar
- Appbar.Header
- Surface
- Card
- FAB
- FAB Group
- Search Bar

feat: Add `elevation` prop to following components
- Appbar
- Appbar.Header
- FAB
- FAB Group
- Search Bar

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
