### PR TITLE
fix: fix TouchableRipple crash when pressed with keyboard on web

### DIFF
--- a/src/components/TouchableRipple/TouchableRipple.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.tsx
@@ -115,13 +115,13 @@ class TouchableRipple extends React.Component<Props> {
     let touchY;
 
     const { changedTouches, touches } = e.nativeEvent;
+    const touch = touches?.[0] ?? changedTouches?.[0];
 
     // If centered or it was pressed using keyboard - enter or space
-    if (centered || (!changedTouches && !touches)) {
+    if (centered || !touch) {
       touchX = dimensions.width / 2;
       touchY = dimensions.height / 2;
     } else {
-      const touch = touches?.[0] ?? changedTouches?.[0];
       touchX = touch.locationX ?? e.pageX;
       touchY = touch.locationY ?? e.pageY;
     }

--- a/src/components/TouchableRipple/TouchableRipple.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.tsx
@@ -111,17 +111,21 @@ class TouchableRipple extends React.Component<Props> {
     const style = window.getComputedStyle(button);
     const dimensions = button.getBoundingClientRect();
 
+    console.log('!@#', { style, dimensions });
+
     let touchX;
     let touchY;
 
-    if (centered) {
+    const { changedTouches, touches } = e.nativeEvent;
+
+    // If centered or it was pressed using keyboard - enter or space
+    if (centered || (!changedTouches && !touches)) {
       touchX = dimensions.width / 2;
       touchY = dimensions.height / 2;
     } else {
-      const { changedTouches, touches } = e.nativeEvent;
       const touch = touches?.[0] ?? changedTouches?.[0];
-      touchX = touch.locationX ?? e.pageX;
-      touchY = touch.locationY ?? e.pageY;
+      touchX = touch?.locationX ?? e.pageX;
+      touchY = touch?.locationY ?? e.pageY;
     }
 
     // Get the size of the button to determine how big the ripple should be

--- a/src/components/TouchableRipple/TouchableRipple.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.tsx
@@ -111,8 +111,6 @@ class TouchableRipple extends React.Component<Props> {
     const style = window.getComputedStyle(button);
     const dimensions = button.getBoundingClientRect();
 
-    console.log('!@#', { style, dimensions });
-
     let touchX;
     let touchY;
 

--- a/src/components/TouchableRipple/TouchableRipple.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.tsx
@@ -122,8 +122,8 @@ class TouchableRipple extends React.Component<Props> {
       touchY = dimensions.height / 2;
     } else {
       const touch = touches?.[0] ?? changedTouches?.[0];
-      touchX = touch?.locationX ?? e.pageX;
-      touchY = touch?.locationY ?? e.pageY;
+      touchX = touch.locationX ?? e.pageX;
+      touchY = touch.locationY ?? e.pageY;
     }
 
     // Get the size of the button to determine how big the ripple should be


### PR DESCRIPTION
### Summary

We were trying to access `touches` on the event, but it is undefined when touchable is pressed using keyboard on web.
In such a situation we simply show ripple in the middle of the touchable.

### Test plan
