### PR TITLE
feat: add textStyle prop for Affix

### DIFF
--- a/src/components/TextInput/Adornment/Affix.tsx
+++ b/src/components/TextInput/Adornment/Affix.tsx
@@ -17,6 +17,7 @@ const AFFIX_OFFSET = 12;
 type Props = {
   text: string;
   onLayout?: (event: LayoutChangeEvent) => void;
+  textStyle?: StyleProp<TextStyle>;
   /**
    * @optional
    */
@@ -58,7 +59,7 @@ export const AffixAdornment: React.FunctionComponent<
   );
 };
 
-const TextInputAffix = ({ text, theme }: Props) => {
+const TextInputAffix = ({ text, textStyle: labelStyle, theme }: Props) => {
   const { textStyle, onLayout, topPosition, side, visible } = React.useContext(
     AffixContext
   );
@@ -87,7 +88,7 @@ const TextInputAffix = ({ text, theme }: Props) => {
       ]}
       onLayout={onLayout}
     >
-      <Text style={[{ color: textColor }, textStyle]}>{text}</Text>
+      <Text style={[{ color: textColor }, textStyle, labelStyle]}>{text}</Text>
     </Animated.View>
   );
 };

--- a/src/components/__tests__/TextInput.test.js
+++ b/src/components/__tests__/TextInput.test.js
@@ -18,7 +18,12 @@ it('correctly renders left-side icon adornment, and right-side affix adornment',
           }}
         />
       }
-      right={<TextInput.Affix text={affixTextValue} />}
+      right={
+        <TextInput.Affix
+          text={affixTextValue}
+          textStyle={{ color: '#FF0000' }}
+        />
+      }
     />
   );
   expect(() => getByText(affixTextValue)).not.toThrow();
@@ -34,7 +39,12 @@ it('correctly renders left-side icon adornment, and right-side affix adornment '
       placeholder="Type something"
       value={'Some test value'}
       onChangeText={(text) => this.setState({ text })}
-      left={<TextInput.Affix text={affixTextValue} />}
+      left={
+        <TextInput.Affix
+          text={affixTextValue}
+          textStyle={{ color: '#FF0000' }}
+        />
+      }
       right={
         <TextInput.Icon
           name="heart"

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -196,6 +196,9 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
             "fontSize": 16,
             "fontWeight": undefined,
           },
+          Object {
+            "color": "#FF0000",
+          },
         ]
       }
     >
@@ -608,6 +611,9 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
             "fontFamily": "System",
             "fontSize": 16,
             "fontWeight": undefined,
+          },
+          Object {
+            "color": "#FF0000",
           },
         ]
       }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Fixes: #2194

This PR adds `textStyle` prop to `<TextInput.Affix>` component.

Old PR: #2195 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

**Usage:**
```js
<TextInput.Affix text='lbs' textStyle={{ fontFamily: 'Custom Font', color: 'red' }} />
```

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
