### PR TITLE
fix: onPress RadioButton not working

### DIFF
--- a/src/components/RadioButton/utils.ts
+++ b/src/components/RadioButton/utils.ts
@@ -7,7 +7,8 @@ export const handlePress = ({
   value: string;
   onValueChange?: (value: string) => void;
 }) => {
-  onValueChange ? onValueChange(value) : onPress?.();
+  onValueChange && onValueChange(value);
+  onPress && onPress();
 };
 
 export const isChecked = ({


### PR DESCRIPTION
### Summary

Fix prop `onPress` of `RadioButton` and `RadioButton.Item` not working

### Test plan
