### PR TITLE
fix: fix oversight in BottomNavigation

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -737,9 +737,7 @@ class BottomNavigation extends React.Component<Props, State> {
                     { top },
                     Platform.OS === 'web'
                       ? {
-                          display: loaded.includes(index.toString())
-                            ? 'flex'
-                            : 'none',
+                          display: loaded.includes(route.key) ? 'flex' : 'none',
                         }
                       : null,
                   ]}


### PR DESCRIPTION
Replaced index.toString() by route.key, as loaded.includes needs the key string (album, library) instead of index (0, 1)

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
This code worked previously with my own repo, but using the new 4.3.0 release didn't work with bottom navigation. `loaded.includes` needs the key string (album, library) instead of index (0, 1), this pull changes that to be right. Somehow I missed this in my pull request https://github.com/callstack/react-native-paper/pull/2280.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
`yarn example web`, open bottom navigation and switch between tabs.
