### PR TITLE
fix: fix memory leak in TextInput placeholder animation

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -303,7 +303,9 @@ class TextInput extends React.Component<TextInputProps, State> {
         ios: false,
         default: true,
       }),
-    }).start(this.hidePlaceholder);
+    }).start(({ finished }) => {
+      if (finished) this.showPlaceholder();
+    });
   };
 
   private hideError = () => {


### PR DESCRIPTION
### Summary
I was getting random warning messages like `Can't perform a React state update on an unmounted component.` when testing with jest because the animation wasn't checking whether it was finished.