### PR TITLE
fix: wrong types for onPress and onLongPress and bug in example app

### DIFF
--- a/example/src/Examples/ToggleButtonExample.tsx
+++ b/example/src/Examples/ToggleButtonExample.tsx
@@ -21,7 +21,7 @@ const ToggleButtonExample = () => {
             icon="android"
             value="android"
             status={status}
-            onPress={(status) =>
+            onPress={() =>
               setStatus(status === 'checked' ? 'unchecked' : 'checked')
             }
           />

--- a/src/components/Appbar/AppbarAction.tsx
+++ b/src/components/Appbar/AppbarAction.tsx
@@ -4,6 +4,7 @@ import type {
   StyleProp,
   ViewStyle,
   TouchableWithoutFeedback,
+  GestureResponderEvent,
 } from 'react-native';
 import { black } from '../../styles/colors';
 import IconButton from '../IconButton';
@@ -33,7 +34,7 @@ type Props = React.ComponentPropsWithoutRef<typeof IconButton> & {
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   style?: StyleProp<ViewStyle>;
   ref?: React.RefObject<TouchableWithoutFeedback>;
 };

--- a/src/components/Appbar/AppbarBackAction.tsx
+++ b/src/components/Appbar/AppbarBackAction.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import type { $Omit } from './../../types';
 import AppbarAction from './AppbarAction';
 import AppbarBackIcon from './AppbarBackIcon';
-import type { StyleProp, ViewStyle } from 'react-native';
+import type { StyleProp, ViewStyle, GestureResponderEvent } from 'react-native';
 
 type Props = $Omit<
   React.ComponentPropsWithoutRef<typeof AppbarAction>,
@@ -27,7 +27,7 @@ type Props = $Omit<
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   style?: StyleProp<ViewStyle>;
 };
 

--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  GestureResponderEvent,
   Platform,
   StyleProp,
   StyleSheet,
@@ -45,7 +46,7 @@ type Props = $RemoveChildren<typeof View> & {
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   style?: StyleProp<ViewStyle>;
   /**
    * @optional

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { View, ViewStyle, StyleSheet, StyleProp, Animated } from 'react-native';
+import {
+  View,
+  ViewStyle,
+  StyleSheet,
+  StyleProp,
+  Animated,
+  GestureResponderEvent,
+} from 'react-native';
 import Surface from './Surface';
 import Text from './Typography/Text';
 import Button from './Button';
@@ -35,7 +42,7 @@ type Props = $RemoveChildren<typeof Surface> & {
    */
   actions: Array<{
     label: string;
-    onPress: () => void;
+    onPress: (event: GestureResponderEvent) => void;
   }>;
   /**
    * Style of banner's inner content.

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   StyleProp,
   TextStyle,
+  GestureResponderEvent,
 } from 'react-native';
 import color from 'color';
 
@@ -64,11 +65,11 @@ type Props = React.ComponentProps<typeof Surface> & {
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   /**
    * Function to execute on long press.
    */
-  onLongPress?: () => void;
+  onLongPress?: (event: GestureResponderEvent) => void;
   /**
    * Style of button's inner content.
    * Use this prop to apply custom height and width and to set the icon on the right with `flexDirection: 'row-reverse'`.

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -6,6 +6,7 @@ import {
   TouchableWithoutFeedback,
   View,
   ViewStyle,
+  GestureResponderEvent,
 } from 'react-native';
 import CardContent from './CardContent';
 import CardActions from './CardActions';
@@ -24,11 +25,11 @@ type Props = React.ComponentProps<typeof Surface> & {
   /**
    * Function to execute on long press.
    */
-  onLongPress?: () => void;
+  onLongPress?: (event: GestureResponderEvent) => void;
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   /**
    * Content of the `Card`.
    */

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Platform } from 'react-native';
+import { GestureResponderEvent, Platform } from 'react-native';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import CheckboxIOS, { CheckboxIOS as _CheckboxIOS } from './CheckboxIOS';
 import CheckboxAndroid, {
@@ -21,7 +21,7 @@ type Props = {
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   /**
    * Custom color for unchecked checkbox.
    */

--- a/src/components/Checkbox/CheckboxAndroid.tsx
+++ b/src/components/Checkbox/CheckboxAndroid.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { Animated, View, StyleSheet } from 'react-native';
+import {
+  Animated,
+  View,
+  StyleSheet,
+  GestureResponderEvent,
+} from 'react-native';
 import color from 'color';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
@@ -18,7 +23,7 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   /**
    * Custom color for unchecked checkbox.
    */

--- a/src/components/Checkbox/CheckboxIOS.tsx
+++ b/src/components/Checkbox/CheckboxIOS.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { GestureResponderEvent, StyleSheet, View } from 'react-native';
 import color from 'color';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
@@ -18,7 +18,7 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   /**
    * Custom color for checkbox.
    */

--- a/src/components/Checkbox/CheckboxItem.tsx
+++ b/src/components/Checkbox/CheckboxItem.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import {
+  GestureResponderEvent,
   StyleProp,
   StyleSheet,
   TextStyle,
@@ -31,7 +32,7 @@ type Props = {
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   /**
    * Custom color for unchecked checkbox.
    */

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -3,6 +3,7 @@ import {
   AccessibilityState,
   AccessibilityTrait,
   Animated,
+  GestureResponderEvent,
   Platform,
   StyleProp,
   StyleSheet,
@@ -63,11 +64,11 @@ type Props = React.ComponentProps<typeof Surface> & {
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   /**
    * Function to execute on long press.
    */
-  onLongPress?: () => void;
+  onLongPress?: (event: GestureResponderEvent) => void;
   /**
    * Function to execute on close button press. The close button appears only when this prop is specified.
    */

--- a/src/components/DataTable/DataTableCell.tsx
+++ b/src/components/DataTable/DataTableCell.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { StyleSheet, StyleProp, ViewStyle } from 'react-native';
+import {
+  StyleSheet,
+  StyleProp,
+  ViewStyle,
+  GestureResponderEvent,
+} from 'react-native';
 import Text from '../Typography/Text';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import type { $RemoveChildren } from '../../types';
@@ -16,7 +21,7 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   style?: StyleProp<ViewStyle>;
 };
 

--- a/src/components/DataTable/DataTableRow.tsx
+++ b/src/components/DataTable/DataTableRow.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import color from 'color';
-import { StyleSheet, StyleProp, View, ViewStyle } from 'react-native';
+import {
+  StyleSheet,
+  StyleProp,
+  View,
+  ViewStyle,
+  GestureResponderEvent,
+} from 'react-native';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { black, white } from '../../styles/colors';
 import { withTheme } from '../../core/theming';
@@ -14,7 +20,7 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   style?: StyleProp<ViewStyle>;
   /**
    * @optional

--- a/src/components/DataTable/DataTableTitle.tsx
+++ b/src/components/DataTable/DataTableTitle.tsx
@@ -7,6 +7,7 @@ import {
   View,
   ViewStyle,
   I18nManager,
+  GestureResponderEvent,
 } from 'react-native';
 import color from 'color';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
@@ -33,7 +34,7 @@ type Props = React.ComponentPropsWithRef<typeof TouchableWithoutFeedback> & {
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   style?: StyleProp<ViewStyle>;
   /**
    * @optional

--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -1,6 +1,12 @@
 import color from 'color';
 import * as React from 'react';
-import { View, StyleSheet, StyleProp, ViewStyle } from 'react-native';
+import {
+  View,
+  StyleSheet,
+  StyleProp,
+  ViewStyle,
+  GestureResponderEvent,
+} from 'react-native';
 import Text from '../Typography/Text';
 import Icon, { IconSource } from '../Icon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
@@ -22,7 +28,7 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   /**
    * Accessibility label for the button. This is read by the screen reader when the user taps the button.
    */

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -1,6 +1,13 @@
 import color from 'color';
 import * as React from 'react';
-import { Animated, View, ViewStyle, StyleSheet, StyleProp } from 'react-native';
+import {
+  Animated,
+  View,
+  ViewStyle,
+  StyleSheet,
+  StyleProp,
+  GestureResponderEvent,
+} from 'react-native';
 import ActivityIndicator from '../ActivityIndicator';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import FABGroup, { FABGroup as _FABGroup } from './FABGroup';
@@ -64,11 +71,11 @@ type Props = $RemoveChildren<typeof Surface> & {
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   /**
    * Function to execute on long press.
    */
-  onLongPress?: () => void;
+  onLongPress?: (event: GestureResponderEvent) => void;
   style?: StyleProp<ViewStyle>;
   /**
    * @optional

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -7,6 +7,7 @@ import {
   TouchableWithoutFeedback,
   View,
   ViewStyle,
+  GestureResponderEvent,
 } from 'react-native';
 import color from 'color';
 import FAB from './FAB';
@@ -32,7 +33,7 @@ type Props = {
     color?: string;
     accessibilityLabel?: string;
     style?: StyleProp<ViewStyle>;
-    onPress: () => void;
+    onPress: (event: GestureResponderEvent) => void;
     testID?: string;
   }>;
   /**
@@ -51,7 +52,7 @@ type Props = {
   /**
    * Function to execute on pressing the `FAB`.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   /**
    * Whether the speed dial is open.
    */
@@ -171,7 +172,7 @@ const FABGroup = ({
         color?: string;
         accessibilityLabel?: string;
         style?: StyleProp<ViewStyle>;
-        onPress: () => void;
+        onPress: (event: GestureResponderEvent) => void;
         testID?: string;
       }[]
     | null
@@ -284,8 +285,8 @@ const FABGroup = ({
                       },
                     ] as StyleProp<ViewStyle>
                   }
-                  onPress={() => {
-                    it.onPress();
+                  onPress={(e) => {
+                    it.onPress(e);
                     close();
                   }}
                   accessibilityLabel={
@@ -314,8 +315,8 @@ const FABGroup = ({
                     it.style,
                   ] as StyleProp<ViewStyle>
                 }
-                onPress={() => {
-                  it.onPress();
+                onPress={(e) => {
+                  it.onPress(e);
                   close();
                 }}
                 accessibilityLabel={
@@ -333,8 +334,8 @@ const FABGroup = ({
           ))}
         </View>
         <FAB
-          onPress={() => {
-            onPress?.();
+          onPress={(e) => {
+            onPress?.(e);
             toggle();
           }}
           icon={icon}

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -44,7 +44,7 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * Function to execute on press.
    */
-  onPress?: (e: GestureResponderEvent) => void;
+  onPress?: (event: GestureResponderEvent) => void;
   style?: StyleProp<ViewStyle>;
   ref?: React.RefObject<TouchableWithoutFeedback>;
   /**

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -7,6 +7,7 @@ import {
   StyleProp,
   TextStyle,
   I18nManager,
+  GestureResponderEvent,
 } from 'react-native';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
@@ -37,7 +38,7 @@ type Props = {
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   /**
    * Content of the section.
    */
@@ -141,8 +142,8 @@ const ListAccordion = ({
     expandedProp || false
   );
 
-  const handlePressAction = () => {
-    onPress?.();
+  const handlePressAction = (e: GestureResponderEvent) => {
+    onPress?.(e);
 
     if (expandedProp === undefined) {
       // Only update state of the `expanded` prop was not passed

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -1,6 +1,7 @@
 import color from 'color';
 import * as React from 'react';
 import {
+  GestureResponderEvent,
   StyleProp,
   StyleSheet,
   TextStyle,
@@ -54,7 +55,7 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   /**
    * @optional
    */

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -6,6 +6,7 @@ import {
   TextStyle,
   ViewStyle,
   StyleProp,
+  GestureResponderEvent,
 } from 'react-native';
 import Icon, { IconSource } from '../Icon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
@@ -29,7 +30,7 @@ type Props = {
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   /**
    * @optional
    */

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Platform } from 'react-native';
+import { GestureResponderEvent, Platform } from 'react-native';
 import RadioButtonGroup from './RadioButtonGroup';
 import RadioButtonAndroid from './RadioButtonAndroid';
 import RadioButtonIOS from './RadioButtonIOS';
@@ -22,7 +22,7 @@ export type Props = {
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   /**
    * Custom color for unchecked radio.
    */

--- a/src/components/RadioButton/RadioButtonAndroid.tsx
+++ b/src/components/RadioButton/RadioButtonAndroid.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { Animated, View, StyleSheet } from 'react-native';
+import {
+  Animated,
+  View,
+  StyleSheet,
+  GestureResponderEvent,
+} from 'react-native';
 import color from 'color';
 import { RadioButtonContext, RadioButtonContextType } from './RadioButtonGroup';
 import { handlePress, isChecked } from './utils';
@@ -23,7 +28,7 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * Function to execute on press.
    */
-  onPress?: (param?: any) => void;
+  onPress?: (event: GestureResponderEvent) => void;
   /**
    * Custom color for unchecked radio.
    */
@@ -143,11 +148,12 @@ const RadioButtonAndroid = ({
             onPress={
               disabled
                 ? undefined
-                : () => {
+                : (event) => {
                     handlePress({
                       onPress,
                       onValueChange: context?.onValueChange,
                       value,
+                      event,
                     });
                   }
             }

--- a/src/components/RadioButton/RadioButtonIOS.tsx
+++ b/src/components/RadioButton/RadioButtonIOS.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { GestureResponderEvent, StyleSheet, View } from 'react-native';
 import color from 'color';
 import { RadioButtonContext, RadioButtonContextType } from './RadioButtonGroup';
 import { handlePress, isChecked } from './utils';
@@ -24,7 +24,7 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   /**
    * Custom color for radio.
    */
@@ -94,11 +94,12 @@ const RadioButtonIOS = ({
             onPress={
               disabled
                 ? undefined
-                : () => {
+                : (event) => {
                     handlePress({
                       onPress,
                       value,
                       onValueChange: context?.onValueChange,
+                      event,
                     });
                   }
             }

--- a/src/components/RadioButton/RadioButtonItem.tsx
+++ b/src/components/RadioButton/RadioButtonItem.tsx
@@ -5,6 +5,7 @@ import {
   StyleProp,
   ViewStyle,
   TextStyle,
+  GestureResponderEvent,
 } from 'react-native';
 import { withTheme } from '../../core/theming';
 import { RadioButtonContext, RadioButtonContextType } from './RadioButtonGroup';
@@ -31,7 +32,7 @@ export type Props = {
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   /**
    * Accessibility label for the touchable. This is read by the screen reader when the user taps the touchable.
    */
@@ -134,11 +135,12 @@ const RadioButtonItem = ({
             onPress={
               disabled
                 ? undefined
-                : () =>
+                : (event) =>
                     handlePress({
-                      onPress: onPress,
+                      onPress,
                       onValueChange: context?.onValueChange,
                       value,
+                      event,
                     })
             }
             accessibilityLabel={accessibilityLabel}

--- a/src/components/RadioButton/utils.ts
+++ b/src/components/RadioButton/utils.ts
@@ -1,13 +1,17 @@
+import type { GestureResponderEvent } from 'react-native';
+
 export const handlePress = ({
   onPress,
   value,
   onValueChange,
+  event,
 }: {
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   value: string;
   onValueChange?: (value: string) => void;
+  event: GestureResponderEvent;
 }) => {
-  onValueChange ? onValueChange(value) : onPress?.();
+  onValueChange ? onValueChange(value) : onPress?.(event);
 };
 
 export const isChecked = ({

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -6,6 +6,7 @@ import {
   I18nManager,
   ViewStyle,
   TextStyle,
+  GestureResponderEvent,
 } from 'react-native';
 
 import color from 'color';
@@ -43,7 +44,7 @@ type Props = React.ComponentPropsWithRef<typeof TextInput> & {
   /**
    * Callback to execute if we want the left icon to act as button.
    */
-  onIconPress?: () => void;
+  onIconPress?: (event: GestureResponderEvent) => void;
   /**
    * Set style of the TextInput component inside the searchbar
    */

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   ViewStyle,
   View,
+  GestureResponderEvent,
 } from 'react-native';
 
 import Button from './Button';
@@ -26,7 +27,7 @@ type Props = React.ComponentProps<typeof Surface> & {
   action?: {
     label: string;
     accessibilityLabel?: string;
-    onPress: () => void;
+    onPress: (event: GestureResponderEvent) => void;
   };
   /**
    * The duration for which the Snackbar is shown.
@@ -210,8 +211,8 @@ const Snackbar = ({
         {action ? (
           <Button
             accessibilityLabel={action.accessibilityLabel}
-            onPress={() => {
-              action.onPress();
+            onPress={(e) => {
+              action.onPress(e);
               onDismiss();
             }}
             style={styles.button}

--- a/src/components/TextInput/Adornment/TextInputIcon.tsx
+++ b/src/components/TextInput/Adornment/TextInputIcon.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { View, StyleSheet, StyleProp, ViewStyle } from 'react-native';
+import {
+  View,
+  StyleSheet,
+  StyleProp,
+  ViewStyle,
+  GestureResponderEvent,
+} from 'react-native';
 
 import IconButton from '../../IconButton';
 import type { $Omit } from '../../../../src/types';
@@ -10,7 +16,7 @@ type Props = $Omit<
   'icon' | 'theme'
 > & {
   name: IconSource;
-  onPress?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
   forceTextInputFocus?: boolean;
   style?: StyleProp<ViewStyle>;
   theme?: ReactNativePaper.Theme;
@@ -60,12 +66,15 @@ const TextInputIcon = ({
     StyleContext
   );
 
-  const onPressWithFocusControl = React.useCallback(() => {
-    if (forceTextInputFocus && !isTextInputFocused) {
-      forceFocus();
-    }
-    onPress?.();
-  }, [forceTextInputFocus, forceFocus, isTextInputFocused, onPress]);
+  const onPressWithFocusControl = React.useCallback(
+    (event: GestureResponderEvent) => {
+      if (forceTextInputFocus && !isTextInputFocused) {
+        forceFocus();
+      }
+      onPress?.(event);
+    },
+    [forceTextInputFocus, forceFocus, isTextInputFocused, onPress]
+  );
 
   return (
     <View style={[styles.container, style]}>

--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -39,7 +39,7 @@ type Props = {
   /**
    * Function to execute on press.
    */
-  onPress?: (value?: GestureResponderEvent | string) => void;
+  onPress?: (event: GestureResponderEvent) => void;
   /**
    * Value of button.
    */
@@ -123,7 +123,7 @@ const ToggleButton = ({
           <IconButton
             borderless={false}
             icon={icon}
-            onPress={(e?: GestureResponderEvent | string) => {
+            onPress={(e) => {
               if (onPress) {
                 onPress(e);
               }

--- a/src/components/TouchableRipple/TouchableRipple.native.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.native.tsx
@@ -8,6 +8,7 @@ import {
   TouchableWithoutFeedback,
   View,
   ViewStyle,
+  GestureResponderEvent,
 } from 'react-native';
 import color from 'color';
 import { withTheme } from '../../core/theming';
@@ -19,7 +20,7 @@ type Props = React.ComponentProps<typeof TouchableWithoutFeedback> & {
   borderless?: boolean;
   background?: BackgroundPropType;
   disabled?: boolean;
-  onPress?: () => void | null;
+  onPress?: (event: GestureResponderEvent) => void | null;
   rippleColor?: string;
   underlayColor?: string;
   children: React.ReactNode;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
I'm working on a navigation library on top of react-router-dom and react-native-navigation. But the Link component I'm using won't work well with the onPress of react-native-paper in typescript since the event is not defined in typescript (but is provided to the function)

```
  const onPress = React.useCallback(
    (event: GestureResponderEvent) => {
      if (!event.defaultPrevented) {
        event.preventDefault();
        navigation.push(to, params);
      }
    },
    [navigation, to, params],
  );
```


Types of property 'onPress' are incompatible.         Type '(e: GestureResponderEvent) => any' is not assignable to type '() => void'.
<img width="952" alt="Schermafbeelding 2020-12-02 om 23 26 23" src="https://user-images.githubusercontent.com/6492229/100939055-f6f7d100-34f5-11eb-8dcd-d3ab24ca68fb.png">

I decided to fix it everywhere so I can use links on some places or it just good to provide it to users so can they can provide preventDefault() or things like that.
### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
