### PR TITLE
Update documentation on custom font imports

### DIFF
--- a/docs/pages/4.fonts.md
+++ b/docs/pages/4.fonts.md
@@ -41,10 +41,11 @@ Now, you are able to use `fontFamily` from font files.
 
 ## Configuring fonts in ThemeProvider
 
-To create a custom font you need to prepare `fontConfig` where fonts are divided by platforms. 
-After that, you have to pass the `fontConfig` into `configureFonts` method in a custom theme. 
+To create a custom font, prepare a `fontConfig` object where fonts are divided by platforms. After that, you have to pass the `fontConfig` into `configureFonts` method in a custom theme. 
 
-Note: To override font on all platforms use `default` key.
+The `fontConfig` object accepts `ios`, `android`, `macos`, `windows`, `web`, and `native`. Use these to override fonts on particular platforms.
+
+Note: At a minimum, you need to explicitly pass fonts for `android`, `ios`, and `web`.
 
 Check the [default theme](https://github.com/callstack/react-native-paper/blob/master/src/styles/DefaultTheme.tsx) to see what customization options are supported.
 
@@ -54,7 +55,7 @@ import { configureFonts, DefaultTheme, Provider as PaperProvider } from 'react-n
 import App from './src/App';
 
 const fontConfig = {
-  default: {
+  web: {
     regular: {
       fontFamily: 'sans-serif',
       fontWeight: 'normal',
@@ -72,6 +73,42 @@ const fontConfig = {
       fontWeight: 'normal',
     },
   },
+  ios: {
+    regular: {
+      fontFamily: 'sans-serif',
+      fontWeight: 'normal',
+    },
+    medium: {
+      fontFamily: 'sans-serif-medium',
+      fontWeight: 'normal',
+    },
+    light: {
+      fontFamily: 'sans-serif-light',
+      fontWeight: 'normal',
+    },
+    thin: {
+      fontFamily: 'sans-serif-thin',
+      fontWeight: 'normal',
+    },
+  },
+  android: {
+    regular: {
+      fontFamily: 'sans-serif',
+      fontWeight: 'normal',
+    },
+    medium: {
+      fontFamily: 'sans-serif-medium',
+      fontWeight: 'normal',
+    },
+    light: {
+      fontFamily: 'sans-serif-light',
+      fontWeight: 'normal',
+    },
+    thin: {
+      fontFamily: 'sans-serif-thin',
+      fontWeight: 'normal',
+    },
+  }
 };
 
 const theme = {


### PR DESCRIPTION
### Summary

Currently, it's not clear that users must explicitly include in `fontConfig` overrides for `ios`, `android`, and `web` as part of their custom fonts. As such, this PR is to update the font import instructions documentation and the corresponding code example. 

See issue #2317 for more information.

### Test plan

Check the [Configuring fonts in ThemeProvider](https://callstack.github.io/react-native-paper/fonts.html) page.
