### PR TITLE
fix: fab custom icon click and animation

### DIFF
--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -59,7 +59,9 @@ const getIconId = (source: any) => {
 };
 
 export const isValidIcon = (source: any) =>
-  typeof source === 'string' || isImageSource(source);
+  typeof source === 'string' ||
+  typeof source === 'function' ||
+  isImageSource(source);
 
 export const isEqualIcon = (a: any, b: any) =>
   a === b || getIconId(a) === getIconId(b);


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

#1876

FAB was not working properly when a function was passed to the icon prop. There was no animation and the icon didn't change according to a state. 

I assume that after enabling using custom icons in FAB, sb forgot to add a new type to isValidIcon.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

Before: 
![before](https://user-images.githubusercontent.com/44026723/81219574-4584d180-8fe0-11ea-86ed-3e5389c0a38f.gif)

After:
![after](https://user-images.githubusercontent.com/44026723/81219603-4ddd0c80-8fe0-11ea-868e-caf4568091d9.gif)


### Test plan

Reproduce the scenario in #1876

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
