### PR TITLE
chore: exported Prop types for components

### DIFF
--- a/src/components/ActivityIndicator.tsx
+++ b/src/components/ActivityIndicator.tsx
@@ -8,6 +8,7 @@ import {
   View,
   ViewStyle,
 } from 'react-native';
+import type { SetPropAsOptional } from '../types';
 import { withTheme } from '../core/theming';
 
 type Props = React.ComponentPropsWithRef<typeof View> & {
@@ -250,5 +251,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type ActivityIndicatorProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(ActivityIndicator);

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -14,6 +14,7 @@ import Surface from '../Surface';
 import { withTheme } from '../../core/theming';
 import { black, white } from '../../styles/colors';
 import overlay from '../../styles/overlay';
+import type { SetPropAsOptional } from '../../types';
 
 type Props = Partial<React.ComponentPropsWithRef<typeof View>> & {
   /**
@@ -198,5 +199,8 @@ const styles = StyleSheet.create({
     width: 48,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type AppBarProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(Appbar);

--- a/src/components/Appbar/AppbarAction.tsx
+++ b/src/components/Appbar/AppbarAction.tsx
@@ -9,7 +9,7 @@ import { black } from '../../styles/colors';
 import IconButton from '../IconButton';
 import type { IconSource } from '../Icon';
 
-type Props = React.ComponentPropsWithoutRef<typeof IconButton> & {
+export type Props = React.ComponentPropsWithoutRef<typeof IconButton> & {
   /**
    *  Custom color for action icon.
    */

--- a/src/components/Appbar/AppbarBackAction.tsx
+++ b/src/components/Appbar/AppbarBackAction.tsx
@@ -4,7 +4,7 @@ import AppbarAction from './AppbarAction';
 import AppbarBackIcon from './AppbarBackIcon';
 import type { StyleProp, ViewStyle } from 'react-native';
 
-type Props = $Omit<
+export type Props = $Omit<
   React.ComponentPropsWithoutRef<typeof AppbarAction>,
   'icon'
 > & {

--- a/src/components/Appbar/AppbarBackIcon.tsx
+++ b/src/components/Appbar/AppbarBackIcon.tsx
@@ -2,7 +2,12 @@ import * as React from 'react';
 import { Platform, I18nManager, View, Image, StyleSheet } from 'react-native';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
 
-const AppbarBackIcon = ({ size, color }: { size: number; color: string }) =>
+export type Props = {
+  size: number;
+  color: string;
+};
+
+const AppbarBackIcon = ({ size, color }: Props) =>
   Platform.OS === 'ios' ? (
     <View
       style={[

--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -15,7 +15,7 @@ import Text from '../Typography/Text';
 import { withTheme } from '../../core/theming';
 import { white } from '../../styles/colors';
 
-import type { $RemoveChildren } from '../../types';
+import type { $RemoveChildren, SetPropAsOptional } from '../../types';
 
 type Props = $RemoveChildren<typeof View> & {
   /**
@@ -143,6 +143,9 @@ const styles = StyleSheet.create({
     fontSize: Platform.OS === 'ios' ? 11 : 14,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type AppBarContentProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(AppbarContent);
 

--- a/src/components/Appbar/AppbarHeader.tsx
+++ b/src/components/Appbar/AppbarHeader.tsx
@@ -11,6 +11,7 @@ import Appbar, { DEFAULT_APPBAR_HEIGHT } from './Appbar';
 import shadow from '../../styles/shadow';
 import { withTheme } from '../../core/theming';
 import { APPROX_STATUSBAR_HEIGHT } from '../../constants';
+import type { SetPropAsOptional } from '../../types';
 
 type Props = React.ComponentProps<typeof Appbar> & {
   /**
@@ -133,6 +134,9 @@ const styles = StyleSheet.create({
     elevation: 0,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type AppBarHeaderProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(AppbarHeader);
 

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,8 +1,8 @@
 // @component ./AvatarIcon.tsx
-export { default as Icon } from './AvatarIcon';
+export { default as Icon, AvatarIconProps } from './AvatarIcon';
 
 // @component ./AvatarImage.tsx
-export { default as Image } from './AvatarImage';
+export { default as Image, AvatarImageProps } from './AvatarImage';
 
 // @component ./AvatarText.tsx
-export { default as Text } from './AvatarText';
+export { default as Text, AvatarTextProps } from './AvatarText';

--- a/src/components/Avatar/AvatarIcon.tsx
+++ b/src/components/Avatar/AvatarIcon.tsx
@@ -5,6 +5,7 @@ import Icon from '../Icon';
 import { withTheme } from '../../core/theming';
 import { white } from '../../styles/colors';
 import type { IconSource } from './../Icon';
+import type { SetPropAsOptional } from '../../types';
 
 const defaultSize = 64;
 
@@ -89,5 +90,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type AvatarIconProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(Avatar);

--- a/src/components/Avatar/AvatarImage.tsx
+++ b/src/components/Avatar/AvatarImage.tsx
@@ -7,6 +7,7 @@ import {
   ViewStyle,
   StyleProp,
 } from 'react-native';
+import type { SetPropAsOptional } from '../../types';
 import { withTheme } from '../../core/theming';
 
 const defaultSize = 64;
@@ -91,5 +92,8 @@ class AvatarImage extends React.Component<Props> {
     );
   }
 }
+
+// Set the theme to be optional as it should be provided through withTheme
+export type AvatarImageProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(AvatarImage);

--- a/src/components/Avatar/AvatarText.tsx
+++ b/src/components/Avatar/AvatarText.tsx
@@ -10,6 +10,7 @@ import Color from 'color';
 import Text from '../Typography/Text';
 import { withTheme } from '../../core/theming';
 import { white } from '../../styles/colors';
+import type { SetPropAsOptional } from '../../types';
 
 const defaultSize = 64;
 
@@ -126,5 +127,7 @@ const styles = StyleSheet.create({
     textAlignVertical: 'center',
   },
 });
+// Set the theme to be optional as it should be provided through withTheme
+export type AvatarTextProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(AvatarText);

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -3,6 +3,7 @@ import { Animated, StyleSheet, StyleProp, TextStyle } from 'react-native';
 import color from 'color';
 import { black, white } from '../styles/colors';
 import { withTheme } from '../core/theming';
+import type { SetPropAsOptional } from '../types';
 
 const defaultSize = 20;
 
@@ -109,6 +110,9 @@ const Badge = ({
     </Animated.Text>
   );
 };
+
+// Set the theme to be optional as it should be provided through withTheme
+export type BadgeProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(Badge);
 

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -5,7 +5,7 @@ import Text from './Typography/Text';
 import Button from './Button';
 import Icon, { IconSource } from './Icon';
 import { withTheme } from '../core/theming';
-import type { $RemoveChildren } from '../types';
+import type { $RemoveChildren, SetPropAsOptional } from '../types';
 import shadow from '../styles/shadow';
 
 const ELEVATION = 1;
@@ -256,5 +256,8 @@ const styles = StyleSheet.create({
     margin: 4,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type BannerProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(Banner);

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -23,6 +23,7 @@ import TouchableRipple from './TouchableRipple/TouchableRipple';
 import Text from './Typography/Text';
 import { black, white } from '../styles/colors';
 import { withTheme } from '../core/theming';
+import type { SetPropAsOptional } from '../types';
 
 type Route = {
   key: string;
@@ -1001,6 +1002,9 @@ class BottomNavigation extends React.Component<Props, State> {
     );
   }
 }
+
+// Set the theme to be optional as it should be provided through withTheme
+export type BottomNavigationProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(BottomNavigation);
 

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -16,6 +16,7 @@ import Text from './Typography/Text';
 import TouchableRipple from './TouchableRipple/TouchableRipple';
 import { black, white } from '../styles/colors';
 import { withTheme } from '../core/theming';
+import type { SetPropAsOptional } from '../types';
 
 type Props = React.ComponentProps<typeof Surface> & {
   /**
@@ -329,5 +330,8 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type ButtonProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(Button);

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -15,6 +15,7 @@ import CardCover, { CardCover as _CardCover } from './CardCover';
 import CardTitle, { CardTitle as _CardTitle } from './CardTitle';
 import Surface from '../Surface';
 import { withTheme } from '../../core/theming';
+import type { SetPropAsOptional } from '../../types';
 
 type Props = React.ComponentProps<typeof Surface> & {
   /**
@@ -176,5 +177,8 @@ const styles = StyleSheet.create({
     flexShrink: 1,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type CardProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(Card);

--- a/src/components/Card/CardActions.tsx
+++ b/src/components/Card/CardActions.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { StyleSheet, StyleProp, View, ViewStyle } from 'react-native';
 
-type Props = React.ComponentPropsWithRef<typeof View> & {
+export type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Items inside the `CardActions`.
    */

--- a/src/components/Card/CardContent.tsx
+++ b/src/components/Card/CardContent.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { StyleSheet, StyleProp, View, ViewStyle } from 'react-native';
 
-type Props = React.ComponentPropsWithRef<typeof View> & {
+export type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Items inside the `Card.Content`.
    */

--- a/src/components/Card/CardCover.tsx
+++ b/src/components/Card/CardCover.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { StyleSheet, View, ViewStyle, Image, StyleProp } from 'react-native';
+import type { SetPropAsOptional } from '../../types';
 import { withTheme } from '../../core/theming';
 import { grey200 } from '../../styles/colors';
 
@@ -89,6 +90,8 @@ const styles = StyleSheet.create({
     resizeMode: 'cover',
   },
 });
+// Set the theme to be optional as it should be provided through withTheme
+export type CardCoverProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(CardCover);
 

--- a/src/components/Card/CardTitle.tsx
+++ b/src/components/Card/CardTitle.tsx
@@ -6,6 +6,7 @@ import {
   View,
   ViewStyle,
 } from 'react-native';
+import type { SetPropAsOptional } from '../../types';
 
 import { withTheme } from '../../core/theming';
 import Caption from './../Typography/Caption';
@@ -183,6 +184,9 @@ const styles = StyleSheet.create({
     marginVertical: 0,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type CardTitleProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(CardTitle);
 

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -8,6 +8,7 @@ import CheckboxAndroid, {
 } from './CheckboxAndroid';
 import CheckboxItem from './CheckboxItem';
 import { withTheme } from '../../core/theming';
+import type { SetPropAsOptional } from '../../types';
 
 type Props = {
   /**
@@ -98,5 +99,8 @@ Checkbox.Android = CheckboxAndroid;
 
 // @component ./CheckboxIOS.tsx
 Checkbox.IOS = CheckboxIOS;
+
+// Set the theme to be optional as it should be provided through withTheme
+export type CheckboxProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(Checkbox);

--- a/src/components/Checkbox/CheckboxAndroid.tsx
+++ b/src/components/Checkbox/CheckboxAndroid.tsx
@@ -4,7 +4,7 @@ import color from 'color';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { withTheme } from '../../core/theming';
-import type { $RemoveChildren } from '../../types';
+import type { $RemoveChildren, SetPropAsOptional } from '../../types';
 
 type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
@@ -177,6 +177,9 @@ const styles = StyleSheet.create({
     width: 14,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type CheckboxAndroidProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(CheckboxAndroid);
 

--- a/src/components/Checkbox/CheckboxIOS.tsx
+++ b/src/components/Checkbox/CheckboxIOS.tsx
@@ -4,7 +4,7 @@ import color from 'color';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { withTheme } from '../../core/theming';
-import type { $RemoveChildren } from '../../types';
+import type { $RemoveChildren, SetPropAsOptional } from '../../types';
 
 type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
@@ -110,6 +110,9 @@ const styles = StyleSheet.create({
     padding: 6,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type CheckboxIOSProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(CheckboxIOS);
 

--- a/src/components/Checkbox/CheckboxItem.tsx
+++ b/src/components/Checkbox/CheckboxItem.tsx
@@ -12,6 +12,7 @@ import CheckBox from './Checkbox';
 import Text from '../Typography/Text';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { withTheme } from '../../core/theming';
+import type { SetPropAsOptional } from '../../types';
 
 type Props = {
   /**
@@ -96,6 +97,9 @@ const CheckboxItem = ({
 );
 
 CheckboxItem.displayName = 'Checkbox.Item';
+
+// Set the theme to be optional as it should be provided through withTheme
+export type CheckboxItemProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(CheckboxItem);
 

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -19,7 +19,7 @@ import Text from './Typography/Text';
 import TouchableRipple from './TouchableRipple/TouchableRipple';
 import { withTheme } from '../core/theming';
 import { black, white } from '../styles/colors';
-import type { EllipsizeProp } from '../types';
+import type { EllipsizeProp, SetPropAsOptional } from '../types';
 
 type Props = React.ComponentProps<typeof Surface> & {
   /**
@@ -376,5 +376,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type ChipProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(Chip);

--- a/src/components/CrossFadeIcon.tsx
+++ b/src/components/CrossFadeIcon.tsx
@@ -3,6 +3,7 @@ import { Animated, StyleSheet, View } from 'react-native';
 import Icon, { isValidIcon, isEqualIcon, IconSource } from './Icon';
 
 import { withTheme } from '../core/theming';
+import type { SetPropAsOptional } from '../types';
 
 type Props = {
   /**
@@ -131,6 +132,9 @@ class CrossFadeIcon extends React.Component<Props, State> {
     );
   }
 }
+
+// Set the theme to be optional as it should be provided through withTheme
+export type CrossFadeIconProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(CrossFadeIcon);
 

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -16,7 +16,7 @@ import DataTablePagination, {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import DataTableRow, { DataTableRow as _DataTableRow } from './DataTableRow';
 
-type Props = React.ComponentPropsWithRef<typeof View> & {
+export type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Content of the `DataTable`.
    */

--- a/src/components/DataTable/DataTableCell.tsx
+++ b/src/components/DataTable/DataTableCell.tsx
@@ -4,7 +4,7 @@ import Text from '../Typography/Text';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import type { $RemoveChildren } from '../../types';
 
-type Props = $RemoveChildren<typeof TouchableRipple> & {
+export type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * Content of the `DataTableCell`.
    */

--- a/src/components/DataTable/DataTableHeader.tsx
+++ b/src/components/DataTable/DataTableHeader.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, StyleProp, View, ViewStyle } from 'react-native';
 import { black, white } from '../../styles/colors';
 import { withTheme } from '../../core/theming';
 
-type Props = React.ComponentPropsWithRef<typeof View> & {
+export type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Content of the `DataTableHeader`.
    */

--- a/src/components/DataTable/DataTablePagination.tsx
+++ b/src/components/DataTable/DataTablePagination.tsx
@@ -11,6 +11,7 @@ import IconButton from '../IconButton';
 import Text from '../Typography/Text';
 import { withTheme } from '../../core/theming';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
+import type { SetPropAsOptional } from '../../types';
 
 type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
@@ -153,6 +154,9 @@ const styles = StyleSheet.create({
     marginRight: 44,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type DataTablePaginationProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(DataTablePagination);
 

--- a/src/components/DataTable/DataTableRow.tsx
+++ b/src/components/DataTable/DataTableRow.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, StyleProp, View, ViewStyle } from 'react-native';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { black, white } from '../../styles/colors';
 import { withTheme } from '../../core/theming';
-import type { $RemoveChildren } from '../../types';
+import type { $RemoveChildren, SetPropAsOptional } from '../../types';
 
 type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
@@ -84,6 +84,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type DataTableRowProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(DataTableRow);
 

--- a/src/components/DataTable/DataTableTitle.tsx
+++ b/src/components/DataTable/DataTableTitle.tsx
@@ -12,6 +12,7 @@ import color from 'color';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
 import Text from '../Typography/Text';
 import { withTheme } from '../../core/theming';
+import type { SetPropAsOptional } from '../../types';
 
 type Props = React.ComponentPropsWithRef<typeof TouchableWithoutFeedback> & {
   /**
@@ -182,6 +183,9 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type DataTableTitleProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(DataTableTitle);
 

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -8,6 +8,7 @@ import DialogTitle, { DialogTitle as _DialogTitle } from './DialogTitle';
 import DialogScrollArea from './DialogScrollArea';
 import { withTheme } from '../../core/theming';
 import overlay from '../../styles/overlay';
+import type { SetPropAsOptional } from '../../types';
 
 type Props = {
   /**
@@ -145,5 +146,8 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-start',
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type DialogProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(Dialog);

--- a/src/components/Dialog/DialogActions.tsx
+++ b/src/components/Dialog/DialogActions.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { StyleSheet, StyleProp, View, ViewStyle } from 'react-native';
 
-type Props = React.ComponentPropsWithRef<typeof View> & {
+export type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Content of the `DialogActions`.
    */

--- a/src/components/Dialog/DialogContent.tsx
+++ b/src/components/Dialog/DialogContent.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { View, ViewStyle, StyleSheet, StyleProp } from 'react-native';
 
-type Props = React.ComponentPropsWithRef<typeof View> & {
+export type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Content of the `DialogContent`.
    */

--- a/src/components/Dialog/DialogScrollArea.tsx
+++ b/src/components/Dialog/DialogScrollArea.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { View, ViewStyle, StyleSheet, StyleProp } from 'react-native';
 
-type Props = React.ComponentPropsWithRef<typeof View> & {
+export type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Content of the `DialogScrollArea`.
    */

--- a/src/components/Dialog/DialogTitle.tsx
+++ b/src/components/Dialog/DialogTitle.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { StyleSheet, StyleProp, TextStyle } from 'react-native';
 import Title from '../Typography/Title';
 import { withTheme } from '../../core/theming';
+import type { SetPropAsOptional } from '../../types';
 
 type Props = React.ComponentPropsWithRef<typeof Title> & {
   /**
@@ -69,6 +70,9 @@ const styles = StyleSheet.create({
     marginHorizontal: 24,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type DialogTitleProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(DialogTitle);
 

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -3,7 +3,7 @@ import color from 'color';
 import { StyleSheet, View, ViewStyle, StyleProp } from 'react-native';
 import { withTheme } from '../core/theming';
 import { black, white } from '../styles/colors';
-import type { $RemoveChildren } from '../types';
+import type { $RemoveChildren, SetPropAsOptional } from '../types';
 
 type Props = $RemoveChildren<typeof View> & {
   /**
@@ -71,5 +71,8 @@ const styles = StyleSheet.create({
     marginLeft: 72,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type DividerProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(Divider);

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -1,5 +1,5 @@
 // @component ./DrawerItem.tsx
-export { default as Item } from './DrawerItem';
+export { default as Item, DrawerItemProps } from './DrawerItem';
 
 // @component ./DrawerSection.tsx
-export { default as Section } from './DrawerSection';
+export { default as Section, DrawerSectionProps } from './DrawerSection';

--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -5,6 +5,7 @@ import Text from '../Typography/Text';
 import Icon, { IconSource } from '../Icon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { withTheme } from '../../core/theming';
+import type { SetPropAsOptional } from '../../types';
 
 type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
@@ -136,5 +137,8 @@ const styles = StyleSheet.create({
     marginRight: 32,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type DrawerItemProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(DrawerItem);

--- a/src/components/Drawer/DrawerSection.tsx
+++ b/src/components/Drawer/DrawerSection.tsx
@@ -4,6 +4,7 @@ import { View, ViewStyle, StyleSheet, StyleProp } from 'react-native';
 import Text from '../Typography/Text';
 import Divider from '../Divider';
 import { withTheme } from '../../core/theming';
+import type { SetPropAsOptional } from '../../types';
 
 type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
@@ -95,5 +96,8 @@ const styles = StyleSheet.create({
     marginTop: 4,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type DrawerSectionProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(DrawerSection);

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -11,7 +11,7 @@ import Text from '../Typography/Text';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { black, white } from '../../styles/colors';
 import { withTheme } from '../../core/theming';
-import type { $RemoveChildren } from '../../types';
+import type { $RemoveChildren, SetPropAsOptional } from '../../types';
 import type { IconSource } from './../Icon';
 
 type Props = $RemoveChildren<typeof Surface> & {
@@ -294,5 +294,8 @@ const styles = StyleSheet.create({
     elevation: 0,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type FABProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(FAB);

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -14,6 +14,7 @@ import Text from '../Typography/Text';
 import Card from '../Card/Card';
 import { withTheme } from '../../core/theming';
 import type { IconSource } from '../Icon';
+import type { SetPropAsOptional } from '../../types';
 
 type Props = {
   /**
@@ -349,6 +350,9 @@ class FABGroup extends React.Component<Props, State> {
     );
   }
 }
+
+// Set the theme to be optional as it should be provided through withTheme
+export type FABGroupProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(FABGroup);
 

--- a/src/components/HelperText.tsx
+++ b/src/components/HelperText.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-native';
 import AnimatedText from './Typography/AnimatedText';
 import { withTheme } from '../core/theming';
-import type { $Omit } from '../types';
+import type { $Omit, SetPropAsOptional } from '../types';
 
 type Props = $Omit<
   $Omit<React.ComponentPropsWithRef<typeof AnimatedText>, 'padding'>,
@@ -168,5 +168,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type HelperTextProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(HelperText);

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -8,20 +8,21 @@ import {
 import { Consumer as SettingsConsumer } from '../core/settings';
 import { accessibilityProps } from './MaterialCommunityIcon';
 import { withTheme } from '../core/theming';
+import type { SetPropAsOptional } from '../types';
 
 type IconSourceBase = string | ImageSourcePropType;
 
 export type IconSource =
   | IconSourceBase
   | Readonly<{ source: IconSourceBase; direction: 'rtl' | 'ltr' | 'auto' }>
-  | ((props: IconProps & { color: string }) => React.ReactNode);
+  | ((props: IconBaseProps & { color: string }) => React.ReactNode);
 
-type IconProps = {
+type IconBaseProps = {
   size: number;
   allowFontScaling?: boolean;
 };
 
-type Props = IconProps & {
+type Props = IconBaseProps & {
   color?: string;
   source: any;
   /**
@@ -121,5 +122,8 @@ const Icon = ({ source, color, size, theme, ...rest }: Props) => {
 
   return null;
 };
+
+// Set the theme to be optional as it should be provided through withTheme
+export type IconProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(Icon);

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -14,7 +14,7 @@ import Icon, { IconSource } from './Icon';
 import CrossFadeIcon from './CrossFadeIcon';
 import { withTheme } from '../core/theming';
 
-import type { $RemoveChildren } from '../types';
+import type { $RemoveChildren, SetPropAsOptional } from '../types';
 
 type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
@@ -147,5 +147,8 @@ const styles = StyleSheet.create({
     opacity: 0.32,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type IconButtonProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(IconButton);

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -1,17 +1,20 @@
 // @component ./ListAccordion.tsx
-export { default as Accordion } from './ListAccordion';
+export { default as Accordion, ListAccordionProps } from './ListAccordion';
 
 // @component ./ListAccordionGroup.tsx
-export { default as AccordionGroup } from './ListAccordionGroup';
+export {
+  default as AccordionGroup,
+  Props as ListAccordionGroupProps,
+} from './ListAccordionGroup';
 
 // @component ./ListIcon.tsx
-export { default as Icon } from './ListIcon';
+export { default as Icon, Props as ListIconProps } from './ListIcon';
 
 // @component ./ListItem.tsx
-export { default as Item } from './ListItem';
+export { default as Item, ListItemProps } from './ListItem';
 
 // @component ./ListSection.tsx
-export { default as Section } from './ListSection';
+export { default as Section, ListSectionProps } from './ListSection';
 
 // @component ./ListSubheader.tsx
-export { default as Subheader } from './ListSubheader';
+export { default as Subheader, ListSubheaderProps } from './ListSubheader';

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -17,6 +17,7 @@ import {
   ListAccordionGroupContext,
   ListAccordionGroupContextType,
 } from './ListAccordionGroup';
+import type { SetPropAsOptional } from '../../types';
 
 type Props = {
   /**
@@ -308,5 +309,8 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type ListAccordionProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(ListAccordion);

--- a/src/components/List/ListAccordionGroup.tsx
+++ b/src/components/List/ListAccordionGroup.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-type Props = {
+export type Props = {
   /**
    * Function to execute on selection change.
    */

--- a/src/components/List/ListIcon.tsx
+++ b/src/components/List/ListIcon.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { View, ViewStyle, StyleSheet, StyleProp } from 'react-native';
 import Icon, { IconSource } from '../Icon';
 
-type Props = {
+export type Props = {
   /**
    * Icon to show.
    */

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -11,7 +11,11 @@ import {
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import Text from '../Typography/Text';
 import { withTheme } from '../../core/theming';
-import type { $RemoveChildren, EllipsizeProp } from '../../types';
+import type {
+  $RemoveChildren,
+  EllipsizeProp,
+  SetPropAsOptional,
+} from '../../types';
 
 type Description =
   | React.ReactNode
@@ -251,5 +255,8 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type ListItemProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(ListItem);

--- a/src/components/List/ListSection.tsx
+++ b/src/components/List/ListSection.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-native';
 import ListSubheader from './ListSubheader';
 import { withTheme } from '../../core/theming';
+import type { SetPropAsOptional } from '../../types';
 
 type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
@@ -75,5 +76,8 @@ const styles = StyleSheet.create({
     marginVertical: 8,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type ListSectionProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(ListSection);

--- a/src/components/List/ListSubheader.tsx
+++ b/src/components/List/ListSubheader.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, StyleProp, TextStyle } from 'react-native';
 import color from 'color';
 import Text from '../Typography/Text';
 import { withTheme } from '../../core/theming';
+import type { SetPropAsOptional } from '../../types';
 
 type Props = React.ComponentProps<typeof Text> & {
   /**
@@ -53,5 +54,8 @@ const styles = StyleSheet.create({
     paddingVertical: 13,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type ListSubheaderProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(ListSubheader);

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -17,7 +17,7 @@ import {
 } from 'react-native';
 
 import { withTheme } from '../../core/theming';
-import type { $Omit } from '../../types';
+import type { $Omit, SetPropAsOptional } from '../../types';
 import Portal from '../Portal/Portal';
 import Surface from '../Surface';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -586,5 +586,8 @@ const styles = StyleSheet.create({
     elevation: 8,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type MenuProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(Menu);

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -12,6 +12,7 @@ import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import Text from '../Typography/Text';
 import { withTheme } from '../../core/theming';
 import { black, white } from '../../styles/colors';
+import type { SetPropAsOptional } from '../../types';
 
 type Props = {
   /**
@@ -171,6 +172,9 @@ const styles = StyleSheet.create({
     maxWidth: maxWidth - (iconWidth + 48),
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type MenuItemProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(MenuItem);
 

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -11,6 +11,7 @@ import {
 import SafeAreaView from 'react-native-safe-area-view';
 import Surface from './Surface';
 import { withTheme } from '../core/theming';
+import type { SetPropAsOptional } from '../types';
 
 type Props = {
   /**
@@ -227,6 +228,9 @@ class Modal extends React.Component<Props, State> {
     );
   }
 }
+
+// Set the theme to be optional as it should be provided through withTheme
+export type ModalProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(Modal);
 

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -6,6 +6,7 @@ import {
   Consumer as SettingsConsumer,
 } from '../../core/settings';
 import { ThemeProvider, withTheme } from '../../core/theming';
+import type { SetPropAsOptional } from '../../types';
 
 type Props = {
   /**
@@ -61,5 +62,8 @@ class Portal extends React.Component<Props> {
     );
   }
 }
+
+// Set the theme to be optional as it should be provided through withTheme
+export type PortalProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(Portal);

--- a/src/components/Portal/PortalConsumer.tsx
+++ b/src/components/Portal/PortalConsumer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { PortalMethods } from './PortalHost';
 
-type Props = {
+export type Props = {
   manager: PortalMethods;
   children: React.ReactNode;
 };

--- a/src/components/Portal/PortalHost.tsx
+++ b/src/components/Portal/PortalHost.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { View, StyleSheet } from 'react-native';
 import PortalManager from './PortalManager';
 
-type Props = {
+export type Props = {
   children: React.ReactNode;
 };
 

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import setColor from 'color';
 import { withTheme } from '../core/theming';
+import type { SetPropAsOptional } from '../types';
 
 type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
@@ -259,5 +260,8 @@ const styles = StyleSheet.create({
     flex: 1,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type ProgressBarProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(ProgressBar);

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -5,6 +5,7 @@ import RadioButtonAndroid from './RadioButtonAndroid';
 import RadioButtonIOS from './RadioButtonIOS';
 import RadioButtonItem from './RadioButtonItem';
 import { withTheme } from '../../core/theming';
+import type { SetPropAsOptional } from '../../types';
 
 export type Props = {
   /**
@@ -111,5 +112,8 @@ RadioButton.IOS = RadioButtonIOS;
 
 // @component ./RadioButtonItem.tsx
 RadioButton.Item = RadioButtonItem;
+
+// Set the theme to be optional as it should be provided through withTheme
+export type RadioButtonProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(RadioButton);

--- a/src/components/RadioButton/RadioButtonAndroid.tsx
+++ b/src/components/RadioButton/RadioButtonAndroid.tsx
@@ -5,7 +5,7 @@ import { RadioButtonContext, RadioButtonContextType } from './RadioButtonGroup';
 import { handlePress, isChecked } from './utils';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { withTheme } from '../../core/theming';
-import type { $RemoveChildren } from '../../types';
+import type { $RemoveChildren, SetPropAsOptional } from '../../types';
 
 type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
@@ -205,6 +205,9 @@ const styles = StyleSheet.create({
     borderRadius: 5,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type RadioButtonAndroidProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(RadioButtonAndroid);
 

--- a/src/components/RadioButton/RadioButtonGroup.tsx
+++ b/src/components/RadioButton/RadioButtonGroup.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { View } from 'react-native';
 
-type Props = {
+export type Props = {
   /**
    * Function to execute on selection change.
    */

--- a/src/components/RadioButton/RadioButtonIOS.tsx
+++ b/src/components/RadioButton/RadioButtonIOS.tsx
@@ -6,7 +6,7 @@ import { handlePress, isChecked } from './utils';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { withTheme } from '../../core/theming';
-import type { $RemoveChildren } from '../../types';
+import type { $RemoveChildren, SetPropAsOptional } from '../../types';
 
 type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
@@ -136,6 +136,9 @@ const styles = StyleSheet.create({
     padding: 6,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type RadioButtonIOSProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(RadioButtonIOS);
 

--- a/src/components/RadioButton/RadioButtonItem.tsx
+++ b/src/components/RadioButton/RadioButtonItem.tsx
@@ -12,6 +12,7 @@ import { handlePress } from './utils';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import RadioButton from './RadioButton';
 import Text from '../Typography/Text';
+import type { SetPropAsOptional } from '../../types';
 
 export type Props = {
   /**
@@ -143,6 +144,9 @@ const RadioButtonItem = ({
 );
 
 RadioButtonItem.displayName = 'RadioButton.Item';
+
+// Set the theme to be optional as it should be provided through withTheme
+export type RadioButtonProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(RadioButtonItem);
 

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -14,6 +14,7 @@ import Surface from './Surface';
 import { withTheme } from '../core/theming';
 import type { IconSource } from './Icon';
 import MaterialCommunityIcon from './MaterialCommunityIcon';
+import type { SetPropAsOptional } from '../types';
 
 type Props = React.ComponentPropsWithRef<typeof TextInput> & {
   /**
@@ -249,5 +250,8 @@ const styles = StyleSheet.create({
     minWidth: 0,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type SearchbarProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(Searchbar);

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -12,6 +12,7 @@ import Button from './Button';
 import Surface from './Surface';
 import Text from './Typography/Text';
 import { withTheme } from '../core/theming';
+import type { SetPropAsOptional } from '../types';
 
 type Props = React.ComponentProps<typeof Surface> & {
   /**
@@ -267,5 +268,8 @@ const styles = StyleSheet.create({
     marginVertical: 6,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type SnackbarProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(Snackbar);

--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -3,6 +3,7 @@ import { Animated, StyleSheet, View, StyleProp, ViewStyle } from 'react-native';
 import shadow from '../styles/shadow';
 import { withTheme } from '../core/theming';
 import overlay from '../styles/overlay';
+import type { SetPropAsOptional } from '../types';
 
 type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
@@ -80,5 +81,8 @@ const Surface = ({ style, theme, ...rest }: Props) => {
     />
   );
 };
+
+// Set the theme to be optional as it should be provided through withTheme
+export type SurfaceProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(Surface);

--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import setColor from 'color';
 import { withTheme } from '../core/theming';
+import type { SetPropAsOptional } from '../types';
 
 const version = NativeModules.PlatformConstants
   ? NativeModules.PlatformConstants.reactNativeVersion
@@ -132,5 +133,8 @@ const Switch = ({
     />
   );
 };
+
+// Set the theme to be optional as it should be provided through withTheme
+export type SwitchProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(Switch);

--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -4,8 +4,8 @@ import type {
   TextStyle,
   LayoutChangeEvent,
 } from 'react-native';
-import type { TextInputProps } from './TextInput';
-import type { $Omit } from './../../types';
+import type { TextInputProps as TextInputBaseProps } from './TextInput';
+import type { $Omit, SetPropAsOptional } from './../../types';
 
 export type RenderProps = {
   ref: (a: NativeTextInput | null | undefined) => void;
@@ -23,7 +23,7 @@ export type RenderProps = {
   value?: string;
   adjustsFontSizeToFit?: boolean;
 };
-type TextInputTypesWithoutMode = $Omit<TextInputProps, 'mode'>;
+type TextInputTypesWithoutMode = $Omit<TextInputBaseProps, 'mode'>;
 export type State = {
   labeled: Animated.Value;
   error: Animated.Value;
@@ -81,3 +81,6 @@ export type LabelBackgroundProps = {
   labelStyle: any;
   parentState: State;
 };
+
+// Set the theme to be optional as it should be provided through withTheme
+export type TextInputProps = SetPropAsOptional<TextInputBaseProps, 'theme'>;

--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -14,6 +14,7 @@ import ToggleButtonGroup, {
 import ToggleButtonRow from './ToggleButtonRow';
 import { black, white } from '../../styles/colors';
 import type { IconSource } from '../Icon';
+import type { SetPropAsOptional } from '../../types';
 
 type Props = {
   /**
@@ -169,5 +170,8 @@ const styles = StyleSheet.create({
     margin: 0,
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type ToggleButtonProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(ToggleButton);

--- a/src/components/ToggleButton/ToggleButtonGroup.tsx
+++ b/src/components/ToggleButton/ToggleButtonGroup.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-type Props = {
+export type Props = {
   /**
    * Function to execute on selection change.
    */

--- a/src/components/ToggleButton/ToggleButtonRow.tsx
+++ b/src/components/ToggleButton/ToggleButtonRow.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StyleSheet, View, StyleProp, ViewStyle } from 'react-native';
 import ToggleButton from './ToggleButton';
 
-type Props = {
+export type Props = {
   /**
    * Function to execute on selection change.
    */

--- a/src/components/TouchableRipple/TouchableRipple.native.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.native.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import color from 'color';
 import { withTheme } from '../../core/theming';
+import type { SetPropAsOptional } from '../../types';
 
 const ANDROID_VERSION_LOLLIPOP = 21;
 const ANDROID_VERSION_PIE = 28;
@@ -91,5 +92,8 @@ const TouchableRipple = ({
 
 TouchableRipple.supported =
   Platform.OS === 'android' && Platform.Version >= ANDROID_VERSION_LOLLIPOP;
+
+// Set the theme to be optional as it should be provided through withTheme
+export type TouchableRippleProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(TouchableRipple);

--- a/src/components/TouchableRipple/TouchableRipple.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import color from 'color';
 import { withTheme } from '../../core/theming';
+import type { SetPropAsOptional } from '../../types';
 
 type Props = React.ComponentPropsWithRef<typeof TouchableWithoutFeedback> & {
   /**
@@ -256,5 +257,8 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
 });
+
+// Set the theme to be optional as it should be provided through withTheme
+export type TouchableRippleProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(TouchableRipple);

--- a/src/components/Typography/AnimatedText.tsx
+++ b/src/components/Typography/AnimatedText.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Animated, TextStyle, I18nManager, StyleProp } from 'react-native';
+import type { SetPropAsOptional } from '../../types';
 import { withTheme } from '../../core/theming';
 
 type Props = React.ComponentPropsWithRef<typeof Animated.Text> & {
@@ -34,5 +35,8 @@ function AnimatedText({ style, theme, ...rest }: Props) {
     />
   );
 }
+
+// Set the theme to be optional as it should be provided through withTheme
+export type AnimatedTextProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(AnimatedText);

--- a/src/components/Typography/Caption.tsx
+++ b/src/components/Typography/Caption.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Text, TextStyle, StyleSheet, StyleProp } from 'react-native';
 import StyledText from './StyledText';
 
-type Props = React.ComponentProps<typeof Text> & {
+export type Props = React.ComponentProps<typeof Text> & {
   style?: StyleProp<TextStyle>;
   children: React.ReactNode;
 };

--- a/src/components/Typography/Headline.tsx
+++ b/src/components/Typography/Headline.tsx
@@ -3,7 +3,7 @@ import { Text, TextStyle, StyleSheet, StyleProp } from 'react-native';
 
 import StyledText from './StyledText';
 
-type Props = React.ComponentProps<typeof Text> & {
+export type Props = React.ComponentProps<typeof Text> & {
   style?: StyleProp<TextStyle>;
   children: React.ReactNode;
 };

--- a/src/components/Typography/Paragraph.tsx
+++ b/src/components/Typography/Paragraph.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { TextProps, StyleSheet } from 'react-native';
 import StyledText from './StyledText';
 
-type Props = TextProps & {
+export type Props = TextProps & {
   children: React.ReactNode;
 };
 

--- a/src/components/Typography/StyledText.tsx
+++ b/src/components/Typography/StyledText.tsx
@@ -4,6 +4,7 @@ import { I18nManager, StyleProp, TextStyle } from 'react-native';
 
 import Text from './Text';
 import { withTheme } from '../../core/theming';
+import type { SetPropAsOptional } from '../../types';
 
 type Props = React.ComponentProps<typeof Text> & {
   alpha: number;
@@ -31,5 +32,8 @@ class StyledText extends React.Component<Props> {
     );
   }
 }
+
+// Set the theme to be optional as it should be provided through withTheme
+export type StyledTextProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(StyledText);

--- a/src/components/Typography/Subheading.tsx
+++ b/src/components/Typography/Subheading.tsx
@@ -3,7 +3,7 @@ import { Text, TextStyle, StyleSheet, StyleProp } from 'react-native';
 
 import StyledText from './StyledText';
 
-type Props = React.ComponentProps<typeof Text> & {
+export type Props = React.ComponentProps<typeof Text> & {
   style?: StyleProp<TextStyle>;
   children: React.ReactNode;
 };

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Text as NativeText, TextStyle, StyleProp } from 'react-native';
+import type { SetPropAsOptional } from '../../types';
 import { withTheme } from '../../core/theming';
 
 type Props = React.ComponentProps<typeof NativeText> & {
@@ -48,5 +49,8 @@ class Text extends React.Component<Props> {
     );
   }
 }
+
+// Set the theme to be optional as it should be provided through withTheme
+export type TextProps = SetPropAsOptional<Props, 'theme'>;
 
 export default withTheme(Text);

--- a/src/components/Typography/Title.tsx
+++ b/src/components/Typography/Title.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Text, StyleSheet } from 'react-native';
 import StyledText from './StyledText';
 
-type Props = React.ComponentProps<typeof Text> & {
+export type Props = React.ComponentProps<typeof Text> & {
   children: React.ReactNode;
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,37 +17,85 @@ import * as Drawer from './components/Drawer/Drawer';
 
 export { Avatar, List, Drawer };
 
-export { default as Badge } from './components/Badge';
-export { default as ActivityIndicator } from './components/ActivityIndicator';
-export { default as Banner } from './components/Banner';
-export { default as BottomNavigation } from './components/BottomNavigation';
-export { default as Button } from './components/Button';
-export { default as Card } from './components/Card/Card';
-export { default as Checkbox } from './components/Checkbox/Checkbox';
-export { default as Chip } from './components/Chip';
-export { default as DataTable } from './components/DataTable/DataTable';
-export { default as Dialog } from './components/Dialog/Dialog';
-export { default as Divider } from './components/Divider';
-export { default as FAB } from './components/FAB/FAB';
-export { default as HelperText } from './components/HelperText';
-export { default as IconButton } from './components/IconButton';
-export { default as Menu } from './components/Menu/Menu';
-export { default as Modal } from './components/Modal';
-export { default as Portal } from './components/Portal/Portal';
-export { default as ProgressBar } from './components/ProgressBar';
-export { default as RadioButton } from './components/RadioButton/RadioButton';
-export { default as Searchbar } from './components/Searchbar';
-export { default as Snackbar } from './components/Snackbar';
-export { default as Surface } from './components/Surface';
-export { default as Switch } from './components/Switch';
-export { default as Appbar } from './components/Appbar/Appbar';
-export { default as TouchableRipple } from './components/TouchableRipple/TouchableRipple';
-export { default as TextInput } from './components/TextInput/TextInput';
-export { default as ToggleButton } from './components/ToggleButton/ToggleButton';
+export { default as Badge, BadgeProps } from './components/Badge';
+export {
+  default as ActivityIndicator,
+  ActivityIndicatorProps,
+} from './components/ActivityIndicator';
+export { default as Banner, BannerProps } from './components/Banner';
+export {
+  default as BottomNavigation,
+  BottomNavigationProps,
+} from './components/BottomNavigation';
+export { default as Button, ButtonProps } from './components/Button';
+export { default as Card, CardProps } from './components/Card/Card';
+export {
+  default as Checkbox,
+  CheckboxProps,
+} from './components/Checkbox/Checkbox';
+export { default as Chip, ChipProps } from './components/Chip';
+export {
+  default as DataTable,
+  Props as DataTableProps,
+} from './components/DataTable/DataTable';
+export { default as Dialog, DialogProps } from './components/Dialog/Dialog';
+export { default as Divider, DividerProps } from './components/Divider';
+export { default as FAB, FABProps } from './components/FAB/FAB';
+export {
+  default as HelperText,
+  HelperTextProps,
+} from './components/HelperText';
+export {
+  default as IconButton,
+  IconButtonProps,
+} from './components/IconButton';
+export { default as Menu, MenuProps } from './components/Menu/Menu';
+export { default as Modal, ModalProps } from './components/Modal';
+export { default as Portal, PortalProps } from './components/Portal/Portal';
+export {
+  default as ProgressBar,
+  ProgressBarProps,
+} from './components/ProgressBar';
+export {
+  default as RadioButton,
+  RadioButtonProps,
+} from './components/RadioButton/RadioButton';
+export { default as Searchbar, SearchbarProps } from './components/Searchbar';
+export { default as Snackbar, SnackbarProps } from './components/Snackbar';
+export { default as Surface, SurfaceProps } from './components/Surface';
+export { default as Switch, SwitchProps } from './components/Switch';
+export { default as Appbar, AppBarProps } from './components/Appbar/Appbar';
+export {
+  default as TouchableRipple,
+  TouchableRippleProps,
+} from './components/TouchableRipple/TouchableRipple';
+export {
+  default as TextInput,
+  TextInputProps,
+} from './components/TextInput/TextInput';
+export {
+  default as ToggleButton,
+  ToggleButtonProps,
+} from './components/ToggleButton/ToggleButton';
 
-export { default as Caption } from './components/Typography/Caption';
-export { default as Headline } from './components/Typography/Headline';
-export { default as Paragraph } from './components/Typography/Paragraph';
-export { default as Subheading } from './components/Typography/Subheading';
-export { default as Title } from './components/Typography/Title';
-export { default as Text } from './components/Typography/Text';
+export {
+  default as Caption,
+  Props as CaptionProps,
+} from './components/Typography/Caption';
+export {
+  default as Headline,
+  Props as HeadlineProps,
+} from './components/Typography/Headline';
+export {
+  default as Paragraph,
+  Props as ParagraphProps,
+} from './components/Typography/Paragraph';
+export {
+  default as Subheading,
+  Props as SubheadingProps,
+} from './components/Typography/Subheading';
+export {
+  default as Title,
+  Props as TitleProps,
+} from './components/Typography/Title';
+export { default as Text, TextProps } from './components/Typography/Text';

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -109,3 +109,9 @@ declare global {
     }
   }
 }
+
+export type SetPropAsOptional<T, K extends string | number | symbol> = Omit<
+  T,
+  K
+> &
+  { [P in Extract<keyof T, K>]?: T[P] };


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

Often we would like to extend some components from `react-native-paper` and would like to extend the props so that consumer of our custom components will still pass correct props to the component below. To help with this, we would need the Props typing to be exported out. So I have now exported out the Props

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
* Run tests as per [contribution-guidelines](https://github.com/callstack/react-native-paper/blob/master/CONTRIBUTING.md#linting-and-tests)

* Import the component and the Props and extend them to make sure it works
```tsx
// example-custom-button.tsx
import React from 'react';
import { Button, ButtonProps } from 'react-native-paper';

export const CustomBlueCircleButton: React.FC<ButtonProps> = ({ children, ...props }) => {
  return (
    <Button mode="outlined" compact style={{
      backgroundColor: 'blue'
      borderRadius: 50,
    }} {...props}>{children}</Button>
  )
}

```