### PR TITLE
docs: add react-native-paper-tabs + react-native-bottom-sheet

### DIFF
--- a/docs/pages/6.recommended-libraries.md
+++ b/docs/pages/6.recommended-libraries.md
@@ -11,18 +11,25 @@ Here are some of the libraries we recommend:
 ## Tabs
 
 [react-native-community/react-native-tab-view](https://github.com/react-native-community/react-native-tab-view)
-
 Material Design themed [swipeable tabs](https://material.io/design/components/tabs.html), maintained by [@satya164](https://twitter.com/satya164) and [@mosdnk](https://twitter.com/mosdnk).
+
+[react-native-paper-tabs](https://github.com/web-ridge/react-native-paper-tabs)
+Material Design themed [swipeable tabs](https://material.io/design/components/tabs.html) for React Native Paper, maintained by [@RichardLindhout](https://twitter.com/RichardLindhout) from [@web_ridge](https://twitter.com/web_ridge)
 
 ## Bottom sheet
 
-[osdnk/reanimated-bottom-sheet](https://github.com/osdnk/react-native-reanimated-bottom-sheet)
+[gorhom/react-native-bottom-sheet](https://github.com/gorhom/react-native-bottom-sheet)
+An implementation of the [bottom sheet behaviour](https://material.io/design/components/sheets-bottom.html), maintained by [@Gorhom](https://twitter.com/Gorhom).
 
-An implementation [bottom sheet behaviour](https://material.io/design/components/sheets-bottom.html), maintained by [@mosdnk](https://twitter.com/mosdnk).
+[osdnk/reanimated-bottom-sheet](https://github.com/osdnk/react-native-reanimated-bottom-sheet)
+An implementation of the [bottom sheet behaviour](https://material.io/design/components/sheets-bottom.html), maintained by [@mosdnk](https://twitter.com/mosdnk).
 
 ## Date Picker
-[web-ridge/react-native-paper-dates](https://github.com/web-ridge/react-native-paper-dates)   
+[web-ridge/react-native-paper-dates](https://github.com/web-ridge/react-native-paper-dates)
+Material Design themed [date picker](https://material.io/components/date-pickers), maintained by [@RichardLindhout](https://twitter.com/RichardLindhout) from [@web_ridge](https://twitter.com/web_ridge)
+ 
 [react-native-community/react-native-datetimepicker](https://github.com/react-native-community/react-native-datetimepicker)
 
 ## Time Picker
 [web-ridge/react-native-paper-dates](https://github.com/web-ridge/react-native-paper-dates)
+Material Design themed [time picker](https://material.io/components/time-pickers), maintained by [@RichardLindhout](https://twitter.com/RichardLindhout) from [@web_ridge](https://twitter.com/web_ridge)

--- a/docs/pages/6.recommended-libraries.md
+++ b/docs/pages/6.recommended-libraries.md
@@ -14,22 +14,23 @@ Here are some of the libraries we recommend:
 Material Design themed [swipeable tabs](https://material.io/design/components/tabs.html), maintained by [@satya164](https://twitter.com/satya164) and [@mosdnk](https://twitter.com/mosdnk).
 
 [react-native-paper-tabs](https://github.com/web-ridge/react-native-paper-tabs)
-Material Design themed [swipeable tabs](https://material.io/design/components/tabs.html) for React Native Paper, maintained by [@RichardLindhout](https://twitter.com/RichardLindhout) from [@web_ridge](https://twitter.com/web_ridge)
+Material Design themed [swipeable tabs](https://material.io/design/components/tabs.html) for React Native Paper, maintained by [@RichardLindhout](https://twitter.com/RichardLindhout)
 
 ## Bottom sheet
-
-[gorhom/react-native-bottom-sheet](https://github.com/gorhom/react-native-bottom-sheet)
-An implementation of the [bottom sheet behaviour](https://material.io/design/components/sheets-bottom.html), maintained by [@Gorhom](https://twitter.com/Gorhom).
 
 [osdnk/reanimated-bottom-sheet](https://github.com/osdnk/react-native-reanimated-bottom-sheet)
 An implementation of the [bottom sheet behaviour](https://material.io/design/components/sheets-bottom.html), maintained by [@mosdnk](https://twitter.com/mosdnk).
 
+[gorhom/react-native-bottom-sheet](https://github.com/gorhom/react-native-bottom-sheet)
+An implementation of the [bottom sheet behaviour](https://material.io/design/components/sheets-bottom.html), maintained by [@Gorhom](https://twitter.com/Gorhom).
+
+
 ## Date Picker
 [web-ridge/react-native-paper-dates](https://github.com/web-ridge/react-native-paper-dates)
-Material Design themed [date picker](https://material.io/components/date-pickers), maintained by [@RichardLindhout](https://twitter.com/RichardLindhout) from [@web_ridge](https://twitter.com/web_ridge)
+Material Design themed [date picker](https://material.io/components/date-pickers), maintained by [@RichardLindhout](https://twitter.com/RichardLindhout)
  
 [react-native-community/react-native-datetimepicker](https://github.com/react-native-community/react-native-datetimepicker)
 
 ## Time Picker
 [web-ridge/react-native-paper-dates](https://github.com/web-ridge/react-native-paper-dates)
-Material Design themed [time picker](https://material.io/components/time-pickers), maintained by [@RichardLindhout](https://twitter.com/RichardLindhout) from [@web_ridge](https://twitter.com/web_ridge)
+Material Design themed [time picker](https://material.io/components/time-pickers), maintained by [@RichardLindhout](https://twitter.com/RichardLindhout) 


### PR DESCRIPTION
gorhom/react-native-bottom-sheet is really smooth and react-native-paper-tabs has great integration with React Native Paper and fully implements the Material Design Spec + great web support (no dependencies on web)

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
https://www.reactnativepapertabs.com/
https://github.com/web-ridge/react-native-paper-tabs

https://github.com/gorhom/react-native-bottom-sheet
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
