### PR TITLE
fix: add useNativeDriver: false to RadioButton.Android

### DIFF
--- a/src/components/RadioButton/RadioButtonAndroid.tsx
+++ b/src/components/RadioButton/RadioButtonAndroid.tsx
@@ -79,6 +79,7 @@ class RadioButtonAndroid extends React.Component<Props, State> {
       Animated.timing(this.state.radioAnim, {
         toValue: 1,
         duration: 150 * scale,
+        useNativeDriver: false,
       }).start();
     } else {
       this.state.borderAnim.setValue(10);
@@ -86,6 +87,7 @@ class RadioButtonAndroid extends React.Component<Props, State> {
       Animated.timing(this.state.borderAnim, {
         toValue: BORDER_WIDTH,
         duration: 150 * scale,
+        useNativeDriver: false,
       }).start();
     }
   }


### PR DESCRIPTION
Attempts to fix #1870 by adding `useNativeDriver: false` to the `Animated.timing`s in `RadioButton.Android`.

Caveat: I wasn't able to reproduce the original issue (i.e. the yellow box triggering with the warning about `useNativeDriver`), would appreciate if @hugosbg could verify that this resolves it.