### PR TITLE
fix: memory leak in Menu hide animation

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -325,7 +325,7 @@ class Menu extends React.Component<Props, State> {
       duration: ANIMATION_DURATION * animation.scale,
       easing: EASING,
       useNativeDriver: true,
-    }).start(finished => {
+    }).start(({ finished }) => {
       if (finished) {
         this.setState({ menuLayout: { width: 0, height: 0 }, rendered: false });
         this.state.scaleAnimation.setValue({ x: 0, y: 0 });


### PR DESCRIPTION
### Summary
Unmounting a Menu was causing memory leaks because the animation wasn't properly handled.
Animation invokes the completion callback with `{finished: true}`

### Reference
https://reactnative.dev/docs/animated#working-with-animations