### PR TITLE
fix: ensure compatible animation drive for cards

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -105,21 +105,29 @@ class Card extends React.Component<Props, State> {
   };
 
   private handlePressIn = () => {
-    const { scale } = this.props.theme.animation;
+    const {
+      dark,
+      mode,
+      animation: { scale },
+    } = this.props.theme;
     Animated.timing(this.state.elevation, {
       toValue: 8,
       duration: 150 * scale,
-      useNativeDriver: true,
+      useNativeDriver: !dark || mode === 'exact',
     }).start();
   };
 
   private handlePressOut = () => {
-    const { scale } = this.props.theme.animation;
+    const {
+      dark,
+      mode,
+      animation: { scale },
+    } = this.props.theme;
     Animated.timing(this.state.elevation, {
       // @ts-ignore
       toValue: this.props.elevation,
       duration: 150 * scale,
-      useNativeDriver: true,
+      useNativeDriver: !dark || mode === 'exact',
     }).start();
   };
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

On dark themes, the default mode is adaptive. This mode will change the `backgroundColor`. This property is not animatable using the nativeDriver. Upstream issue: https://github.com/facebook/react-native/issues/14178

The bug was introduced in https://github.com/callstack/react-native-paper/pull/1787
Fixes https://github.com/callstack/react-native-paper/issues/2063