### PR TITLE
feat: add content style prop to Menu.Item component

### DIFF
--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -35,6 +35,7 @@ type Props = {
    */
   theme: ReactNativePaper.Theme;
   style?: StyleProp<ViewStyle>;
+  contentStyle?: StyleProp<ViewStyle>;
   titleStyle?: StyleProp<TextStyle>;
   /**
    * TestID used for testing purposes
@@ -82,6 +83,7 @@ class MenuItem extends React.Component<Props> {
       onPress,
       theme,
       style,
+      contentStyle,
       testID,
       titleStyle,
     } = this.props;
@@ -117,6 +119,7 @@ class MenuItem extends React.Component<Props> {
               styles.item,
               styles.content,
               icon ? styles.widthWithIcon : null,
+              contentStyle,
             ]}
             pointerEvents="none"
           >


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Current implementation of `<Menu.Item />` doesn't allow lib's user to customise maxWidth of the component (which is ok for mobile according to MD guidelines, but is kind of a blocker in the web). This PR adds `contentStyle` prop providing user na option to override the maxWidth value.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
BEFORE: 
![image](https://user-images.githubusercontent.com/16213922/95564865-ab5a0700-0a1f-11eb-80eb-da02d34d1544.png)

AFTER:
![image](https://user-images.githubusercontent.com/16213922/95564770-92e9ec80-0a1f-11eb-9c14-fb60499c7c24.png)


