### PR TITLE
fix: read prop without default value in appbar header

### DIFF
--- a/src/components/Appbar/AppbarHeader.tsx
+++ b/src/components/Appbar/AppbarHeader.tsx
@@ -75,13 +75,15 @@ type Props = React.ComponentProps<typeof Appbar> & {
  * export default MyComponent;
  * ```
  */
-const AppbarHeader = ({
-  // Don't use default props since we check it to know whether we should use SafeAreaView
-  statusBarHeight = APPROX_STATUSBAR_HEIGHT,
-  style,
-  dark,
-  ...rest
-}: Props) => {
+const AppbarHeader = (props: Props) => {
+  const {
+    // Don't use default props since we check it to know whether we should use SafeAreaView
+    statusBarHeight = APPROX_STATUSBAR_HEIGHT,
+    style,
+    dark,
+    ...rest
+  } = props;
+
   const { dark: isDarkTheme, colors, mode } = rest.theme;
   const {
     height = DEFAULT_APPBAR_HEIGHT,
@@ -96,8 +98,8 @@ const AppbarHeader = ({
     ? overlay(elevation, colors.surface)
     : colors.primary;
   // Let the user override the behaviour
-  const Wrapper = typeof statusBarHeight === 'number' ? View : SafeAreaView;
-
+  const Wrapper =
+    typeof props.statusBarHeight === 'number' ? View : SafeAreaView;
   return (
     <Wrapper
       style={


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

statusBarHeight prop is now used without default value in condition whether to use View or SafeAreaView
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
