### PR TITLE
fix Portal.tsx example snack

### DIFF
--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -34,21 +34,12 @@ type Props = {
  *   render() {
  *     return (
  *       <Provider>
- *       
- *         <View style={{
- *           flex: 1,
- *           justifyContent: 'center',
- *           alignContent: 'center'
- *         }}>
- *           <Text style={{
- *             textAlign: 'center'
- *           }}>This is rendered in the normal place</Text>
+ *         <View>
+ *           <Text>This is rendered in the normal place</Text>
  *         </View>
- *       
  *        <Portal>
  *           <Text>This is rendered at a different place</Text>
  *        </Portal>
- *
  *      </Provider>
  *    );
  *  }

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -27,16 +27,31 @@ type Props = {
  * ## Usage
  * ```js
  * import * as React from 'react';
- * import { Portal, Text } from 'react-native-paper';
- *
+ * import { Provider, Portal, Text } from 'react-native-paper';
+ * import { View } from 'react-native';
+ * 
  * export default class MyComponent extends React.Component {
  *   render() {
  *     return (
- *       <Portal>
- *         <Text>This is rendered at a different place</Text>
- *       </Portal>
- *     );
- *   }
+ *       <Provider>
+ *       
+ *         <View style={{
+ *           flex: 1,
+ *           justifyContent: 'center',
+ *           alignContent: 'center'
+ *         }}>
+ *           <Text style={{
+ *             textAlign: 'center'
+ *           }}>This is rendered in the normal place</Text>
+ *         </View>
+ *       
+ *        <Portal>
+ *           <Text>This is rendered at a different place</Text>
+ *        </Portal>
+ *
+ *      </Provider>
+ *    );
+ *  }
  * }
  * ```
  */


### PR DESCRIPTION
Made changes to example snack so that it works again

Example snack was giving the error:

```
Looks like you forgot to wrap your root component with `Provider` component from `react-native-paper`.
```

Solution: Wrapped the root component with Provider and added a couple of react-native components in the normal flow for contrast.