### PR TITLE
feat: add labelStyle prop for FABGroup labels

### DIFF
--- a/example/src/Examples/FABExample.tsx
+++ b/example/src/Examples/FABExample.tsx
@@ -22,7 +22,7 @@ class ButtonExample extends React.Component<Props, State> {
   render() {
     const {
       theme: {
-        colors: { background },
+        colors: { background, primary, accent },
       },
     } = this.props;
 
@@ -80,7 +80,15 @@ class ButtonExample extends React.Component<Props, State> {
                 { icon: 'plus', onPress: () => {} },
                 { icon: 'star', label: 'Star', onPress: () => {} },
                 { icon: 'email', label: 'Email', onPress: () => {} },
-                { icon: 'bell', label: 'Remind', onPress: () => {} },
+                {
+                  labelStyle: {
+                    backgroundColor: accent,
+                    color: primary,
+                  },
+                  icon: 'bell',
+                  label: 'Remind',
+                  onPress: () => {},
+                },
               ]}
               onStateChange={({ open }: { open: boolean }) =>
                 this.setState({ open })

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -7,6 +7,7 @@ import {
   TouchableWithoutFeedback,
   View,
   ViewStyle,
+  TextStyle,
 } from 'react-native';
 import color from 'color';
 import FAB from './FAB';
@@ -25,6 +26,7 @@ type Props = {
    * - `accessibilityLabel`: accessibility label for the action, uses label by default if specified
    * - `color`: custom icon color of the action item
    * - `style`: pass additional styles for the fab item, for example, `backgroundColor`
+   * - `labelStyle`: pass additional styles for the fab label container and text, for example, `fontFamily` and 'backgroundColor'
    * - `onPress`: callback that is called when `FAB` is pressed (required)
    */
   actions: Array<{
@@ -33,6 +35,7 @@ type Props = {
     color?: string;
     accessibilityLabel?: string;
     style?: StyleProp<ViewStyle>;
+    labelStyle?: StyleProp<ViewStyle | TextStyle>;
     onPress: () => void;
   }>;
   /**
@@ -263,6 +266,7 @@ class FABGroup extends React.Component<Props, State> {
                           transform: [{ scale: scales[i] }],
                           opacity: opacities[i],
                         },
+                        it.labelStyle,
                       ] as StyleProp<ViewStyle>
                     }
                     onPress={() => {
@@ -278,7 +282,18 @@ class FABGroup extends React.Component<Props, State> {
                     accessibilityComponentType="button"
                     accessibilityRole="button"
                   >
-                    <Text style={{ color: labelColor }}>{it.label}</Text>
+                    <Text
+                      style={
+                        [
+                          {
+                            color: labelColor,
+                          },
+                          it.labelStyle,
+                        ] as StyleProp<TextStyle>
+                      }
+                    >
+                      {it.label}
+                    </Text>
                   </Card>
                 )}
                 <FAB


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

The current implementation of the FABGroup makes it so the FABs in the group can be styled but the labels cannot. This change makes it so the FAB labels can be styled independently of the FAB buttons next to them. The main goal of this change is to be able to style the text in the label but extends to allowing you to style the container of the label as well, though that need may be more niche.

The prop added covers styling both the container for the label and the text inside of the label itself. I can imagine a lot of cases where the FAB button and the label next to it should not be in sync as far as styling (the button may have a colored background but the label may be white for readability).

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

Testing can just be done by passing the `labelStyle` prop to individual actions in the FABGroup. The prop takes `ViewStyle` and `TextStyle` properties which should not overlap but would be the biggest point of failure on this change if they did since you could somehow end up with conflicts in styles. 

<img width="584" alt="image" src="https://user-images.githubusercontent.com/5879831/77198110-c2093280-6abc-11ea-845b-878e0472658f.png">
