### PR TITLE
feat: export icon (#1694)

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -28,6 +28,6 @@
     "del-cli": "^3.0.0",
     "file-loader": "^4.2.0",
     "metro-react-native-babel-preset": "^0.56.0",
-    "url-loader": "^2.2.0"
+    "url-loader": "^4.1.0"
   }
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -4599,6 +4599,15 @@ loader-utils@^1.4.0:
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
+loader-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.0.tgz#e4cace5b816d425a166b5f097e10cd12b36064b0"
+  integrity sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^2.1.2"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -4929,6 +4938,18 @@ mime-db@1.40.0:
   version "1.40.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
   integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
+
+mime-db@1.43.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.43.0.tgz#0a12e0502650e473d735535050e7c8f4eb4fae58"
+  integrity sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==
+
+mime-types@^2.1.26:
+  version "2.1.26"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.26.tgz#9c921fc09b7e149a65dfdc0da4d20997200b0a06"
+  integrity sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==
+  dependencies:
+    mime-db "1.43.0"
 
 mime-types@~2.1.24:
   version "2.1.24"
@@ -6460,7 +6481,7 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.0.0, schema-utils@^2.4.1:
+schema-utils@^2.0.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.5.0.tgz#8f254f618d402cc80257486213c8970edfd7c22f"
   integrity sha512-32ISrwW2scPXHUSusP8qMg5dLUawKkyV+/qIEV9JdXKx+rsM6mi8vZY8khg2M69Qom16rtroWXD3Ybtiws38gQ==
@@ -6468,7 +6489,7 @@ schema-utils@^2.0.0, schema-utils@^2.4.1:
     ajv "^6.10.2"
     ajv-keywords "^3.4.1"
 
-schema-utils@^2.5.0, schema-utils@^2.6.0:
+schema-utils@^2.5.0, schema-utils@^2.6.0, schema-utils@^2.6.5:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.5.tgz#c758f0a7e624263073d396e29cd40aa101152d8a"
   integrity sha512-5KXuwKziQrTVHh8j/Uxz+QUbxkaLW9X/86NBlx/gnKgtsZA2GIVMUn17qWhRFwF8jdYb3Dig5hRO/W5mZqy6SQ==
@@ -7409,14 +7430,14 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-url-loader@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-2.2.0.tgz#af321aece1fd0d683adc8aaeb27829f29c75b46e"
-  integrity sha512-G8nk3np8ZAnwhHXas1JxJEwJyQdqFXAKJehfgZ/XrC48volFBRtO+FIKtF2u0Ma3bw+4vnDVjHPAQYlF9p2vsw==
+url-loader@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-4.1.0.tgz#c7d6b0d6b0fccd51ab3ffc58a78d32b8d89a7be2"
+  integrity sha512-IzgAAIC8wRrg6NYkFIJY09vtktQcsvU8V6HhtQj9PTefbYImzLB1hufqo4m+RyM5N3mLx5BqJKccgxJS+W3kqw==
   dependencies:
-    loader-utils "^1.2.3"
-    mime "^2.4.4"
-    schema-utils "^2.4.1"
+    loader-utils "^2.0.0"
+    mime-types "^2.1.26"
+    schema-utils "^2.6.5"
 
 url@^0.11.0:
   version "0.11.0"

--- a/example/package.json
+++ b/example/package.json
@@ -30,7 +30,7 @@
     "react-native-reanimated": "~1.8.0",
     "react-native-safe-area-context": "0.7.3",
     "react-native-safe-area-view": "^0.14.6",
-    "react-native-screens": "~2.2.0",
+    "react-native-screens": "~2.5.0",
     "react-native-vector-icons": "^6.6.0",
     "react-native-web": "^0.11.7",
     "typeface-roboto": "^0.0.54"

--- a/example/package.json
+++ b/example/package.json
@@ -13,7 +13,7 @@
   "main": "node_modules/expo/AppEntry.js",
   "dependencies": {
     "@callstack/react-theme-provider": "^3.0.2",
-    "@react-native-community/masked-view": "0.1.7",
+    "@react-native-community/masked-view": "0.1.8",
     "@react-navigation/drawer": "^5.0.0",
     "@react-navigation/native": "^5.0.0",
     "@react-navigation/stack": "^5.0.0",

--- a/example/package.json
+++ b/example/package.json
@@ -27,7 +27,7 @@
     "react-lifecycles-compat": "^3.0.4",
     "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.0.tar.gz",
     "react-native-gesture-handler": "~1.6.0",
-    "react-native-reanimated": "~1.7.1",
+    "react-native-reanimated": "~1.8.0",
     "react-native-safe-area-context": "0.7.3",
     "react-native-safe-area-view": "^0.14.6",
     "react-native-screens": "~2.2.0",

--- a/example/src/ExampleList.tsx
+++ b/example/src/ExampleList.tsx
@@ -18,6 +18,7 @@ import DataTableExample from './Examples/DataTableExample';
 import DialogExample from './Examples/DialogExample';
 import DividerExample from './Examples/DividerExample';
 import FABExample from './Examples/FABExample';
+import IconExample from './Examples/IconExample';
 import IconButtonExample from './Examples/IconButtonExample';
 import ListAccordionExample from './Examples/ListAccordionExample';
 import ListAccordionExampleGroup from './Examples/ListAccordionGroupExample';
@@ -53,6 +54,7 @@ export const examples: Record<
   dialog: DialogExample,
   divider: DividerExample,
   fab: FABExample,
+  icon: IconExample,
   iconButton: IconButtonExample,
   listAccordion: ListAccordionExample,
   listAccordionGroup: ListAccordionExampleGroup,

--- a/example/src/Examples/IconExample.tsx
+++ b/example/src/Examples/IconExample.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+
+import { Colors, Icon, Theme, withTheme } from 'react-native-paper';
+import { StyleSheet, View } from 'react-native';
+
+type Props = {
+  theme: Theme;
+};
+
+type State = {
+  loading: boolean;
+};
+
+class IconExample extends React.Component<Props, State> {
+  static title = 'Icon';
+
+  render() {
+    const { colors } = this.props.theme;
+
+    return (
+      <View style={[styles.container, { backgroundColor: colors.background }]}>
+        <Icon source="camera" size={20} color={Colors.green500} />
+        <Icon source="heart" size={24} color={Colors.red500} />
+        <Icon source="lock" size={36} color={Colors.blue500} />
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    flexDirection: 'row',
+    padding: 8,
+  },
+});
+
+export default withTheme(IconExample);

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2029,10 +2029,10 @@
     wcwidth "^1.0.1"
     ws "^1.1.0"
 
-"@react-native-community/masked-view@0.1.7":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.7.tgz#a65ce0702f55cb67fd777995de6fc7b3e5781903"
-  integrity sha512-9KbP7LTLFz9dx1heURJbO6nuVMdSjDez8znlrUzaB1nUwKVsTTwlKRuHxGUYIIkReLWrJQeCv9tidy+84z2eCw==
+"@react-native-community/masked-view@0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.8.tgz#05c9c800f258274a34abd584596464b86fbd92dc"
+  integrity sha512-y+mnsPPC4Etzs/waHIC9Pj3DwhVQGqVru0n1KSqHZc0moKNAZ0NRBWYVat9awLIjjVrnepUva/+/bi31T4hR4A==
 
 "@react-navigation/core@^5.0.0":
   version "5.0.0"

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -10158,10 +10158,10 @@ react-native-safe-area-view@^0.14.6:
   dependencies:
     hoist-non-react-statics "^2.3.1"
 
-react-native-screens@~2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.2.0.tgz#cc4cdf17426fdda97ad93a5e812a1899390f1978"
-  integrity sha512-a0VzxOWot7F9B/GQyDSssBRd3jUJazFnTQS61IiyReWB6aHlFhf3Xz10jBRoURXy1EMCDCHgenmTVTkKHpKyqQ==
+react-native-screens@~2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.5.0.tgz#2c5b5a56d3b8be64d459d53da154bde926021a50"
+  integrity sha512-5Ak/J41eZzvU2zvik8YH825ppFdKR4cootbAq9ETwdQoN0fu4GBdOpX7paKW2jFCTsh3OOoyRRW2xYvLczZqVw==
   dependencies:
     debounce "^1.2.0"
 

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -10139,10 +10139,10 @@ react-native-iphone-x-helper@^1.2.1:
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.1.tgz#645e2ffbbb49e80844bb4cbbe34a126fda1e6772"
   integrity sha512-/VbpIEp8tSNNHIvstuA3Swx610whci1Zpc9mqNkqn14DkMbw+ORviln2u0XyHG1kPvvwTNGZY6QpeFwxYaSdbQ==
 
-react-native-reanimated@~1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-1.7.1.tgz#6363c7f3ebbabc56a05d5dccaf09d95f3b6a2d69"
-  integrity sha512-aBwhoQdH4shkeTPbi7vKcAwYOzBp/6zElEKuIOgby11TceoM7y5SgNImC3HbDWWld3QV2PA2AgQGwAy51WgF3Q==
+react-native-reanimated@~1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-1.8.0.tgz#0b5719b20c1fed9aaf8afd9a12e21c9bd46ee428"
+  integrity sha512-vGTt94lE5fsZmfMwERWFIsCr5LHsyllOESeNvlKryLgAg7h4cnJ5XSmVSy4L3qogdgFYCL6HEgY+s7tQmKXiiQ==
   dependencies:
     fbjs "^1.0.0"
 

--- a/src/components/ActivityIndicator.tsx
+++ b/src/components/ActivityIndicator.tsx
@@ -11,7 +11,7 @@ import {
 import { withTheme } from '../core/theming';
 import { Theme } from '../types';
 
-type Props = React.ComponentProps<typeof View> & {
+type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Whether to show the indicator or hide it.
    */

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -16,7 +16,7 @@ import { black, white } from '../../styles/colors';
 import { Theme } from '../../types';
 import overlay from '../../styles/overlay';
 
-type Props = Partial<React.ComponentProps<typeof View>> & {
+type Props = Partial<React.ComponentPropsWithRef<typeof View>> & {
   /**
    * Whether the background color is a dark color. A dark appbar will render light text and vice-versa.
    */

--- a/src/components/Appbar/AppbarAction.tsx
+++ b/src/components/Appbar/AppbarAction.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import color from 'color';
-import { StyleProp, ViewStyle } from 'react-native';
+import { StyleProp, ViewStyle, TouchableWithoutFeedback } from 'react-native';
 import { black } from '../../styles/colors';
 import IconButton from '../IconButton';
 import { IconSource } from '../Icon';
 
-type Props = React.ComponentProps<typeof IconButton> & {
+type Props = React.ComponentPropsWithoutRef<typeof IconButton> & {
   /**
    *  Custom color for action icon.
    */
@@ -31,6 +31,7 @@ type Props = React.ComponentProps<typeof IconButton> & {
    */
   onPress?: () => void;
   style?: StyleProp<ViewStyle>;
+  ref?: React.RefObject<TouchableWithoutFeedback>;
 };
 
 /**

--- a/src/components/Appbar/AppbarBackAction.tsx
+++ b/src/components/Appbar/AppbarBackAction.tsx
@@ -13,31 +13,31 @@ import AppbarAction from './AppbarAction';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
 
 type Props = $Omit<
-  React.ComponentProps<typeof AppbarAction> & {
-    /**
-     *  Custom color for back icon.
-     */
-    color?: string;
-    /**
-     * Optional icon size.
-     */
-    size?: number;
-    /**
-     * Whether the button is disabled. A disabled button is greyed out and `onPress` is not called on touch.
-     */
-    disabled?: boolean;
-    /**
-     * Accessibility label for the button. This is read by the screen reader when the user taps the button.
-     */
-    accessibilityLabel?: string;
-    /**
-     * Function to execute on press.
-     */
-    onPress?: () => void;
-    style?: StyleProp<ViewStyle>;
-  },
+  React.ComponentPropsWithoutRef<typeof AppbarAction>,
   'icon'
->;
+> & {
+  /**
+   *  Custom color for back icon.
+   */
+  color?: string;
+  /**
+   * Optional icon size.
+   */
+  size?: number;
+  /**
+   * Whether the button is disabled. A disabled button is greyed out and `onPress` is not called on touch.
+   */
+  disabled?: boolean;
+  /**
+   * Accessibility label for the button. This is read by the screen reader when the user taps the button.
+   */
+  accessibilityLabel?: string;
+  /**
+   * Function to execute on press.
+   */
+  onPress?: () => void;
+  style?: StyleProp<ViewStyle>;
+};
 
 /**
  * A component used to display a back button in the appbar.

--- a/src/components/Avatar/AvatarIcon.tsx
+++ b/src/components/Avatar/AvatarIcon.tsx
@@ -9,7 +9,7 @@ import { IconSource } from './../Icon';
 
 const defaultSize = 64;
 
-type Props = {
+type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Icon to display for the `Avatar`.
    */
@@ -56,7 +56,7 @@ class Avatar extends React.Component<Props> {
   };
 
   render() {
-    const { icon, size = defaultSize, style, theme } = this.props;
+    const { icon, size = defaultSize, style, theme, ...rest } = this.props;
 
     const { backgroundColor = theme.colors.primary, ...restStyle } =
       StyleSheet.flatten(style) || {};
@@ -76,6 +76,7 @@ class Avatar extends React.Component<Props> {
           styles.container,
           restStyle,
         ]}
+        {...rest}
       >
         <Icon source={icon} color={textColor} size={size * 0.6} />
       </View>

--- a/src/components/Avatar/AvatarImage.tsx
+++ b/src/components/Avatar/AvatarImage.tsx
@@ -12,7 +12,7 @@ import { Theme } from '../../types';
 
 const defaultSize = 64;
 
-type Props = {
+type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Image to display for the `Avatar`.
    */
@@ -55,7 +55,7 @@ class AvatarImage extends React.Component<Props> {
   };
 
   render() {
-    const { size = defaultSize, source, style, theme } = this.props;
+    const { size = defaultSize, source, style, theme, ...rest } = this.props;
     const { colors } = theme;
 
     const { backgroundColor = colors.primary } =
@@ -72,6 +72,7 @@ class AvatarImage extends React.Component<Props> {
           },
           style,
         ]}
+        {...rest}
       >
         <Image
           source={source}

--- a/src/components/Avatar/AvatarText.tsx
+++ b/src/components/Avatar/AvatarText.tsx
@@ -6,7 +6,7 @@ import {
   StyleProp,
   TextStyle,
 } from 'react-native';
-import color from 'color';
+import Color from 'color';
 import Text from '../Typography/Text';
 import { withTheme } from '../../core/theming';
 import { white } from '../../styles/colors';
@@ -14,7 +14,7 @@ import { Theme } from '../../types';
 
 const defaultSize = 64;
 
-type Props = {
+type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Initials to show as the text in the `Avatar`.
    */
@@ -68,13 +68,21 @@ class AvatarText extends React.Component<Props> {
   };
 
   render() {
-    const { label, size = defaultSize, style, theme, labelStyle } = this.props;
+    const {
+      label,
+      size = defaultSize,
+      style,
+      theme,
+      labelStyle,
+      color,
+      ...rest
+    } = this.props;
 
     const { backgroundColor = theme.colors.primary, ...restStyle } =
       StyleSheet.flatten(style) || {};
     const textColor =
-      this.props.color ||
-      (color(backgroundColor).isLight() ? 'rgba(0, 0, 0, .54)' : white);
+      color ||
+      (Color(backgroundColor).isLight() ? 'rgba(0, 0, 0, .54)' : white);
 
     return (
       <View
@@ -88,6 +96,7 @@ class AvatarText extends React.Component<Props> {
           styles.container,
           restStyle,
         ]}
+        {...rest}
       >
         <Text
           style={[

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Animated, StyleSheet, StyleProp, Text, TextStyle } from 'react-native';
+import { Animated, StyleSheet, StyleProp, TextStyle } from 'react-native';
 import color from 'color';
 import { black, white } from '../styles/colors';
 import { withTheme } from '../core/theming';
@@ -7,7 +7,7 @@ import { Theme } from '../types';
 
 const defaultSize = 20;
 
-type Props = React.ComponentProps<typeof Text> & {
+type Props = React.ComponentProps<typeof Animated.Text> & {
   /**
    * Whether the badge is visible
    */
@@ -21,6 +21,7 @@ type Props = React.ComponentProps<typeof Text> & {
    */
   size?: number;
   style?: StyleProp<TextStyle>;
+  ref?: React.RefObject<typeof Animated.Text>;
   /**
    * @optional
    */
@@ -75,7 +76,15 @@ class Badge extends React.Component<Props, State> {
   }
 
   render() {
-    const { children, size = defaultSize, style, theme } = this.props;
+    const {
+      children,
+      size = defaultSize,
+      style,
+      theme,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      visible,
+      ...rest
+    } = this.props;
     const { opacity } = this.state;
 
     const { backgroundColor = theme.colors.notification, ...restStyle } =
@@ -102,6 +111,7 @@ class Badge extends React.Component<Props, State> {
           styles.container,
           restStyle,
         ]}
+        {...rest}
       >
         {children}
       </Animated.Text>

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -43,6 +43,7 @@ type Props = $RemoveChildren<typeof Surface> & {
    */
   contentStyle?: StyleProp<ViewStyle>;
   style?: StyleProp<ViewStyle>;
+  ref?: React.RefObject<View>;
   /**
    * @optional
    */

--- a/src/components/Card/CardActions.tsx
+++ b/src/components/Card/CardActions.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { StyleSheet, StyleProp, View, ViewStyle } from 'react-native';
 
-type Props = React.ComponentProps<typeof View> & {
+type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Items inside the `CardActions`.
    */

--- a/src/components/Card/CardContent.tsx
+++ b/src/components/Card/CardContent.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { StyleSheet, StyleProp, View, ViewStyle } from 'react-native';
 
-type Props = React.ComponentProps<typeof View> & {
+type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Items inside the `Card.Content`.
    */

--- a/src/components/Card/CardCover.tsx
+++ b/src/components/Card/CardCover.tsx
@@ -4,7 +4,7 @@ import { withTheme } from '../../core/theming';
 import { grey200 } from '../../styles/colors';
 import { Theme } from '../../types';
 
-type Props = React.ComponentProps<typeof Image> & {
+type Props = React.ComponentPropsWithRef<typeof Image> & {
   /**
    * @internal
    */

--- a/src/components/Card/CardTitle.tsx
+++ b/src/components/Card/CardTitle.tsx
@@ -12,7 +12,7 @@ import Caption from './../Typography/Caption';
 import Title from './../Typography/Title';
 import { Theme } from '../../types';
 
-type Props = React.ComponentProps<typeof View> & {
+type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Text for the title. Note that this will only accept a string or `<Text>`-based node.
    */

--- a/src/components/Card/CardTitle.tsx
+++ b/src/components/Card/CardTitle.tsx
@@ -135,6 +135,7 @@ class CardTitle extends React.Component<Props> {
                 { marginBottom: subtitle ? 0 : 2 },
                 titleStyle,
               ]}
+              numberOfLines={1}
             >
               {title}
             </Title>

--- a/src/components/CheckboxAndroid.tsx
+++ b/src/components/CheckboxAndroid.tsx
@@ -74,12 +74,14 @@ class CheckboxAndroid extends React.Component<Props, State> {
       Animated.timing(this.state.scaleAnim, {
         toValue: 0.85,
         duration: checked ? ANIMATION_DURATION * animation.scale : 0,
+        useNativeDriver: false,
       }),
       Animated.timing(this.state.scaleAnim, {
         toValue: 1,
         duration: checked
           ? ANIMATION_DURATION * animation.scale
           : ANIMATION_DURATION * animation.scale * 1.75,
+        useNativeDriver: false,
       }),
     ]).start();
   }

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -16,7 +16,7 @@ import DataTablePagination, {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import DataTableRow, { DataTableRow as _DataTableRow } from './DataTableRow';
 
-type Props = React.ComponentProps<typeof View> & {
+type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Content of the `DataTable`.
    */

--- a/src/components/DataTable/DataTableHeader.tsx
+++ b/src/components/DataTable/DataTableHeader.tsx
@@ -5,7 +5,7 @@ import { black, white } from '../../styles/colors';
 import { withTheme } from '../../core/theming';
 import { Theme } from '../../types';
 
-type Props = React.ComponentProps<typeof View> & {
+type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Content of the `DataTableHeader`.
    */

--- a/src/components/DataTable/DataTablePagination.tsx
+++ b/src/components/DataTable/DataTablePagination.tsx
@@ -13,7 +13,7 @@ import { withTheme } from '../../core/theming';
 import { Theme } from '../../types';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
 
-type Props = React.ComponentProps<typeof View> & {
+type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * The currently visible page (starting with 0).
    */

--- a/src/components/DataTable/DataTableTitle.tsx
+++ b/src/components/DataTable/DataTableTitle.tsx
@@ -14,7 +14,7 @@ import Text from '../Typography/Text';
 import { withTheme } from '../../core/theming';
 import { Theme } from '../../types';
 
-type Props = React.ComponentProps<typeof TouchableWithoutFeedback> & {
+type Props = React.ComponentPropsWithRef<typeof TouchableWithoutFeedback> & {
   /**
    * Text content of the `DataTableTitle`.
    */

--- a/src/components/Dialog/DialogActions.tsx
+++ b/src/components/Dialog/DialogActions.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { StyleSheet, StyleProp, View, ViewStyle } from 'react-native';
 
-type Props = React.ComponentProps<typeof View> & {
+type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Content of the `DialogActions`.
    */

--- a/src/components/Dialog/DialogContent.tsx
+++ b/src/components/Dialog/DialogContent.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { View, ViewStyle, StyleSheet, StyleProp } from 'react-native';
 
-type Props = React.ComponentProps<typeof View> & {
+type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Content of the `DialogContent`.
    */

--- a/src/components/Dialog/DialogScrollArea.tsx
+++ b/src/components/Dialog/DialogScrollArea.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { View, ViewStyle, StyleSheet, StyleProp } from 'react-native';
 
-type Props = React.ComponentProps<typeof View> & {
+type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Content of the `DialogScrollArea`.
    */

--- a/src/components/Dialog/DialogTitle.tsx
+++ b/src/components/Dialog/DialogTitle.tsx
@@ -4,7 +4,7 @@ import Title from '../Typography/Title';
 import { withTheme } from '../../core/theming';
 import { Theme } from '../../types';
 
-type Props = React.ComponentProps<typeof Title> & {
+type Props = React.ComponentPropsWithRef<typeof Title> & {
   /**
    * Title text for the `DialogTitle`.
    */

--- a/src/components/Drawer/DrawerSection.tsx
+++ b/src/components/Drawer/DrawerSection.tsx
@@ -6,7 +6,7 @@ import Divider from '../Divider';
 import { withTheme } from '../../core/theming';
 import { Theme } from '../../types';
 
-type Props = React.ComponentProps<typeof View> & {
+type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Title to show as the header for the section.
    */

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -262,7 +262,7 @@ class FABGroup extends React.Component<Props, State> {
               <View
                 key={i} // eslint-disable-line react/no-array-index-key
                 style={styles.item}
-                pointerEvents="box-none"
+                pointerEvents={open ? 'box-none' : 'none'}
               >
                 {it.label && (
                   <Card
@@ -318,6 +318,7 @@ class FABGroup extends React.Component<Props, State> {
                   accessibilityComponentType="button"
                   accessibilityRole="button"
                   testID={it.testID}
+                  visible={open}
                 />
               </View>
             ))}

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -118,9 +118,9 @@ type State = {
  *          <Portal>
  *            <FAB.Group
  *              open={open}
- *              icon={open ? 'today' : 'add'}
+ *              icon={open ? 'calendar-today' : 'plus'}
  *              actions={[
- *                { icon: 'add', onPress: () => console.log('Pressed add') },
+ *                { icon: 'plus', onPress: () => console.log('Pressed add') },
  *                { icon: 'star', label: 'Star', onPress: () => console.log('Pressed star')},
  *                { icon: 'email', label: 'Email', onPress: () => console.log('Pressed email') },
  *                { icon: 'bell', label: 'Remind', onPress: () => console.log('Pressed notifications') },

--- a/src/components/HelperText.tsx
+++ b/src/components/HelperText.tsx
@@ -12,7 +12,7 @@ import { withTheme } from '../core/theming';
 import { Theme, $Omit } from '../types';
 
 type Props = $Omit<
-  $Omit<React.ComponentProps<typeof AnimatedText>, 'padding'>,
+  $Omit<React.ComponentPropsWithRef<typeof AnimatedText>, 'padding'>,
   'type'
 > & {
   /**

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -31,6 +31,24 @@ type Props = IconProps & {
   theme: Theme;
 };
 
+/**
+ * ## Usage
+ * ```js
+ * import * as React from 'react';
+ * import { Icon, Colors } from 'react-native-paper';
+ *
+ * const MyComponent = () => (
+ *   <Icon
+ *     source="camera"
+ *     color={Colors.red500}
+ *     size={20}
+ *   />
+ * );
+ *
+ * export default MyComponent;
+ * ```
+ */
+
 const isImageSource = (source: any) =>
   // source is an object with uri
   (typeof source === 'object' &&

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   StyleProp,
   GestureResponderEvent,
+  TouchableWithoutFeedback,
 } from 'react-native';
 import color from 'color';
 
@@ -45,6 +46,7 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
    */
   onPress?: (e: GestureResponderEvent) => void;
   style?: StyleProp<ViewStyle>;
+  ref?: React.RefObject<TouchableWithoutFeedback>;
   /**
    * @optional
    */

--- a/src/components/List/ListSection.tsx
+++ b/src/components/List/ListSection.tsx
@@ -10,7 +10,7 @@ import ListSubheader from './ListSubheader';
 import { withTheme } from '../../core/theming';
 import { Theme } from '../../types';
 
-type Props = React.ComponentProps<typeof View> & {
+type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Title text for the section.
    */

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -122,9 +122,11 @@ const iconWidth = 40;
 
 const styles = StyleSheet.create({
   container: {
-    padding: 8,
+    paddingHorizontal: 8,
     minWidth,
     maxWidth,
+    height: 48,
+    justifyContent: 'center',
   },
   row: {
     flexDirection: 'row',
@@ -136,7 +138,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
   },
   item: {
-    margin: 8,
+    marginHorizontal: 8,
   },
   content: {
     justifyContent: 'center',

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -13,7 +13,7 @@ import setColor from 'color';
 import { withTheme } from '../core/theming';
 import { Theme } from '../types';
 
-type Props = {
+type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Progress value (between 0 and 1).
    */
@@ -166,7 +166,17 @@ class ProgressBar extends React.Component<Props, State> {
   };
 
   render() {
-    const { color, indeterminate, style, theme } = this.props;
+    const {
+      color,
+      indeterminate,
+      style,
+      theme,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      progress,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      visible,
+      ...rest
+    } = this.props;
     const { fade, timer, width } = this.state;
     const tintColor = color || theme.colors.primary;
     const trackTintColor = setColor(tintColor)
@@ -175,7 +185,7 @@ class ProgressBar extends React.Component<Props, State> {
       .string();
 
     return (
-      <View onLayout={this.onLayout}>
+      <View onLayout={this.onLayout} {...rest}>
         <Animated.View
           style={[
             styles.container,

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -16,7 +16,7 @@ import { Theme } from '../types';
 import { IconSource } from './Icon';
 import MaterialCommunityIcon from './MaterialCommunityIcon';
 
-type Props = React.ComponentProps<typeof TextInput> & {
+type Props = React.ComponentPropsWithRef<typeof TextInput> & {
   /**
    * Accessibility label for the button. This is read by the screen reader when the user taps the button.
    */

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -5,6 +5,7 @@ import {
   StyleProp,
   StyleSheet,
   ViewStyle,
+  View,
 } from 'react-native';
 
 import Button from './Button';
@@ -13,7 +14,7 @@ import Text from './Typography/Text';
 import { withTheme } from '../core/theming';
 import { Theme } from '../types';
 
-type Props = {
+type Props = React.ComponentProps<typeof Surface> & {
   /**
    * Whether the Snackbar is currently visible.
    */
@@ -41,6 +42,7 @@ type Props = {
    */
   children: React.ReactNode;
   style?: StyleProp<ViewStyle>;
+  ref?: React.RefObject<View>;
   /**
    * @optional
    */
@@ -209,7 +211,17 @@ class Snackbar extends React.Component<Props, State> {
   private hideTimeout?: number;
 
   render() {
-    const { children, visible, action, onDismiss, theme, style } = this.props;
+    const {
+      children,
+      visible,
+      action,
+      onDismiss,
+      theme,
+      style,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      duration,
+      ...rest
+    } = this.props;
     const { colors, roundness } = theme;
 
     if (this.state.hidden) {
@@ -242,6 +254,7 @@ class Snackbar extends React.Component<Props, State> {
               style,
             ] as StyleProp<ViewStyle>
           }
+          {...rest}
         >
           <Text
             style={[

--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -15,7 +15,7 @@ const version = NativeModules.PlatformConstants
   ? NativeModules.PlatformConstants.reactNativeVersion
   : undefined;
 
-type Props = React.ComponentProps<typeof NativeSwitch> & {
+type Props = React.ComponentPropsWithRef<typeof NativeSwitch> & {
   /**
    * Disable toggling the switch.
    */

--- a/src/components/TouchableRipple/index.tsx
+++ b/src/components/TouchableRipple/index.tsx
@@ -10,7 +10,7 @@ import color from 'color';
 import { withTheme } from '../../core/theming';
 import { Theme } from '../../types';
 
-type Props = React.ComponentProps<typeof TouchableWithoutFeedback> & {
+type Props = React.ComponentPropsWithRef<typeof TouchableWithoutFeedback> & {
   /**
    * Whether to render the ripple outside the view bounds.
    */

--- a/src/components/Typography/AnimatedText.tsx
+++ b/src/components/Typography/AnimatedText.tsx
@@ -3,7 +3,7 @@ import { Animated, TextStyle, I18nManager, StyleProp } from 'react-native';
 import { withTheme } from '../../core/theming';
 import { Theme } from '../../types';
 
-type Props = React.ComponentProps<typeof Animated.Text> & {
+type Props = React.ComponentPropsWithRef<typeof Animated.Text> & {
   style?: StyleProp<TextStyle>;
   /**
    * @optional

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,6 +33,7 @@ export { default as Dialog } from './components/Dialog/Dialog';
 export { default as Divider } from './components/Divider';
 export { default as FAB } from './components/FAB/FAB';
 export { default as HelperText } from './components/HelperText';
+export { default as Icon } from './components/Icon';
 export { default as IconButton } from './components/IconButton';
 export { default as Menu } from './components/Menu/Menu';
 export { default as Modal } from './components/Modal';

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -49,7 +49,7 @@ export type Theme = {
 
 export type $Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 export type $RemoveChildren<T extends React.ComponentType<any>> = $Omit<
-  React.ComponentProps<T>,
+  React.ComponentPropsWithoutRef<T>,
   'children'
 >;
 


### PR DESCRIPTION
### Motivation

This PR solves #1694, exporting `Icon` component in order to allow users to customize react-native-paper components.

Please let me know about any necessary changes
