### PR TITLE
docs update getting started example index to include the default nami…

### DIFF
--- a/docs/pages/1.getting-started.md
+++ b/docs/pages/1.getting-started.md
@@ -77,6 +77,7 @@ Example:
 import * as React from 'react';
 import { AppRegistry } from 'react-native';
 import { Provider as PaperProvider } from 'react-native-paper';
+import { name as appName } from './app.json';
 import App from './src/App';
 
 export default function Main() {
@@ -87,7 +88,7 @@ export default function Main() {
   );
 }
 
-AppRegistry.registerComponent('main', () => Main);
+AppRegistry.registerComponent(appName, () => Main);
 ```
 
 The `PaperProvider` component provides the theme to all the components in the framework. It also acts as a portal to components which need to be rendered at the top level.


### PR DESCRIPTION
…ng to fix error of 'has not been registered'

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

The current getting started `index.js` example removes the default "appName" import and registers the project as "main", where this will throw an error unless your RN project is named "main".

https://callstack.github.io/react-native-paper/getting-started.html
![image](https://user-images.githubusercontent.com/8321838/81478939-63c01c80-91ee-11ea-93d9-4a0e1b14b609.png)

This will cause a sorta vague error for anyone who copy pastes this into their index.js file along the lines of "module.registry name application has not been registered"

### New

This PR updates the example to keep with the default naming from RN init

![image](https://user-images.githubusercontent.com/8321838/81479244-1d6bbd00-91f0-11ea-829e-5dd9db3d5684.png)

### Other

`import App from './src/App'; `
This assumes the user has moved their App from root to a src folder, which is not the default structure from RN Init, but this error is easier to follow for anyone getting started with RN Paper and I think points people in a good direction for organization. I also like using `App` as a folder for my project, so to each their own here, but the registry naming error above is vague enough to be a frustrating hindrance for any users new/getting started with RN. 

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

Go into your index.js on any project and rename your entry point in `AppRegistry.registerComponent` to "main", this will throw an error unless your project is named "main". 

```javascript
AppRegistry.registerComponent("main", () => Main);
```
