### PR TITLE
fix: activityindictor crash on android

### DIFF
--- a/src/components/ActivityIndicator.tsx
+++ b/src/components/ActivityIndicator.tsx
@@ -183,7 +183,10 @@ class ActivityIndicator extends React.Component<Props, State> {
 
     return (
       <View style={[styles.container, style]} {...rest}>
-        <Animated.View style={[{ width: size, height: size, opacity: fade }]}>
+        <Animated.View
+          style={[{ width: size, height: size, opacity: fade }]}
+          collapsable={false}
+        >
           {[0, 1].map(index => {
             // Thanks to https://github.com/n4kz/react-native-indicators for the great work
             const inputRange = Array.from(

--- a/src/components/__tests__/__snapshots__/ActivityIndicator.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ActivityIndicator.test.js.snap
@@ -13,6 +13,7 @@ exports[`renders colored indicator 1`] = `
   }
 >
   <View
+    collapsable={false}
     style={
       Object {
         "height": 24,
@@ -195,6 +196,7 @@ exports[`renders hidden indicator 1`] = `
   }
 >
   <View
+    collapsable={false}
     style={
       Object {
         "height": 24,
@@ -377,6 +379,7 @@ exports[`renders indicator 1`] = `
   }
 >
   <View
+    collapsable={false}
     style={
       Object {
         "height": 24,
@@ -559,6 +562,7 @@ exports[`renders large indicator 1`] = `
   }
 >
   <View
+    collapsable={false}
     style={
       Object {
         "height": 48,

--- a/src/components/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.js.snap
@@ -580,6 +580,7 @@ exports[`renders loading button 1`] = `
         }
       >
         <View
+          collapsable={false}
           style={
             Object {
               "height": 16,


### PR DESCRIPTION
### Motivation

I had an issue with the activity indicator crashing on android. Happens when there is an ActivityIndicator on the first page. The same issue as this https://github.com/callstack/react-native-paper/issues/893

I followed what the discussion said and added ```collapsable={false}``` to the Animated view. And it seemed to fix the issue.

Reproducible error on this repo https://github.com/runningdeveloper/crash-test 

### Test plan

I am using expo and pixel 3a emulator. 
I had to update the snapshots on activityindicator and button. Loading on the button still looks normal.

Let me know if I have done anything incorrectly.
