### PR TITLE
docs: add useTheme example

### DIFF
--- a/docs/pages/2.theming.md
+++ b/docs/pages/2.theming.md
@@ -107,6 +107,18 @@ export default withTheme(MyComponent);
 
 Components wrapped with `withTheme` support the theme from the `Provider` as well as from the `theme` prop.
 
+You can also use the `useTheme` hook.
+
+```js
+import * as React from 'react';
+import { useTheme } from 'react-native-paper';
+
+function MyComponent(props) {
+  const { colors } = useTheme();
+  return <Text style={{ color: colors.primary }}>Yo!</Text>;
+}
+```
+
 ## Customizing all instances of a component
 
 Sometimes you want to style a component in a different way everywhere and don't want to change the properties in the theme so that other components are not affected. For example, say you want to change the font for all your buttons, but don't want to change `theme.fonts.medium` because it affects other components.


### PR DESCRIPTION
Add an example for the useTheme hook

### Where to test

In the `Theming` page, in the `Using the theme in your own components` section ([here](https://17506-71323749-gh.circle-artifacts.com/0/docs/theming.html#using-the-theme-in-your-own-components))
