### PR TITLE
feat: add bold option to font namespace

### DIFF
--- a/docs/pages/2.theming.md
+++ b/docs/pages/2.theming.md
@@ -67,6 +67,7 @@ A theme usually contains the following properties:
 - `fonts` (`object`): various fonts used throughout different elements.
   - `regular`
   - `medium`
+  - `bold`
   - `light`
   - `thin`
 - `animation` (`object`)

--- a/docs/pages/4.fonts.md
+++ b/docs/pages/4.fonts.md
@@ -63,6 +63,10 @@ const fontConfig = {
       fontFamily: 'sans-serif-medium',
       fontWeight: 'normal',
     },
+    bold: {
+      fontFamily: 'sans-serif-bold',
+      fontWeight: 'normal',
+    },
     light: {
       fontFamily: 'sans-serif-light',
       fontWeight: 'normal',

--- a/src/components/Typography/StyledText.tsx
+++ b/src/components/Typography/StyledText.tsx
@@ -7,7 +7,7 @@ import { withTheme } from '../../core/theming';
 
 type Props = React.ComponentProps<typeof Text> & {
   alpha: number;
-  family: 'regular' | 'medium' | 'light' | 'thin';
+  family: 'regular' | 'medium' | 'bold' | 'light' | 'thin';
   style?: StyleProp<TextStyle>;
   theme: ReactNativePaper.Theme;
 };

--- a/src/components/__tests__/__snapshots__/ListSection.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.js.snap
@@ -31,6 +31,10 @@ exports[`renders list section with custom title style 1`] = `
       },
       "dark": false,
       "fonts": Object {
+        "bold": Object {
+          "fontFamily": "System",
+          "fontWeight": "700",
+        },
         "light": Object {
           "fontFamily": "System",
           "fontWeight": "300",
@@ -363,6 +367,10 @@ exports[`renders list section with subheader 1`] = `
       },
       "dark": false,
       "fonts": Object {
+        "bold": Object {
+          "fontFamily": "System",
+          "fontWeight": "700",
+        },
         "light": Object {
           "fontFamily": "System",
           "fontWeight": "300",
@@ -693,6 +701,10 @@ exports[`renders list section without subheader 1`] = `
       },
       "dark": false,
       "fonts": Object {
+        "bold": Object {
+          "fontFamily": "System",
+          "fontWeight": "700",
+        },
         "light": Object {
           "fontFamily": "System",
           "fontWeight": "300",

--- a/src/styles/fonts.tsx
+++ b/src/styles/fonts.tsx
@@ -11,6 +11,10 @@ const fontConfig = {
       fontFamily: 'Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif',
       fontWeight: '500' as '500',
     },
+    bold: {
+      fontFamily: 'Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif',
+      fontWeight: '700' as '700',
+    },
     light: {
       fontFamily: 'Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif',
       fontWeight: '300' as '300',
@@ -29,6 +33,10 @@ const fontConfig = {
       fontFamily: 'System',
       fontWeight: '500' as '500',
     },
+    bold: {
+      fontFamily: 'System',
+      fontWeight: '700' as '700',
+    },
     light: {
       fontFamily: 'System',
       fontWeight: '300' as '300',
@@ -45,6 +53,10 @@ const fontConfig = {
     },
     medium: {
       fontFamily: 'sans-serif-medium',
+      fontWeight: 'normal' as 'normal',
+    },
+    bold: {
+      fontFamily: 'sans-serif-bold',
       fontWeight: 'normal' as 'normal',
     },
     light: {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -19,6 +19,7 @@ export type Font = {
 export type Fonts = {
   regular: Font;
   medium: Font;
+  bold: Font;
   light: Font;
   thin: Font;
 };
@@ -77,6 +78,7 @@ declare global {
     interface ThemeFonts {
       regular: ThemeFont;
       medium: ThemeFont;
+      bold: ThemeFont;
       light: ThemeFont;
       thin: ThemeFont;
     }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
This PR adds `bold` to the type definition for `ThemeFont` (refer to #1449). 

This can also be achieved by extending the global ReactNativePaper namespace to add the additional font weight (as described in the theming docs and also demonstrated in the example with _superLight_). However, someone using this approach loses the ability to swap between the default React Native Paper theme and their custom theme (or they need to add a bunch of conditional checks to check for the existence of the bold font anywhere they want to use it).

The bold weight is a standard of the Material Design type system (https://material.io/design/typography/understanding-typography.html) and so should be included in React Native Paper even though it is not explicitly used in any of the components (yet). 

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

In `example/src/Examples/TextExample.tsx` add an example that utilizes the bold font family/weight to verify that it is available and works as expected:
```tsx
const TextExample = () => {
  const {
    colors: { background },
    fonts
  } = useTheme();

  return (
    <View style={[styles.container, { backgroundColor: background }]}>
      <Caption style={styles.text}>Caption</Caption>
      <Paragraph style={styles.text}>Paragraph</Paragraph>
      <Subheading style={styles.text}>Subheading</Subheading>
      <Title style={styles.text}>Title</Title>
      <Headline style={styles.text}>Headline</Headline>
      <Headline style={{fontFamily: fonts.bold.fontFamily, fontWeight: fonts.bold.fontWeight}}>I'm Bold</Headline>
    </View>
  );
};
```