### PR TITLE
fix: warning requesting `useNativeDriver` config

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -139,6 +139,7 @@ class Button extends React.Component<Props, State> {
       Animated.timing(this.state.elevation, {
         toValue: 8,
         duration: 200 * scale,
+        useNativeDriver: false
       }).start();
     }
   };
@@ -149,6 +150,7 @@ class Button extends React.Component<Props, State> {
       Animated.timing(this.state.elevation, {
         toValue: 2,
         duration: 150 * scale,
+        useNativeDriver: false
       }).start();
     }
   };

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -139,7 +139,7 @@ class Button extends React.Component<Props, State> {
       Animated.timing(this.state.elevation, {
         toValue: 8,
         duration: 200 * scale,
-        useNativeDriver: false
+        useNativeDriver: false,
       }).start();
     }
   };
@@ -150,7 +150,7 @@ class Button extends React.Component<Props, State> {
       Animated.timing(this.state.elevation, {
         toValue: 2,
         duration: 150 * scale,
-        useNativeDriver: false
+        useNativeDriver: false,
       }).start();
     }
   };


### PR DESCRIPTION
Fixes #1782

After React Native update to version 0.62, a new warning is visible whenever a Button imported from this lib is clicked, requesting to set `useNativeDriver` property explicity in the animation config for this action.

```
Animated: useNativeDriver was not specified. This is a required option and must be explicitly set to true or false
```

### Motivation

This Pull Request sets the `useNativeDriver` flag explicitly to `false` so the warning stops showing.

### Test plan

- Start a new project with React Native version 0.62
- Install `react-native-paper` to the project
- Add the Paper Provider so themes can be available
- Add a Button to the screen with `import { Button } from 'react-native-paper';`
- Run the app and click it
- See the warning in the emulator/simulator/device and in the console
