### PR TITLE
docs : Remove rogue </Card> from DataTableTitle doc

### DIFF
--- a/src/components/DataTable/DataTableTitle.tsx
+++ b/src/components/DataTable/DataTableTitle.tsx
@@ -72,7 +72,6 @@ type State = {
  *           <DataTable.Title numeric>Fat (g)</DataTable.Title>
  *         </DataTable.Header>
  *       </DataTable>
- *   </Card>
  * );
  *
  * export default MyComponent;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
There currently is a rogue `</Card>` in the docs of data table title:
```
const MyComponent = () => (
      <DataTable>
        <DataTable.Header>
          <DataTable.Title
            sortDirection='descending'
          >
            Dessert
          </DataTable.Title>
          <DataTable.Title numeric>Calories</DataTable.Title>
          <DataTable.Title numeric>Fat (g)</DataTable.Title>
        </DataTable.Header>
      </DataTable>
  </Card>
);
```
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
