### PR TITLE
docs: explain how to change theme based on device settings

### DIFF
--- a/docs/pages/2.theming.md
+++ b/docs/pages/2.theming.md
@@ -224,6 +224,10 @@ That's why if you are using dark theme you can switch between two dark theme `mo
 - `exact` where everything is like it was before. `Appbar` and `BottomNavigation` will still use primary colour by default.</br>
 - `adaptive` where we follow [Material design guidelines](https://material.io/design/color/dark-theme.html), the surface will use white overlay with opacity to show elevation, `Appbar` and `BottomNavigation` will use surface colour as a background.
 
+If you don't use a custom theme, Paper will automatically change between the default theme and the default dark theme, depending on device settings.
+
+Otherwise, your custom theme will need to handle it manually, using React Native's [Appearance API](https://reactnative.dev/docs/appearance).
+
 ## Gotchas
 
 The `Provider` exposes the theme to the components via [React's context API](https://reactjs.org/docs/context.html), which means that the component must be in the same tree as the `Provider`. Some React Native components will render a different tree such as a `Modal`, in which case the components inside the `Modal` won't be able to access the theme. The work around is to get the theme using the `withTheme` HOC and pass it down to the components as props, or expose it again with the exported `ThemeProvider` component.


### PR DESCRIPTION
### Summary

In the theming section of the documentation it states that if you don't use a custom theme, then animations will be turned on and off based on device settings.

The same is true for toggling of dark theme based on device settings, react-native-paper does it for the default theme but not if you use a custom theme. It didn't mention this anywhere in the documentation so I added it to the dark theme section