### PR TITLE
fix: fix chip ripple/highlight effect not covering whole component.

### DIFF
--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -267,7 +267,7 @@ class Chip extends React.Component<Props, State> {
           accessibilityState={accessibilityState}
           testID={testID}
         >
-          <View style={styles.content}>
+          <View style={[styles.content, { paddingRight: onClose ? 32 : 4 }]}>
             {avatar && !icon ? (
               <View
                 style={[styles.avatarWrapper, disabled && { opacity: 0.26 }]}
@@ -323,22 +323,24 @@ class Chip extends React.Component<Props, State> {
           </View>
         </TouchableRipple>
         {onClose ? (
-          <TouchableWithoutFeedback
-            onPress={onClose}
-            accessibilityTraits="button"
-            accessibilityComponentType="button"
-            accessibilityRole="button"
-            accessibilityLabel={closeIconAccessibilityLabel}
-          >
-            <View style={[styles.icon, styles.closeIcon]}>
-              <MaterialCommunityIcon
-                name="close-circle"
-                size={16}
-                color={iconColor}
-                direction="ltr"
-              />
-            </View>
-          </TouchableWithoutFeedback>
+          <View style={styles.closeButtonStyle}>
+            <TouchableWithoutFeedback
+              onPress={onClose}
+              accessibilityTraits="button"
+              accessibilityComponentType="button"
+              accessibilityRole="button"
+              accessibilityLabel={closeIconAccessibilityLabel}
+            >
+              <View style={[styles.icon, styles.closeIcon]}>
+                <MaterialCommunityIcon
+                  name="close-circle"
+                  size={16}
+                  color={iconColor}
+                  direction="ltr"
+                />
+              </View>
+            </TouchableWithoutFeedback>
+          </View>
         ) : null}
       </Surface>
     );
@@ -354,7 +356,8 @@ const styles = StyleSheet.create({
   content: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingHorizontal: 4,
+    paddingLeft: 4,
+    position: 'relative',
   },
   icon: {
     padding: 4,
@@ -382,6 +385,13 @@ const styles = StyleSheet.create({
     top: 4,
     left: 4,
     backgroundColor: 'rgba(0, 0, 0, .29)',
+  },
+  closeButtonStyle: {
+    position: 'absolute',
+    right: 0,
+    height: '100%',
+    justifyContent: 'center',
+    alignItems: 'center',
   },
 });
 

--- a/src/components/__tests__/__snapshots__/Chip.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.js.snap
@@ -44,11 +44,17 @@ exports[`renders chip with close button 1`] = `
   >
     <View
       style={
-        Object {
-          "alignItems": "center",
-          "flexDirection": "row",
-          "paddingHorizontal": 4,
-        }
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "paddingLeft": 4,
+            "position": "relative",
+          },
+          Object {
+            "paddingRight": 32,
+          },
+        ]
       }
     >
       <View
@@ -131,63 +137,75 @@ exports[`renders chip with close button 1`] = `
     </View>
   </View>
   <View
-    accessibilityLabel="Close"
-    accessibilityRole="button"
-    accessible={true}
-    focusable={true}
-    onClick={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
     style={
-      Array [
-        Object {
-          "alignSelf": "center",
-          "padding": 4,
-        },
-        Object {
-          "marginRight": 4,
-        },
-      ]
+      Object {
+        "alignItems": "center",
+        "height": "100%",
+        "justifyContent": "center",
+        "position": "absolute",
+        "right": 0,
+      }
     }
   >
-    <Text
-      accessibilityElementsHidden={true}
-      allowFontScaling={false}
-      importantForAccessibility="no-hide-descendants"
-      pointerEvents="none"
+    <View
+      accessibilityLabel="Close"
+      accessibilityRole="button"
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
         Array [
           Object {
-            "color": "rgba(0, 0, 0, 0.54)",
-            "fontSize": 16,
+            "alignSelf": "center",
+            "padding": 4,
           },
-          Array [
-            Object {
-              "transform": Array [
-                Object {
-                  "scaleX": 1,
-                },
-              ],
-            },
-            Object {
-              "backgroundColor": "transparent",
-            },
-          ],
           Object {
-            "fontFamily": "Material Design Icons",
-            "fontStyle": "normal",
-            "fontWeight": "normal",
+            "marginRight": 4,
           },
-          Object {},
         ]
       }
     >
-      
-    </Text>
+      <Text
+        accessibilityElementsHidden={true}
+        allowFontScaling={false}
+        importantForAccessibility="no-hide-descendants"
+        pointerEvents="none"
+        style={
+          Array [
+            Object {
+              "color": "rgba(0, 0, 0, 0.54)",
+              "fontSize": 16,
+            },
+            Array [
+              Object {
+                "transform": Array [
+                  Object {
+                    "scaleX": 1,
+                  },
+                ],
+              },
+              Object {
+                "backgroundColor": "transparent",
+              },
+            ],
+            Object {
+              "fontFamily": "Material Design Icons",
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {},
+          ]
+        }
+      >
+        
+      </Text>
+    </View>
   </View>
 </View>
 `;
@@ -236,11 +254,17 @@ exports[`renders chip with icon 1`] = `
   >
     <View
       style={
-        Object {
-          "alignItems": "center",
-          "flexDirection": "row",
-          "paddingHorizontal": 4,
-        }
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "paddingLeft": 4,
+            "position": "relative",
+          },
+          Object {
+            "paddingRight": 4,
+          },
+        ]
       }
     >
       <View
@@ -369,11 +393,17 @@ exports[`renders chip with onPress 1`] = `
   >
     <View
       style={
-        Object {
-          "alignItems": "center",
-          "flexDirection": "row",
-          "paddingHorizontal": 4,
-        }
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "paddingLeft": 4,
+            "position": "relative",
+          },
+          Object {
+            "paddingRight": 4,
+          },
+        ]
       }
     >
       <Text
@@ -456,11 +486,17 @@ exports[`renders outlined disabled chip 1`] = `
   >
     <View
       style={
-        Object {
-          "alignItems": "center",
-          "flexDirection": "row",
-          "paddingHorizontal": 4,
-        }
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "paddingLeft": 4,
+            "position": "relative",
+          },
+          Object {
+            "paddingRight": 4,
+          },
+        ]
       }
     >
       <Text
@@ -543,11 +579,17 @@ exports[`renders selected chip 1`] = `
   >
     <View
       style={
-        Object {
-          "alignItems": "center",
-          "flexDirection": "row",
-          "paddingHorizontal": 4,
-        }
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "paddingLeft": 4,
+            "position": "relative",
+          },
+          Object {
+            "paddingRight": 4,
+          },
+        ]
       }
     >
       <View

--- a/src/components/__tests__/__snapshots__/ListItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.js.snap
@@ -124,11 +124,17 @@ exports[`renders list item with custom description 1`] = `
             >
               <View
                 style={
-                  Object {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                    "paddingHorizontal": 4,
-                  }
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "paddingLeft": 4,
+                      "position": "relative",
+                    },
+                    Object {
+                      "paddingRight": 4,
+                    },
+                  ]
                 }
               >
                 <View


### PR DESCRIPTION
### Summary

Followup to https://github.com/callstack/react-native-paper/pull/2144

By rendering the close button absolutely we ensure that the ripple/highlight effect is displayed on the whole chip and we keep the ability to select only the close button using a screen reader.

### Test plan


