### PR TITLE
docs: Fix incorrect function name in theming with RN Navigation

### DIFF
--- a/docs/pages/8.theming-with-react-navigation.md
+++ b/docs/pages/8.theming-with-react-navigation.md
@@ -169,7 +169,7 @@ First, we define our Context.
 import React from 'react';
 
 export const PreferencesContext = React.createContext({
-  setTheme: () => {},
+  toggleTheme: () => {},
   isThemeDark: false,
 });
 ```


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

The documentation names the theme setter function as `setTheme` in the context but used `toggleTheme`instead. This replaces `setTheme` in the [Create Context section](https://callstack.github.io/react-native-paper/theming-with-react-navigation.html#creating-context) to `toggleTheme`. 

### Test plan

Check the Create Context section on [Theming with React Navigation](https://callstack.github.io/react-native-paper/theming-with-react-navigation.html) page.
