### PR TITLE
chore: add a custom yarn script to make setup easier

### DIFF
--- a/.github/workflows/publish-each-pr.yml
+++ b/.github/workflows/publish-each-pr.yml
@@ -36,7 +36,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install dependencies
-        run: yarn bootstrap
+        run: yarn
 
       - name: Publish Expo app
         working-directory: ./example

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
-      
+
       - name: Setup Expo
         uses: expo/expo-github-action@v5
         with:
@@ -23,20 +23,20 @@ jobs:
           expo-username: ${{ secrets.EXPO_CLI_USERNAME }}
           expo-password: ${{ secrets.EXPO_CLI_PASSWORD }}
           expo-cache: true
-      
+
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
-    
+
       - uses: actions/cache@v1
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      
+
       - name: Install dependencies
-        run: yarn bootstrap
+        run: yarn
 
       - name: Publish Expo app
         working-directory: ./example

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+yarn-path "scripts/bootstrap.js"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ The core team works directly on GitHub and all work is public.
 > **Working on your first pull request?** You can learn how from this *free* series: [How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github).
 
 1. Fork the repo and create your branch from `master` (a guide on [how to fork a repository](https://help.github.com/articles/fork-a-repo/)).
-2. Run `yarn bootstrap` to setup the development environment.
+2. Run `yarn` to setup the development environment.
 3. Do the changes you want and test them out in the example app before sending a pull request.
 
 ### Commit message convention

--- a/example/README.md
+++ b/example/README.md
@@ -6,7 +6,7 @@ You can run the React Native app with [this Snack](https://snack.expo.io/@react-
 
 If you want to run the example from the repo,
 
-- Clone the repository and run `yarn bootstrap` in the root
+- Clone the repository and run `yarn` in the root
 - Run `yarn example start` to start the packager
 - Follow the instructions to open it with the [Expo app](https://expo.io/)
 
@@ -14,5 +14,5 @@ If you want to run the example from the repo,
 
 You can also run the example app as a web app using [react-native-web](https://github.com/necolas/react-native-web),
 
-- Clone the repository and run `yarn bootstrap` in the root
+- Clone the repository and run `yarn` in the root
 - Run `yarn example web` to start the webpack server and open the app in your browser

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -1,0 +1,15 @@
+const child_process = require('child_process');
+
+const args = process.argv.slice(2);
+const options = {
+  cwd: process.cwd(),
+  env: process.env,
+  stdio: [process.stdin, process.stdout, process.stderr],
+  encoding: 'utf-8',
+};
+
+if (args.length) {
+  child_process.spawnSync('yarn', args, options);
+} else {
+  child_process.spawnSync('yarn', ['bootstrap'], options);
+}


### PR DESCRIPTION
Currently we need to run 'yarn bootstrap' to setup the repo. However it's easy to forget. This PR overrides the Yarn command to run the 'bootstrap' script if no arguments are specified.
