### PR TITLE
fix: Use text color for Checkbox.Item label

### DIFF
--- a/src/components/Checkbox/CheckboxItem.tsx
+++ b/src/components/Checkbox/CheckboxItem.tsx
@@ -106,7 +106,7 @@ const CheckboxItem = ({
     <TouchableRipple onPress={onPress} testID={testID}>
       <View style={[styles.container, style]} pointerEvents="none">
         <Text
-          style={[styles.label, { color: theme.colors.primary }, labelStyle]}
+          style={[styles.label, { color: theme.colors.text }, labelStyle]}
         >
           {label}
         </Text>

--- a/src/components/Checkbox/CheckboxItem.tsx
+++ b/src/components/Checkbox/CheckboxItem.tsx
@@ -105,9 +105,7 @@ const CheckboxItem = ({
   return (
     <TouchableRipple onPress={onPress} testID={testID}>
       <View style={[styles.container, style]} pointerEvents="none">
-        <Text
-          style={[styles.label, { color: theme.colors.text }, labelStyle]}
-        >
+        <Text style={[styles.label, { color: theme.colors.text }, labelStyle]}>
           {label}
         </Text>
         {checkbox}

--- a/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.js.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.js.snap
@@ -47,7 +47,7 @@ exports[`can render the Android checkbox on different platforms 1`] = `
               "fontSize": 16,
             },
             Object {
-              "color": "#6200ee",
+              "color": "#000000",
             },
             undefined,
           ],
@@ -215,7 +215,7 @@ exports[`can render the iOS checkbox on different platforms 1`] = `
               "fontSize": 16,
             },
             Object {
-              "color": "#6200ee",
+              "color": "#000000",
             },
             undefined,
           ],
@@ -349,7 +349,7 @@ exports[`renders unchecked 1`] = `
               "fontSize": 16,
             },
             Object {
-              "color": "#6200ee",
+              "color": "#000000",
             },
             undefined,
           ],


### PR DESCRIPTION
I noticed there is an inconsistency between the `RadioButton.Item` and `Checkbox.Item` components.
Radio is using `colors.text` for its label, however, checkbox is using `colors.primary`.

This PR attempts to fix that by also using `colors.text` for the `Checkbox.Item` component.

Snacks from the doc for quick preview of the issue:

- [Radio](https://snack.expo.io/?name=RadioButton.Item&description=https%3A%2F%2Fcallstack.github.io%2Freact-native-paper%2Fradio-button-item.html&code=import%20*%20as%20React%20from%20%27react%27%3B%0Aimport%20%7B%20RadioButton%20%7D%20from%20%27react-native-paper%27%3B%0A%0Aconst%20MyComponent%20%3D%20()%20%3D%3E%20%7B%0A%20%20const%20%5Bvalue%2C%20setValue%5D%20%3D%20React.useState(%27first%27)%3B%0A%0A%20%20return%20(%0A%20%20%20%20%3CRadioButton.Group%20onValueChange%3D%7Bvalue%20%3D%3E%20setValue(value)%7D%20value%3D%7Bvalue%7D%3E%0A%20%20%20%20%20%20%3CRadioButton.Item%20label%3D%22First%20item%22%20value%3D%22first%22%20%2F%3E%0A%20%20%20%20%20%20%3CRadioButton.Item%20label%3D%22Second%20item%22%20value%3D%22second%22%20%2F%3E%0A%20%20%20%20%3C%2FRadioButton.Group%3E%0A%20%20)%3B%0A%7D%3B%0A%0Aexport%20default%20MyComponent%3B&dependencies=react-native-paper)
- [Checkbox](https://snack.expo.io/?name=Checkbox.Item&description=https%3A%2F%2Fcallstack.github.io%2Freact-native-paper%2Fcheckbox-item.html&code=import%20*%20as%20React%20from%20%27react%27%3B%0Aimport%20%7B%20View%20%7D%20from%20%27react-native%27%3B%0Aimport%20%7B%20Checkbox%20%7D%20from%20%27react-native-paper%27%3B%0A%0Aconst%20MyComponent%20%3D%20()%20%3D%3E%20(%0A%20%20%3CView%3E%0A%20%20%20%20%3CCheckbox.Item%20label%3D%22Item%22%20status%3D%22checked%22%20%2F%3E%0A%20%20%3C%2FView%3E%0A)%3B%0A%0Aexport%20default%20MyComponent%3B&dependencies=react-native-paper)