### PR TITLE
fix: paddingHorizontal with TextInput.Affix

### DIFF
--- a/src/components/TextInput/Adornment/Affix.tsx
+++ b/src/components/TextInput/Adornment/Affix.tsx
@@ -30,6 +30,7 @@ type ContextState = {
   visible?: Animated.Value;
   textStyle?: StyleProp<TextStyle>;
   side: AdornmentSide;
+  paddingHorizontal?: number | string;
 };
 
 const AffixContext = React.createContext<ContextState>({
@@ -43,7 +44,15 @@ export const AffixAdornment: React.FunctionComponent<
     affix: React.ReactNode;
     testID: string;
   } & ContextState
-> = ({ affix, side, textStyle, topPosition, onLayout, visible }) => {
+> = ({
+  affix,
+  side,
+  textStyle,
+  topPosition,
+  onLayout,
+  visible,
+  paddingHorizontal,
+}) => {
   return (
     <AffixContext.Provider
       value={{
@@ -52,6 +61,7 @@ export const AffixAdornment: React.FunctionComponent<
         topPosition,
         onLayout,
         visible,
+        paddingHorizontal,
       }}
     >
       {affix}
@@ -60,17 +70,25 @@ export const AffixAdornment: React.FunctionComponent<
 };
 
 const TextInputAffix = ({ text, textStyle: labelStyle, theme }: Props) => {
-  const { textStyle, onLayout, topPosition, side, visible } = React.useContext(
-    AffixContext
-  );
+  const {
+    textStyle,
+    onLayout,
+    topPosition,
+    side,
+    visible,
+    paddingHorizontal,
+  } = React.useContext(AffixContext);
   const textColor = color(theme.colors.text)
     .alpha(theme.dark ? 0.7 : 0.54)
     .rgb()
     .string();
 
+  const offset =
+    typeof paddingHorizontal === 'number' ? paddingHorizontal : AFFIX_OFFSET;
+
   const style = {
     top: topPosition,
-    [side]: AFFIX_OFFSET,
+    [side]: offset,
   };
 
   return (

--- a/src/components/TextInput/Adornment/TextInputAdornment.tsx
+++ b/src/components/TextInput/Adornment/TextInputAdornment.tsx
@@ -50,21 +50,27 @@ export function getAdornmentStyleAdjustmentForNativeInput({
   adornmentConfig,
   leftAffixWidth,
   rightAffixWidth,
+  paddingHorizontal,
   inputOffset = 0,
 }: {
   inputOffset?: number;
   adornmentConfig: AdornmentConfig[];
   leftAffixWidth: number;
   rightAffixWidth: number;
+  paddingHorizontal?: number | string;
 }): AdornmentStyleAdjustmentForNativeInput | {} {
   if (adornmentConfig.length) {
     const adornmentStyleAdjustmentForNativeInput = adornmentConfig.map(
       ({ type, side }: AdornmentConfig) => {
         const isWeb = Platform.OS !== 'ios' && Platform.OS !== 'android';
         const isLeftSide = side === AdornmentSide.Left;
-        const offset =
-          (isLeftSide ? leftAffixWidth : rightAffixWidth) + ADORNMENT_OFFSET;
         const paddingKey = `padding${captalize(side)}`;
+        const affixWidth = isLeftSide ? leftAffixWidth : rightAffixWidth;
+        const padding =
+          typeof paddingHorizontal === 'number'
+            ? paddingHorizontal
+            : ADORNMENT_OFFSET;
+        const offset = affixWidth + padding;
 
         if (isWeb) return { [paddingKey]: offset };
 
@@ -114,6 +120,7 @@ export interface TextInputAdornmentProps {
   textStyle?: StyleProp<TextStyle>;
   visible?: Animated.Value;
   isTextInputFocused: boolean;
+  paddingHorizontal?: number | string;
 }
 
 const TextInputAdornment: React.FunctionComponent<TextInputAdornmentProps> = ({
@@ -126,6 +133,7 @@ const TextInputAdornment: React.FunctionComponent<TextInputAdornmentProps> = ({
   topPosition,
   isTextInputFocused,
   forceFocus,
+  paddingHorizontal,
 }) => {
   if (adornmentConfig.length) {
     return (
@@ -143,6 +151,7 @@ const TextInputAdornment: React.FunctionComponent<TextInputAdornmentProps> = ({
             side: side,
             testID: `${side}-${type}-adornment`,
             isTextInputFocused,
+            paddingHorizontal,
           };
           if (type === AdornmentType.Icon) {
             return (

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -129,6 +129,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
         adornmentConfig,
         rightAffixWidth,
         leftAffixWidth,
+        paddingHorizontal,
         inputOffset: FLAT_INPUT_OFFSET,
       }
     );
@@ -285,6 +286,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
     };
 
     let adornmentProps: TextInputAdornmentProps = {
+      paddingHorizontal,
       adornmentConfig,
       forceFocus,
       topPosition: {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Fixes: #2303 

`paddingHorizontal` is disregarded when using `left` prop on `TextInput`.
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
Snack: https://snack.expo.io/@dcangulo/textinput

**Sample Code in screenshot:**
```js
import React from 'react';
import { SafeAreaView, View } from 'react-native';
import { TextInput } from 'react-native-paper';

export default function App() {
  const [text, setText] = React.useState('');

  return (
    <SafeAreaView>
      <View style={{ padding: 20 }}>
        <TextInput
          label='Contact Number'
          value={text}
          onChangeText={setText}
          left={<TextInput.Affix text='+63' />}
          style={{ paddingHorizontal: 60 }}
        />
      </View>
    </SafeAreaView>
  );
}
```

**Before this PR:**
<img width="357" alt="Screen Shot 2020-10-23 at 10 08 14 PM" src="https://user-images.githubusercontent.com/36528176/97015554-499caf80-157e-11eb-8690-0de84c109753.png">

**After this PR:**
<img width="373" alt="Screen Shot 2020-10-23 at 10 17 53 PM" src="https://user-images.githubusercontent.com/36528176/97015648-646f2400-157e-11eb-808d-e30b6c0feba1.png">

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
