### PR TITLE
fix: BottomNavigation clickthrough in tabs

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -737,7 +737,7 @@ class BottomNavigation extends React.Component<Props, State> {
                     { top },
                     Platform.OS === 'web'
                       ? {
-                          display: loaded.includes(route.key) ? 'flex' : 'none',
+                          display: focused ? 'flex' : 'none',
                         }
                       : null,
                   ]}


### PR DESCRIPTION
Fixes https://github.com/callstack/react-native-paper/issues/2366

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes #2366 by replacing rendering tab on first load to rendering tab on first load and only when tab is focused.

### Test plan
Test this in an app that contains buttons in multiple tabs, check if you can click the buttons and they don't click through.
`yarn && yarn prepare`
`cp {babel.js,lib,LICENSE.md,package.json,README.md,src} ~/MyProject/node_modules/react-native-paper -rf`
