### PR TITLE
Fix:Add animated prop to FAB

### DIFF
--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -6,6 +6,7 @@ import ActivityIndicator from '../ActivityIndicator';
 import FABGroup, { FABGroup as _FABGroup } from './FABGroup';
 import Surface from '../Surface';
 import CrossFadeIcon from '../CrossFadeIcon';
+import Icon from '../Icon';
 import Text from '../Typography/Text';
 import TouchableRipple from '../TouchableRipple';
 import { black, white } from '../../styles/colors';
@@ -27,6 +28,10 @@ type Props = $RemoveChildren<typeof Surface> & {
    * Uses `label` by default if specified.
    */
   accessibilityLabel?: string;
+  /**
+   * Whether an icon change is animated.
+   */
+  animated?: boolean;
   /**
    *  Whether FAB is mini-sized, used to create visual continuity with other elements. This has no effect if `label` is specified.
    */
@@ -137,6 +142,7 @@ class FAB extends React.Component<Props, State> {
       icon,
       label,
       accessibilityLabel = label,
+      animated = true,
       color: customColor,
       disabled,
       onPress,
@@ -148,6 +154,8 @@ class FAB extends React.Component<Props, State> {
       ...rest
     } = this.props;
     const { visibility } = this.state;
+
+    const IconComponent = animated ? CrossFadeIcon : Icon;
 
     const disabledColor = color(theme.dark ? white : black)
       .alpha(0.12)
@@ -216,7 +224,7 @@ class FAB extends React.Component<Props, State> {
             pointerEvents="none"
           >
             {icon && loading !== true ? (
-              <CrossFadeIcon source={icon} size={24} color={foregroundColor} />
+              <IconComponent source={icon} size={24} color={foregroundColor} />
             ) : null}
             {loading ? (
               <ActivityIndicator size={18} color={foregroundColor} />


### PR DESCRIPTION
### Summary

Fixes #2067

Note: For backward compatibility, I kept the default for `animated` as `true`.
However, `IconButton` [uses `false` as the default](https://github.com/callstack/react-native-paper/blob/master/src/components/IconButton.tsx#L95). This feels inconsistent. 

What can we do about it?


Edit:

After trying this out, I am not fully satisfied with this solution, because I have go go to every single place where I use a <FAB> and set the `animated` prop. I will also have to remember to set it each time I use a new one. That is something easy to forget unfortunately. 

This is kinda annoying.
As I said, ideally, we should set `animated`to false by default, but this is a breaking change. 
As I understand, v4 is out of beta, so that would be for version 5?

