### PR TITLE
Fix: fix visible props not being applied to Fab actions

### DIFF
--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -287,34 +287,36 @@ class FABGroup extends React.Component<Props, State> {
                     <Text style={{ color: labelColor }}>{it.label}</Text>
                   </Card>
                 )}
-                <FAB
-                  small
-                  icon={it.icon}
-                  color={it.color}
-                  style={
-                    [
-                      {
-                        transform: [{ scale: scales[i] }],
-                        opacity: opacities[i],
-                        backgroundColor: theme.colors.surface,
-                      },
-                      it.style,
-                    ] as StyleProp<ViewStyle>
-                  }
-                  onPress={() => {
-                    it.onPress();
-                    this.close();
-                  }}
-                  accessibilityLabel={
-                    typeof it.accessibilityLabel !== 'undefined'
-                      ? it.accessibilityLabel
-                      : it.label
-                  }
-                  accessibilityTraits="button"
-                  accessibilityComponentType="button"
-                  accessibilityRole="button"
-                  testID={it.testID}
-                />
+                {(visible === undefined || visible) && (
+                  <FAB
+                    small
+                    icon={it.icon}
+                    color={it.color}
+                    style={
+                      [
+                        {
+                          transform: [{ scale: scales[i] }],
+                          opacity: opacities[i],
+                          backgroundColor: theme.colors.surface,
+                        },
+                        it.style,
+                      ] as StyleProp<ViewStyle>
+                    }
+                    onPress={() => {
+                      it.onPress();
+                      this.close();
+                    }}
+                    accessibilityLabel={
+                      typeof it.accessibilityLabel !== 'undefined'
+                        ? it.accessibilityLabel
+                        : it.label
+                    }
+                    accessibilityTraits="button"
+                    accessibilityComponentType="button"
+                    accessibilityRole="button"
+                    testID={it.testID}
+                  />
+                )}
               </View>
             ))}
           </View>


### PR DESCRIPTION
### Motivation

When using `<Portal>` and `<Fab.Group />` with `visible` props, only the Fab main button get hidden before the page transition.

### Test plan

Using react-navigation 5, use `isFocus` on a `<FabGroup />`.

- Without it: it will keep the FAB icon
- With it: it will hide the FAB icon at the same time as the Fab group icon