### PR TITLE
fix: fix menu item height

### DIFF
--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -122,9 +122,11 @@ const iconWidth = 40;
 
 const styles = StyleSheet.create({
   container: {
-    padding: 8,
+    paddingHorizontal: 8,
     minWidth,
     maxWidth,
+    height: 48,
+    justifyContent: 'center',
   },
   row: {
     flexDirection: 'row',
@@ -136,7 +138,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
   },
   item: {
-    margin: 8,
+    marginHorizontal: 8,
   },
   content: {
     justifyContent: 'center',


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

the current implementation of MenuItem does not completely follow the material spec: https://material.io/components/menus#specs

height of item should be 48, but with the current code it is not enforced, and is different.

### Test plan

tested locally

this PR

<img src="https://user-images.githubusercontent.com/1566403/79699578-a9916100-8290-11ea-86e5-4830dbd73db6.png" width="200" />

master branch

<img src="https://user-images.githubusercontent.com/1566403/79699577-a8603400-8290-11ea-8759-581c7658d72e.png" width="200" />


