### PR TITLE
docs: adding documentation for multiline support in Datatable.Cell

### DIFF
--- a/src/components/DataTable/DataTableCell.tsx
+++ b/src/components/DataTable/DataTableCell.tsx
@@ -46,6 +46,9 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
  *
  * export default MyComponent;
  * ```
+ *
+ * If you want to support multiline text, please use View instead, as multiline text doesn't comply with
+ * MD Guidelines (https://github.com/callstack/react-native-paper/issues/2381).
  */
 
 const DataTableCell = ({ children, style, numeric, ...rest }: Props) => (


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

The documentation was not clear about multiline support. As mentioned in #2381, the best option is to use `View` instead to keep the library MD compliant.  This PR adds that suggestion into the current docs for ` Datatable.Cell`.
![imagen](https://user-images.githubusercontent.com/6154802/100514112-503dc880-31b5-11eb-8149-7e80e6b6c915.png)

### Test plan

Check the updated documentation in Datatable.Cell

