### PR TITLE
feat: add onLongPress event to List.Accordion

### DIFF
--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -39,6 +39,10 @@ type Props = {
    */
   onPress?: () => void;
   /**
+   * Function to execute on long press.
+   */
+  onLongPress?: () => void;
+  /**
    * Content of the section.
    */
   children: React.ReactNode;
@@ -135,6 +139,7 @@ const ListAccordion = ({
   id,
   testID,
   onPress,
+  onLongPress,
   expanded: expandedProp,
 }: Props) => {
   const [expanded, setExpanded] = React.useState<boolean>(
@@ -174,6 +179,7 @@ const ListAccordion = ({
       <TouchableRipple
         style={[styles.container, style]}
         onPress={handlePress}
+        onLongPress={onLongPress}
         accessibilityTraits="button"
         accessibilityComponentType="button"
         accessibilityRole="button"


### PR DESCRIPTION
### Summary

As List.Accordion uses TouchableRipple for onPress handling amongst other things it would be great to offer onLongPress support, too. Since TouchableRipple already offers onLongPress support, the function can simply be forwarded.

No additional handling as for the onPress event (expandable) is required since the onLongPress functionality should not interfere with the default behaviour of List.Accordion, but simply add more press event capabilities.