### PR TITLE
refactor(Menu): attach listeners earlier and add prop testID

### DIFF
--- a/example/src/Examples/MenuExample.tsx
+++ b/example/src/Examples/MenuExample.tsx
@@ -120,10 +120,7 @@ const MenuExample = ({ navigation }: Props) => {
           <Menu.Item onPress={() => {}} title="Item 3" disabled />
         </Menu>
         <List.Section style={styles.list} title="Contextual menu">
-          <TouchableRipple
-            onPress={() => {}}
-            onLongPress={_handleLongPress}
-          >
+          <TouchableRipple onPress={() => {}} onLongPress={_handleLongPress}>
             <List.Item
               title="List item"
               description="Long press me to open contextual menu"

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -57,6 +57,10 @@ type Props = {
    * @optional
    */
   theme: Theme;
+  /**
+   * testID to be used on tests.
+   */
+  testID?: string;
 };
 
 type Layout = $Omit<$Omit<LayoutRectangle, 'x'>, 'y'>;
@@ -253,6 +257,8 @@ class Menu extends React.Component<Props, State> {
   };
 
   private show = async () => {
+    this.removeListeners();
+    this.attachListeners();
     const windowLayout = Dimensions.get('window');
     const [menuLayout, anchorLayout] = await Promise.all([
       this.measureMenuLayout(),
@@ -291,8 +297,6 @@ class Menu extends React.Component<Props, State> {
         },
       }),
       () => {
-        this.attachListeners();
-
         const { animation } = this.props.theme;
         Animated.parallel([
           Animated.timing(this.state.scaleAnimation, {
@@ -344,6 +348,7 @@ class Menu extends React.Component<Props, State> {
       theme,
       statusBarHeight,
       onDismiss,
+      testID,
     } = this.props;
 
     const {
@@ -546,6 +551,7 @@ class Menu extends React.Component<Props, State> {
               accessibilityViewIsModal={visible}
               style={[styles.wrapper, positionStyle, style]}
               pointerEvents={visible ? 'box-none' : 'none'}
+              testID={testID}
             >
               <Animated.View style={{ transform: positionTransforms }}>
                 <Surface


### PR DESCRIPTION
### Summary

Problem: Since [react-native-testing-library@2.0.0](https://github.com/callstack/react-native-testing-library) `getByTestId` queries does not return non-native instances. Therefore, we can't trigger the behavior `dismiss` when Menu is dismissed as before to test whether it changed the prop `visible` to `false`.

Solution: Removing and attaching the listeners when the method show is called does the trick as the component [modal#showModal](https://github.com/callstack/react-native-paper/blob/master/src/components/Modal.tsx#L134) does. Now we can trigger `dismiss` with `hardwareBackPress`  as react-native does [here](https://github.com/facebook/react-native/blob/a903d1b86ab56163abcdcb584f335949ba0c85fc/Libraries/Utilities/__mocks__/BackHandler.js) and check the presence of the menu with the `testID` prop (could also be an accessibility prop).
