### PR TITLE
fix: Update RadioButtonItem, reorder label styles

### DIFF
--- a/src/components/RadioButton/RadioButtonItem.tsx
+++ b/src/components/RadioButton/RadioButtonItem.tsx
@@ -102,7 +102,7 @@ class RadioButtonItem extends React.Component<Props> {
             >
               <View style={[styles.container, style]} pointerEvents="none">
                 <Text
-                  style={[styles.label, { color: colors.primary }, labelStyle]}
+                  style={[styles.label, { color: colors.text }, labelStyle]}
                 >
                   {label}
                 </Text>

--- a/src/components/RadioButton/RadioButtonItem.tsx
+++ b/src/components/RadioButton/RadioButtonItem.tsx
@@ -102,7 +102,7 @@ class RadioButtonItem extends React.Component<Props> {
             >
               <View style={[styles.container, style]} pointerEvents="none">
                 <Text
-                  style={[styles.label, labelStyle, { color: colors.primary }]}
+                  style={[styles.label, { color: colors.primary }, labelStyle]}
                 >
                   {label}
                 </Text>


### PR DESCRIPTION
### Motivation

In dark mode, the default color for the RadioButtonItem label is the primary color, which is very hard to read in my case, so I wanted to change the color of the label to the default text color (white in my case). But that isn't possible using the `labelStyle` prop, as the color is always overwritten to primary (and there aren't any other options).

That's how the RadioButtonItem currently looks like with a blue primary color in dark:
![Screenshot_20200429-221010](https://user-images.githubusercontent.com/7737876/80642459-ce42c100-8a66-11ea-9fba-36bcad01b8b8.png)

and that's how it looks like with this change and `labelStyle={{color: theme.colors.text}}` applied:
![Screenshot_20200429-221547](https://user-images.githubusercontent.com/7737876/80642728-3c878380-8a67-11ea-8084-531c7ee425a9.png)


Maybe the color of the RadioButtonItem label should be the text color by default? The offical [screenshots of the RadioButton](https://callstack.github.io/react-native-paper/radio-button.html) also have a black label.

### Test plan

There shouldn't be any immediate effects, it just allows the user to change the RadioButtonItem text color (which should be quite a common use case IMO).