### PR TITLE
fix: Changed sorting arrow direction in data table

### DIFF
--- a/src/components/DataTable/DataTableTitle.tsx
+++ b/src/components/DataTable/DataTableTitle.tsx
@@ -106,7 +106,7 @@ const DataTableTitle = ({
   const icon = sortDirection ? (
     <Animated.View style={[styles.icon, { transform: [{ rotate: spin }] }]}>
       <MaterialCommunityIcon
-        name="arrow-down"
+        name="arrow-up"
         size={16}
         color={theme.colors.text}
         direction={I18nManager.isRTL ? 'rtl' : 'ltr'}

--- a/src/components/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.js.snap
@@ -657,7 +657,7 @@ exports[`renders data table title with press handler 1`] = `
         ]
       }
     >
-      
+      
     </Text>
   </View>
   <Text
@@ -760,7 +760,7 @@ exports[`renders data table title with sort icon 1`] = `
         ]
       }
     >
-      
+      
     </Text>
   </View>
   <Text


### PR DESCRIPTION
Fix related to [issue](https://github.com/callstack/react-native-paper/issues/2417).
According to Material design guidelines: `The downward arrow shows that the schedule column is sorted in descending order.`

Currently `sortDirection` prop in `DataTableTitle` set to `descending` was making the arrow to point up instead of down. Documentation is showing correct behaviour but the code was doing the opposite.

