### PR TITLE
feat(Modal): improve accessibility around dismissing

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -551,7 +551,6 @@ class Menu extends React.Component<Props, State> {
               accessibilityViewIsModal={visible}
               style={[styles.wrapper, positionStyle, style]}
               pointerEvents={visible ? 'box-none' : 'none'}
-              // @ts-ignore - FIX ME
               onAccessibilityEscape={onDismiss}
             >
               <Animated.View style={{ transform: positionTransforms }}>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -22,6 +22,10 @@ type Props = {
    */
   onDismiss?: () => void;
   /**
+   * Accessibility label for the overlay. This is read by the screen reader when the user taps outside the modal.
+   */
+  overlayAccessibilityLabel?: string;
+  /**
    * Determines Whether the modal is visible.
    */
   visible: boolean;
@@ -90,6 +94,7 @@ class Modal extends React.Component<Props, State> {
   static defaultProps = {
     dismissable: true,
     visible: false,
+    overlayAccessibilityLabel: 'Close modal',
   };
 
   static getDerivedStateFromProps(nextProps: Props, prevState: State) {
@@ -178,7 +183,13 @@ class Modal extends React.Component<Props, State> {
 
     if (!rendered) return null;
 
-    const { children, dismissable, theme, contentContainerStyle } = this.props;
+    const {
+      children,
+      dismissable,
+      theme,
+      contentContainerStyle,
+      overlayAccessibilityLabel,
+    } = this.props;
     const { colors } = theme;
     return (
       <Animated.View
@@ -186,8 +197,11 @@ class Modal extends React.Component<Props, State> {
         accessibilityViewIsModal
         accessibilityLiveRegion="polite"
         style={StyleSheet.absoluteFill}
+        onAccessibilityEscape={this.hideModal}
       >
         <TouchableWithoutFeedback
+          accessibilityLabel={overlayAccessibilityLabel}
+          accessibilityRole="button"
           disabled={!dismissable}
           onPress={dismissable ? this.hideModal : undefined}
         >


### PR DESCRIPTION
### Test plan
#### Android
1. Check `accessibilityLabel` of the overlay with TalkBack

#### iOS
1. Check whether `onAccessibilityEscape` dismiss the modal with the escape/scrub gesture