### PR TITLE
feat: add disable prop to RadioButton.Item

### DIFF
--- a/example/src/Examples/RadioButtonExample.tsx
+++ b/example/src/Examples/RadioButtonExample.tsx
@@ -14,7 +14,7 @@ type Props = {
 };
 
 type State = {
-  checked: 'normal' | 'normal-ios' | 'custom';
+  checked: 'normal' | 'normal-ios' | 'custom' | 'item';
 };
 
 class RadioButtonExample extends React.Component<Props, State> {
@@ -67,6 +67,12 @@ class RadioButtonExample extends React.Component<Props, State> {
             </View>
           </View>
         </TouchableRipple>
+        <RadioButton.Item
+          label="Normal 3 - Item"
+          value="item"
+          status={this.state.checked === 'item' ? 'checked' : 'unchecked'}
+          onPress={() => this.setState({ checked: 'item' })}
+        />
         <TouchableRipple onPress={() => this.setState({ checked: 'custom' })}>
           <View style={styles.row}>
             <Paragraph>Custom</Paragraph>
@@ -89,6 +95,18 @@ class RadioButtonExample extends React.Component<Props, State> {
           <Paragraph>Unchecked (Disabled)</Paragraph>
           <RadioButton value="second" status="unchecked" disabled />
         </View>
+        <RadioButton.Item
+          label="Checked - Item (Disabled)"
+          value="item-disabled-first"
+          status="checked"
+          disabled
+        />
+        <RadioButton.Item
+          label="Unchecked - Item (Disabled)"
+          value="item-disabled-second"
+          status="unchecked"
+          disabled
+        />
       </View>
     );
   }

--- a/src/components/RadioButton/RadioButtonItem.tsx
+++ b/src/components/RadioButton/RadioButtonItem.tsx
@@ -32,6 +32,10 @@ export type Props = {
    */
   status?: 'checked' | 'unchecked';
   /**
+   * Whether radio is disabled.
+   */
+  disabled?: boolean;
+  /**
    * Additional styles for container View.
    */
   style?: StyleProp<ViewStyle>;
@@ -85,6 +89,7 @@ class RadioButtonItem extends React.Component<Props> {
       onPress,
       status,
       theme: { colors },
+      disabled,
     } = this.props;
 
     return (
@@ -92,12 +97,16 @@ class RadioButtonItem extends React.Component<Props> {
         {(context?: RadioButtonContextType) => {
           return (
             <TouchableRipple
-              onPress={() =>
-                handlePress({
-                  onPress: onPress,
-                  onValueChange: context?.onValueChange,
-                  value,
-                })
+              onPress={
+                disabled
+                  ? undefined
+                  : () => {
+                      handlePress({
+                        onPress: onPress,
+                        onValueChange: context?.onValueChange,
+                        value,
+                      });
+                    }
               }
             >
               <View style={[styles.container, style]} pointerEvents="none">
@@ -106,7 +115,11 @@ class RadioButtonItem extends React.Component<Props> {
                 >
                   {label}
                 </Text>
-                <RadioButton value={value} status={status}></RadioButton>
+                <RadioButton
+                  value={value}
+                  status={status}
+                  disabled={disabled}
+                ></RadioButton>
               </View>
             </TouchableRipple>
           );


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

`RadioButton(.Android|.IOS)?` has `disabled` prop, but `RadioButton.Item` does not.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

Use example. "Normal 3 - Item", "Checked - Item (Disabled)" and "Unchecked - Item (Disabled)" are made by `RadioButton.Item`.

![RPReplay_Final1583737354 2020-03-09 16_17_39](https://user-images.githubusercontent.com/434227/76190989-aa5ebe00-6221-11ea-85ee-dd4251272662.gif)
