### PR TITLE
fix: add flexShrink to inner Card container

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -176,6 +176,7 @@ class Card extends React.Component<Props, State> {
 const styles = StyleSheet.create({
   innerContainer: {
     flexGrow: 1,
+    flexShrink: 1,
   },
 });
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

I noticed that the Card somehow behaves strange while resizing  and keeps having the same size. It seems that `flexShrink` was missing. This style change should not have any side-effects.

### Test plan

n/a
