### PR TITLE
feat: add style prop in Modal

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -18,10 +18,6 @@ import { withTheme } from '../core/theming';
 
 type Props = {
   /**
-   * Determine whether the insets are applied.
-   */
-  disableSafeAreaInsets?: boolean;
-  /**
    * Determines whether clicking outside the modal dismiss it.
    */
   dismissable?: boolean;
@@ -45,6 +41,11 @@ type Props = {
    * Style for the content of the modal
    */
   contentContainerStyle?: StyleProp<ViewStyle>;
+  /**
+   * Style for the wrapper of the modal.
+   * Use this prop to change the default wrapper style or to override safe area insets with marginTop and marginBottom.
+   */
+  style?: StyleProp<ViewStyle>;
   /**
    * @optional
    */
@@ -102,7 +103,6 @@ const BOTTOM_INSET = getBottomSpace();
 class Modal extends React.Component<Props, State> {
   static defaultProps = {
     dismissable: true,
-    disableSafeAreaInsets: false,
     visible: false,
     overlayAccessibilityLabel: 'Close modal',
   };
@@ -196,7 +196,7 @@ class Modal extends React.Component<Props, State> {
     const {
       children,
       dismissable,
-      disableSafeAreaInsets,
+      style,
       theme,
       contentContainerStyle,
       overlayAccessibilityLabel,
@@ -226,10 +226,8 @@ class Modal extends React.Component<Props, State> {
         <View
           style={[
             styles.wrapper,
-            !disableSafeAreaInsets && {
-              marginTop: TOP_INSET,
-              marginBottom: BOTTOM_INSET,
-            },
+            { marginTop: TOP_INSET, marginBottom: BOTTOM_INSET },
+            style,
           ]}
           pointerEvents="box-none"
         >

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -18,6 +18,10 @@ import { withTheme } from '../core/theming';
 
 type Props = {
   /**
+   * Determine whether the insets are applied.
+   */
+  disableSafeAreaInsets?: boolean;
+  /**
    * Determines whether clicking outside the modal dismiss it.
    */
   dismissable?: boolean;
@@ -98,6 +102,7 @@ const BOTTOM_INSET = getBottomSpace();
 class Modal extends React.Component<Props, State> {
   static defaultProps = {
     dismissable: true,
+    disableSafeAreaInsets: false,
     visible: false,
     overlayAccessibilityLabel: 'Close modal',
   };
@@ -191,6 +196,7 @@ class Modal extends React.Component<Props, State> {
     const {
       children,
       dismissable,
+      disableSafeAreaInsets,
       theme,
       contentContainerStyle,
       overlayAccessibilityLabel,
@@ -220,7 +226,10 @@ class Modal extends React.Component<Props, State> {
         <View
           style={[
             styles.wrapper,
-            { marginTop: TOP_INSET, marginBottom: BOTTOM_INSET },
+            !disableSafeAreaInsets && {
+              marginTop: TOP_INSET,
+              marginBottom: BOTTOM_INSET,
+            },
           ]}
           pointerEvents="box-none"
         >


### PR DESCRIPTION
### Motivation

This prop is necessary when you need to see content in full screen on iPhone X/11

### Test plan
1. Download this branch
2. Open Modal example
3. Pass style prop with this values (iPhone X/11):
```js
 { marginTop: 0, marginBottom: 0 }
```
### Actual behaviour
![image](https://user-images.githubusercontent.com/12452003/79098271-a0a00d00-7d2f-11ea-8fb2-7e91b3ca3808.png)

### Behaviour with  style = { marginTop: 0, marginBottom: 0 }
![image](https://user-images.githubusercontent.com/12452003/79098267-9bdb5900-7d2f-11ea-963d-b6647ae4e15e.png)