### PR TITLE
fix: switch colors incorrect on react-native-web

### DIFF
--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -117,6 +117,12 @@ class Switch extends React.Component<Props> {
             onTintColor,
             thumbTintColor,
           }
+        : Platform.OS === 'web'
+        ? {
+            activeTrackColor: onTintColor,
+            thumbColor: thumbTintColor,
+            activeThumbColor: checkedColor,
+          }
         : {
             thumbColor: thumbTintColor,
             trackColor: {


### PR DESCRIPTION
React-native-web uses different switch color syntax from ios/android,
update the code to work with this syntax. See https://necolas.github.io/react-native-web/docs/?path=/docs/components-switch--active-thumb-color

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
This pull request solves that the Switch component wasn't rendered correctly in react-native-web. The color of the thumb remained the default React Native color for the switch component. This may be able to be fixed in react-native-web itself?

### Test plan

I already tested my branch on web, ios and android and it works correctly

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
Open example app, go to switches, check if switch (thumb) color is correct.
![Schermafdruk van 2020-10-02 15-34-24](https://user-images.githubusercontent.com/42558625/94929086-e78fe380-04c4-11eb-9af1-9147c4f6c4ce.png)
