### PR TITLE
Add info about required icon packs

### DIFF
--- a/docs/pages/1.getting-started.md
+++ b/docs/pages/1.getting-started.md
@@ -16,7 +16,7 @@ or
 npm install react-native-paper
 ```
 If you're on a vanilla React Native project, you also need to install and link [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons).
-```MaterialCommunityIcons``` icon pack needs to be included in the project, because some components use them internally (e.g. ```AppBar.BackAction``` on Android). 
+Specifically `MaterialCommunityIcons` icon pack needs to be included in the project, because some components use those internally (e.g. `AppBar.BackAction` on Android). 
 
 ```sh
 yarn add react-native-vector-icons

--- a/docs/pages/1.getting-started.md
+++ b/docs/pages/1.getting-started.md
@@ -16,6 +16,7 @@ or
 npm install react-native-paper
 ```
 If you're on a vanilla React Native project, you also need to install and link [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons).
+
 Specifically `MaterialCommunityIcons` icon pack needs to be included in the project, because some components use those internally (e.g. `AppBar.BackAction` on Android). 
 
 ```sh

--- a/docs/pages/1.getting-started.md
+++ b/docs/pages/1.getting-started.md
@@ -16,6 +16,7 @@ or
 npm install react-native-paper
 ```
 If you're on a vanilla React Native project, you also need to install and link [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons).
+```MaterialCommunityIcons``` icon pack needs to be included in the project, because some components use them internally (e.g. ```AppBar.BackAction``` on Android). 
 
 ```sh
 yarn add react-native-vector-icons


### PR DESCRIPTION
### Summary

There is no information in documentation that ```MaterialCommunityIcons``` are required for some components to be displayed correctly.
For example ```AppBar.BackAction``` uses ```arrow-left``` from this icon pack.
If user specifies in config what icon packs they want to bundle, it may break display of these icons.