### PR TITLE
feat: add ellipsizeMode prop to Chip

### DIFF
--- a/example/src/Examples/ChipExample.tsx
+++ b/example/src/Examples/ChipExample.tsx
@@ -197,6 +197,17 @@ const ChipExample = () => {
             >
               With custom size
             </Chip>
+            <Chip
+              onPress={() => {}}
+              onClose={() => {}}
+              style={{ flex: 1 }}
+              textStyle={{ flex: -1 }}
+              ellipsizeMode="middle"
+            >
+              With a very big text: React Native Paper is a high-quality,
+              standard-compliant Material Design library that has you covered in
+              all major use-cases.
+            </Chip>
           </View>
         </List.Section>
       </ScrollView>

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -17,6 +17,7 @@ import Text from './Typography/Text';
 import TouchableRipple from './TouchableRipple/TouchableRipple';
 import { withTheme } from '../core/theming';
 import { black, white } from '../styles/colors';
+import type { EllipsizeProp } from '../types';
 
 type Props = React.ComponentProps<typeof Surface> & {
   /**
@@ -79,6 +80,10 @@ type Props = React.ComponentProps<typeof Surface> & {
    * Pass down testID from chip props to touchable for Detox tests.
    */
   testID?: string;
+  /**
+   * Ellipsize Mode for the children text
+   */
+  ellipsizeMode?: EllipsizeProp;
 };
 
 type State = {
@@ -157,6 +162,7 @@ class Chip extends React.Component<Props, State> {
       theme,
       testID,
       selectedColor,
+      ellipsizeMode,
       ...rest
     } = this.props;
     const { dark, colors } = theme;
@@ -293,6 +299,7 @@ class Chip extends React.Component<Props, State> {
                 },
                 textStyle,
               ]}
+              ellipsizeMode={ellipsizeMode}
             >
               {children}
             </Text>


### PR DESCRIPTION
### Summary
It'd be nice to be able to truncate the chip text when it's too big.

![example](https://user-images.githubusercontent.com/6487206/91662193-20e4c600-eab7-11ea-80ca-2225cd2f0702.jpeg)
