### PR TITLE
fix: avoid initial animation in (Checkbox|RadioButton).Android

### DIFF
--- a/src/components/Checkbox/CheckboxAndroid.tsx
+++ b/src/components/Checkbox/CheckboxAndroid.tsx
@@ -67,12 +67,19 @@ const CheckboxAndroid = ({
   const { current: scaleAnim } = React.useRef<Animated.Value>(
     new Animated.Value(1)
   );
+  const isFirstRendering = React.useRef<boolean>(true);
 
   const {
     animation: { scale },
   } = theme;
 
   React.useEffect(() => {
+    // Do not run animation on very first rendering
+    if (isFirstRendering.current) {
+      isFirstRendering.current = false;
+      return;
+    }
+
     const checked = status === 'checked';
 
     Animated.sequence([

--- a/src/components/RadioButton/RadioButtonAndroid.tsx
+++ b/src/components/RadioButton/RadioButtonAndroid.tsx
@@ -77,9 +77,17 @@ const RadioButtonAndroid = ({
     new Animated.Value(1)
   );
 
+  const isFirstRendering = React.useRef<boolean>(true);
+
   const { scale } = theme.animation;
 
   React.useEffect(() => {
+    // Do not run animation on very first rendering
+    if (isFirstRendering.current) {
+      isFirstRendering.current = false;
+      return;
+    }
+
     if (status === 'checked') {
       radioAnim.setValue(1.2);
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Currently, whenever the `Checkbox.Android` is rendered there is a very short animation that is irritating and not necessary.

### Test plan

1. Check any `Checkbox.Android` and see if there is an initial animation (even easier if you set the animation scale in theme to a high number).
