### PR TITLE
feat(Appbar): use height based on the platform

### DIFF
--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -31,7 +31,11 @@ type Props = Partial<React.ComponentPropsWithRef<typeof View>> & {
   style?: StyleProp<ViewStyle>;
 };
 
-export const DEFAULT_APPBAR_HEIGHT = 56;
+export const DEFAULT_APPBAR_HEIGHT = Platform.select({
+  ios: 44,
+  android: 56,
+  default: 64,
+});
 
 /**
  * A component to display action items in a bar. It can be placed at the top or bottom.

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
@@ -8,7 +8,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
       "backgroundColor": "#6200ee",
       "elevation": 4,
       "flexDirection": "row",
-      "height": 56,
+      "height": 44,
       "paddingHorizontal": 4,
       "shadowColor": "#000000",
       "shadowOffset": Object {
@@ -252,7 +252,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
       "backgroundColor": "#6200ee",
       "elevation": 4,
       "flexDirection": "row",
-      "height": 56,
+      "height": 44,
       "paddingHorizontal": 4,
       "shadowColor": "#000000",
       "shadowOffset": Object {


### PR DESCRIPTION
### Summary
Appbar is using the wrong height on iOS. This was noticed when using Appbar as a custom header in react-navigation.

This implementation still differs from [react-navigation](https://github.com/react-navigation/react-navigation/blob/main/packages/stack/src/views/Header/HeaderSegment.tsx#L56) because we aren't checking if the orientation is landscape.

### Test plan
1. Open the example app on iOS
2. Check if the header has a height of 44px