### PR TITLE
fix(Badge): avoid initial animation

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -65,12 +65,19 @@ const Badge = ({
   const { current: opacity } = React.useRef<Animated.Value>(
     new Animated.Value(visible ? 1 : 0)
   );
+  const isFirstRendering = React.useRef<boolean>(true);
 
   const {
     animation: { scale },
   } = theme;
 
   React.useEffect(() => {
+    // Do not run animation on very first rendering
+    if (isFirstRendering.current) {
+      isFirstRendering.current = false;
+      return;
+    }
+
     Animated.timing(opacity, {
       toValue: visible ? 1 : 0,
       duration: 150 * scale,


### PR DESCRIPTION
### Summary
Similar to #2349, the component Badge is also animating in the first render.

### Test plan
1. Open the example app
2. Check if the component Badge is working properly.