### PR TITLE
fix: catch empty touches

### DIFF
--- a/src/components/TouchableRipple/index.tsx
+++ b/src/components/TouchableRipple/index.tsx
@@ -119,12 +119,10 @@ class TouchableRipple extends React.Component<Props> {
       touchX = dimensions.width / 2;
       touchY = dimensions.height / 2;
     } else {
-      const startX = e.nativeEvent.touches
-        ? e.nativeEvent.touches[0].pageX
-        : e.pageX;
-      const startY = e.nativeEvent.touches
-        ? e.nativeEvent.touches[0].pageY
-        : e.pageY;
+      const { changedTouches, touches } = e.nativeEvent;
+      const touch = touches?.[0] || changedTouches?.[0];
+      const startX = touch.pageX || e.pageX;
+      const startY = touch.pageY || e.pageY;
 
       touchX = startX - dimensions.left;
       touchY = startY - dimensions.top;

--- a/src/components/TouchableRipple/index.tsx
+++ b/src/components/TouchableRipple/index.tsx
@@ -120,9 +120,9 @@ class TouchableRipple extends React.Component<Props> {
       touchY = dimensions.height / 2;
     } else {
       const { changedTouches, touches } = e.nativeEvent;
-      const touch = touches?.[0] || changedTouches?.[0];
-      const startX = touch.pageX || e.pageX;
-      const startY = touch.pageY || e.pageY;
+      const touch = touches?.[0] ?? changedTouches?.[0];
+      const startX = touch.pageX ?? e.pageX;
+      const startY = touch.pageY ?? e.pageY;
 
       touchX = startX - dimensions.left;
       touchY = startY - dimensions.top;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

There are situations when the `touches` array is empty and thus it causes errors.
![image](https://user-images.githubusercontent.com/5358638/86093808-db544e80-baaf-11ea-9cfd-e61c8a82eda1.png)

As I noticed it especially with `react-native-web@^0.13.0` I checked their code and they have a similar check:
https://github.com/necolas/react-native-web/blob/master/packages/react-native-web/src/hooks/usePressEvents/PressResponder.js#L548-L557

### Test plan

Unfortunately, I cannot provide an example that reproduces the issue but I noticed it once in a while with `react-native-web@^0.13.0`.
