### PR TITLE
docs: clarify color prop for FAB

### DIFF
--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -32,7 +32,7 @@ type Props = $RemoveChildren<typeof Surface> & {
    */
   small?: boolean;
   /**
-   * Custom text color for the `FAB`.
+   * Custom color for the icon and label of the `FAB`.
    */
   color?: string;
   /**

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -32,7 +32,7 @@ type Props = $RemoveChildren<typeof Surface> & {
    */
   small?: boolean;
   /**
-   * Custom color for the `FAB`.
+   * Custom text color for the `FAB`.
    */
   color?: string;
   /**


### PR DESCRIPTION
Explicitly mention that the `color` prop of `FAB` refers to its *text* color (and not its *background* color).