### PR TITLE
fix: fix the bug of overlap of placeholder and label when error is true

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -303,7 +303,7 @@ class TextInput extends React.Component<TextInputProps, State> {
         ios: false,
         default: true,
       }),
-    }).start(this.showPlaceholder);
+    }).start(this.hidePlaceholder);
   };
 
   private hideError = () => {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
This Pr is related to [this issue](https://github.com/callstack/react-native-paper/issues/1943). 
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
A reproducible code can be found [here](https://github.com/callstack/react-native-paper/issues/1943#issue-623397804)
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
Here is list of screen shots after the change is applied to the TextInput:
Normal:
![Simulator Screen Shot - iPhone 11 - 2020-07-01 at 03 12 24](https://user-images.githubusercontent.com/10198892/86185055-b2cd6280-bb4a-11ea-8919-8da63195b1b7.png)
Error without focus:
![Simulator Screen Shot - iPhone 11 - 2020-07-01 at 03 09 32](https://user-images.githubusercontent.com/10198892/86185117-d395b800-bb4a-11ea-8990-8301a462d973.png)
Error with focus:
![Simulator Screen Shot - iPhone 11 - 2020-07-01 at 03 09 40](https://user-images.githubusercontent.com/10198892/86185165-f031f000-bb4a-11ea-87d9-f5ec3e572368.png)


