### PR TITLE
feat: do not set Appearance module when theme prop is passed

### DIFF
--- a/src/core/Provider.tsx
+++ b/src/core/Provider.tsx
@@ -13,44 +13,61 @@ type Props = {
   settings?: Settings;
 };
 
-type State = {
-  colorScheme: ColorSchemeName;
-  reduceMotionEnabled: boolean;
-};
+const Provider = ({ ...props }: Props) => {
+  const colorSchemeName =
+    (!props.theme && Appearance?.getColorScheme()) || 'light';
 
-export default class Provider extends React.Component<Props, State> {
-  state = {
-    reduceMotionEnabled: false,
-    colorScheme: Appearance?.getColorScheme() || 'light',
-  };
+  const [reduceMotionEnabled, setreduceMotionEnabled] = React.useState<boolean>(
+    false
+  );
+  const [colorScheme, setColorScheme] = React.useState<ColorSchemeName>(
+    colorSchemeName
+  );
 
-  async componentDidMount() {
-    AccessibilityInfo.addEventListener(
-      'reduceMotionChanged',
-      this.updateReduceMotionSettingsInfo
-    );
-    this.updateReduceMotionSettingsInfo();
-    Appearance?.addChangeListener(this.handleAppearanceChange);
-  }
-
-  componentWillUnmount() {
-    AccessibilityInfo.removeEventListener(
-      'reduceMotionChanged',
-      this.updateReduceMotionSettingsInfo
-    );
-    Appearance?.removeChangeListener(this.handleAppearanceChange);
-  }
-
-  private handleAppearanceChange = (
+  const handleAppearanceChange = (
     preferences: Appearance.AppearancePreferences
   ) => {
     const { colorScheme } = preferences;
-    this.setState({ colorScheme });
+    setColorScheme(colorScheme);
   };
 
-  private getTheme = () => {
-    const { theme: providedTheme } = this.props;
-    const { reduceMotionEnabled, colorScheme } = this.state;
+  const updateReduceMotionSettingsInfo = async () => {
+    try {
+      const reduceMotionEnabled = await AccessibilityInfo.isReduceMotionEnabled();
+      if (reduceMotionEnabled) {
+        setreduceMotionEnabled(reduceMotionEnabled);
+      }
+    } catch (err) {
+      console.warn(err);
+    }
+  };
+
+  React.useEffect(() => {
+    AccessibilityInfo.addEventListener(
+      'reduceMotionChanged',
+      updateReduceMotionSettingsInfo
+    );
+
+    updateReduceMotionSettingsInfo();
+
+    return () => {
+      AccessibilityInfo.removeEventListener(
+        'reduceMotionChanged',
+        updateReduceMotionSettingsInfo
+      );
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (!props.theme) Appearance?.addChangeListener(handleAppearanceChange);
+    return () => {
+      if (!props.theme)
+        Appearance?.removeChangeListener(handleAppearanceChange);
+    };
+  }, [props.theme]);
+
+  const getTheme = () => {
+    const { theme: providedTheme } = props;
 
     if (providedTheme) {
       return providedTheme;
@@ -69,25 +86,14 @@ export default class Provider extends React.Component<Props, State> {
     }
   };
 
-  private updateReduceMotionSettingsInfo = async () => {
-    try {
-      const reduceMotionEnabled = await AccessibilityInfo.isReduceMotionEnabled();
+  const { children, settings } = props;
+  return (
+    <PortalHost>
+      <SettingsProvider value={settings || { icon: MaterialCommunityIcon }}>
+        <ThemeProvider theme={getTheme()}>{children}</ThemeProvider>
+      </SettingsProvider>
+    </PortalHost>
+  );
+};
 
-      this.setState({ reduceMotionEnabled });
-    } catch (err) {
-      console.warn(err);
-    }
-  };
-
-  render() {
-    const { children, settings } = this.props;
-
-    return (
-      <PortalHost>
-        <SettingsProvider value={settings || { icon: MaterialCommunityIcon }}>
-          <ThemeProvider theme={this.getTheme()}>{children}</ThemeProvider>
-        </SettingsProvider>
-      </PortalHost>
-    );
-  }
-}
+export default Provider;

--- a/src/core/Provider.tsx
+++ b/src/core/Provider.tsx
@@ -35,14 +35,14 @@ const Provider = ({ ...props }: Props) => {
     if (!props.theme) {
       AccessibilityInfo.addEventListener(
         'reduceMotionChanged',
-        (reduceMotionEnabled) => setReduceMotionEnabled(reduceMotionEnabled)
+        setReduceMotionEnabled
       );
     }
     return () => {
       if (!props.theme) {
         AccessibilityInfo.removeEventListener(
           'reduceMotionChanged',
-          (reduceMotionEnabled) => setReduceMotionEnabled(reduceMotionEnabled)
+          setReduceMotionEnabled
         );
       }
     };

--- a/src/core/Provider.tsx
+++ b/src/core/Provider.tsx
@@ -17,7 +17,7 @@ const Provider = ({ ...props }: Props) => {
   const colorSchemeName =
     (!props.theme && Appearance?.getColorScheme()) || 'light';
 
-  const [reduceMotionEnabled, setreduceMotionEnabled] = React.useState<boolean>(
+  const [reduceMotionEnabled, setReduceMotionEnabled] = React.useState<boolean>(
     false
   );
   const [colorScheme, setColorScheme] = React.useState<ColorSchemeName>(
@@ -31,32 +31,22 @@ const Provider = ({ ...props }: Props) => {
     setColorScheme(colorScheme);
   };
 
-  const updateReduceMotionSettingsInfo = async () => {
-    try {
-      const reduceMotionEnabled = await AccessibilityInfo.isReduceMotionEnabled();
-      if (reduceMotionEnabled) {
-        setreduceMotionEnabled(reduceMotionEnabled);
-      }
-    } catch (err) {
-      console.warn(err);
-    }
-  };
-
   React.useEffect(() => {
-    AccessibilityInfo.addEventListener(
-      'reduceMotionChanged',
-      updateReduceMotionSettingsInfo
-    );
-
-    updateReduceMotionSettingsInfo();
-
-    return () => {
-      AccessibilityInfo.removeEventListener(
+    if (!props.theme) {
+      AccessibilityInfo.addEventListener(
         'reduceMotionChanged',
-        updateReduceMotionSettingsInfo
+        (reduceMotionEnabled) => setReduceMotionEnabled(reduceMotionEnabled)
       );
+    }
+    return () => {
+      if (!props.theme) {
+        AccessibilityInfo.removeEventListener(
+          'reduceMotionChanged',
+          (reduceMotionEnabled) => setReduceMotionEnabled(reduceMotionEnabled)
+        );
+      }
     };
-  }, []);
+  }, [props.theme]);
 
   React.useEffect(() => {
     if (!props.theme) Appearance?.addChangeListener(handleAppearanceChange);

--- a/src/core/__tests__/Provider.test.js
+++ b/src/core/__tests__/Provider.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Appearance, View } from 'react-native';
-import { render } from 'react-native-testing-library';
+import { render, act } from 'react-native-testing-library';
 import Provider from '../Provider';
 import { useTheme } from '../theming';
 import DarkTheme from '../../styles/DarkTheme';
@@ -15,6 +15,9 @@ const mockAppearance = () => {
     return {
       ...realApp,
       addChangeListener: jest.fn((cb) => {
+        listeners.push(cb);
+      }),
+      removeChangeListener: jest.fn((cb) => {
         listeners.push(cb);
       }),
       getColorScheme: jest.fn(() => {
@@ -49,9 +52,31 @@ describe('Provider', () => {
     expect(getByTestId('provider-child-view').props.theme).toStrictEqual(
       DefaultTheme
     );
-    Appearance.__internalListeners[0]({ colorScheme: 'dark' });
+    act(() => Appearance.__internalListeners[0]({ colorScheme: 'dark' }));
     expect(getByTestId('provider-child-view').props.theme).toStrictEqual(
       DarkTheme
+    );
+  });
+
+  it('should set Appearance listeners, if there is no theme', async () => {
+    mockAppearance();
+    const { getByTestId } = render(createProvider(null));
+
+    expect(Appearance.addChangeListener).toHaveBeenCalled();
+    act(() => Appearance.__internalListeners[0]({ colorScheme: 'dark' }));
+    expect(getByTestId('provider-child-view').props.theme).toStrictEqual(
+      DarkTheme
+    );
+  });
+
+  it('should not set Appearance listeners, if the theme is passed', async () => {
+    mockAppearance();
+    const { getByTestId } = render(createProvider(DefaultTheme));
+
+    expect(Appearance.addChangeListener).not.toHaveBeenCalled();
+    expect(Appearance.removeChangeListener).not.toHaveBeenCalled();
+    expect(getByTestId('provider-child-view').props.theme).toStrictEqual(
+      DefaultTheme
     );
   });
 

--- a/src/core/__tests__/Provider.test.js
+++ b/src/core/__tests__/Provider.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Appearance, View } from 'react-native';
+import { Appearance, AccessibilityInfo, View } from 'react-native';
 import { render, act } from 'react-native-testing-library';
 import Provider from '../Provider';
 import { useTheme } from '../theming';
@@ -53,6 +53,27 @@ describe('Provider', () => {
       DefaultTheme
     );
     act(() => Appearance.__internalListeners[0]({ colorScheme: 'dark' }));
+    expect(getByTestId('provider-child-view').props.theme).toStrictEqual(
+      DarkTheme
+    );
+  });
+
+  it('should set AccessibilityInfo listeners, if there is no theme', async () => {
+    mockAppearance();
+    const { getByTestId } = render(createProvider(null));
+
+    expect(AccessibilityInfo.addEventListener).toHaveBeenCalled();
+    expect(getByTestId('provider-child-view').props.theme).toStrictEqual(
+      DefaultTheme
+    );
+  });
+
+  it('should not set AccessibilityInfo listeners, if there is no theme', async () => {
+    mockAppearance();
+    const { getByTestId } = render(createProvider(DarkTheme));
+
+    expect(AccessibilityInfo.addEventListener).not.toHaveBeenCalled();
+    expect(AccessibilityInfo.removeEventListener).not.toHaveBeenCalled();
     expect(getByTestId('provider-child-view').props.theme).toStrictEqual(
       DarkTheme
     );


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
PR resolves issue:  automatic theme handling is being set up even though the theme prop is passed to the Provider  (#2272)
And also contains refactor Provider component to a functional with hooks.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
