### PR TITLE
feat: support for multi-line Text in DataTableCell

### DIFF
--- a/src/components/DataTable/DataTableCell.tsx
+++ b/src/components/DataTable/DataTableCell.tsx
@@ -53,7 +53,7 @@ const DataTableCell = ({ children, style, numeric, ...rest }: Props) => (
     {...rest}
     style={[styles.container, numeric && styles.right, style]}
   >
-    <Text numberOfLines={1}>{children}</Text>
+    <Text>{children}</Text>
   </TouchableRipple>
 );
 

--- a/src/components/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.js.snap
@@ -27,7 +27,6 @@ exports[`renders data table cell 1`] = `
   }
 >
   <Text
-    numberOfLines={1}
     style={
       Array [
         Object {
@@ -822,7 +821,6 @@ exports[`renders right aligned data table cell 1`] = `
   }
 >
   <Text
-    numberOfLines={1}
     style={
       Array [
         Object {


### PR DESCRIPTION
### Summary

Text in DataTableCell only support single-line but some use-cases, like #2381, need to support multi-line.
It enable to support multi-line text in DataTableCell.

### Test plan

- See Data Table in Example app
- single line text
![image](https://user-images.githubusercontent.com/303984/100239790-27c78b80-2f75-11eb-9e39-e207d40b8083.png)
- multi line text
![image](https://user-images.githubusercontent.com/303984/100239760-1da58d00-2f75-11eb-9d9d-87f460924e97.png)

