### PR TITLE
fix: fix warning when animating without passing useNativeDriver

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -151,6 +151,7 @@ class Banner extends React.Component<Props, State> {
     Animated.timing(this.state.position, {
       duration: 250 * scale,
       toValue: 1,
+      useNativeDriver: false,
     }).start();
   };
 
@@ -159,6 +160,7 @@ class Banner extends React.Component<Props, State> {
     Animated.timing(this.state.position, {
       duration: 200 * scale,
       toValue: 0,
+      useNativeDriver: false,
     }).start();
   };
 

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -139,6 +139,7 @@ class Button extends React.Component<Props, State> {
       Animated.timing(this.state.elevation, {
         toValue: 8,
         duration: 200 * scale,
+        useNativeDriver: false,
       }).start();
     }
   };
@@ -149,6 +150,7 @@ class Button extends React.Component<Props, State> {
       Animated.timing(this.state.elevation, {
         toValue: 2,
         duration: 150 * scale,
+        useNativeDriver: false,
       }).start();
     }
   };

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -110,6 +110,7 @@ class Card extends React.Component<Props, State> {
     Animated.timing(this.state.elevation, {
       toValue: 8,
       duration: 150 * scale,
+      useNativeDriver: false,
     }).start();
   };
 
@@ -119,6 +120,7 @@ class Card extends React.Component<Props, State> {
       // @ts-ignore
       toValue: this.props.elevation,
       duration: 150 * scale,
+      useNativeDriver: false,
     }).start();
   };
 

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -128,6 +128,7 @@ class Chip extends React.Component<Props, State> {
     Animated.timing(this.state.elevation, {
       toValue: 4,
       duration: 200 * scale,
+      useNativeDriver: false,
     }).start();
   };
 
@@ -136,6 +137,7 @@ class Chip extends React.Component<Props, State> {
     Animated.timing(this.state.elevation, {
       toValue: 0,
       duration: 150 * scale,
+      useNativeDriver: false,
     }).start();
   };
 

--- a/src/components/CrossFadeIcon.tsx
+++ b/src/components/CrossFadeIcon.tsx
@@ -68,6 +68,7 @@ class CrossFadeIcon extends React.Component<Props, State> {
     Animated.timing(this.state.fade, {
       duration: scale * 200,
       toValue: 0,
+      useNativeDriver: false,
     }).start();
   }
 


### PR DESCRIPTION
We pass false in all animations just to not break users who are still on RN < 0.60. This is gonna be changed to true in 4.0 version.
