### PR TITLE
fix: broken link react-native URL docs with anchor

### DIFF
--- a/src/components/Card/CardCover.tsx
+++ b/src/components/Card/CardCover.tsx
@@ -42,7 +42,7 @@ type Props = React.ComponentPropsWithRef<typeof Image> & {
  * export default MyComponent;
  * ```
  *
- * @extends Image props https://facebook.github.io/react-native/docs/image.html#props
+ * @extends Image props https://reactnative.dev/docs/image#props
  */
 const CardCover = ({ index, total, style, theme, ...rest }: Props) => {
   const { roundness } = theme;

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -163,7 +163,7 @@ export type TextInputProps = React.ComponentPropsWithRef<
  * export default MyComponent;
  * ```
  *
- * @extends TextInput props https://facebook.github.io/react-native/docs/textinput.html#props
+ * @extends TextInput props https://reactnative.dev/docs/textinput#props
  */
 
 class TextInput extends React.Component<TextInputProps, State> {

--- a/src/components/TouchableRipple/TouchableRipple.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.tsx
@@ -17,7 +17,7 @@ type Props = React.ComponentPropsWithRef<typeof TouchableWithoutFeedback> & {
   borderless?: boolean;
   /**
    * Type of background drawabale to display the feedback (Android).
-   * https://facebook.github.io/react-native/docs/touchablenativefeedback.html#background
+   * https://reactnative.dev/docs/touchablenativefeedback#background
    */
   background?: Object;
   /**

--- a/src/components/Typography/AnimatedText.tsx
+++ b/src/components/Typography/AnimatedText.tsx
@@ -13,7 +13,7 @@ type Props = React.ComponentPropsWithRef<typeof Animated.Text> & {
 /**
  * Text component which follows styles from the theme.
  *
- * @extends Text props https://facebook.github.io/react-native/docs/text.html#props
+ * @extends Text props https://reactnative.dev/docs/text#props
  */
 function AnimatedText({ style, theme, ...rest }: Props) {
   const writingDirection = I18nManager.isRTL ? 'rtl' : 'ltr';

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -15,7 +15,7 @@ type Props = React.ComponentProps<typeof NativeText> & {
 /**
  * Text component which follows styles from the theme.
  *
- * @extends Text props https://facebook.github.io/react-native/docs/text.html#props
+ * @extends Text props https://reactnative.dev/docs/text#props
  */
 const Text: React.RefForwardingComponent<{}, Props> = (
   { style, theme, ...rest }: Props,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Based on the reported issue https://github.com/callstack/react-native-paper/issues/2331, there are some broken Link with react-native documentation URL. And, that does not take in account the anchor (#) element in the URL.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
Check the updated documentation 
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
