### PR TITLE
feat: add prop accessibilityLabel to RadioButtonItem

### DIFF
--- a/src/components/RadioButton/RadioButtonItem.tsx
+++ b/src/components/RadioButton/RadioButtonItem.tsx
@@ -32,6 +32,10 @@ export type Props = {
    */
   onPress?: () => void;
   /**
+   * Accessibility label for the touchable. This is read by the screen reader when the user taps the touchable.
+   */
+  accessibilityLabel?: string;
+  /**
    * Custom color for unchecked radio.
    */
   uncheckedColor?: string;
@@ -107,6 +111,7 @@ class RadioButtonItem extends React.Component<Props> {
       uncheckedColor,
       status,
       theme: { colors },
+      accessibilityLabel,
     } = this.props;
 
     return (
@@ -124,6 +129,7 @@ class RadioButtonItem extends React.Component<Props> {
                         value,
                       })
               }
+              accessibilityLabel={accessibilityLabel}
             >
               <View style={[styles.container, style]} pointerEvents="none">
                 <Text


### PR DESCRIPTION
### Motivation
It's not possible to press on a RadioButtonItem using appium or other testing tools without passing an accessibilityLabel to the touchable.