### PR TITLE
feat(Menu): improve accessibility around dismissing

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -47,7 +47,7 @@ type Props = {
   /**
    * Accessibility label for the overlay. This is read by the screen reader when the user taps outside the menu.
    */
-  dismissAccessibilityLabel?: string;
+  overlayAccessibilityLabel?: string;
   /**
    * Content of the `Menu`.
    */
@@ -134,7 +134,7 @@ class Menu extends React.Component<Props, State> {
 
   static defaultProps = {
     statusBarHeight: APPROX_STATUSBAR_HEIGHT,
-    dismissAccessibilityLabel: 'Close menu',
+    overlayAccessibilityLabel: 'Close menu',
   };
 
   static getDerivedStateFromProps(nextProps: Props, prevState: State) {
@@ -344,7 +344,7 @@ class Menu extends React.Component<Props, State> {
       theme,
       statusBarHeight,
       onDismiss,
-      dismissAccessibilityLabel,
+      overlayAccessibilityLabel,
     } = this.props;
 
     const {
@@ -537,7 +537,7 @@ class Menu extends React.Component<Props, State> {
         {rendered ? (
           <Portal>
             <TouchableWithoutFeedback
-              accessibilityLabel={dismissAccessibilityLabel}
+              accessibilityLabel={overlayAccessibilityLabel}
               accessibilityRole="button"
               onPress={onDismiss}
             >

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -134,7 +134,7 @@ class Menu extends React.Component<Props, State> {
 
   static defaultProps = {
     statusBarHeight: APPROX_STATUSBAR_HEIGHT,
-    overlayAccessibilityLabel: 'Close menu',
+    dismissAccessibilityLabel: 'Close menu',
   };
 
   static getDerivedStateFromProps(nextProps: Props, prevState: State) {

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -45,6 +45,10 @@ type Props = {
    */
   onDismiss: () => void;
   /**
+   * Accessibility label for the overlay. This is read by the screen reader when the user taps outside the menu.
+   */
+  dismissAccessibilityLabel?: string;
+  /**
    * Content of the `Menu`.
    */
   children: React.ReactNode;
@@ -130,6 +134,7 @@ class Menu extends React.Component<Props, State> {
 
   static defaultProps = {
     statusBarHeight: APPROX_STATUSBAR_HEIGHT,
+    overlayAccessibilityLabel: 'Close menu',
   };
 
   static getDerivedStateFromProps(nextProps: Props, prevState: State) {
@@ -339,6 +344,7 @@ class Menu extends React.Component<Props, State> {
       theme,
       statusBarHeight,
       onDismiss,
+      dismissAccessibilityLabel,
     } = this.props;
 
     const {
@@ -530,7 +536,11 @@ class Menu extends React.Component<Props, State> {
         {this.isAnchorCoord() ? null : anchor}
         {rendered ? (
           <Portal>
-            <TouchableWithoutFeedback onPress={onDismiss}>
+            <TouchableWithoutFeedback
+              accessibilityLabel={dismissAccessibilityLabel}
+              accessibilityRole="button"
+              onPress={onDismiss}
+            >
               <View style={StyleSheet.absoluteFill} />
             </TouchableWithoutFeedback>
             <View
@@ -541,6 +551,8 @@ class Menu extends React.Component<Props, State> {
               accessibilityViewIsModal={visible}
               style={[styles.wrapper, positionStyle, style]}
               pointerEvents={visible ? 'box-none' : 'none'}
+              // @ts-ignore - FIX ME
+              onAccessibilityEscape={onDismiss}
             >
               <Animated.View style={{ transform: positionTransforms }}>
                 <Surface


### PR DESCRIPTION
following up #2010

### Test plan
#### Android
1. Check `accessibilityLabel` of the overlay with TalkBack

#### iOS
1. Check whether `onAccessibilityEscape` dismiss the menu with the escape/scrub gesture