### PR TITLE
feat: set TouchableRipple delayPressIn default to 0

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -254,7 +254,6 @@ const Button = ({
     >
       <TouchableRipple
         borderless
-        delayPressIn={0}
         onPress={onPress}
         onLongPress={onLongPress}
         onPressIn={handlePressIn}

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -239,7 +239,6 @@ const Chip = ({
     >
       <TouchableRipple
         borderless
-        delayPressIn={0}
         style={{ borderRadius }}
         onPress={onPress}
         onLongPress={onLongPress}

--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -90,7 +90,6 @@ const DrawerItem = ({
     >
       <TouchableRipple
         borderless
-        delayPressIn={0}
         onPress={onPress}
         style={{ borderRadius: roundness }}
         accessibilityTraits={active ? ['button', 'selected'] : 'button'}

--- a/src/components/TouchableRipple/TouchableRipple.native.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.native.tsx
@@ -36,6 +36,7 @@ const TouchableRipple = ({
   underlayColor,
   children,
   theme,
+  delayPressIn = 0,
   ...rest
 }: Props) => {
   const { dark, colors } = theme;
@@ -57,6 +58,7 @@ const TouchableRipple = ({
   if (TouchableRipple.supported) {
     return (
       <TouchableNativeFeedback
+        delayPressIn={delayPressIn}
         {...rest}
         disabled={disabled}
         useForeground={useForeground}

--- a/src/components/TouchableRipple/TouchableRipple.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.tsx
@@ -95,6 +95,7 @@ const TouchableRipple = ({
   underlayColor: _underlayColor,
   children,
   theme,
+  delayPressIn = 0,
   ...rest
 }: Props) => {
   const handlePressIn = (e: any) => {
@@ -233,6 +234,7 @@ const TouchableRipple = ({
 
   return (
     <TouchableWithoutFeedback
+      delayPressIn={delayPressIn}
       {...rest}
       onPressIn={handlePressIn}
       onPressOut={handlePressOut}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Ripple animation is slow when `TouchableNativeFeedback` `delayPressIn` property is not zero. Refer to https://github.com/facebook/react-native/issues/3958#issuecomment-154658193

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Test `TouchableRipple` component and releated components to focus whether animation speed up.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
