### PR TITLE
fix: expose ref type

### DIFF
--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -5,7 +5,7 @@ import { withTheme } from '../core/theming';
 import { Theme } from '../types';
 import overlay from '../styles/overlay';
 
-type Props = React.ComponentProps<typeof View> & {
+type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Content of the `Surface`.
    */


### PR DESCRIPTION
### Motivation

Currently, it is not possible to pass `ref` to Surfaces (i.e. also Buttons).

### Test plan

Use `Button`, pass `ref` to it and no typing errors should be there.
