### PR TITLE
Handle null ListItem title

### DIFF
--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -185,13 +185,15 @@ const ListItem = ({
             })
           : null}
         <View style={[styles.item, styles.content]}>
-          <Text
-            ellipsizeMode={titleEllipsizeMode}
-            numberOfLines={titleNumberOfLines}
-            style={[styles.title, { color: titleColor }, titleStyle]}
-          >
-            {title}
-          </Text>
+          {title
+            ? <Text
+                ellipsizeMode={titleEllipsizeMode}
+                numberOfLines={titleNumberOfLines}
+                style={[styles.title, { color: titleColor }, titleStyle]}
+              >
+                {title}
+              </Text>
+            : null}
           {description
             ? renderDescription(descriptionColor, description)
             : null}


### PR DESCRIPTION
### Summary

Don't take up empty space if `ListItem` `title` is `null`.  The `description` property may then be used for arbitrary content, as the opinionated `<Text>` wrapper is avoided, which causes trouble on Android.


