### PR TITLE
feat: ability to use number as radio btn value

### DIFF
--- a/example/src/Examples/RadioButtonGroupExample.tsx
+++ b/example/src/Examples/RadioButtonGroupExample.tsx
@@ -9,8 +9,8 @@ import {
 } from 'react-native-paper';
 
 const RadioButtonGroupExample = () => {
-  const [value, setValue] = React.useState<string>('first');
-  const [value2, setValue2] = React.useState<string>('first');
+  const [value, setValue] = React.useState<string | number>('first');
+  const [value2, setValue2] = React.useState<string | number>('first');
 
   const {
     colors: { background, primary },
@@ -27,7 +27,7 @@ const RadioButtonGroupExample = () => {
       <List.Section title="With RadioButton">
         <RadioButton.Group
           value={value}
-          onValueChange={(value: string) => setValue(value)}
+          onValueChange={(value: string | number) => setValue(value)}
         >
           <View style={styles.row}>
             <Paragraph>First</Paragraph>
@@ -46,7 +46,7 @@ const RadioButtonGroupExample = () => {
       <List.Section title="With RadioButton.Item">
         <RadioButton.Group
           value={value2}
-          onValueChange={(value: string) => setValue2(value)}
+          onValueChange={(value: string | number) => setValue2(value)}
         >
           <RadioButton.Item label="First item" value="first" />
           <RadioButton.Item label="Second item" value="second" />

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -11,7 +11,7 @@ export type Props = {
   /**
    * Value of the radio button
    */
-  value: string;
+  value: string | number;
   /**
    * Status of radio button.
    */

--- a/src/components/RadioButton/RadioButtonAndroid.tsx
+++ b/src/components/RadioButton/RadioButtonAndroid.tsx
@@ -11,7 +11,7 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * Value of the radio button
    */
-  value: string;
+  value: string | number;
   /**
    * Status of radio button.
    */

--- a/src/components/RadioButton/RadioButtonGroup.tsx
+++ b/src/components/RadioButton/RadioButtonGroup.tsx
@@ -27,6 +27,17 @@ export const RadioButtonContext = React.createContext<RadioButtonContextType>(
 /**
  * Radio button group allows to control a group of radio buttons.
  *
+ * <div class="screenshots">
+ *   <figure>
+ *     <img class="medium" src="screenshots/radio-button-group-android.gif" />
+ *  <figcaption>Android</figcaption>
+ *   </figure>
+ *   <figure>
+ *     <img class="medium" src="screenshots/radio-button-group-ios.gif" />
+ *  <figcaption>iOS</figcaption>
+ *   </figure>
+ * </div>
+ *
  * ## Usage
  * ```js
  * import * as React from 'react';

--- a/src/components/RadioButton/RadioButtonGroup.tsx
+++ b/src/components/RadioButton/RadioButtonGroup.tsx
@@ -4,11 +4,11 @@ type Props = {
   /**
    * Function to execute on selection change.
    */
-  onValueChange: (value: string) => void;
+  onValueChange: (value: string | number) => void;
   /**
    * Value of the currently selected radio button.
    */
-  value: string;
+  value: string | number;
   /**
    * React elements containing radio buttons.
    */
@@ -16,8 +16,8 @@ type Props = {
 };
 
 export type RadioButtonContextType = {
-  value: string;
-  onValueChange: (item: string) => void;
+  value: string | number;
+  onValueChange: (item: string | number) => void;
 };
 
 export const RadioButtonContext = React.createContext<RadioButtonContextType>(
@@ -26,17 +26,6 @@ export const RadioButtonContext = React.createContext<RadioButtonContextType>(
 
 /**
  * Radio button group allows to control a group of radio buttons.
- *
- * <div class="screenshots">
- *   <figure>
- *     <img class="medium" src="screenshots/radio-button-group-android.gif" />
- *  <figcaption>Android</figcaption>
- *   </figure>
- *   <figure>
- *     <img class="medium" src="screenshots/radio-button-group-ios.gif" />
- *  <figcaption>iOS</figcaption>
- *   </figure>
- * </div>
  *
  * ## Usage
  * ```js

--- a/src/components/RadioButton/RadioButtonIOS.tsx
+++ b/src/components/RadioButton/RadioButtonIOS.tsx
@@ -12,7 +12,7 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * Value of the radio button
    */
-  value: string;
+  value: string | number;
   /**
    * Status of radio button.
    */

--- a/src/components/RadioButton/utils.ts
+++ b/src/components/RadioButton/utils.ts
@@ -4,8 +4,8 @@ export const handlePress = ({
   onValueChange,
 }: {
   onPress?: () => void;
-  value: string;
-  onValueChange?: (value: string) => void;
+  value: string | number;
+  onValueChange?: (value: string | number) => void;
 }) => {
   onValueChange ? onValueChange(value) : onPress?.();
 };
@@ -15,9 +15,9 @@ export const isChecked = ({
   status,
   contextValue,
 }: {
-  value: string;
+  value: string | number;
   status?: 'checked' | 'unchecked';
-  contextValue?: string;
+  contextValue?: string | number;
 }) => {
   if (contextValue) {
     return contextValue === value ? 'checked' : 'unchecked';


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Ability to use Number in value prop of radio btn. Why?

Let's say I get data from an endpoint and the returned data is in this form.

```
{
  "data": {
    "project_types": [
      {
        "id": 1,
        "name": "Web Development"
      },
      {
        "id": 2,
        "name": "Web Designing"
      },
      {
        "id": 3,
        "name": "UX/UI Designing (Prototyping)"
      }
    ]
  }
}
```

Datatype of id is number & I can safely assume it is unique so I can directly loop through the data in render.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

```
<View>
    <RadioButton
      value={1}
      status={checked === 1 ? 'checked' : 'unchecked'}
      onPress={() => { this.setState({ checked: 1 }); }}
    />
    <RadioButton
      value={2}
       status={checked === 2 ? 'checked' : 'unchecked'}
      onPress={() => { this.setState({ checked: 2 }); }}
    />
</View>
```

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
