### PR TITLE
fix: disable tab switching animation by default in bottom navigation

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -394,6 +394,7 @@ class BottomNavigation extends React.Component<Props, State> {
   static defaultProps = {
     labeled: true,
     keyboardHidesNavigationBar: true,
+    sceneAnimationEnabled: false,
   };
 
   static getDerivedStateFromProps(nextProps: any, prevState: State) {
@@ -710,8 +711,11 @@ class BottomNavigation extends React.Component<Props, State> {
             }
             const focused = navigationState.index === index;
 
-            const opacity =
-              sceneAnimationEnabled !== false ? tabs[index] : focused ? 1 : 0;
+            const opacity = sceneAnimationEnabled
+              ? tabs[index]
+              : focused
+              ? 1
+              : 0;
 
             const top = offsets[index].interpolate({
               inputRange: [0, 1],


### PR DESCRIPTION
There's a bug with animating elevation on Android, so we disable scene animation by default to avoid having such glitches with default props.
