### PR TITLE
fix: Dialog background color in dark mode

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -122,11 +122,10 @@ class Card extends React.Component<Props, State> {
      * toggling the theme will stay at that animated value until
      * the next press-in
      */
-
     const { dark: isDark, mode } = this.props.theme;
     const { dark: wasDark } = prevProps.theme;
     const { elevation, elevationDarkAdaptive } = this.state;
-    if (isDark && mode === 'adaptive' && isDark !== wasDark) {
+    if (isDark && mode === 'adaptive' && !wasDark) {
       // @ts-ignore
       elevation.setValue(this.props.elevation);
       // @ts-ignore

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -7,6 +7,7 @@ import DialogActions from './DialogActions';
 import DialogTitle, { DialogTitle as _DialogTitle } from './DialogTitle';
 import DialogScrollArea from './DialogScrollArea';
 import { withTheme } from '../../core/theming';
+import overlay from '../../styles/overlay';
 
 type Props = {
   /**
@@ -31,6 +32,8 @@ type Props = {
    */
   theme: ReactNativePaper.Theme;
 };
+
+const DIALOG_ELEVATION: number = 24
 
 /**
  * Dialogs inform users about a specific task and may contain critical information, require decisions, or involve multiple tasks.
@@ -108,7 +111,9 @@ class Dialog extends React.Component<Props> {
         contentContainerStyle={[
           {
             borderRadius: theme.roundness,
-            backgroundColor: theme.colors.surface,
+            backgroundColor: theme.dark
+              ? (overlay(DIALOG_ELEVATION, theme.colors.surface) as string)
+              : theme.colors.surface,
           },
           styles.container,
           style,
@@ -146,7 +151,7 @@ const styles = StyleSheet.create({
      */
     marginVertical: Platform.OS === 'android' ? 44 : 0,
     marginHorizontal: 26,
-    elevation: 24,
+    elevation: DIALOG_ELEVATION,
     justifyContent: 'flex-start',
   },
 });

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -111,9 +111,10 @@ class Dialog extends React.Component<Props> {
         contentContainerStyle={[
           {
             borderRadius: theme.roundness,
-            backgroundColor: theme.dark
-              ? (overlay(DIALOG_ELEVATION, theme.colors.surface) as string)
-              : theme.colors.surface,
+            backgroundColor:
+              theme.dark && theme.mode === 'adaptive'
+                ? (overlay(DIALOG_ELEVATION, theme.colors.surface) as string)
+                : theme.colors.surface,
           },
           styles.container,
           style,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

The [Dialog](https://github.com/callstack/react-native-paper/blob/master/src/components/Dialog/Dialog.tsx) component follows only the `exact` dark mode. This PR ensures the overlay if using `adaptive` mode.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

# Before

![before](https://user-images.githubusercontent.com/39778068/90021272-69af1900-dc87-11ea-93ce-c735acf755ee.jpeg)

# After

![after](https://user-images.githubusercontent.com/39778068/90021286-6ddb3680-dc87-11ea-989c-0da32f5db535.jpeg)

