### PR TITLE
fix: keep TextInput placeholder when error is true

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -303,7 +303,7 @@ class TextInput extends React.Component<TextInputProps, State> {
         ios: false,
         default: true,
       }),
-    }).start(this.hidePlaceholder);
+    }).start();
   };
 
   private hideError = () => {


### PR DESCRIPTION
### Summary
Recently I noticed that the component `TextInput` is hiding the placeholder as in the gif below when you change the prop error from false to true. I don't think this makes sense since the placeholder is shown after focusing it again.
![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/6487206/92527774-f48b2100-f1fd-11ea-82f7-7d49608c3055.gif)

Snack
https://snack.expo.io/@bruno.castro/paper-textinput-bug

How to reproduce:
1. Click on the textinput
2. Click on the button `Add error` while the input is focused

### Test plan
Following up #1943 and #2032 I didn't have any problems regarding overlapping the label and the placeholder.