### PR TITLE
Add react-native-paper-dates to recommended libraries

### DIFF
--- a/docs/pages/6.recommended-libraries.md
+++ b/docs/pages/6.recommended-libraries.md
@@ -21,5 +21,8 @@ Material Design themed [swipeable tabs](https://material.io/design/components/ta
 An implementation [bottom sheet behaviour](https://material.io/design/components/sheets-bottom.html), maintained by [@mosdnk](https://twitter.com/mosdnk).
 
 ## Date Picker
-
+[web-ridge/react-native-paper-dates](https://github.com/web-ridge/react-native-paper-dates)
 [react-native-community/react-native-datetimepicker](https://github.com/react-native-community/react-native-datetimepicker)
+
+## Time Picker
+[web-ridge/react-native-paper-dates](https://github.com/web-ridge/react-native-paper-dates)


### PR DESCRIPTION

### Summary
It has been build for react-native-paper

### Test plan
The library is tested on all platforms (iOS, Android, web)

