### PR TITLE
Feat: DataTableCell move numberOfLines to defaultProps

### DIFF
--- a/src/components/DataTable/DataTableCell.tsx
+++ b/src/components/DataTable/DataTableCell.tsx
@@ -18,20 +18,26 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
    */
   onPress?: () => void;
   style?: StyleProp<ViewStyle>;
+  /**
+   * Strict material ui guidelines only shows 1 line per cells
+   */
+  numberOfLines?: number;
 };
 
 class DataTableCell extends React.Component<Props> {
   static displayName = 'DataTable.Cell';
-
+  static defaultProps = {
+    numberOfLines: 1,
+  };
   render() {
-    const { children, style, numeric, ...rest } = this.props;
+    const { children, style, numeric, numberOfLines, ...rest } = this.props;
 
     return (
       <TouchableRipple
         {...rest}
         style={[styles.container, numeric && styles.right, style]}
       >
-        <Text numberOfLines={1}>{children}</Text>
+        <Text numberOfLines={numberOfLines}>{children}</Text>
       </TouchableRipple>
     );
   }


### PR DESCRIPTION
Adding a feature to allow edition of numberOfLines

### Motivation

After a talk with @satya164 , it seems that this can be done to allow the rendering of many lines in a datagrid cell.

### Test plan

Create a cell with long content, it will be truncated, then increase the number of lines or just set it to 0 to see the full content.