### PR TITLE
feat(TextInput): allow opening a Menu onPress of icon's adornment

### DIFF
--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -5,8 +5,15 @@ import {
   ScrollView,
   KeyboardAvoidingView,
   Platform,
+  GestureResponderEvent,
 } from 'react-native';
-import { TextInput, HelperText, useTheme } from 'react-native-paper';
+import {
+  TextInput,
+  HelperText,
+  useTheme,
+  Menu,
+  Divider,
+} from 'react-native-paper';
 import { inputReducer, State } from '../../utils';
 
 const MAX_LENGTH = 20;
@@ -57,8 +64,15 @@ const TextInputAvoidingView = ({ children }: AvoidingViewProps) => {
   );
 };
 
+type ContextualMenuCoord = { x: number; y: number };
+
 const TextInputExample = () => {
   const [state, dispatch] = React.useReducer(inputReducer, initialState);
+  const [menuVisible, setMenuVisible] = React.useState<boolean>(false);
+  const [contextualMenuCoord, setContextualMenuCoord] = React.useState<
+    ContextualMenuCoord
+  >({ x: 0, y: 0 });
+
   const {
     text,
     name,
@@ -111,6 +125,15 @@ const TextInputExample = () => {
       type: 'iconsColor',
       payload: colors,
     });
+  };
+
+  const handleIconPress = (event: GestureResponderEvent) => {
+    const { nativeEvent } = event;
+    setContextualMenuCoord({
+      x: nativeEvent.pageX,
+      y: nativeEvent.pageY,
+    });
+    setMenuVisible(true);
   };
 
   return (
@@ -388,6 +411,30 @@ const TextInputExample = () => {
           >
             Error: Only letters are allowed
           </HelperText>
+        </View>
+        <View style={styles.inputContainerStyle}>
+          <TextInput
+            label="Input opening a menu"
+            value={name}
+            right={
+              <TextInput.Icon
+                name="chevron-down"
+                color={flatRightIcon}
+                onPress={handleIconPress}
+                autoFocus={false}
+              />
+            }
+          />
+          <Menu
+            visible={menuVisible}
+            onDismiss={() => setMenuVisible(false)}
+            anchor={contextualMenuCoord}
+          >
+            <Menu.Item onPress={() => {}} title="Item 1" />
+            <Menu.Item onPress={() => {}} title="Item 2" />
+            <Divider />
+            <Menu.Item onPress={() => {}} title="Item 3" disabled />
+          </Menu>
         </View>
       </ScrollView>
     </TextInputAvoidingView>

--- a/src/components/TextInput/Adornment/Icon.tsx
+++ b/src/components/TextInput/Adornment/Icon.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { View, StyleSheet, StyleProp, ViewStyle } from 'react-native';
+import {
+  View,
+  StyleSheet,
+  StyleProp,
+  ViewStyle,
+  GestureResponderEvent,
+} from 'react-native';
 
 import IconButton from '../../IconButton';
 import type { $Omit } from '../../../../src/types';
@@ -9,7 +15,8 @@ type Props = $Omit<
   'icon' | 'theme'
 > & {
   name: string;
-  onPress?: () => void;
+  onPress?: (e: GestureResponderEvent) => void;
+  autoFocus?: Boolean;
   style?: StyleProp<ViewStyle>;
   theme?: ReactNativePaper.Theme;
 };
@@ -48,17 +55,20 @@ export const IconAdornment: React.FunctionComponent<
   );
 };
 
-const TextInputIcon = ({ name, onPress, ...rest }: Props) => {
+const TextInputIcon = ({ name, onPress, autoFocus, ...rest }: Props) => {
   const { style, isTextInputFocused, forceFocus } = React.useContext(
     StyleContext
   );
 
-  const onPressWithFocusControl = React.useCallback(() => {
-    if (!isTextInputFocused) {
-      forceFocus();
-    }
-    onPress?.();
-  }, [forceFocus, isTextInputFocused, onPress]);
+  const onPressWithFocusControl = React.useCallback(
+    (e: GestureResponderEvent) => {
+      if (autoFocus && !isTextInputFocused) {
+        forceFocus();
+      }
+      onPress?.(e);
+    },
+    [autoFocus, forceFocus, isTextInputFocused, onPress]
+  );
 
   return (
     <View style={[styles.container, style]}>
@@ -73,6 +83,10 @@ const TextInputIcon = ({ name, onPress, ...rest }: Props) => {
   );
 };
 TextInputIcon.displayName = 'TextInput.Icon';
+
+TextInputIcon.defaultProps = {
+  autoFocus: true,
+};
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
This PR do the following changes:
1. Add the prop `autoFocus` to `TextInputIcon` since we don't want the input to focus when the menu is opened.
2. Pass the event up to the `onPress` prop on the [L68](https://github.com/callstack/react-native-paper/pull/2078/files#diff-5c7a1356b821b108f5584d2b4ea4c02aR68) so we can catch the coordinates.

![menu](https://user-images.githubusercontent.com/6487206/88357395-7e138c00-cd41-11ea-8a9b-ca78875a9e29.jpeg)

### Test plan
1. Once you open the `TextInput` section, scroll down to the last input
2. Then click on the chevron icon and check whether the menu has opened.