### PR TITLE
fix: fix showing unwanted rotations in header back btn on state changes

### DIFF
--- a/src/components/Appbar/AppbarBackAction.tsx
+++ b/src/components/Appbar/AppbarBackAction.tsx
@@ -1,16 +1,8 @@
 import * as React from 'react';
-import {
-  View,
-  Image,
-  I18nManager,
-  StyleSheet,
-  Platform,
-  StyleProp,
-  ViewStyle,
-} from 'react-native';
 import type { $Omit } from './../../types';
 import AppbarAction from './AppbarAction';
-import MaterialCommunityIcon from '../MaterialCommunityIcon';
+import AppbarBackIcon from './AppbarBackIcon';
+import type { StyleProp, ViewStyle } from 'react-native';
 
 type Props = $Omit<
   React.ComponentPropsWithoutRef<typeof AppbarAction>,
@@ -79,50 +71,8 @@ class AppbarBackAction extends React.Component<Props> {
   };
 
   render() {
-    return (
-      <AppbarAction
-        {...this.props}
-        icon={({ size, color }: { size: number; color: string }) =>
-          Platform.OS === 'ios' ? (
-            <View
-              style={[
-                styles.wrapper,
-                {
-                  width: size,
-                  height: size,
-                  transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
-                },
-              ]}
-            >
-              <Image
-                source={require('../../assets/back-chevron.png')}
-                style={[styles.icon, { tintColor: color }]}
-              />
-            </View>
-          ) : (
-            <MaterialCommunityIcon
-              name="arrow-left"
-              color={color}
-              size={size}
-              direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
-            />
-          )
-        }
-      />
-    );
+    return <AppbarAction {...this.props} icon={AppbarBackIcon} />;
   }
 }
-
-const styles = StyleSheet.create({
-  wrapper: {
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  icon: {
-    height: 21,
-    width: 21,
-    resizeMode: 'contain',
-  },
-});
 
 export default AppbarBackAction;

--- a/src/components/Appbar/AppbarBackIcon.tsx
+++ b/src/components/Appbar/AppbarBackIcon.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { Platform, I18nManager, View, Image, StyleSheet } from 'react-native';
+import MaterialCommunityIcon from '../MaterialCommunityIcon';
+
+const AppbarBackIcon = ({ size, color }: { size: number; color: string }) =>
+  Platform.OS === 'ios' ? (
+    <View
+      style={[
+        styles.wrapper,
+        {
+          width: size,
+          height: size,
+          transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
+        },
+      ]}
+    >
+      <Image
+        source={require('../../assets/back-chevron.png')}
+        style={[styles.icon, { tintColor: color }]}
+      />
+    </View>
+  ) : (
+    <MaterialCommunityIcon
+      name="arrow-left"
+      color={color}
+      size={size}
+      direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
+    />
+  );
+
+const styles = StyleSheet.create({
+  wrapper: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  icon: {
+    height: 21,
+    width: 21,
+    resizeMode: 'contain',
+  },
+});
+
+export default AppbarBackIcon;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Related to [this issue](https://github.com/callstack/react-native-paper/issues/2046).
[Here](https://github.com/callstack/react-native-paper/blob/4237fd6adce733a628ac553bd4ad933f8d54ffe4/src/components/Appbar/AppbarBackAction.tsx#L85) is how the icon is passed, and causing [this condition](https://github.com/callstack/react-native-paper/blob/4237fd6adce733a628ac553bd4ad933f8d54ffe4/src/components/CrossFadeIcon.tsx#L35) to fail every time and causing a re-render/rotation animation. I also decided to extract the icon to a new file/component.
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
