### PR TITLE
fix: useNativeDriver warning from CheckboxAndroid component

### DIFF
--- a/src/components/CheckboxAndroid.tsx
+++ b/src/components/CheckboxAndroid.tsx
@@ -74,12 +74,14 @@ class CheckboxAndroid extends React.Component<Props, State> {
       Animated.timing(this.state.scaleAnim, {
         toValue: 0.85,
         duration: checked ? ANIMATION_DURATION * animation.scale : 0,
+        useNativeDriver: false,
       }),
       Animated.timing(this.state.scaleAnim, {
         toValue: 1,
         duration: checked
           ? ANIMATION_DURATION * animation.scale
           : ANIMATION_DURATION * animation.scale * 1.75,
+        useNativeDriver: false,
       }),
     ]).start();
   }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Fix useNativeDriver warning from CheckboxAndroid component. All other places are already fixed by #1796 but this one might have been forgotten.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Check whether useNativeDriver warning is going away from Checkbox component on Android.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
