### PR TITLE
fix: BottomNavigation center label on web

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -1060,6 +1060,7 @@ const styles = StyleSheet.create({
     ...(Platform.OS === 'web'
       ? {
           whiteSpace: 'nowrap',
+          alignSelf: 'center'
         }
       : null),
   },

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -1060,7 +1060,7 @@ const styles = StyleSheet.create({
     ...(Platform.OS === 'web'
       ? {
           whiteSpace: 'nowrap',
-          alignSelf: 'center'
+          alignSelf: 'center',
         }
       : null),
   },


### PR DESCRIPTION
### Summary

The labels of BottomNavigation are not centered on web, especially if the label is long, like "Notifications". This will fix it.

### Test plan

Before:

![screenshot1](https://user-images.githubusercontent.com/39778068/88187389-d1d08900-cc0c-11ea-98af-db56f4a38491.jpg)

After:

![screenshot2](https://user-images.githubusercontent.com/39778068/88187463-f0368480-cc0c-11ea-9aa2-9b92b6249ef2.jpg)


