### PR TITLE
Allow DataTable.Cell text to wrap on multiple lines

### DIFF
--- a/src/components/DataTable/DataTableCell.tsx
+++ b/src/components/DataTable/DataTableCell.tsx
@@ -13,6 +13,10 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
    * Align the text to the right. Generally monetary or number fields are aligned to right.
    */
   numeric?: boolean;
+   /**
+   * The number of lines to show.
+   */  
+  numberOfLines?: number;  
   /**
    * Function to execute on press.
    */
@@ -48,12 +52,12 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
  * ```
  */
 
-const DataTableCell = ({ children, style, numeric, ...rest }: Props) => (
+const DataTableCell = ({ children, style, numeric, numberOfLines = 1, ...rest }: Props) => (
   <TouchableRipple
     {...rest}
     style={[styles.container, numeric && styles.right, style]}
   >
-    <Text numberOfLines={1}>{children}</Text>
+    <Text numberOfLines={numberOfLines}>{children}</Text>
   </TouchableRipple>
 );
 


### PR DESCRIPTION
This PR will allow text to wrap by specifying the `numberOfLines`

```jsx
<DataTable.Row>
    <DataTable.Cell numberOfLines={3}>
...
```

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
