### PR TITLE
feat: Add `imageProps` to Avatar.Image

### DIFF
--- a/src/components/Avatar/AvatarImage.tsx
+++ b/src/components/Avatar/AvatarImage.tsx
@@ -13,7 +13,7 @@ const defaultSize = 64;
 
 export type AvatarImageSource =
   | ImageSourcePropType
-  | (props: { size: number }) => React.ReactNode;
+  | ((props: { size: number }) => React.ReactNode);
 
 type Props = React.ComponentPropsWithRef<typeof View> & {
   /**

--- a/src/components/Avatar/AvatarImage.tsx
+++ b/src/components/Avatar/AvatarImage.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import {
   Image,
+  ImageProps,
+  ImageSourcePropType,
   StyleSheet,
   View,
   ViewStyle,
   StyleProp,
-  ImageSourcePropType,
 } from 'react-native';
 import { withTheme } from '../../core/theming';
 
@@ -16,6 +17,10 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
    * Image to display for the `Avatar`.
    */
   source: ImageSourcePropType;
+  /**
+   * Props for the `Image`
+   */
+  imageProps?: ImageProps;
   /**
    * Size of the avatar.
    */
@@ -55,7 +60,14 @@ class AvatarImage extends React.Component<Props> {
   };
 
   render() {
-    const { size = defaultSize, source, style, theme, ...rest } = this.props;
+    const {
+      size = defaultSize,
+      source,
+      style,
+      theme,
+      imageProps,
+      ...rest
+    } = this.props;
     const { colors } = theme;
 
     const { backgroundColor = colors.primary } =
@@ -77,6 +89,7 @@ class AvatarImage extends React.Component<Props> {
         <Image
           source={source}
           style={{ width: size, height: size, borderRadius: size / 2 }}
+          {...imageProps}
         />
       </View>
     );

--- a/src/components/Avatar/AvatarImage.tsx
+++ b/src/components/Avatar/AvatarImage.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
   Image,
-  ImageProps,
   ImageSourcePropType,
   StyleSheet,
   View,
@@ -12,15 +11,15 @@ import { withTheme } from '../../core/theming';
 
 const defaultSize = 64;
 
+export type AvatarImageSource =
+  | ImageSourcePropType
+  | ((props: { size: number }) => React.ReactNode);
+
 type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Image to display for the `Avatar`.
    */
-  source: ImageSourcePropType;
-  /**
-   * Props for the `Image`
-   */
-  imageProps?: ImageProps;
+  source: AvatarImageSource;
   /**
    * Size of the avatar.
    */
@@ -60,14 +59,7 @@ class AvatarImage extends React.Component<Props> {
   };
 
   render() {
-    const {
-      size = defaultSize,
-      source,
-      style,
-      theme,
-      imageProps,
-      ...rest
-    } = this.props;
+    const { size = defaultSize, source, style, theme, ...rest } = this.props;
     const { colors } = theme;
 
     const { backgroundColor = colors.primary } =
@@ -86,11 +78,13 @@ class AvatarImage extends React.Component<Props> {
         ]}
         {...rest}
       >
-        <Image
-          source={source}
-          style={{ width: size, height: size, borderRadius: size / 2 }}
-          {...imageProps}
-        />
+        {typeof source === 'function' && source({ size })}
+        {typeof source !== 'function' && (
+          <Image
+            source={source}
+            style={{ width: size, height: size, borderRadius: size / 2 }}
+          />
+        )}
       </View>
     );
   }

--- a/src/components/Avatar/AvatarImage.tsx
+++ b/src/components/Avatar/AvatarImage.tsx
@@ -13,11 +13,13 @@ const defaultSize = 64;
 
 export type AvatarImageSource =
   | ImageSourcePropType
-  | ((props: { size: number }) => React.ReactNode);
+  | (props: { size: number }) => React.ReactNode;
 
 type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Image to display for the `Avatar`.
+   * It accepts a standard React Native Image `source` prop
+   * Or a function that returns an `Image`.
    */
   source: AvatarImageSource;
   /**


### PR DESCRIPTION
New PR for https://github.com/callstack/react-native-paper/pull/1817

It will allow you to pass any props to the `<Image>` component inside of `Avatar.Image`.
Eg: `defaultSource`, `resizeMode`, etc...
