### PR TITLE
fix: set line height to Icon

### DIFF
--- a/src/components/MaterialCommunityIcon.tsx
+++ b/src/components/MaterialCommunityIcon.tsx
@@ -92,6 +92,7 @@ const defaultIcon = ({
     style={[
       {
         transform: [{ scaleX: direction === 'rtl' ? -1 : 1 }],
+        lineHeight: size,
       },
       styles.icon,
     ]}

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
@@ -100,6 +100,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
               },
               Array [
                 Object {
+                  "lineHeight": 24,
                   "transform": Array [
                     Object {
                       "scaleX": 1,
@@ -217,6 +218,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
               },
               Array [
                 Object {
+                  "lineHeight": 24,
                   "transform": Array [
                     Object {
                       "scaleX": 1,
@@ -537,6 +539,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
                 },
                 Array [
                   Object {
+                    "lineHeight": 24,
                     "transform": Array [
                       Object {
                         "scaleX": 1,

--- a/src/components/__tests__/Checkbox/__snapshots__/Checkbox.test.js.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/Checkbox.test.js.snap
@@ -52,6 +52,7 @@ exports[`renders Checkbox with custom testID 1`] = `
           },
           Array [
             Object {
+              "lineHeight": 24,
               "transform": Array [
                 Object {
                   "scaleX": 1,
@@ -128,6 +129,7 @@ exports[`renders checked Checkbox with color 1`] = `
           },
           Array [
             Object {
+              "lineHeight": 24,
               "transform": Array [
                 Object {
                   "scaleX": 1,
@@ -204,6 +206,7 @@ exports[`renders checked Checkbox with onPress 1`] = `
           },
           Array [
             Object {
+              "lineHeight": 24,
               "transform": Array [
                 Object {
                   "scaleX": 1,
@@ -280,6 +283,7 @@ exports[`renders indeterminate Checkbox 1`] = `
           },
           Array [
             Object {
+              "lineHeight": 24,
               "transform": Array [
                 Object {
                   "scaleX": 1,
@@ -356,6 +360,7 @@ exports[`renders indeterminate Checkbox with color 1`] = `
           },
           Array [
             Object {
+              "lineHeight": 24,
               "transform": Array [
                 Object {
                   "scaleX": 1,
@@ -432,6 +437,7 @@ exports[`renders unchecked Checkbox with color 1`] = `
           },
           Array [
             Object {
+              "lineHeight": 24,
               "transform": Array [
                 Object {
                   "scaleX": 1,
@@ -508,6 +514,7 @@ exports[`renders unchecked Checkbox with onPress 1`] = `
           },
           Array [
             Object {
+              "lineHeight": 24,
               "transform": Array [
                 Object {
                   "scaleX": 1,

--- a/src/components/__tests__/RadioButton/__snapshots__/RadioButton.test.js.snap
+++ b/src/components/__tests__/RadioButton/__snapshots__/RadioButton.test.js.snap
@@ -52,6 +52,7 @@ exports[`RadioButton RadioButton with custom testID renders properly 1`] = `
           },
           Array [
             Object {
+              "lineHeight": 24,
               "transform": Array [
                 Object {
                   "scaleX": 1,
@@ -128,6 +129,7 @@ exports[`RadioButton on default platform renders properly 1`] = `
           },
           Array [
             Object {
+              "lineHeight": 24,
               "transform": Array [
                 Object {
                   "scaleX": 1,
@@ -204,6 +206,7 @@ exports[`RadioButton on ios platform renders properly 1`] = `
           },
           Array [
             Object {
+              "lineHeight": 24,
               "transform": Array [
                 Object {
                   "scaleX": 1,
@@ -280,6 +283,7 @@ exports[`RadioButton when RadioButton is wrapped by RadioButtonContext.Provider 
           },
           Array [
             Object {
+              "lineHeight": 24,
               "transform": Array [
                 Object {
                   "scaleX": 1,

--- a/src/components/__tests__/RadioButton/__snapshots__/RadioButtonGroup.test.js.snap
+++ b/src/components/__tests__/RadioButton/__snapshots__/RadioButtonGroup.test.js.snap
@@ -55,6 +55,7 @@ exports[`RadioButtonGroup renders properly 1`] = `
             },
             Array [
               Object {
+                "lineHeight": 24,
                 "transform": Array [
                   Object {
                     "scaleX": 1,

--- a/src/components/__tests__/__snapshots__/Avatar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Avatar.test.js.snap
@@ -31,6 +31,7 @@ exports[`renders avatar with icon 1`] = `
         },
         Array [
           Object {
+            "lineHeight": 38.4,
             "transform": Array [
               Object {
                 "scaleX": 1,
@@ -86,6 +87,7 @@ exports[`renders avatar with icon and custom background color 1`] = `
         },
         Array [
           Object {
+            "lineHeight": 38.4,
             "transform": Array [
               Object {
                 "scaleX": 1,

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
@@ -172,6 +172,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -220,6 +221,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -358,6 +360,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -406,6 +409,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -544,6 +548,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -592,6 +597,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -860,6 +866,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -908,6 +915,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -1046,6 +1054,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -1094,6 +1103,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -1232,6 +1242,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -1280,6 +1291,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -3016,6 +3028,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -3064,6 +3077,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -3282,6 +3296,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -3330,6 +3345,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -3548,6 +3564,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -3596,6 +3613,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -3944,6 +3962,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -3992,6 +4011,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -4173,6 +4193,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -4221,6 +4242,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -4402,6 +4424,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -4450,6 +4473,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -4741,6 +4765,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -4789,6 +4814,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -5007,6 +5033,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -5055,6 +5082,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -5273,6 +5301,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -5321,6 +5350,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -5669,6 +5699,7 @@ exports[`renders shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -5717,6 +5748,7 @@ exports[`renders shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -5898,6 +5930,7 @@ exports[`renders shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -5946,6 +5979,7 @@ exports[`renders shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -6127,6 +6161,7 @@ exports[`renders shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -6175,6 +6210,7 @@ exports[`renders shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -6356,6 +6392,7 @@ exports[`renders shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -6404,6 +6441,7 @@ exports[`renders shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -6585,6 +6623,7 @@ exports[`renders shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,
@@ -6633,6 +6672,7 @@ exports[`renders shifting bottom navigation 1`] = `
                       },
                       Array [
                         Object {
+                          "lineHeight": 24,
                           "transform": Array [
                             Object {
                               "scaleX": 1,

--- a/src/components/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.js.snap
@@ -265,6 +265,7 @@ exports[`renders button with icon 1`] = `
               },
               Array [
                 Object {
+                  "lineHeight": 16,
                   "transform": Array [
                     Object {
                       "scaleX": 1,

--- a/src/components/__tests__/__snapshots__/Chip.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.js.snap
@@ -81,6 +81,7 @@ exports[`renders chip with close button 1`] = `
               },
               Array [
                 Object {
+                  "lineHeight": 18,
                   "transform": Array [
                     Object {
                       "scaleX": 1,
@@ -184,6 +185,7 @@ exports[`renders chip with close button 1`] = `
             },
             Array [
               Object {
+                "lineHeight": 16,
                 "transform": Array [
                   Object {
                     "scaleX": 1,
@@ -291,6 +293,7 @@ exports[`renders chip with icon 1`] = `
               },
               Array [
                 Object {
+                  "lineHeight": 18,
                   "transform": Array [
                     Object {
                       "scaleX": 1,
@@ -616,6 +619,7 @@ exports[`renders selected chip 1`] = `
               },
               Array [
                 Object {
+                  "lineHeight": 18,
                   "transform": Array [
                     Object {
                       "scaleX": 1,

--- a/src/components/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.js.snap
@@ -264,6 +264,7 @@ exports[`renders data table pagination 1`] = `
             },
             Array [
               Object {
+                "lineHeight": 24,
                 "transform": Array [
                   Object {
                     "scaleX": 1,
@@ -348,6 +349,7 @@ exports[`renders data table pagination 1`] = `
             },
             Array [
               Object {
+                "lineHeight": 24,
                 "transform": Array [
                   Object {
                     "scaleX": 1,
@@ -473,6 +475,7 @@ exports[`renders data table pagination with label 1`] = `
             },
             Array [
               Object {
+                "lineHeight": 24,
                 "transform": Array [
                   Object {
                     "scaleX": 1,
@@ -557,6 +560,7 @@ exports[`renders data table pagination with label 1`] = `
             },
             Array [
               Object {
+                "lineHeight": 24,
                 "transform": Array [
                   Object {
                     "scaleX": 1,
@@ -633,6 +637,7 @@ exports[`renders data table title with press handler 1`] = `
           },
           Array [
             Object {
+              "lineHeight": 16,
               "transform": Array [
                 Object {
                   "scaleX": 1,
@@ -735,6 +740,7 @@ exports[`renders data table title with sort icon 1`] = `
           },
           Array [
             Object {
+              "lineHeight": 16,
               "transform": Array [
                 Object {
                   "scaleX": 1,

--- a/src/components/__tests__/__snapshots__/DrawerItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DrawerItem.test.js.snap
@@ -65,6 +65,7 @@ exports[`renders DrawerItem with icon 1`] = `
             },
             Array [
               Object {
+                "lineHeight": 24,
                 "transform": Array [
                   Object {
                     "scaleX": 1,
@@ -182,6 +183,7 @@ exports[`renders active DrawerItem 1`] = `
             },
             Array [
               Object {
+                "lineHeight": 24,
                 "transform": Array [
                   Object {
                     "scaleX": 1,

--- a/src/components/__tests__/__snapshots__/FAB.test.js.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.js.snap
@@ -111,6 +111,7 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
                 },
                 Array [
                   Object {
+                    "lineHeight": 24,
                     "transform": Array [
                       Object {
                         "scaleX": 1,
@@ -243,6 +244,7 @@ exports[`renders disabled FAB 1`] = `
                 },
                 Array [
                   Object {
+                    "lineHeight": 24,
                     "transform": Array [
                       Object {
                         "scaleX": 1,
@@ -383,6 +385,7 @@ exports[`renders extended FAB 1`] = `
                 },
                 Array [
                   Object {
+                    "lineHeight": 24,
                     "transform": Array [
                       Object {
                         "scaleX": 1,
@@ -803,6 +806,7 @@ exports[`renders normal FAB 1`] = `
                 },
                 Array [
                   Object {
+                    "lineHeight": 24,
                     "transform": Array [
                       Object {
                         "scaleX": 1,
@@ -942,6 +946,7 @@ exports[`renders not visible FAB 1`] = `
                 },
                 Array [
                   Object {
+                    "lineHeight": 24,
                     "transform": Array [
                       Object {
                         "scaleX": 1,
@@ -1081,6 +1086,7 @@ exports[`renders small FAB 1`] = `
                 },
                 Array [
                   Object {
+                    "lineHeight": 24,
                     "transform": Array [
                       Object {
                         "scaleX": 1,
@@ -1220,6 +1226,7 @@ exports[`renders visible FAB 1`] = `
                 },
                 Array [
                   Object {
+                    "lineHeight": 24,
                     "transform": Array [
                       Object {
                         "scaleX": 1,

--- a/src/components/__tests__/__snapshots__/IconButton.test.js.snap
+++ b/src/components/__tests__/__snapshots__/IconButton.test.js.snap
@@ -64,6 +64,7 @@ exports[`renders disabled icon button 1`] = `
           },
           Array [
             Object {
+              "lineHeight": 24,
               "transform": Array [
                 Object {
                   "scaleX": 1,
@@ -151,6 +152,7 @@ exports[`renders icon button by default 1`] = `
           },
           Array [
             Object {
+              "lineHeight": 24,
               "transform": Array [
                 Object {
                   "scaleX": 1,
@@ -238,6 +240,7 @@ exports[`renders icon button with color 1`] = `
           },
           Array [
             Object {
+              "lineHeight": 24,
               "transform": Array [
                 Object {
                   "scaleX": 1,
@@ -325,6 +328,7 @@ exports[`renders icon button with size 1`] = `
           },
           Array [
             Object {
+              "lineHeight": 30,
               "transform": Array [
                 Object {
                   "scaleX": 1,
@@ -443,6 +447,7 @@ exports[`renders icon change animated 1`] = `
               },
               Array [
                 Object {
+                  "lineHeight": 24,
                   "transform": Array [
                     Object {
                       "scaleX": 1,

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.js.snap
@@ -95,6 +95,7 @@ exports[`renders expanded accordion 1`] = `
               },
               Array [
                 Object {
+                  "lineHeight": 24,
                   "transform": Array [
                     Object {
                       "scaleX": 1,
@@ -254,6 +255,7 @@ exports[`renders list accordion with children 1`] = `
               },
               Array [
                 Object {
+                  "lineHeight": 24,
                   "transform": Array [
                     Object {
                       "scaleX": 1,
@@ -337,6 +339,7 @@ exports[`renders list accordion with children 1`] = `
               },
               Array [
                 Object {
+                  "lineHeight": 24,
                   "transform": Array [
                     Object {
                       "scaleX": 1,
@@ -491,6 +494,7 @@ exports[`renders list accordion with custom title and description styles 1`] = `
               },
               Array [
                 Object {
+                  "lineHeight": 24,
                   "transform": Array [
                     Object {
                       "scaleX": 1,
@@ -580,6 +584,7 @@ exports[`renders list accordion with left items 1`] = `
               },
               Array [
                 Object {
+                  "lineHeight": 24,
                   "transform": Array [
                     Object {
                       "scaleX": 1,
@@ -663,6 +668,7 @@ exports[`renders list accordion with left items 1`] = `
               },
               Array [
                 Object {
+                  "lineHeight": 24,
                   "transform": Array [
                     Object {
                       "scaleX": 1,
@@ -813,6 +819,7 @@ exports[`renders multiline list accordion 1`] = `
               },
               Array [
                 Object {
+                  "lineHeight": 24,
                   "transform": Array [
                     Object {
                       "scaleX": 1,

--- a/src/components/__tests__/__snapshots__/ListItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.js.snap
@@ -161,6 +161,7 @@ exports[`renders list item with custom description 1`] = `
                         },
                         Array [
                           Object {
+                            "lineHeight": 18,
                             "transform": Array [
                               Object {
                                 "scaleX": 1,
@@ -451,6 +452,7 @@ exports[`renders list item with left and right items 1`] = `
             },
             Array [
               Object {
+                "lineHeight": 24,
                 "transform": Array [
                   Object {
                     "scaleX": 1,
@@ -539,6 +541,7 @@ exports[`renders list item with left item 1`] = `
             },
             Array [
               Object {
+                "lineHeight": 24,
                 "transform": Array [
                   Object {
                     "scaleX": 1,

--- a/src/components/__tests__/__snapshots__/ListSection.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.js.snap
@@ -142,6 +142,7 @@ exports[`renders list section with custom title style 1`] = `
               },
               Array [
                 Object {
+                  "lineHeight": 24,
                   "transform": Array [
                     Object {
                       "scaleX": 1,
@@ -266,6 +267,7 @@ exports[`renders list section with custom title style 1`] = `
               },
               Array [
                 Object {
+                  "lineHeight": 24,
                   "transform": Array [
                     Object {
                       "scaleX": 1,
@@ -472,6 +474,7 @@ exports[`renders list section with subheader 1`] = `
               },
               Array [
                 Object {
+                  "lineHeight": 24,
                   "transform": Array [
                     Object {
                       "scaleX": 1,
@@ -596,6 +599,7 @@ exports[`renders list section with subheader 1`] = `
               },
               Array [
                 Object {
+                  "lineHeight": 24,
                   "transform": Array [
                     Object {
                       "scaleX": 1,
@@ -775,6 +779,7 @@ exports[`renders list section without subheader 1`] = `
               },
               Array [
                 Object {
+                  "lineHeight": 24,
                   "transform": Array [
                     Object {
                       "scaleX": 1,
@@ -899,6 +904,7 @@ exports[`renders list section without subheader 1`] = `
               },
               Array [
                 Object {
+                  "lineHeight": 24,
                   "transform": Array [
                     Object {
                       "scaleX": 1,

--- a/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
@@ -81,6 +81,7 @@ exports[`renders with placeholder 1`] = `
             },
             Array [
               Object {
+                "lineHeight": 24,
                 "transform": Array [
                   Object {
                     "scaleX": 1,
@@ -198,6 +199,7 @@ exports[`renders with placeholder 1`] = `
             },
             Array [
               Object {
+                "lineHeight": 24,
                 "transform": Array [
                   Object {
                     "scaleX": 1,
@@ -305,6 +307,7 @@ exports[`renders with text 1`] = `
             },
             Array [
               Object {
+                "lineHeight": 24,
                 "transform": Array [
                   Object {
                     "scaleX": 1,
@@ -421,6 +424,7 @@ exports[`renders with text 1`] = `
             },
             Array [
               Object {
+                "lineHeight": 24,
                 "transform": Array [
                   Object {
                     "scaleX": 1,

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -285,6 +285,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
               },
               Array [
                 Object {
+                  "lineHeight": 24,
                   "transform": Array [
                     Object {
                       "scaleX": 1,
@@ -564,6 +565,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
               },
               Array [
                 Object {
+                  "lineHeight": 24,
                   "transform": Array [
                     Object {
                       "scaleX": 1,

--- a/src/components/__tests__/__snapshots__/ToggleButton.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ToggleButton.test.js.snap
@@ -75,6 +75,7 @@ exports[`renders disabled toggle button 1`] = `
           },
           Array [
             Object {
+              "lineHeight": 24,
               "transform": Array [
                 Object {
                   "scaleX": 1,
@@ -173,6 +174,7 @@ exports[`renders toggle button 1`] = `
           },
           Array [
             Object {
+              "lineHeight": 24,
               "transform": Array [
                 Object {
                   "scaleX": 1,
@@ -273,6 +275,7 @@ exports[`renders unchecked toggle button 1`] = `
           },
           Array [
             Object {
+              "lineHeight": 24,
               "transform": Array [
                 Object {
                   "scaleX": 1,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Currently, the icon is slightly shifted to the bottom on web because there is no line height. In this example the size is 24 but the actual height of the rendered icon element is 28:
<img width="138" alt="image" src="https://user-images.githubusercontent.com/5358638/98778032-03ef3c00-23f2-11eb-8ab7-27babf6e5137.png">

If we pass a line height as well the height of the icon element will be 24 (as expected):
<img width="145" alt="image" src="https://user-images.githubusercontent.com/5358638/98778068-17020c00-23f2-11eb-97be-95168b1c5744.png">


### Test plan

1. Check if icon (for example in Appbar) is not shifted to the bottom anymore
