### PR TITLE
fix: align icon & label colors in FAB group

### DIFF
--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -228,9 +228,7 @@ class FABGroup extends React.Component<Props, State> {
     } = this.props;
     const { colors } = theme;
 
-    const labelColor = theme.dark
-      ? colors.text
-      : color(colors.text).fade(0.54).rgb().string();
+    const labelColor = colors.text;
     const backdropOpacity = open
       ? this.state.backdrop.interpolate({
           inputRange: [0, 0.5, 1],


### PR DESCRIPTION
It's not very clear to me why the labels for the FAB group need to have a 54% fade when using a light theme, as opposed to simply align with the icon color. Is this an official material design recommendation?

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
