### PR TITLE
feat: improve chip accessibility

### DIFF
--- a/example/src/Examples/ChipExample.tsx
+++ b/example/src/Examples/ChipExample.tsx
@@ -22,7 +22,12 @@ const ChipExample = () => {
             >
               Simple
             </Chip>
-            <Chip onPress={() => {}} onClose={() => {}} style={styles.chip}>
+            <Chip
+              onPress={() => {}}
+              onClose={() => {}}
+              style={styles.chip}
+              closeIconAccessibilityLabel="Close icon accessibility label"
+            >
               Close button
             </Chip>
             <Chip

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -55,6 +55,10 @@ type Props = React.ComponentProps<typeof Surface> & {
    */
   accessibilityLabel?: string;
   /**
+   * Accessibility label for the close icon. This is read by the screen reader when the user taps the close icon.
+   */
+  closeIconAccessibilityLabel?: string;
+  /**
    * Function to execute on press.
    */
   onPress?: () => void;
@@ -121,6 +125,7 @@ class Chip extends React.Component<Props, State> {
     mode: 'flat',
     disabled: false,
     selected: false,
+    closeIconAccessibilityLabel: 'Close',
   };
 
   state = {
@@ -154,6 +159,7 @@ class Chip extends React.Component<Props, State> {
       selected,
       disabled,
       accessibilityLabel,
+      closeIconAccessibilityLabel,
       onPress,
       onLongPress,
       onClose,
@@ -294,7 +300,7 @@ class Chip extends React.Component<Props, State> {
                 {
                   ...theme.fonts.regular,
                   color: textColor,
-                  marginRight: onClose ? 4 : 8,
+                  marginRight: onClose ? 0 : 8,
                   marginLeft: avatar || icon || selected ? 4 : 8,
                 },
                 textStyle,
@@ -303,19 +309,21 @@ class Chip extends React.Component<Props, State> {
             >
               {children}
             </Text>
-            {onClose ? (
-              <TouchableWithoutFeedback
-                onPress={onClose}
-                accessibilityTraits="button"
-                accessibilityComponentType="button"
-              >
-                <View style={styles.icon}>
-                  <Icon source="close-circle" size={16} color={iconColor} />
-                </View>
-              </TouchableWithoutFeedback>
-            ) : null}
           </View>
         </TouchableRipple>
+        {onClose ? (
+          <TouchableWithoutFeedback
+            onPress={onClose}
+            accessibilityTraits="button"
+            accessibilityComponentType="button"
+            accessibilityRole="button"
+            accessibilityLabel={closeIconAccessibilityLabel}
+          >
+            <View style={[styles.icon, styles.closeIcon]}>
+              <Icon source="close-circle" size={16} color={iconColor} />
+            </View>
+          </TouchableWithoutFeedback>
+        ) : null}
       </Surface>
     );
   }
@@ -325,6 +333,7 @@ const styles = StyleSheet.create({
   container: {
     borderWidth: StyleSheet.hairlineWidth,
     borderStyle: 'solid',
+    flexDirection: 'row',
   },
   content: {
     flexDirection: 'row',
@@ -333,6 +342,10 @@ const styles = StyleSheet.create({
   },
   icon: {
     padding: 4,
+    alignSelf: 'center',
+  },
+  closeIcon: {
+    marginRight: 4,
   },
   text: {
     minHeight: 24,

--- a/src/components/__tests__/__snapshots__/Chip.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.js.snap
@@ -10,6 +10,7 @@ exports[`renders chip with close button 1`] = `
       "borderStyle": "solid",
       "borderWidth": 0.5,
       "elevation": 0,
+      "flexDirection": "row",
     }
   }
 >
@@ -54,6 +55,7 @@ exports[`renders chip with close button 1`] = `
         style={
           Array [
             Object {
+              "alignSelf": "center",
               "padding": 4,
             },
             null,
@@ -117,7 +119,7 @@ exports[`renders chip with close button 1`] = `
                 "fontFamily": "System",
                 "fontWeight": "400",
                 "marginLeft": 4,
-                "marginRight": 4,
+                "marginRight": 0,
               },
               undefined,
             ],
@@ -126,58 +128,66 @@ exports[`renders chip with close button 1`] = `
       >
         Example Chip
       </Text>
-      <View
-        accessible={true}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
+    </View>
+  </View>
+  <View
+    accessibilityLabel="Close"
+    accessibilityRole="button"
+    accessible={true}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "alignSelf": "center",
+          "padding": 4,
+        },
+        Object {
+          "marginRight": 4,
+        },
+      ]
+    }
+  >
+    <Text
+      accessibilityElementsHidden={true}
+      allowFontScaling={false}
+      importantForAccessibility="no-hide-descendants"
+      pointerEvents="none"
+      style={
+        Array [
           Object {
-            "padding": 4,
-          }
-        }
-      >
-        <Text
-          accessibilityElementsHidden={true}
-          allowFontScaling={false}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          style={
-            Array [
-              Object {
-                "color": "rgba(0, 0, 0, 0.54)",
-                "fontSize": 16,
-              },
-              Array [
+            "color": "rgba(0, 0, 0, 0.54)",
+            "fontSize": 16,
+          },
+          Array [
+            Object {
+              "transform": Array [
                 Object {
-                  "transform": Array [
-                    Object {
-                      "scaleX": 1,
-                    },
-                  ],
-                },
-                Object {
-                  "backgroundColor": "transparent",
+                  "scaleX": 1,
                 },
               ],
-              Object {
-                "fontFamily": "Material Design Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          
-        </Text>
-      </View>
-    </View>
+            },
+            Object {
+              "backgroundColor": "transparent",
+            },
+          ],
+          Object {
+            "fontFamily": "Material Design Icons",
+            "fontStyle": "normal",
+            "fontWeight": "normal",
+          },
+          Object {},
+        ]
+      }
+    >
+      
+    </Text>
   </View>
 </View>
 `;
@@ -192,6 +202,7 @@ exports[`renders chip with icon 1`] = `
       "borderStyle": "solid",
       "borderWidth": 0.5,
       "elevation": 0,
+      "flexDirection": "row",
     }
   }
 >
@@ -236,6 +247,7 @@ exports[`renders chip with icon 1`] = `
         style={
           Array [
             Object {
+              "alignSelf": "center",
               "padding": 4,
             },
             null,
@@ -323,6 +335,7 @@ exports[`renders chip with onPress 1`] = `
       "borderStyle": "solid",
       "borderWidth": 0.5,
       "elevation": 0,
+      "flexDirection": "row",
     }
   }
 >
@@ -409,6 +422,7 @@ exports[`renders outlined disabled chip 1`] = `
       "borderStyle": "solid",
       "borderWidth": 0.5,
       "elevation": 0,
+      "flexDirection": "row",
     }
   }
 >
@@ -495,6 +509,7 @@ exports[`renders selected chip 1`] = `
       "borderStyle": "solid",
       "borderWidth": 0.5,
       "elevation": 0,
+      "flexDirection": "row",
     }
   }
 >
@@ -539,6 +554,7 @@ exports[`renders selected chip 1`] = `
         style={
           Array [
             Object {
+              "alignSelf": "center",
               "padding": 4,
             },
             null,

--- a/src/components/__tests__/__snapshots__/ListItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.js.snap
@@ -90,6 +90,7 @@ exports[`renders list item with custom description 1`] = `
                 "borderStyle": "solid",
                 "borderWidth": 0.5,
                 "elevation": 0,
+                "flexDirection": "row",
               }
             }
           >
@@ -134,6 +135,7 @@ exports[`renders list item with custom description 1`] = `
                   style={
                     Array [
                       Object {
+                        "alignSelf": "center",
                         "padding": 4,
                       },
                       null,


### PR DESCRIPTION
### Summary
As described in #2056, the prop `onClose` it's not accessible on iOS.

### Before (Not being possible to focus on the close icon)
![Photo 21-08-20 11 22 34](https://user-images.githubusercontent.com/6487206/90901861-f18cd580-e3a1-11ea-9f68-c5c2b6fbc865.png)

### Fixed
![Photo 21-08-20 11 21 01](https://user-images.githubusercontent.com/6487206/90901905-0d907700-e3a2-11ea-8699-43d84d98d390.png)

![Photo 21-08-20 11 21 35](https://user-images.githubusercontent.com/6487206/90901951-1d0fc000-e3a2-11ea-8db3-ace8383e0da6.png)

### Android kept the same behavior
![WhatsApp Image 2020-08-21 at 11 35 33 (1)](https://user-images.githubusercontent.com/6487206/90902240-8f80a000-e3a2-11ea-83ea-a85af64e83ba.jpeg)

![WhatsApp Image 2020-08-21 at 11 35 33](https://user-images.githubusercontent.com/6487206/90902260-94455400-e3a2-11ea-8806-62a61d520276.jpeg)


### Test plan

1. Open the example app with both Android(TalkBack) and iOS(VoiceOver)
2. Check whether Chip is accessible or not