### PR TITLE
fix: make the placeholderTextColor work on TextInput

### DIFF
--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -80,6 +80,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
       onRightAffixLayoutChange,
       left,
       right,
+      placeholderTextColor,
       ...rest
     } = this.props;
 
@@ -328,7 +329,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
             placeholder: label
               ? parentState.placeholder
               : this.props.placeholder,
-            placeholderTextColor: placeholderColor,
+            placeholderTextColor: placeholderTextColor || placeholderColor,
             editable: !disabled && editable,
             selectionColor:
               typeof selectionColor === 'undefined'

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -77,6 +77,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
       onRightAffixLayoutChange,
       left,
       right,
+      placeholderTextColor,
       ...rest
     } = this.props;
 
@@ -304,7 +305,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
               placeholder: label
                 ? parentState.placeholder
                 : this.props.placeholder,
-              placeholderTextColor: placeholderColor,
+              placeholderTextColor: placeholderTextColor || placeholderColor,
               editable: !disabled && editable,
               selectionColor:
                 typeof selectionColor === 'undefined'


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Related to [this issue](https://github.com/callstack/react-native-paper/issues/1621).
`TextInput` is extending the `react-native` but the `placeholderTextColor` didn't affect. 
Should mention the fact that if user use this prop, then they should handle the cases like the colors for when the `disabled` is true, etc.
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
just simply passing `placeholderTextColor` prop to `TextInpu`
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
