### PR TITLE
fix: use correct credentials for publishing example app on merge to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,8 +20,8 @@ jobs:
         uses: expo/expo-github-action@v5
         with:
           expo-version: 3.x
-          expo-username: ${{ secrets.EXPO_CLI_USERNAME }}
-          expo-password: ${{ secrets.EXPO_CLI_PASSWORD }}
+          expo-username: ${{ secrets.EXPO_CLI_USERNAME_PAPER }}
+          expo-password: ${{ secrets.EXPO_CLI_PASSWORD_PAPER }}
           expo-cache: true
 
       - name: Get yarn cache


### PR DESCRIPTION
### Summary

Currently, publishing an example app on merge to main doesn't work cause wrong credentials are used in the GitHub action.

### Test plan

Merge the PR and check if the app is published successfully..
