### PR TITLE
feat: add uppercase prop to FAB

### DIFF
--- a/example/src/Examples/FABExample.tsx
+++ b/example/src/Examples/FABExample.tsx
@@ -43,7 +43,14 @@ const ButtonExample = () => {
           visible={visible}
           disabled
         />
-
+        <FAB
+          icon="format-letter-case"
+          label="Mixed case"
+          style={styles.fab}
+          onPress={() => {}}
+          visible={visible}
+          uppercase={false}
+        />
         <FAB
           icon="cancel"
           label="Loading FAB"

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -24,6 +24,10 @@ type Props = $RemoveChildren<typeof Surface> & {
    */
   label?: string;
   /**
+   * Make the label text uppercased.
+   */
+  uppercase?: boolean;
+  /**
    * Accessibility label for the FAB. This is read by the screen reader when the user taps the FAB.
    * Uses `label` by default if specified.
    */
@@ -112,6 +116,7 @@ class FAB extends React.Component<Props, State> {
   static Group = FABGroup;
 
   static defaultProps = {
+    uppercase: true,
     visible: true,
   };
 
@@ -145,6 +150,7 @@ class FAB extends React.Component<Props, State> {
       small,
       icon,
       label,
+      uppercase,
       accessibilityLabel = label,
       animated = true,
       color: customColor,
@@ -239,10 +245,11 @@ class FAB extends React.Component<Props, State> {
               <Text
                 style={[
                   styles.label,
+                  uppercase && styles.uppercaseLabel,
                   { color: foregroundColor, ...theme.fonts.medium },
                 ]}
               >
-                {label.toUpperCase()}
+                {label}
               </Text>
             ) : null}
           </View>
@@ -279,6 +286,9 @@ const styles = StyleSheet.create({
   },
   label: {
     marginHorizontal: 8,
+  },
+  uppercaseLabel: {
+    textTransform: 'uppercase',
   },
   disabled: {
     elevation: 0,

--- a/src/components/__tests__/__snapshots__/FAB.test.js.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.js.snap
@@ -149,6 +149,9 @@ exports[`renders extended FAB 1`] = `
                 "marginHorizontal": 8,
               },
               Object {
+                "textTransform": "uppercase",
+              },
+              Object {
                 "color": "rgba(0, 0, 0, .54)",
                 "fontFamily": "System",
                 "fontWeight": "500",
@@ -157,7 +160,7 @@ exports[`renders extended FAB 1`] = `
           ]
         }
       >
-        ADD ITEMS
+        Add items
       </Text>
     </View>
   </View>


### PR DESCRIPTION
### Summary

Similar to the Button component, in some instances you might not want to uppercase the FAB text. This PR adds that option.

### Test plan

An instance of a non-uppercased FAB has been added to the example app.
1. Verify that by default, the FAB still has uppercase text
2. Verify that the FAB with `uppercase={false}` does not force uppercase
