### PR TITLE
Fix: Update Menu to use FlatList instead of ScrollView

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -12,8 +12,8 @@ import {
   TouchableWithoutFeedback,
   View,
   ViewStyle,
-  ScrollView,
   findNodeHandle,
+  FlatList,
 } from 'react-native';
 
 import { withTheme } from '../../core/theming';
@@ -559,7 +559,12 @@ class Menu extends React.Component<Props, State> {
                   }
                 >
                   {(scrollableMenuHeight && (
-                    <ScrollView>{children}</ScrollView>
+                    <FlatList
+                      data={React.Children.toArray(children)}
+                      renderItem={({ item }) => (
+                        <React.Fragment>{item}</React.Fragment>
+                      )}
+                    />
                   )) || <React.Fragment>{children}</React.Fragment>}
                 </Surface>
               </Animated.View>


### PR DESCRIPTION
Hi React Native Paper team,

I've replaced ScrollView with FlatList which renders items as the user scrolls to improve performance, compared to ScrollView which renders all at once.

### Motivation
I'm attempting to use a few items within the Menu Component ( Timezone settings ) and the large list of items slows down the initial render.

### Test plan
Nothing visual has changed
