### PR TITLE
fix: don't set statusbar style in Appbar.Header

### DIFF
--- a/src/components/Appbar/AppbarHeader.tsx
+++ b/src/components/Appbar/AppbarHeader.tsx
@@ -5,7 +5,6 @@ import {
   View,
   SafeAreaView,
   ViewStyle,
-  StatusBar,
 } from 'react-native';
 import overlay from '../../styles/overlay';
 import Appbar, { DEFAULT_APPBAR_HEIGHT } from './Appbar';
@@ -13,7 +12,6 @@ import shadow from '../../styles/shadow';
 import { withTheme } from '../../core/theming';
 import { Theme } from '../../types';
 import { APPROX_STATUSBAR_HEIGHT } from '../../constants';
-import color from 'color';
 
 type Props = React.ComponentProps<typeof Appbar> & {
   /**
@@ -110,16 +108,6 @@ class AppbarHeader extends React.Component<Props> {
     // Let the user override the behaviour
     const Wrapper =
       typeof this.props.statusBarHeight === 'number' ? View : SafeAreaView;
-    let isDark;
-    if (typeof dark === 'boolean') {
-      isDark = dark;
-    } else {
-      isDark =
-        backgroundColor === 'transparent'
-          ? false
-          : !color(backgroundColor).isLight();
-    }
-    StatusBar.setBarStyle(isDark ? 'light-content' : 'dark-content');
 
     return (
       <Wrapper


### PR DESCRIPTION
The header shouldn't be setting statusbar style. It won't work properly when using libraries such as React Navigation since multiple screens can be mounted at one time, and user has no way to control it or integrate it with react Navigation's lifecycle this way.

If we really want to do this, a better way is to use the `<StatusBar />` component from React Native which will make sure that the style set gets cleaned up when the component unmounts. though it still won't work with React Navigation.

In addition, it's a side-effect and shouldn't be done in render.