### PR TITLE
feat: added iconStyle prop to allow overrides of icon styling

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -78,6 +78,10 @@ type Props = React.ComponentProps<typeof Surface> & {
    */
   labelStyle?: StyleProp<TextStyle>;
   /**
+   * Style for the icon.
+   */
+  iconStyle?: StyleProp<ViewStyle>;
+  /**
    * @optional
    */
   theme: Theme;
@@ -166,6 +170,7 @@ class Button extends React.Component<Props, State> {
       theme,
       contentStyle,
       labelStyle,
+      iconStyle,
       ...rest
     } = this.props;
     const { colors, roundness } = theme;
@@ -270,7 +275,7 @@ class Button extends React.Component<Props, State> {
         >
           <View style={[styles.content, contentStyle]}>
             {icon && loading !== true ? (
-              <View style={styles.icon}>
+              <View style={[styles.icon, iconStyle]}>
                 <Icon source={icon} size={16} color={textColor} />
               </View>
             ) : null}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -80,7 +80,7 @@ type Props = React.ComponentProps<typeof Surface> & {
   /**
    * Style for the icon.
    */
-  iconStyle?: StyleProp<ViewStyle>;
+  iconStyle?: StyleProp<TextStyle>;
   /**
    * @optional
    */
@@ -276,7 +276,7 @@ class Button extends React.Component<Props, State> {
           <View style={[styles.content, contentStyle]}>
             {icon && loading !== true ? (
               <View style={[styles.icon, iconStyle]}>
-                <Icon source={icon} size={16} color={textColor} />
+                <Icon source={icon} size={iconStyle && (iconStyle as TextStyle).fontSize || 16} color={iconStyle && (iconStyle as TextStyle).color || textColor} />
               </View>
             ) : null}
             {loading ? (

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -276,7 +276,13 @@ class Button extends React.Component<Props, State> {
           <View style={[styles.content, contentStyle]}>
             {icon && loading !== true ? (
               <View style={[styles.icon, iconStyle]}>
-                <Icon source={icon} size={iconStyle && (iconStyle as TextStyle).fontSize || 16} color={iconStyle && (iconStyle as TextStyle).color || textColor} />
+                <Icon
+                  source={icon}
+                  size={(iconStyle && (iconStyle as TextStyle).fontSize) || 16}
+                  color={
+                    (iconStyle && (iconStyle as TextStyle).color) || textColor
+                  }
+                />
               </View>
             ) : null}
             {loading ? (

--- a/src/components/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.js.snap
@@ -144,11 +144,14 @@ exports[`renders button with icon 1`] = `
     >
       <View
         style={
-          Object {
-            "marginLeft": 12,
-            "marginRight": -4,
-            "width": 16,
-          }
+          Array [
+            Object {
+              "marginLeft": 12,
+              "marginRight": -4,
+              "width": 16,
+            },
+            undefined,
+          ]
         }
       >
         <Text


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
There has been a need to customize the icons on a button that may not necessarily be following the Material Guidelines as it is for specific screens and use-cases for a particular user experience.

Some current open issues

* #1725 
* #1718 
* #1659 

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
* Provide the prop into a Button and see that it changes the styling of the icon
```tsx
function CustomButton() {
  return (
    <Button iconStyle={{
      backgroundColor: '#f0f'
    }} icon="calendar">Icon should have a background</Button>
  )
}
```