### PR TITLE
fix: memoize MaterialCommunityIcon

### DIFF
--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -104,13 +104,8 @@ const Icon = ({ source, color, size, theme, ...rest }: Props) => {
   } else if (typeof s === 'string') {
     return (
       <SettingsConsumer>
-        {({ icon }) => {
-          return icon({
-            name: s,
-            color: iconColor,
-            size,
-            direction,
-          });
+        {({ icon: Icon }) => {
+          return <Icon name={s} color={iconColor} size={size} direction={direction} />;
         }}
       </SettingsConsumer>
     );

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -105,7 +105,14 @@ const Icon = ({ source, color, size, theme, ...rest }: Props) => {
     return (
       <SettingsConsumer>
         {({ icon: Icon }) => {
-          return <Icon name={s} color={iconColor} size={size} direction={direction} />;
+          return (
+            <Icon
+              name={s}
+              color={iconColor}
+              size={size}
+              direction={direction}
+            />
+          );
         }}
       </SettingsConsumer>
     );

--- a/src/components/MaterialCommunityIcon.tsx
+++ b/src/components/MaterialCommunityIcon.tsx
@@ -76,28 +76,30 @@ export const accessibilityProps =
         importantForAccessibility: 'no-hide-descendants' as 'no-hide-descendants',
       };
 
-const defaultIcon = ({
+const MaterialCommunityIcon = ({
   name,
   color,
   size,
   direction,
   allowFontScaling,
-}: IconProps) => (
-  <MaterialCommunityIcons
-    allowFontScaling={allowFontScaling}
-    name={name}
-    color={color}
-    size={size}
-    style={[
-      {
-        transform: [{ scaleX: direction === 'rtl' ? -1 : 1 }],
-      },
-      styles.icon,
-    ]}
-    pointerEvents="none"
-    {...accessibilityProps}
-  />
-);
+}: IconProps) => {
+  return (
+    <MaterialCommunityIcons
+      allowFontScaling={allowFontScaling}
+      name={name}
+      color={color}
+      size={size}
+      style={[
+        {
+          transform: [{ scaleX: direction === 'rtl' ? -1 : 1 }],
+        },
+        styles.icon,
+      ]}
+      pointerEvents="none"
+      {...accessibilityProps}
+    />
+  );
+};
 
 const styles = StyleSheet.create({
   icon: {
@@ -105,4 +107,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default defaultIcon;
+export default React.memo(MaterialCommunityIcon);

--- a/src/core/settings.tsx
+++ b/src/core/settings.tsx
@@ -4,7 +4,7 @@ import MaterialCommunityIcon, {
 } from '../components/MaterialCommunityIcon';
 
 export type Settings = {
-  icon: ({ name, color, size, direction }: IconProps) => React.ReactNode;
+  icon: React.FC<IconProps>;
 };
 
 export const { Provider, Consumer } = React.createContext<Settings>({


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

While trying to identify performance bottle necks I found that the Icon is rendered too often because the styles are changing:
https://github.com/callstack/react-native-paper/blob/2a29dc6d6bca0cb8f529b192d2af3a1794e61a2a/src/components/MaterialCommunityIcon.tsx#L93 
This change will memoize the component to prevent unnecessary rerenders.

### Test plan

Nothing should change and icons should behave as usually.
