### PR TITLE
fix: allow labelStyle to override all built-in styles

### DIFF
--- a/src/components/Checkbox/CheckboxItem.tsx
+++ b/src/components/Checkbox/CheckboxItem.tsx
@@ -88,7 +88,7 @@ class CheckboxItem extends React.Component<Props> {
     return (
       <TouchableRipple onPress={onPress}>
         <View style={[styles.container, style]} pointerEvents="none">
-          <Text style={[styles.label, labelStyle, { color: colors.primary }]}>
+          <Text style={[styles.label, { color: colors.primary }, labelStyle]}>
             {label}
           </Text>
           <CheckBox status={status} {...props}></CheckBox>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Currently it's not possible to override the text color using `labelStyle` prop due to the internal overriding order.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
