### PR TITLE
feat: change icon prop in TextInput

### DIFF
--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -7,12 +7,14 @@ import {
   Platform,
 } from 'react-native';
 import { TextInput, HelperText, useTheme } from 'react-native-paper';
+import Icon from 'react-native-vector-icons/FontAwesome';
 import { inputReducer, State } from '../../utils';
 
 const MAX_LENGTH = 20;
 
 const initialState: State = {
   text: '',
+  customIconText: '',
   name: '',
   outlinedText: '',
   largeText: '',
@@ -36,6 +38,7 @@ const initialState: State = {
     flatRightIcon: undefined,
     outlineLeftIcon: undefined,
     outlineRightIcon: undefined,
+    customIcon: undefined,
   },
 };
 
@@ -61,6 +64,7 @@ const TextInputExample = () => {
   const [state, dispatch] = React.useReducer(inputReducer, initialState);
   const {
     text,
+    customIconText,
     name,
     outlinedText,
     largeText,
@@ -84,6 +88,7 @@ const TextInputExample = () => {
       flatRightIcon,
       outlineLeftIcon,
       outlineRightIcon,
+      customIcon,
     },
   } = state;
 
@@ -175,6 +180,28 @@ const TextInputExample = () => {
                 })
               }
               forceTextInputFocus={false}
+            />
+          }
+        />
+        <TextInput
+          style={styles.inputContainerStyle}
+          label="Flat input with custom icon"
+          placeholder="Type something"
+          value={customIconText}
+          onChangeText={(text) => inputActionHandler('customIconText', text)}
+          right={<TextInput.Affix text="/100" />}
+          left={
+            <TextInput.Icon
+              name={() => (
+                <Icon
+                  name="heart"
+                  size={24}
+                  color={customIcon}
+                  onPress={() => {
+                    changeIconColor('customIcon');
+                  }}
+                />
+              )}
             />
           }
         />

--- a/example/utils/index.ts
+++ b/example/utils/index.ts
@@ -8,10 +8,12 @@ type IconsColor = {
   flatRightIcon: string | undefined;
   outlineLeftIcon: string | undefined;
   outlineRightIcon: string | undefined;
+  customIcon: string | undefined;
 };
 
 export type State = {
   text: string;
+  customIconText: string;
   name: string;
   outlinedText: string;
   largeText: string;

--- a/src/components/TextInput/Adornment/Icon.tsx
+++ b/src/components/TextInput/Adornment/Icon.tsx
@@ -3,12 +3,13 @@ import { View, StyleSheet, StyleProp, ViewStyle } from 'react-native';
 
 import IconButton from '../../IconButton';
 import type { $Omit } from '../../../../src/types';
+import type { IconSource } from '../../Icon';
 
 type Props = $Omit<
   React.ComponentProps<typeof IconButton>,
   'icon' | 'theme'
 > & {
-  name: string;
+  name: IconSource;
   onPress?: () => void;
   forceTextInputFocus?: boolean;
   style?: StyleProp<ViewStyle>;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
PR resolves an issue with setting custom icon  (e.g material, font awesome)

`<TextInput
       label="Email"
       value={text}
       onChangeText={text => setText(text)}
       left={<TextInput.Icon name={() => <IconComponent />} />}
    />`

#2231
### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
