### PR TITLE
fix: menu example

### DIFF
--- a/example/src/Examples/MenuExample.tsx
+++ b/example/src/Examples/MenuExample.tsx
@@ -120,10 +120,7 @@ const MenuExample = ({ navigation }: Props) => {
           <Menu.Item onPress={() => {}} title="Item 3" disabled />
         </Menu>
         <List.Section style={styles.list} title="Contextual menu">
-          <TouchableRipple
-            onPress={() => {}}
-            onLongPress={() => _handleLongPress}
-          >
+          <TouchableRipple onPress={() => {}} onLongPress={_handleLongPress}>
             <List.Item
               title="List item"
               description="Long press me to open contextual menu"


### PR DESCRIPTION
### Summary

The example showing how to display a menu using `onLongPress` was not working.