### PR TITLE
feat: add numberOfLines prop to button

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -78,6 +78,10 @@ type Props = React.ComponentProps<typeof Surface> & {
    */
   labelStyle?: StyleProp<TextStyle>;
   /**
+   * Maximum number of lines for the label.
+   */
+  numberOfLines?: number;
+  /**
    * @optional
    */
   theme: Theme;
@@ -172,6 +176,7 @@ class Button extends React.Component<Props, State> {
       theme,
       contentStyle,
       labelStyle,
+      numberOfLines,
       testID,
       ...rest
     } = this.props;
@@ -298,7 +303,7 @@ class Button extends React.Component<Props, State> {
               />
             ) : null}
             <Text
-              numberOfLines={1}
+              numberOfLines={numberOfLines || 1}
               style={[
                 styles.label,
                 compact && styles.compactLabel,


### PR DESCRIPTION
### Summary
Closes #1968 

For some of the buttons in my project, labels that are too long may sometimes get clipped with an ellipses. This is usually made more difficult by supporting multiple languages - a text size or similar change for one language may not work for another. By adding a `numberOfLines` prop to the button, I can choose to make some buttons wrap in order to fit their contents.

### Test plan

1. In the example app, create a new button component with a long label, and pass the prop `numberOfLines={2}` or similar
2. Similarly, buttons that do not have the prop or have a value of `numberOfLines={1}` should appear unchanged.

![example](https://user-images.githubusercontent.com/6651364/83773426-680c1800-a67c-11ea-9cc9-508a759da25a.jpg)
