### PR TITLE
fix: card title with 1 line only

### DIFF
--- a/src/components/Card/CardTitle.tsx
+++ b/src/components/Card/CardTitle.tsx
@@ -22,6 +22,10 @@ type Props = React.ComponentProps<typeof View> & {
    */
   titleStyle?: StyleProp<TextStyle>;
   /**
+   * Number of line for the title.
+   */
+  titleNumberOfLines?: number;
+  /**
    * Text for the subtitle. Note that this will only accept a string or `<Text>`-based node.
    */
   subtitle?: React.ReactNode;
@@ -109,6 +113,7 @@ class CardTitle extends React.Component<Props> {
       style,
       title,
       titleStyle,
+      titleNumberOfLines,
     } = this.props;
 
     return (
@@ -135,6 +140,7 @@ class CardTitle extends React.Component<Props> {
                 { marginBottom: subtitle ? 0 : 2 },
                 titleStyle,
               ]}
+              numberOfLines={titleNumberOfLines}
             >
               {title}
             </Title>

--- a/src/components/Card/CardTitle.tsx
+++ b/src/components/Card/CardTitle.tsx
@@ -98,6 +98,7 @@ class CardTitle extends React.Component<Props> {
   static displayName = 'Card.Title';
 
   static defaultProps = {
+    titleNumberOfLines: 1,
     subtitleNumberOfLines: 1,
   };
 

--- a/src/components/Card/CardTitle.tsx
+++ b/src/components/Card/CardTitle.tsx
@@ -22,10 +22,6 @@ type Props = React.ComponentProps<typeof View> & {
    */
   titleStyle?: StyleProp<TextStyle>;
   /**
-   * Number of line for the title.
-   */
-  titleNumberOfLines?: number;
-  /**
    * Text for the subtitle. Note that this will only accept a string or `<Text>`-based node.
    */
   subtitle?: React.ReactNode;
@@ -98,7 +94,6 @@ class CardTitle extends React.Component<Props> {
   static displayName = 'Card.Title';
 
   static defaultProps = {
-    titleNumberOfLines: 1,
     subtitleNumberOfLines: 1,
   };
 
@@ -114,7 +109,6 @@ class CardTitle extends React.Component<Props> {
       style,
       title,
       titleStyle,
-      titleNumberOfLines,
     } = this.props;
 
     return (
@@ -141,7 +135,7 @@ class CardTitle extends React.Component<Props> {
                 { marginBottom: subtitle ? 0 : 2 },
                 titleStyle,
               ]}
-              numberOfLines={titleNumberOfLines}
+              numberOfLines={1}
             >
               {title}
             </Title>


### PR DESCRIPTION
### Motivation
Card titles should be always **1** line. Per https://github.com/callstack/react-native-paper/pull/1576 discussion.

![card](https://user-images.githubusercontent.com/5667514/79005826-5ba48c80-7b1d-11ea-8e61-eb6f9344c8b2.png)
