### PR TITLE
feat: Custom affix text style prop

### DIFF
--- a/src/components/TextInput/Adornment/Affix.tsx
+++ b/src/components/TextInput/Adornment/Affix.tsx
@@ -17,6 +17,7 @@ const AFFIX_OFFSET = 12;
 type Props = {
   text: string;
   onLayout?: (event: LayoutChangeEvent) => void;
+  customTextStyle?: StyleProp<TextStyle>;
   /**
    * @optional
    */
@@ -58,7 +59,7 @@ export const AffixAdornment: React.FunctionComponent<
   );
 };
 
-const TextInputAffix = ({ text, theme }: Props) => {
+const TextInputAffix = ({ text, theme, customTextStyle }: Props) => {
   const { textStyle, onLayout, topPosition, side, visible } = React.useContext(
     AffixContext
   );
@@ -87,7 +88,7 @@ const TextInputAffix = ({ text, theme }: Props) => {
       ]}
       onLayout={onLayout}
     >
-      <Text style={[{ color: textColor }, textStyle]}>{text}</Text>
+      <Text style={[{ color: textColor }, textStyle, customTextStyle]}>{text}</Text>
     </Animated.View>
   );
 };

--- a/src/components/TextInput/Adornment/Affix.tsx
+++ b/src/components/TextInput/Adornment/Affix.tsx
@@ -17,7 +17,7 @@ const AFFIX_OFFSET = 12;
 type Props = {
   text: string;
   onLayout?: (event: LayoutChangeEvent) => void;
-  customTextStyle?: StyleProp<TextStyle>;
+  textStyle?: StyleProp<TextStyle>;
   /**
    * @optional
    */
@@ -59,7 +59,7 @@ export const AffixAdornment: React.FunctionComponent<
   );
 };
 
-const TextInputAffix = ({ text, theme, customTextStyle }: Props) => {
+const TextInputAffix = ({ text, textStyle: labelStyle, theme }: Props) => {
   const { textStyle, onLayout, topPosition, side, visible } = React.useContext(
     AffixContext
   );
@@ -88,7 +88,7 @@ const TextInputAffix = ({ text, theme, customTextStyle }: Props) => {
       ]}
       onLayout={onLayout}
     >
-      <Text style={[{ color: textColor }, textStyle, customTextStyle]}>{text}</Text>
+      <Text style={[{ color: textColor }, textStyle, labelStyle]}>{text}</Text>
     </Animated.View>
   );
 };


### PR DESCRIPTION
### Summary
I added a `customTextStyle` prop for `TextInput.Affix` component.
Fixes: #2194 

### Test plan
```javascript
// Usage:
<TextInput.Affix text='lbs' customTextStyle={{color: 'red'}} />
```
Output: https://imgur.com/a/DYsctHi
