### PR TITLE
fix: expose ref on DrawerItem

### DIFF
--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -7,7 +7,7 @@ import TouchableRipple from '../TouchableRipple';
 import { withTheme } from '../../core/theming';
 import { Theme } from '../../types';
 
-type Props = {
+type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * The label text of the item.
    */


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Currently, it is not possible to pass ref to DrawerItem.

### Test plan

Use DrawerItem, pass ref to it and no typing errors should be there.
