### PR TITLE
Fix example in List.Icon

### DIFF
--- a/src/components/List/ListIcon.tsx
+++ b/src/components/List/ListIcon.tsx
@@ -31,9 +31,11 @@ const ICON_SIZE = 24;
  * import { List, Colors } from 'react-native-paper';
  *
  * const MyComponent = () => (
- *   <List.Icon color={Colors.blue500} icon="folder" />
- *   <List.Icon color={Colors.blue500} icon="equal" />
- *   <List.Icon color={Colors.blue500} icon="calendar" />
+ *   <>
+ *     <List.Icon color={Colors.blue500} icon="folder" />
+ *     <List.Icon color={Colors.blue500} icon="equal" />
+ *     <List.Icon color={Colors.blue500} icon="calendar" />
+ *   </>
  * );
  *
  * export default MyComponent;


### PR DESCRIPTION
### Summary

Current example does not wrap multiple elements in container component.
Thus it does not work on Snack out of the box.
I added ```React.Fragment``` to fix it.

### Test plan

This is a documentation update.
