### PR TITLE
fix: grey screen on first open of tab on react-native-web

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -731,7 +731,15 @@ class BottomNavigation extends React.Component<Props, State> {
                   Platform.OS === 'ios' ? navigationState.index !== index : true
                 }
               >
-                <Animated.View style={[styles.content, { top }]}>
+                <Animated.View
+                  style={[
+                    styles.content,
+                    { top },
+                    Platform.OS === 'web'
+                      ? { display: loaded.includes(index) ? 'flex' : 'none' }
+                      : null,
+                  ]}
+                >
                   {renderScene({
                     route,
                     jumpTo: this.jumpTo,

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -275,7 +275,7 @@ const MIN_RIPPLE_SCALE = 0.001; // Minimum scale is not 0 due to bug with animat
 const MIN_TAB_WIDTH = 96;
 const MAX_TAB_WIDTH = 168;
 const BAR_HEIGHT = 56;
-const FAR_FAR_AWAY = 9999;
+const FAR_FAR_AWAY = Platform.OS === 'web' ? 0 : 9999;
 
 const Touchable = ({
   route: _0,


### PR DESCRIPTION
Summary

On react-native-web, bottom tabs weren't being rendered on the first click (grey screen), probably due to a issue in the way Animated is implemented on react-native-web. This is fixed by this patch by setting FAR_FAR_AWAY to 0px on web, and setting display:none, like in standard react-navigation bottom tabs.

This fixes issue #2270.
Test plan

Switch to different tab in material-bottom-tabs in example app.