### PR TITLE
fix: Unable to style chip icon

### DIFF
--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -11,7 +11,7 @@ import {
   ViewStyle,
 } from 'react-native';
 import color from 'color';
-import Icon, { IconSource } from './Icon';
+import Icon, { IconSource, Props as IconProps } from './Icon';
 import Surface from './Surface';
 import Text from './Typography/Text';
 import TouchableRipple from './TouchableRipple';
@@ -33,6 +33,10 @@ type Props = React.ComponentProps<typeof Surface> & {
    * Icon to display for the `Chip`. Both icon and avatar cannot be specified.
    */
   icon?: IconSource;
+  /**
+   * Props to forward through to `Chip`.
+   */
+  IconProps?: Partial<IconProps>;
   /**
    * Avatar to display for the `Chip`. Both icon and avatar cannot be specified.
    */
@@ -145,6 +149,7 @@ class Chip extends React.Component<Props, State> {
       mode,
       children,
       icon,
+      IconProps,
       avatar,
       selected,
       disabled,
@@ -278,6 +283,7 @@ class Chip extends React.Component<Props, State> {
                   source={icon || 'check'}
                   color={avatar ? white : iconColor}
                   size={18}
+                  {...IconProps}
                 />
               </View>
             ) : null}

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -21,7 +21,7 @@ type IconProps = {
   allowFontScaling?: boolean;
 };
 
-type Props = IconProps & {
+export type Props = IconProps & {
   color?: string;
   source: any;
   /**


### PR DESCRIPTION
#2004 # Summary

Add IconProps prop to Chip component to allow more control over styling (such as color).

### Test plan
1. Add IconProps={{ color: 'red' }} to Chip component consumption.
2. Ensure chip icon color is red