### PR TITLE
fix: textInput label jumps to the center

### DIFF
--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -178,10 +178,11 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
     const baseLabelTranslateY =
       -labelHalfHeight - (topPosition + OUTLINE_MINIMIZED_LABEL_Y_OFFSET);
 
-    const placeholderOpacity = interpolatePlaceholder(
-      parentState.labeled,
-      hasActiveOutline
-    );
+    const placeholderOpacity = hasActiveOutline
+      ? interpolatePlaceholder(parentState.labeled, hasActiveOutline)
+      : parentState.labelLayout.measured
+      ? 1
+      : 0;
 
     const labelProps = {
       label,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
#1648

### Test plan

Merge should be done after merging refactor/text-input
