### PR TITLE
fix: add iconSize parameter to BottomNavigation (reopen #1983)

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -213,6 +213,7 @@ type Props = {
    * barStyle={{ paddingBottom: 48 }}
    * ```
    */
+  iconSize?: number;
   barStyle?: StyleProp<ViewStyle>;
   style?: StyleProp<ViewStyle>;
   /**
@@ -635,6 +636,7 @@ class BottomNavigation extends React.Component<Props, State> {
       style,
       theme,
       sceneAnimationEnabled,
+      iconSize = 24,
     } = this.props;
 
     const {
@@ -868,6 +870,8 @@ class BottomNavigation extends React.Component<Props, State> {
                       <Animated.View
                         style={[
                           styles.iconContainer,
+                          { height: iconSize },
+                          { width: iconSize },
                           { transform: [{ translateY }] },
                         ]}
                       >
@@ -887,7 +891,7 @@ class BottomNavigation extends React.Component<Props, State> {
                             <Icon
                               source={route.icon as IconSource}
                               color={activeTintColor}
-                              size={24}
+                              size={iconSize}
                             />
                           )}
                         </Animated.View>
@@ -907,7 +911,7 @@ class BottomNavigation extends React.Component<Props, State> {
                             <Icon
                               source={route.icon as IconSource}
                               color={inactiveTintColor}
-                              size={24}
+                              size={iconSize}
                             />
                           )}
                         </Animated.View>
@@ -1036,8 +1040,6 @@ const styles = StyleSheet.create({
     position: 'absolute',
   },
   iconContainer: {
-    height: 24,
-    width: 24,
     marginTop: 2,
     marginHorizontal: 12,
     alignSelf: 'center',


### PR DESCRIPTION
### Summary

BottomNavigation's label icon size was default 24 px. In issue #1926 & #455, people want to change icon size. So, I added iconSize parameter to BottomNavigation in order to change icon size dynamically but still, the icon's default size is 24 px. 

### Test plan

You can give iconSize parameter to BottomNavigation in order to test it.

**24px icon:**
![Simulator Screen Shot - iPhone 11 - 2020-09-06 at 21 00 56](https://user-images.githubusercontent.com/25640196/92332765-db149880-f088-11ea-916e-b207215ee162.png)

**36px icon:**
![Simulator Screen Shot - iPhone 11 - 2020-09-06 at 21 34 34](https://user-images.githubusercontent.com/25640196/92332770-e1a31000-f088-11ea-9486-b4793eaebea2.png)

