### PR TITLE
feat: add label prop to FAB.Group

### DIFF
--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -41,6 +41,10 @@ type Props = {
    */
   icon: IconSource;
   /**
+   * Optional label for extended `FAB`.
+   */
+  label?: string;
+  /**
    * Accessibility label for the FAB. This is read by the screen reader when the user taps the FAB.
    */
   accessibilityLabel?: string;
@@ -146,6 +150,7 @@ type Props = {
 const FABGroup = ({
   actions,
   icon,
+  label,
   open,
   onPress,
   accessibilityLabel,
@@ -338,6 +343,7 @@ const FABGroup = ({
             toggle();
           }}
           icon={icon}
+          label={label}
           color={colorProp}
           accessibilityLabel={accessibilityLabel}
           accessibilityTraits="button"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Similar to the FAB, it would be nice to have the option to add a label to the FAB.Group. This PR adds this option.
### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
In example/src/Examples/FABExample.tsx add the label prop to the FAB.Group component. 

I would duplicate the existing FAB.Group component and add a label as example, but I think that this screen is already full of FABs and we don't really need this exemplified. Also it would be hard to positioning 2 FAB.Group inside Portals.