### PR TITLE
docs: added installation using npm command

### DIFF
--- a/docs/pages/1.getting-started.md
+++ b/docs/pages/1.getting-started.md
@@ -11,7 +11,10 @@ Open a Terminal in your project's folder and run:
 ```sh
 yarn add react-native-paper
 ```
-
+or
+```sh
+npm install react-native-paper
+```
 If you're on a vanilla React Native project, you also need to install and link [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons).
 
 ```sh


### PR DESCRIPTION
Added terminal command in docs to install react-native-paper using npm. This was missing in Getting Started page. This can help users who are using npm.

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Only Yarn command was present in Getting Started page. This could be helpful for users using npm to install dependencies.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
This change is made in docs. Preview looks fine.
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
