### PR TITLE
feat: add prop forceTextInputFocus to icon adornment

### DIFF
--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -174,6 +174,7 @@ const TextInputExample = () => {
                   payload: !flatTextSecureEntry,
                 })
               }
+              forceTextInputFocus={false}
             />
           }
         />

--- a/src/components/TextInput/Adornment/Icon.tsx
+++ b/src/components/TextInput/Adornment/Icon.tsx
@@ -10,6 +10,7 @@ type Props = $Omit<
 > & {
   name: string;
   onPress?: () => void;
+  forceTextInputFocus?: Boolean;
   style?: StyleProp<ViewStyle>;
   theme?: ReactNativePaper.Theme;
 };
@@ -48,17 +49,22 @@ export const IconAdornment: React.FunctionComponent<
   );
 };
 
-const TextInputIcon = ({ name, onPress, ...rest }: Props) => {
+const TextInputIcon = ({
+  name,
+  onPress,
+  forceTextInputFocus,
+  ...rest
+}: Props) => {
   const { style, isTextInputFocused, forceFocus } = React.useContext(
     StyleContext
   );
 
   const onPressWithFocusControl = React.useCallback(() => {
-    if (!isTextInputFocused) {
+    if (forceTextInputFocus && !isTextInputFocused) {
       forceFocus();
     }
     onPress?.();
-  }, [forceFocus, isTextInputFocused, onPress]);
+  }, [forceTextInputFocus, forceFocus, isTextInputFocused, onPress]);
 
   return (
     <View style={[styles.container, style]}>
@@ -73,6 +79,10 @@ const TextInputIcon = ({ name, onPress, ...rest }: Props) => {
   );
 };
 TextInputIcon.displayName = 'TextInput.Icon';
+
+TextInputIcon.defaultProps = {
+  forceTextInputFocus: true,
+};
 
 const styles = StyleSheet.create({
   container: {

--- a/src/components/TextInput/Adornment/Icon.tsx
+++ b/src/components/TextInput/Adornment/Icon.tsx
@@ -10,7 +10,7 @@ type Props = $Omit<
 > & {
   name: string;
   onPress?: () => void;
-  forceTextInputFocus?: Boolean;
+  forceTextInputFocus?: boolean;
   style?: StyleProp<ViewStyle>;
   theme?: ReactNativePaper.Theme;
 };


### PR DESCRIPTION
### Summary
It would be nice being able to control whether the adornment should focus the input. 

### Test plan
1. Open the example app
2. Click on the eye icon in the password input and verify if the input will show the password without being focused.