### PR TITLE
fix: Card correct animation drivers

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -122,11 +122,10 @@ class Card extends React.Component<Props, State> {
      * toggling the theme will stay at that animated value until
      * the next press-in
      */
-
     const { dark: isDark, mode } = this.props.theme;
     const { dark: wasDark } = prevProps.theme;
     const { elevation, elevationDarkAdaptive } = this.state;
-    if (isDark && mode === 'adaptive' && isDark !== wasDark) {
+    if (isDark && mode === 'adaptive' && !wasDark) {
       // @ts-ignore
       elevation.setValue(this.props.elevation);
       // @ts-ignore


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

#2068 was a partial solution for #2063, bug introduced in #1783.

It did solve in case of toggling the theme while there is no animations running, **but if a card is animating during the process** it may (in case of adaptive mode) receive the animation with native drivers and break in the `Surface` component, just as before of #2068.

**[update]**: Just to clarify the "may receive the animation",  the previous one may be with native drivers `true`, then toggling the theme while animating may change the animation to native drivers `false`, but it is not possible to change native drivers of a an animation during an animation, it does breaks the app.

This PR solves this issue, now you can even toggle the theme with `<Card onPress={toggleTheme}>...` which wasn't possible before (with adaptive mode).

~~**[update 2]** Now it fix #2138 too, this is particularly useful if the card is just an image, as in this case there is no feedback when you press it on dark adaptive mode.~~

### Test plan

Try the following code, before and after this PR. Before, it will break.

```jsx
<Card onPress={toggleTheme}>{children}</Card>
```

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
