### PR TITLE
chore: remove deprecated accessibility props

### DIFF
--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -134,8 +134,7 @@ const AppbarContent = ({
           ]}
           numberOfLines={1}
           accessible
-          accessibilityTraits="header"
-          // @ts-expect-error React Native doesn't accept 'heading' as it's web-only
+          // @ts-ignore Type '"heading"' is not assignable to type ...
           accessibilityRole={Platform.OS === 'web' ? 'heading' : 'header'}
         >
           {title}

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -825,11 +825,6 @@ const BottomNavigation = ({
                 onPress: () => handleTabPress(index),
                 testID: getTestID({ route }),
                 accessibilityLabel: getAccessibilityLabel({ route }),
-                // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
-                accessibilityTraits: focused
-                  ? ['button', 'selected']
-                  : 'button',
-                accessibilityComponentType: 'button',
                 accessibilityRole: Platform.OS === 'ios' ? 'button' : 'tab',
                 accessibilityState: { selected: focused },
                 style: [styles.item, isV3 && styles.v3Item],

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -273,9 +273,6 @@ const Button = ({
         onPressOut={handlePressOut}
         accessibilityLabel={accessibilityLabel}
         accessibilityHint={accessibilityHint}
-        // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
-        accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
-        accessibilityComponentType="button"
         accessibilityRole="button"
         accessibilityState={{ disabled }}
         accessible={accessible}

--- a/src/components/Checkbox/CheckboxAndroid.tsx
+++ b/src/components/Checkbox/CheckboxAndroid.tsx
@@ -128,9 +128,6 @@ const CheckboxAndroid = ({
       rippleColor={rippleColor}
       onPress={onPress}
       disabled={disabled}
-      // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
-      accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
-      accessibilityComponentType="button"
       accessibilityRole="checkbox"
       accessibilityState={{ disabled, checked }}
       accessibilityLiveRegion="polite"

--- a/src/components/Checkbox/CheckboxIOS.tsx
+++ b/src/components/Checkbox/CheckboxIOS.tsx
@@ -75,9 +75,6 @@ const CheckboxIOS = ({
       rippleColor={rippleColor}
       onPress={onPress}
       disabled={disabled}
-      // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
-      accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
-      accessibilityComponentType="button"
       accessibilityRole="checkbox"
       accessibilityState={{ disabled, checked }}
       accessibilityLiveRegion="polite"

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -212,19 +212,10 @@ const Chip = ({
     disabled,
   });
 
-  const accessibilityTraits = ['button'];
   const accessibilityState: AccessibilityState = {
     selected,
     disabled,
   };
-
-  if (selected) {
-    accessibilityTraits.push('selected');
-  }
-
-  if (disabled) {
-    accessibilityTraits.push('disabled');
-  }
 
   const elevationStyle = isV3 || Platform.OS === 'android' ? elevation : 0;
   const multiplier = isV3 ? (compact ? 1.5 : 2) : 1;
@@ -270,9 +261,6 @@ const Chip = ({
         underlayColor={underlayColor}
         disabled={disabled}
         accessibilityLabel={accessibilityLabel}
-        // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
-        accessibilityTraits={accessibilityTraits}
-        accessibilityComponentType="button"
         accessibilityRole="button"
         accessibilityState={accessibilityState}
         testID={testID}
@@ -356,9 +344,6 @@ const Chip = ({
         <View style={styles.closeButtonStyle}>
           <TouchableWithoutFeedback
             onPress={onClose}
-            // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
-            accessibilityTraits="button"
-            accessibilityComponentType="button"
             accessibilityRole="button"
             accessibilityLabel={closeIconAccessibilityLabel}
           >

--- a/src/components/Dialog/DialogTitle.tsx
+++ b/src/components/Dialog/DialogTitle.tsx
@@ -60,8 +60,6 @@ const DialogTitle = ({ children, theme, style, ...rest }: Props) => {
   return (
     <TextComponent
       variant="headlineSmall"
-      // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
-      accessibilityTraits="header"
       accessibilityRole="header"
       style={[styles.text, isV3 && styles.v3Text, { color: textColor }, style]}
       {...rest}

--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -111,9 +111,6 @@ const DrawerItem = ({
           isV3 && styles.v3Container,
           style,
         ]}
-        // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
-        accessibilityTraits={active ? ['button', 'selected'] : 'button'}
-        accessibilityComponentType="button"
         accessibilityRole="button"
         accessibilityState={{ selected: active }}
         accessibilityLabel={accessibilityLabel}

--- a/src/components/FAB/AnimatedFAB.tsx
+++ b/src/components/FAB/AnimatedFAB.tsx
@@ -396,9 +396,6 @@ const AnimatedFAB = ({
               rippleColor={rippleColor}
               disabled={disabled}
               accessibilityLabel={accessibilityLabel}
-              // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
-              accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
-              accessibilityComponentType="button"
               accessibilityRole="button"
               accessibilityState={{ ...accessibilityState, disabled }}
               testID={testID}

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -253,9 +253,6 @@ const FAB = ({
         rippleColor={rippleColor}
         disabled={disabled}
         accessibilityLabel={accessibilityLabel}
-        // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
-        accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
-        accessibilityComponentType="button"
         accessibilityRole="button"
         accessibilityState={{ ...accessibilityState, disabled }}
         style={shapeStyle}

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -335,9 +335,6 @@ const FABGroup = ({
                         ? it.accessibilityLabel
                         : it.label
                     }
-                    // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
-                    accessibilityTraits="button"
-                    accessibilityComponentType="button"
                     accessibilityRole="button"
                     {...(isV3 && { elevation: 0 })}
                   >
@@ -374,9 +371,6 @@ const FABGroup = ({
                     ? it.accessibilityLabel
                     : it.label
                 }
-                // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
-                accessibilityTraits="button"
-                accessibilityComponentType="button"
                 accessibilityRole="button"
                 testID={it.testID}
                 visible={open}
@@ -392,9 +386,6 @@ const FABGroup = ({
           icon={icon}
           color={colorProp}
           accessibilityLabel={accessibilityLabel}
-          // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
-          accessibilityTraits="button"
-          accessibilityComponentType="button"
           accessibilityRole="button"
           accessibilityState={{ expanded: open }}
           style={[styles.fab, fabStyle]}

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -196,9 +196,6 @@ const ListAccordion = ({
           style={[styles.container, style]}
           onPress={handlePress}
           onLongPress={onLongPress}
-          // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
-          accessibilityTraits="button"
-          accessibilityComponentType="button"
           accessibilityRole="button"
           accessibilityState={{ expanded: isExpanded }}
           accessibilityLabel={accessibilityLabel}

--- a/src/components/RadioButton/RadioButtonAndroid.tsx
+++ b/src/components/RadioButton/RadioButtonAndroid.tsx
@@ -142,11 +142,6 @@ const RadioButtonAndroid = ({
                     });
                   }
             }
-            // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
-            accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
-            accessibilityComponentType={
-              checked ? 'radiobutton_checked' : 'radiobutton_unchecked'
-            }
             accessibilityRole="radio"
             accessibilityState={{ disabled, checked }}
             accessibilityLiveRegion="polite"

--- a/src/components/RadioButton/RadioButtonIOS.tsx
+++ b/src/components/RadioButton/RadioButtonIOS.tsx
@@ -96,11 +96,6 @@ const RadioButtonIOS = ({
                     });
                   }
             }
-            // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
-            accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
-            accessibilityComponentType={
-              checked ? 'radiobutton_checked' : 'radiobutton_unchecked'
-            }
             accessibilityRole="radio"
             accessibilityState={{ disabled, checked }}
             accessibilityLiveRegion="polite"

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -178,9 +178,6 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
         {...(theme.isV3 && { elevation })}
       >
         <IconButton
-          // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
-          accessibilityTraits="button"
-          accessibilityComponentType="button"
           accessibilityRole="button"
           borderless
           rippleColor={rippleColor}
@@ -217,8 +214,6 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
           underlineColorAndroid="transparent"
           returnKeyType="search"
           keyboardAppearance={dark ? 'dark' : 'light'}
-          // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
-          accessibilityTraits="search"
           accessibilityRole="search"
           ref={root}
           value={value}
@@ -242,9 +237,6 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
               />
             ))
           }
-          // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
-          accessibilityTraits="button"
-          accessibilityComponentType="button"
           accessibilityRole="button"
         />
       </Surface>

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
@@ -120,7 +120,6 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
     </View>
     <TextInput
       accessibilityRole="search"
-      accessibilityTraits="search"
       allowFontScaling={true}
       keyboardAppearance="light"
       placeholder="Search"
@@ -418,7 +417,6 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
   >
     <Text
       accessibilityRole="header"
-      accessibilityTraits="header"
       accessible={true}
       numberOfLines={1}
       style={

--- a/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
@@ -101,7 +101,6 @@ exports[`renders with placeholder 1`] = `
   </View>
   <TextInput
     accessibilityRole="search"
-    accessibilityTraits="search"
     allowFontScaling={true}
     keyboardAppearance="light"
     placeholder="Search"
@@ -314,7 +313,6 @@ exports[`renders with text 1`] = `
   </View>
   <TextInput
     accessibilityRole="search"
-    accessibilityTraits="search"
     allowFontScaling={true}
     keyboardAppearance="light"
     placeholder="Search"


### PR DESCRIPTION
### Summary
`accessibilityTraits` and `accessibilityComponentType`  were deprecated and removed.

Resolve #2442