### PR TITLE
[4.0] change deprecated accessiblityStates to accessibilityState

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -865,7 +865,7 @@ class BottomNavigation extends React.Component<Props, State> {
                     : 'button',
                   accessibilityComponentType: 'button',
                   accessibilityRole: 'button',
-                  accessibilityStates: ['selected'],
+                  accessibilityState: { selected: true },
                   style: styles.item,
                   children: (
                     <View pointerEvents="none">

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -274,7 +274,7 @@ class Button extends React.Component<Props, State> {
           accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
           accessibilityComponentType="button"
           accessibilityRole="button"
-          accessibilityStates={disabled ? ['disabled'] : []}
+          accessibilityState={{ disabled }}
           disabled={disabled}
           rippleColor={rippleColor}
           style={touchableStyle}

--- a/src/components/Checkbox/CheckboxAndroid.tsx
+++ b/src/components/Checkbox/CheckboxAndroid.tsx
@@ -135,7 +135,7 @@ class CheckboxAndroid extends React.Component<Props, State> {
         accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
         accessibilityComponentType="button"
         accessibilityRole="button"
-        accessibilityStates={disabled ? ['disabled'] : []}
+        accessibilityState={{ disabled }}
         accessibilityLiveRegion="polite"
         style={styles.container}
       >

--- a/src/components/Checkbox/CheckboxIOS.tsx
+++ b/src/components/Checkbox/CheckboxIOS.tsx
@@ -82,7 +82,7 @@ class CheckboxIOS extends React.Component<Props> {
         accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
         accessibilityComponentType="button"
         accessibilityRole="button"
-        accessibilityStates={disabled ? ['disabled'] : []}
+        accessibilityState={{ disabled }}
         accessibilityLiveRegion="polite"
         style={styles.container}
       >

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -209,16 +209,17 @@ class Chip extends React.Component<Props, State> {
       : selectedBackgroundColor;
 
     const accessibilityTraits: AccessibilityTrait[] = ['button'];
-    const accessibilityState: AccessibilityState = {};
+    const accessibilityState: AccessibilityState = {
+      selected,
+      disabled,
+    };
 
     if (selected) {
       accessibilityTraits.push('selected');
-      accessibilityState.selected = true;
     }
 
     if (disabled) {
       accessibilityTraits.push('disabled');
-      accessibilityState.disabled = true;
     }
 
     return (

--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -107,7 +107,7 @@ class DrawerItem extends React.Component<Props> {
           accessibilityTraits={active ? ['button', 'selected'] : 'button'}
           accessibilityComponentType="button"
           accessibilityRole="button"
-          accessibilityStates={active ? ['selected'] : []}
+          accessibilityState={{ selected: active }}
           accessibilityLabel={accessibilityLabel}
         >
           <View style={styles.wrapper}>

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -207,7 +207,7 @@ class FAB extends React.Component<Props, State> {
           accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
           accessibilityComponentType="button"
           accessibilityRole="button"
-          accessibilityStates={disabled ? ['disabled'] : []}
+          accessibilityState={{ disabled }}
           style={styles.touchable}
           testID={testID}
         >

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -121,7 +121,7 @@ const IconButton = ({
       accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
       accessibilityComponentType="button"
       accessibilityRole="button"
-      accessibilityStates={disabled ? ['disabled'] : []}
+      accessibilityState={{ disabled }}
       disabled={disabled}
       hitSlop={
         // @ts-ignore - this should be fixed in react-theme-providersince withTheme() is not forwarding static property types

--- a/src/components/RadioButton/RadioButtonAndroid.tsx
+++ b/src/components/RadioButton/RadioButtonAndroid.tsx
@@ -147,7 +147,7 @@ class RadioButtonAndroid extends React.Component<Props, State> {
                 checked ? 'radiobutton_checked' : 'radiobutton_unchecked'
               }
               accessibilityRole="button"
-              accessibilityStates={disabled ? ['disabled'] : []}
+              accessibilityState={{ disabled }}
               accessibilityLiveRegion="polite"
               style={styles.container}
             >

--- a/src/components/RadioButton/RadioButtonIOS.tsx
+++ b/src/components/RadioButton/RadioButtonIOS.tsx
@@ -105,7 +105,7 @@ class RadioButtonIOS extends React.Component<Props> {
                 checked ? 'radiobutton_checked' : 'radiobutton_unchecked'
               }
               accessibilityRole="button"
-              accessibilityStates={disabled ? ['disabled'] : []}
+              accessibilityState={{ disabled }}
               accessibilityLiveRegion="polite"
               style={styles.container}
             >

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
@@ -41,7 +41,11 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
     <View
       accessibilityLabel="search"
       accessibilityRole="button"
-      accessibilityStates={Array []}
+      accessibilityState={
+        Object {
+          "disabled": undefined,
+        }
+      }
       accessible={true}
       focusable={false}
       hitSlop={
@@ -155,10 +159,10 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
     <View
       accessibilityLabel="clear"
       accessibilityRole="button"
-      accessibilityStates={
-        Array [
-          "disabled",
-        ]
+      accessibilityState={
+        Object {
+          "disabled": true,
+        }
       }
       accessible={true}
       focusable={true}
@@ -269,7 +273,11 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
   <View
     accessibilityLabel="Back"
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "disabled": undefined,
+      }
+    }
     accessible={true}
     focusable={true}
     hitSlop={
@@ -448,7 +456,11 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
   </View>
   <View
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "disabled": undefined,
+      }
+    }
     accessible={true}
     focusable={true}
     hitSlop={

--- a/src/components/__tests__/Checkbox/__snapshots__/Checkbox.test.js.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/Checkbox.test.js.snap
@@ -3,7 +3,11 @@
 exports[`renders checked Checkbox with color 1`] = `
 <View
   accessibilityRole="button"
-  accessibilityStates={Array []}
+  accessibilityState={
+    Object {
+      "disabled": undefined,
+    }
+  }
   accessible={true}
   focusable={false}
   isTVSelectable={true}
@@ -74,7 +78,11 @@ exports[`renders checked Checkbox with color 1`] = `
 exports[`renders checked Checkbox with onPress 1`] = `
 <View
   accessibilityRole="button"
-  accessibilityStates={Array []}
+  accessibilityState={
+    Object {
+      "disabled": undefined,
+    }
+  }
   accessible={true}
   focusable={true}
   isTVSelectable={true}
@@ -145,7 +153,11 @@ exports[`renders checked Checkbox with onPress 1`] = `
 exports[`renders indeterminate Checkbox 1`] = `
 <View
   accessibilityRole="button"
-  accessibilityStates={Array []}
+  accessibilityState={
+    Object {
+      "disabled": undefined,
+    }
+  }
   accessible={true}
   focusable={true}
   isTVSelectable={true}
@@ -216,7 +228,11 @@ exports[`renders indeterminate Checkbox 1`] = `
 exports[`renders indeterminate Checkbox with color 1`] = `
 <View
   accessibilityRole="button"
-  accessibilityStates={Array []}
+  accessibilityState={
+    Object {
+      "disabled": undefined,
+    }
+  }
   accessible={true}
   focusable={false}
   isTVSelectable={true}
@@ -287,7 +303,11 @@ exports[`renders indeterminate Checkbox with color 1`] = `
 exports[`renders unchecked Checkbox with color 1`] = `
 <View
   accessibilityRole="button"
-  accessibilityStates={Array []}
+  accessibilityState={
+    Object {
+      "disabled": undefined,
+    }
+  }
   accessible={true}
   focusable={false}
   isTVSelectable={true}
@@ -358,7 +378,11 @@ exports[`renders unchecked Checkbox with color 1`] = `
 exports[`renders unchecked Checkbox with onPress 1`] = `
 <View
   accessibilityRole="button"
-  accessibilityStates={Array []}
+  accessibilityState={
+    Object {
+      "disabled": undefined,
+    }
+  }
   accessible={true}
   focusable={true}
   isTVSelectable={true}

--- a/src/components/__tests__/RadioButton/__snapshots__/RadioButton.test.js.snap
+++ b/src/components/__tests__/RadioButton/__snapshots__/RadioButton.test.js.snap
@@ -3,7 +3,11 @@
 exports[`RadioButton on default platform renders properly 1`] = `
 <View
   accessibilityRole="button"
-  accessibilityStates={Array []}
+  accessibilityState={
+    Object {
+      "disabled": undefined,
+    }
+  }
   accessible={true}
   focusable={true}
   isTVSelectable={true}
@@ -74,7 +78,11 @@ exports[`RadioButton on default platform renders properly 1`] = `
 exports[`RadioButton on ios platform renders properly 1`] = `
 <View
   accessibilityRole="button"
-  accessibilityStates={Array []}
+  accessibilityState={
+    Object {
+      "disabled": undefined,
+    }
+  }
   accessible={true}
   focusable={true}
   isTVSelectable={true}
@@ -145,7 +153,11 @@ exports[`RadioButton on ios platform renders properly 1`] = `
 exports[`RadioButton when RadioButton is wrapped by RadioButtonContext.Provider renders properly 1`] = `
 <View
   accessibilityRole="button"
-  accessibilityStates={Array []}
+  accessibilityState={
+    Object {
+      "disabled": undefined,
+    }
+  }
   accessible={true}
   focusable={true}
   isTVSelectable={true}

--- a/src/components/__tests__/RadioButton/__snapshots__/RadioButtonGroup.test.js.snap
+++ b/src/components/__tests__/RadioButton/__snapshots__/RadioButtonGroup.test.js.snap
@@ -3,7 +3,11 @@
 exports[`RadioButtonGroup renders properly 1`] = `
 <View
   accessibilityRole="button"
-  accessibilityStates={Array []}
+  accessibilityState={
+    Object {
+      "disabled": undefined,
+    }
+  }
   accessible={true}
   focusable={true}
   isTVSelectable={true}

--- a/src/components/__tests__/__snapshots__/Banner.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.js.snap
@@ -192,7 +192,11 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
         >
           <View
             accessibilityRole="button"
-            accessibilityStates={Array []}
+            accessibilityState={
+              Object {
+                "disabled": undefined,
+              }
+            }
             accessible={true}
             focusable={true}
             isTVSelectable={true}
@@ -369,7 +373,11 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
         >
           <View
             accessibilityRole="button"
-            accessibilityStates={Array []}
+            accessibilityState={
+              Object {
+                "disabled": undefined,
+              }
+            }
             accessible={true}
             focusable={true}
             isTVSelectable={true}
@@ -461,7 +469,11 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
         >
           <View
             accessibilityRole="button"
-            accessibilityStates={Array []}
+            accessibilityState={
+              Object {
+                "disabled": undefined,
+              }
+            }
             accessible={true}
             focusable={true}
             isTVSelectable={true}

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
@@ -105,10 +105,10 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
       >
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -291,10 +291,10 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
         </View>
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -477,10 +477,10 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
         </View>
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -792,10 +792,10 @@ exports[`hides labels in shifting bottom navigation 1`] = `
         />
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -978,10 +978,10 @@ exports[`hides labels in shifting bottom navigation 1`] = `
         </View>
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -1164,10 +1164,10 @@ exports[`hides labels in shifting bottom navigation 1`] = `
         </View>
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -1459,10 +1459,10 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
       >
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -1625,10 +1625,10 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
         </View>
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -1791,10 +1791,10 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
         </View>
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -2086,10 +2086,10 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
         />
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -2236,10 +2236,10 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
         </View>
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -2386,10 +2386,10 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
         </View>
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -2536,10 +2536,10 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
         </View>
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -2686,10 +2686,10 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
         </View>
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -2945,10 +2945,10 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
       >
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -3211,10 +3211,10 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
         </View>
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -3477,10 +3477,10 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
         </View>
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -3872,10 +3872,10 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
         />
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -4101,10 +4101,10 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
         </View>
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -4330,10 +4330,10 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
         </View>
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -4668,10 +4668,10 @@ exports[`renders non-shifting bottom navigation 1`] = `
       >
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -4934,10 +4934,10 @@ exports[`renders non-shifting bottom navigation 1`] = `
         </View>
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -5200,10 +5200,10 @@ exports[`renders non-shifting bottom navigation 1`] = `
         </View>
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -5595,10 +5595,10 @@ exports[`renders shifting bottom navigation 1`] = `
         />
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -5824,10 +5824,10 @@ exports[`renders shifting bottom navigation 1`] = `
         </View>
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -6053,10 +6053,10 @@ exports[`renders shifting bottom navigation 1`] = `
         </View>
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -6282,10 +6282,10 @@ exports[`renders shifting bottom navigation 1`] = `
         </View>
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}
@@ -6511,10 +6511,10 @@ exports[`renders shifting bottom navigation 1`] = `
         </View>
         <View
           accessibilityRole="button"
-          accessibilityStates={
-            Array [
-              "selected",
-            ]
+          accessibilityState={
+            Object {
+              "selected": true,
+            }
           }
           accessible={true}
           focusable={true}

--- a/src/components/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.js.snap
@@ -16,7 +16,11 @@ exports[`renders button with color 1`] = `
 >
   <View
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "disabled": undefined,
+      }
+    }
     accessible={true}
     focusable={false}
     isTVSelectable={true}
@@ -108,7 +112,11 @@ exports[`renders button with custom testID 1`] = `
 >
   <View
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "disabled": undefined,
+      }
+    }
     accessible={true}
     focusable={false}
     isTVSelectable={true}
@@ -201,7 +209,11 @@ exports[`renders button with icon 1`] = `
 >
   <View
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "disabled": undefined,
+      }
+    }
     accessible={true}
     focusable={false}
     isTVSelectable={true}
@@ -343,7 +355,11 @@ exports[`renders contained contained with mode 1`] = `
 >
   <View
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "disabled": undefined,
+      }
+    }
     accessible={true}
     focusable={false}
     isTVSelectable={true}
@@ -435,10 +451,10 @@ exports[`renders disabled button 1`] = `
 >
   <View
     accessibilityRole="button"
-    accessibilityStates={
-      Array [
-        "disabled",
-      ]
+    accessibilityState={
+      Object {
+        "disabled": true,
+      }
     }
     accessible={true}
     focusable={false}
@@ -531,7 +547,11 @@ exports[`renders loading button 1`] = `
 >
   <View
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "disabled": undefined,
+      }
+    }
     accessible={true}
     focusable={false}
     isTVSelectable={true}
@@ -805,7 +825,11 @@ exports[`renders outlined button with mode 1`] = `
 >
   <View
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "disabled": undefined,
+      }
+    }
     accessible={true}
     focusable={false}
     isTVSelectable={true}
@@ -897,7 +921,11 @@ exports[`renders text button by default 1`] = `
 >
   <View
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "disabled": undefined,
+      }
+    }
     accessible={true}
     focusable={false}
     isTVSelectable={true}
@@ -989,7 +1017,11 @@ exports[`renders text button with mode 1`] = `
 >
   <View
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "disabled": undefined,
+      }
+    }
     accessible={true}
     focusable={false}
     isTVSelectable={true}

--- a/src/components/__tests__/__snapshots__/Chip.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.js.snap
@@ -15,7 +15,12 @@ exports[`renders chip with close button 1`] = `
 >
   <View
     accessibilityRole="button"
-    accessibilityState={Object {}}
+    accessibilityState={
+      Object {
+        "disabled": false,
+        "selected": false,
+      }
+    }
     accessible={true}
     focusable={false}
     isTVSelectable={true}
@@ -193,7 +198,12 @@ exports[`renders chip with icon 1`] = `
 >
   <View
     accessibilityRole="button"
-    accessibilityState={Object {}}
+    accessibilityState={
+      Object {
+        "disabled": false,
+        "selected": false,
+      }
+    }
     accessible={true}
     focusable={false}
     isTVSelectable={true}
@@ -320,7 +330,12 @@ exports[`renders chip with onPress 1`] = `
 >
   <View
     accessibilityRole="button"
-    accessibilityState={Object {}}
+    accessibilityState={
+      Object {
+        "disabled": false,
+        "selected": false,
+      }
+    }
     accessible={true}
     focusable={true}
     isTVSelectable={true}
@@ -405,6 +420,7 @@ exports[`renders outlined disabled chip 1`] = `
     accessibilityState={
       Object {
         "disabled": true,
+        "selected": false,
       }
     }
     accessible={true}
@@ -490,6 +506,7 @@ exports[`renders selected chip 1`] = `
     accessibilityRole="button"
     accessibilityState={
       Object {
+        "disabled": false,
         "selected": true,
       }
     }

--- a/src/components/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.js.snap
@@ -206,7 +206,11 @@ exports[`renders data table pagination 1`] = `
   />
   <View
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "disabled": false,
+      }
+    }
     accessible={true}
     focusable={true}
     hitSlop={
@@ -289,7 +293,11 @@ exports[`renders data table pagination 1`] = `
   </View>
   <View
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "disabled": false,
+      }
+    }
     accessible={true}
     focusable={true}
     hitSlop={
@@ -413,7 +421,11 @@ exports[`renders data table pagination with label 1`] = `
   </Text>
   <View
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "disabled": false,
+      }
+    }
     accessible={true}
     focusable={true}
     hitSlop={
@@ -496,7 +508,11 @@ exports[`renders data table pagination with label 1`] = `
   </View>
   <View
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "disabled": false,
+      }
+    }
     accessible={true}
     focusable={true}
     hitSlop={

--- a/src/components/__tests__/__snapshots__/DrawerItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DrawerItem.test.js.snap
@@ -18,7 +18,11 @@ exports[`renders DrawerItem with icon 1`] = `
 >
   <View
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "selected": undefined,
+      }
+    }
     accessible={true}
     focusable={false}
     isTVSelectable={true}
@@ -132,10 +136,10 @@ exports[`renders active DrawerItem 1`] = `
 >
   <View
     accessibilityRole="button"
-    accessibilityStates={
-      Array [
-        "selected",
-      ]
+    accessibilityState={
+      Object {
+        "selected": true,
+      }
     }
     accessible={true}
     focusable={false}
@@ -250,7 +254,11 @@ exports[`renders basic DrawerItem 1`] = `
 >
   <View
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "selected": undefined,
+      }
+    }
     accessible={true}
     focusable={true}
     isTVSelectable={true}

--- a/src/components/__tests__/__snapshots__/FAB.test.js.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.js.snap
@@ -27,7 +27,11 @@ exports[`renders extended FAB 1`] = `
   <View
     accessibilityLabel="Add items"
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "disabled": undefined,
+      }
+    }
     accessible={true}
     focusable={true}
     isTVSelectable={true}
@@ -187,7 +191,11 @@ exports[`renders normal FAB 1`] = `
 >
   <View
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "disabled": undefined,
+      }
+    }
     accessible={true}
     focusable={true}
     isTVSelectable={true}
@@ -323,7 +331,11 @@ exports[`renders small FAB 1`] = `
 >
   <View
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "disabled": undefined,
+      }
+    }
     accessible={true}
     focusable={true}
     isTVSelectable={true}

--- a/src/components/__tests__/__snapshots__/IconButton.test.js.snap
+++ b/src/components/__tests__/__snapshots__/IconButton.test.js.snap
@@ -3,10 +3,10 @@
 exports[`renders disabled icon button 1`] = `
 <View
   accessibilityRole="button"
-  accessibilityStates={
-    Array [
-      "disabled",
-    ]
+  accessibilityState={
+    Object {
+      "disabled": true,
+    }
   }
   accessible={true}
   focusable={false}
@@ -95,7 +95,11 @@ exports[`renders disabled icon button 1`] = `
 exports[`renders icon button by default 1`] = `
 <View
   accessibilityRole="button"
-  accessibilityStates={Array []}
+  accessibilityState={
+    Object {
+      "disabled": undefined,
+    }
+  }
   accessible={true}
   focusable={false}
   hitSlop={
@@ -181,7 +185,11 @@ exports[`renders icon button by default 1`] = `
 exports[`renders icon button with color 1`] = `
 <View
   accessibilityRole="button"
-  accessibilityStates={Array []}
+  accessibilityState={
+    Object {
+      "disabled": undefined,
+    }
+  }
   accessible={true}
   focusable={false}
   hitSlop={
@@ -267,7 +275,11 @@ exports[`renders icon button with color 1`] = `
 exports[`renders icon button with size 1`] = `
 <View
   accessibilityRole="button"
-  accessibilityStates={Array []}
+  accessibilityState={
+    Object {
+      "disabled": undefined,
+    }
+  }
   accessible={true}
   focusable={false}
   hitSlop={
@@ -353,7 +365,11 @@ exports[`renders icon button with size 1`] = `
 exports[`renders icon change animated 1`] = `
 <View
   accessibilityRole="button"
-  accessibilityStates={Array []}
+  accessibilityState={
+    Object {
+      "disabled": undefined,
+    }
+  }
   accessible={true}
   focusable={false}
   hitSlop={

--- a/src/components/__tests__/__snapshots__/ListItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.js.snap
@@ -96,7 +96,12 @@ exports[`renders list item with custom description 1`] = `
           >
             <View
               accessibilityRole="button"
-              accessibilityState={Object {}}
+              accessibilityState={
+                Object {
+                  "disabled": false,
+                  "selected": false,
+                }
+              }
               accessible={true}
               focusable={true}
               isTVSelectable={true}

--- a/src/components/__tests__/__snapshots__/Menu.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.js.snap
@@ -19,7 +19,11 @@ exports[`renders menu with content styles 1`] = `
   >
     <View
       accessibilityRole="button"
-      accessibilityStates={Array []}
+      accessibilityState={
+        Object {
+          "disabled": undefined,
+        }
+      }
       accessible={true}
       focusable={false}
       isTVSelectable={true}
@@ -115,7 +119,11 @@ exports[`renders not visible menu 1`] = `
   >
     <View
       accessibilityRole="button"
-      accessibilityStates={Array []}
+      accessibilityState={
+        Object {
+          "disabled": undefined,
+        }
+      }
       accessible={true}
       focusable={false}
       isTVSelectable={true}
@@ -211,7 +219,11 @@ exports[`renders visible menu 1`] = `
   >
     <View
       accessibilityRole="button"
-      accessibilityStates={Array []}
+      accessibilityState={
+        Object {
+          "disabled": undefined,
+        }
+      }
       accessible={true}
       focusable={false}
       isTVSelectable={true}

--- a/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
@@ -22,7 +22,11 @@ exports[`renders with placeholder 1`] = `
   <View
     accessibilityLabel="search"
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "disabled": undefined,
+      }
+    }
     accessible={true}
     focusable={false}
     hitSlop={
@@ -136,10 +140,10 @@ exports[`renders with placeholder 1`] = `
   <View
     accessibilityLabel="clear"
     accessibilityRole="button"
-    accessibilityStates={
-      Array [
-        "disabled",
-      ]
+    accessibilityState={
+      Object {
+        "disabled": true,
+      }
     }
     accessible={true}
     focusable={true}
@@ -248,7 +252,11 @@ exports[`renders with text 1`] = `
   <View
     accessibilityLabel="search"
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "disabled": undefined,
+      }
+    }
     accessible={true}
     focusable={false}
     hitSlop={
@@ -363,7 +371,11 @@ exports[`renders with text 1`] = `
   <View
     accessibilityLabel="clear"
     accessibilityRole="button"
-    accessibilityStates={Array []}
+    accessibilityState={
+      Object {
+        "disabled": false,
+      }
+    }
     accessible={true}
     focusable={true}
     hitSlop={

--- a/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
@@ -163,7 +163,11 @@ exports[`renders snackbar with action button 1`] = `
     >
       <View
         accessibilityRole="button"
-        accessibilityStates={Array []}
+        accessibilityState={
+          Object {
+            "disabled": undefined,
+          }
+        }
         accessible={true}
         focusable={true}
         isTVSelectable={true}

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -221,7 +221,11 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
   >
     <View
       accessibilityRole="button"
-      accessibilityStates={Array []}
+      accessibilityState={
+        Object {
+          "disabled": undefined,
+        }
+      }
       accessible={true}
       focusable={true}
       hitSlop={
@@ -499,7 +503,11 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
   >
     <View
       accessibilityRole="button"
-      accessibilityStates={Array []}
+      accessibilityState={
+        Object {
+          "disabled": undefined,
+        }
+      }
       accessible={true}
       focusable={true}
       hitSlop={

--- a/src/components/__tests__/__snapshots__/ToggleButton.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ToggleButton.test.js.snap
@@ -3,10 +3,10 @@
 exports[`renders disabled toggle button 1`] = `
 <View
   accessibilityRole="button"
-  accessibilityStates={
-    Array [
-      "disabled",
-    ]
+  accessibilityState={
+    Object {
+      "disabled": true,
+    }
   }
   accessible={true}
   focusable={true}
@@ -105,7 +105,11 @@ exports[`renders disabled toggle button 1`] = `
 exports[`renders toggle button 1`] = `
 <View
   accessibilityRole="button"
-  accessibilityStates={Array []}
+  accessibilityState={
+    Object {
+      "disabled": undefined,
+    }
+  }
   accessible={true}
   focusable={true}
   hitSlop={
@@ -201,10 +205,10 @@ exports[`renders toggle button 1`] = `
 exports[`renders unchecked toggle button 1`] = `
 <View
   accessibilityRole="button"
-  accessibilityStates={
-    Array [
-      "disabled",
-    ]
+  accessibilityState={
+    Object {
+      "disabled": true,
+    }
   }
   accessible={true}
   focusable={true}


### PR DESCRIPTION
`accessiblityStates` is removed in `0.62` and that causing typescript errors. With this PR I'm changing paper to use new `accessibilityState` also we want to update `@types/react-native` because  `accessibilityState` wasn't exist in `0.57.61`|
Issue: #1920 
Unfortunately it's a breaking change for people using older version of react-native and we want to add it to 4.0