### PR TITLE
feat: let users choose checkbox for Checkbox.Item

### DIFF
--- a/example/src/ExampleList.tsx
+++ b/example/src/ExampleList.tsx
@@ -13,6 +13,7 @@ import BottomNavigationExample from './Examples/BottomNavigationExample';
 import ButtonExample from './Examples/ButtonExample';
 import CardExample from './Examples/CardExample';
 import CheckboxExample from './Examples/CheckboxExample';
+import CheckboxItemExample from './Examples/CheckboxItemExample';
 import ChipExample from './Examples/ChipExample';
 import DataTableExample from './Examples/DataTableExample';
 import DialogExample from './Examples/DialogExample';
@@ -49,6 +50,7 @@ export const examples: Record<
   button: ButtonExample,
   card: CardExample,
   checkbox: CheckboxExample,
+  checkboxItem: CheckboxItemExample,
   chip: ChipExample,
   dataTable: DataTableExample,
   dialog: DialogExample,

--- a/example/src/Examples/CheckboxItemExample.tsx
+++ b/example/src/Examples/CheckboxItemExample.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Checkbox, Colors, useTheme } from 'react-native-paper';
+
+const CheckboxExample = () => {
+  const [checkedDefault, setCheckedDefault] = React.useState<boolean>(true);
+  const [checkedAndroid, setCheckedAndroid] = React.useState<boolean>(true);
+  const [checkedIOS, setCheckedIOS] = React.useState<boolean>(true);
+  const {
+    colors: { background },
+  } = useTheme();
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: background,
+        },
+      ]}
+    >
+      <Checkbox.Item
+        label="Default (will look like whatever system this is running on)"
+        status={checkedDefault ? 'checked' : 'unchecked'}
+        onPress={() => setCheckedDefault(!checkedDefault)}
+      />
+      <Checkbox.Item
+        label="Android"
+        mode="android"
+        status={checkedAndroid ? 'checked' : 'unchecked'}
+        onPress={() => setCheckedAndroid(!checkedAndroid)}
+      />
+      <Checkbox.Item
+        label="iOS"
+        mode="ios"
+        status={checkedIOS ? 'checked' : 'unchecked'}
+        onPress={() => setCheckedIOS(!checkedIOS)}
+      />
+    </View>
+  );
+};
+
+CheckboxExample.title = 'Checkbox Item';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.white,
+    paddingVertical: 8,
+  },
+});
+
+export default CheckboxExample;

--- a/src/components/Checkbox/CheckboxItem.tsx
+++ b/src/components/Checkbox/CheckboxItem.tsx
@@ -9,6 +9,8 @@ import {
 } from 'react-native';
 
 import CheckBox from './Checkbox';
+import CheckboxAndroid from './CheckboxAndroid';
+import CheckboxIOS from './CheckboxIOS';
 import Text from '../Typography/Text';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { withTheme } from '../../core/theming';
@@ -54,6 +56,11 @@ type Props = {
    * testID to be used on tests.
    */
   testID?: string;
+  /**
+   * Whether the Android or iOS checkbox components should be used.
+   * Left undefined, the checkbox will be based on whatever the system is.
+   */
+  mode?: 'android' | 'ios';
 };
 
 /**
@@ -83,17 +90,33 @@ const CheckboxItem = ({
   labelStyle,
   theme,
   testID,
+  mode,
   ...props
-}: Props) => (
-  <TouchableRipple onPress={onPress} testID={testID}>
-    <View style={[styles.container, style]} pointerEvents="none">
-      <Text style={[styles.label, { color: theme.colors.primary }, labelStyle]}>
-        {label}
-      </Text>
-      <CheckBox status={status} theme={theme} {...props}></CheckBox>
-    </View>
-  </TouchableRipple>
-);
+}: Props) => {
+  const checkboxProps = { ...props, status, theme };
+  let checkbox;
+
+  if (mode === 'android') {
+    checkbox = <CheckboxAndroid {...checkboxProps} />;
+  } else if (mode === 'ios') {
+    checkbox = <CheckboxIOS {...checkboxProps} />;
+  } else {
+    checkbox = <CheckBox {...checkboxProps} />;
+  }
+
+  return (
+    <TouchableRipple onPress={onPress} testID={testID}>
+      <View style={[styles.container, style]} pointerEvents="none">
+        <Text
+          style={[styles.label, { color: theme.colors.primary }, labelStyle]}
+        >
+          {label}
+        </Text>
+        {checkbox}
+      </View>
+    </TouchableRipple>
+  );
+};
 
 CheckboxItem.displayName = 'Checkbox.Item';
 

--- a/src/components/Checkbox/CheckboxItem.tsx
+++ b/src/components/Checkbox/CheckboxItem.tsx
@@ -57,8 +57,8 @@ type Props = {
    */
   testID?: string;
   /**
-   * Whether the Android or iOS checkbox components should be used.
-   * Left undefined, the checkbox will be based on whatever the system is.
+   * Whether `<Checkbox.Android />` or `<Checkbox.IOS />` should be used.
+   * Left undefined `<Checkbox />` will be used.
    */
   mode?: 'android' | 'ios';
 };

--- a/src/components/__tests__/Checkbox/CheckboxItem.test.js
+++ b/src/components/__tests__/Checkbox/CheckboxItem.test.js
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { Platform } from 'react-native';
+import renderer from 'react-test-renderer';
+import CheckboxItem from '../../Checkbox/CheckboxItem';
+
+it('renders unchecked', () => {
+  const tree = renderer
+    .create(<CheckboxItem status="unchecked" label="Unchecked Button" />)
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+it('can render the iOS checkbox on different platforms', () => {
+  Platform.OS = 'android';
+  const tree = renderer
+    .create(<CheckboxItem status="unchecked" label="iOS Checkbox" mode="ios" />)
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+it('can render the Android checkbox on different platforms', () => {
+  Platform.OS = 'ios';
+  const tree = renderer
+    .create(
+      <CheckboxItem status="unchecked" label="iOS Checkbox" mode="android" />
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.js.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.js.snap
@@ -1,0 +1,437 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`can render the Android checkbox on different platforms 1`] = `
+<View
+  accessible={true}
+  focusable={false}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      false,
+      undefined,
+    ]
+  }
+>
+  <View
+    pointerEvents="none"
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+          "paddingHorizontal": 16,
+          "paddingVertical": 8,
+        },
+        undefined,
+      ]
+    }
+  >
+    <Text
+      style={
+        Array [
+          Object {
+            "color": "#000000",
+            "fontFamily": "System",
+            "fontWeight": "400",
+            "textAlign": "left",
+          },
+          Array [
+            Object {
+              "fontSize": 16,
+            },
+            Object {
+              "color": "#6200ee",
+            },
+            undefined,
+          ],
+        ]
+      }
+    >
+      iOS Checkbox
+    </Text>
+    <View
+      accessibilityLiveRegion="polite"
+      accessibilityRole="checkbox"
+      accessibilityState={
+        Object {
+          "checked": false,
+          "disabled": undefined,
+        }
+      }
+      accessible={true}
+      focusable={false}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          Object {
+            "borderRadius": 18,
+            "height": 36,
+            "padding": 6,
+            "width": 36,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Object {
+            "transform": Array [
+              Object {
+                "scale": 1,
+              },
+            ],
+          }
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          allowFontScaling={false}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          style={
+            Array [
+              Object {
+                "color": "rgba(0, 0, 0, 0.54)",
+                "fontSize": 24,
+              },
+              Array [
+                Object {
+                  "lineHeight": 24,
+                  "transform": Array [
+                    Object {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                Object {
+                  "backgroundColor": "transparent",
+                },
+              ],
+              Object {
+                "fontFamily": "Material Design Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          
+        </Text>
+        <View
+          style={
+            Array [
+              Object {
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              Object {
+                "alignItems": "center",
+                "justifyContent": "center",
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Object {
+                "borderColor": "rgba(0, 0, 0, 0.54)",
+                "borderWidth": 0,
+                "height": 14,
+                "width": 14,
+              }
+            }
+          />
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`can render the iOS checkbox on different platforms 1`] = `
+<View
+  accessible={true}
+  focusable={false}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      false,
+      undefined,
+    ]
+  }
+>
+  <View
+    pointerEvents="none"
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+          "paddingHorizontal": 16,
+          "paddingVertical": 8,
+        },
+        undefined,
+      ]
+    }
+  >
+    <Text
+      style={
+        Array [
+          Object {
+            "color": "#000000",
+            "fontFamily": "System",
+            "fontWeight": "400",
+            "textAlign": "left",
+          },
+          Array [
+            Object {
+              "fontSize": 16,
+            },
+            Object {
+              "color": "#6200ee",
+            },
+            undefined,
+          ],
+        ]
+      }
+    >
+      iOS Checkbox
+    </Text>
+    <View
+      accessibilityLiveRegion="polite"
+      accessibilityRole="checkbox"
+      accessibilityState={
+        Object {
+          "checked": false,
+          "disabled": undefined,
+        }
+      }
+      accessible={true}
+      focusable={false}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          Object {
+            "borderRadius": 18,
+            "padding": 6,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Object {
+            "opacity": 0,
+          }
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          allowFontScaling={false}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          style={
+            Array [
+              Object {
+                "color": "#03dac4",
+                "fontSize": 24,
+              },
+              Array [
+                Object {
+                  "lineHeight": 24,
+                  "transform": Array [
+                    Object {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                Object {
+                  "backgroundColor": "transparent",
+                },
+              ],
+              Object {
+                "fontFamily": "Material Design Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`renders unchecked 1`] = `
+<View
+  accessible={true}
+  focusable={false}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      false,
+      undefined,
+    ]
+  }
+>
+  <View
+    pointerEvents="none"
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+          "paddingHorizontal": 16,
+          "paddingVertical": 8,
+        },
+        undefined,
+      ]
+    }
+  >
+    <Text
+      style={
+        Array [
+          Object {
+            "color": "#000000",
+            "fontFamily": "System",
+            "fontWeight": "400",
+            "textAlign": "left",
+          },
+          Array [
+            Object {
+              "fontSize": 16,
+            },
+            Object {
+              "color": "#6200ee",
+            },
+            undefined,
+          ],
+        ]
+      }
+    >
+      Unchecked Button
+    </Text>
+    <View
+      accessibilityLiveRegion="polite"
+      accessibilityRole="checkbox"
+      accessibilityState={
+        Object {
+          "checked": false,
+          "disabled": undefined,
+        }
+      }
+      accessible={true}
+      focusable={false}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          Object {
+            "borderRadius": 18,
+            "padding": 6,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Object {
+            "opacity": 0,
+          }
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          allowFontScaling={false}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          style={
+            Array [
+              Object {
+                "color": "#03dac4",
+                "fontSize": 24,
+              },
+              Array [
+                Object {
+                  "lineHeight": 24,
+                  "transform": Array [
+                    Object {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                Object {
+                  "backgroundColor": "transparent",
+                },
+              ],
+              Object {
+                "fontFamily": "Material Design Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;


### PR DESCRIPTION
### Summary

This makes it so developers are able to specify which checkbox component should be used for `Checkbox.Item`.

My main motivation for this was that, at least for a single checkbox, the iOS checkbox is very difficult to tell there's a thing to check.
