### PR TITLE
feat: allow custom image component

### DIFF
--- a/src/components/Avatar/AvatarImage.tsx
+++ b/src/components/Avatar/AvatarImage.tsx
@@ -1,27 +1,21 @@
 import * as React from 'react';
-import {
-  Image,
-  StyleSheet,
-  View,
-  ViewStyle,
-  StyleProp,
-  ImageSourcePropType,
-} from 'react-native';
+import { Image, StyleSheet, View, ViewStyle, StyleProp } from 'react-native';
 import { withTheme } from '../../core/theming';
 import { Theme } from '../../types';
 
 const defaultSize = 64;
 
-type Props = {
-  /**
-   * Image to display for the `Avatar`.
-   */
-  source: ImageSourcePropType;
+type Props = React.ComponentProps<typeof Image> & {
   /**
    * Size of the avatar.
    */
   size?: number;
   style?: StyleProp<ViewStyle>;
+  /**
+   * Override default image component. The default Image props are provided.
+   * @optional
+   */
+  ImageComponent?: React.ComponentType<any>;
   /**
    * @optional
    */
@@ -55,11 +49,20 @@ class AvatarImage extends React.Component<Props> {
   };
 
   render() {
-    const { size = defaultSize, source, style, theme } = this.props;
+    const {
+      size = defaultSize,
+      style,
+      theme,
+      ImageComponent,
+      source,
+      ...rest
+    } = this.props;
     const { colors } = theme;
 
     const { backgroundColor = colors.primary } =
       StyleSheet.flatten(style) || {};
+
+    const ImageOverridden = ImageComponent || Image;
 
     return (
       <View
@@ -73,7 +76,8 @@ class AvatarImage extends React.Component<Props> {
           style,
         ]}
       >
-        <Image
+        <ImageOverridden
+          {...rest}
           source={source}
           style={{ width: size, height: size, borderRadius: size / 2 }}
         />

--- a/src/components/Card/CardCover.tsx
+++ b/src/components/Card/CardCover.tsx
@@ -15,6 +15,11 @@ type Props = React.ComponentProps<typeof Image> & {
   total?: number;
   style?: StyleProp<ViewStyle>;
   /**
+   * Override default image component. The default Image props are provided.
+   * @optional
+   */
+  ImageComponent?: React.ComponentType<any>;
+  /**
    * @optional
    */
   theme: Theme;
@@ -43,8 +48,10 @@ class CardCover extends React.Component<Props> {
   static displayName = 'Card.Cover';
 
   render() {
-    const { index, total, style, theme, ...rest } = this.props;
+    const { index, total, style, theme, ImageComponent, ...rest } = this.props;
     const { roundness } = theme;
+
+    const ImageOverridden = ImageComponent || Image;
 
     let coverStyle;
 
@@ -67,7 +74,7 @@ class CardCover extends React.Component<Props> {
 
     return (
       <View style={[styles.container, coverStyle, style]}>
-        <Image {...rest} style={[styles.image, coverStyle]} />
+        <ImageOverridden {...rest} style={[styles.image, coverStyle]} />
       </View>
     );
   }


### PR DESCRIPTION
### Motivation

This will allow to use custom component to render images (eg. react-native-fast-image).
It`s based on the `VirtualizedList` and the props `ListHeaderComponent`, `ListEmptyComponent` and `ListFooterComponent`.
