### PR TITLE
fix: pass useNativeDriver to all animations

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -151,6 +151,7 @@ class Banner extends React.Component<Props, State> {
     Animated.timing(this.state.position, {
       duration: 250 * scale,
       toValue: 1,
+      useNativeDriver: false,
     }).start();
   };
 
@@ -159,6 +160,7 @@ class Banner extends React.Component<Props, State> {
     Animated.timing(this.state.position, {
       duration: 200 * scale,
       toValue: 0,
+      useNativeDriver: false,
     }).start();
   };
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -110,6 +110,7 @@ class Card extends React.Component<Props, State> {
     Animated.timing(this.state.elevation, {
       toValue: 8,
       duration: 150 * scale,
+      useNativeDriver: true,
     }).start();
   };
 
@@ -119,6 +120,7 @@ class Card extends React.Component<Props, State> {
       // @ts-ignore
       toValue: this.props.elevation,
       duration: 150 * scale,
+      useNativeDriver: true,
     }).start();
   };
 

--- a/src/components/CheckboxAndroid.tsx
+++ b/src/components/CheckboxAndroid.tsx
@@ -74,12 +74,14 @@ class CheckboxAndroid extends React.Component<Props, State> {
       Animated.timing(this.state.scaleAnim, {
         toValue: 0.85,
         duration: checked ? ANIMATION_DURATION * animation.scale : 0,
+        useNativeDriver: false,
       }),
       Animated.timing(this.state.scaleAnim, {
         toValue: 1,
         duration: checked
           ? ANIMATION_DURATION * animation.scale
           : ANIMATION_DURATION * animation.scale * 1.75,
+        useNativeDriver: false,
       }),
     ]).start();
   }

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -128,6 +128,7 @@ class Chip extends React.Component<Props, State> {
     Animated.timing(this.state.elevation, {
       toValue: 4,
       duration: 200 * scale,
+      useNativeDriver: true,
     }).start();
   };
 
@@ -136,6 +137,7 @@ class Chip extends React.Component<Props, State> {
     Animated.timing(this.state.elevation, {
       toValue: 0,
       duration: 150 * scale,
+      useNativeDriver: true,
     }).start();
   };
 

--- a/src/components/CrossFadeIcon.tsx
+++ b/src/components/CrossFadeIcon.tsx
@@ -68,6 +68,7 @@ class CrossFadeIcon extends React.Component<Props, State> {
     Animated.timing(this.state.fade, {
       duration: scale * 200,
       toValue: 0,
+      useNativeDriver: true,
     }).start();
   }
 


### PR DESCRIPTION
### Motivation

Running animations without explicitly passing `useNativeDriver` property on React-Native > 0.60 is causing warnings.

### Test plan

Run the example app and check if animations work as expected.
