### PR TITLE
Feat: Added loading props to show activity indicator on drawer items

### DIFF
--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { View, StyleSheet, StyleProp, ViewStyle } from 'react-native';
 import Text from '../Typography/Text';
 import Icon, { IconSource } from '../Icon';
+import ActivityIndicator from '../Icon';
 import TouchableRipple from '../TouchableRipple';
 import { withTheme } from '../../core/theming';
 import { Theme } from '../../types';
@@ -33,6 +34,10 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
    * @optional
    */
   theme: Theme;
+  /**
+   * Whether to show a loading indicator.
+   */
+  loading?: boolean;
 };
 
 /**
@@ -62,6 +67,7 @@ class DrawerItem extends React.Component<Props> {
       style,
       onPress,
       accessibilityLabel,
+      loading,
       ...rest
     } = this.props;
     const { colors, roundness } = theme;
@@ -101,9 +107,9 @@ class DrawerItem extends React.Component<Props> {
           accessibilityLabel={accessibilityLabel}
         >
           <View style={styles.wrapper}>
-            {icon ? (
+            {icon && (
               <Icon source={icon} size={24} color={contentColor} />
-            ) : null}
+            )}
             <Text
               numberOfLines={1}
               style={[
@@ -117,6 +123,13 @@ class DrawerItem extends React.Component<Props> {
             >
               {label}
             </Text>
+            {loading ? (
+              <ActivityIndicator
+                size={16}
+                color={contentColor}
+                style={styles.icon}
+              />
+            ) : null}
           </View>
         </TouchableRipple>
       </View>
@@ -136,6 +149,12 @@ const styles = StyleSheet.create({
   },
   label: {
     marginRight: 32,
+  },
+  icon: {
+    position: 'absolute',
+    width: 16,
+    marginRight: 12,
+    right: 0,
   },
 });
 


### PR DESCRIPTION
- Added a loading indicator to the component (tested on web/ios/native)

### Motivation

I am having a logout link in my Drawer and it is asynchronous task, this feature was missing so I did copy the `DrawerItem.ts` in my source code and added this.

I tought this would be appreciated by others, feel free to accept or refuse the feature.

To me, this is especially useful for the web, because the sidebar is docked on the left, while on mobile, the menu is closed directly after the click.

### Test plan

Do `<DrawerItem loading={true} />` , it will display:


![image](https://user-images.githubusercontent.com/1866564/77854069-1e352a80-7212-11ea-8169-b48996f910c7.png)
