### PR TITLE
feat: add prop right to DrawerItem

### DIFF
--- a/example/src/DrawerItems.tsx
+++ b/example/src/DrawerItems.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { View, StyleSheet, Platform } from 'react-native';
 import {
+  Badge,
   Drawer,
   Switch,
   TouchableRipple,
@@ -18,7 +19,18 @@ type Props = {
 
 const DrawerItemsData = [
   { label: 'Inbox', icon: 'inbox', key: 0 },
-  { label: 'Starred', icon: 'star', key: 1 },
+  {
+    label: 'Starred',
+    icon: 'star',
+    key: 1,
+    right: ({ color }: { color: string }) => (
+      <Badge
+        visible
+        size={8}
+        style={[styles.badge, { backgroundColor: color }]}
+      />
+    ),
+  },
   { label: 'Sent mail', icon: 'send', key: 2 },
   { label: 'Colored label', icon: 'palette', key: 3 },
   { label: 'A very long title that will be truncated', icon: 'delete', key: 4 },
@@ -81,6 +93,9 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     paddingVertical: 12,
     paddingHorizontal: 16,
+  },
+  badge: {
+    alignSelf: 'center',
   },
 });
 

--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -27,6 +27,10 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
    * Accessibility label for the button. This is read by the screen reader when the user taps the button.
    */
   accessibilityLabel?: string;
+  /**
+   * Callback which returns a React element to display on the right side. For instance a Badge.
+   */
+  right?: (props: { color: string }) => React.ReactNode;
   style?: StyleProp<ViewStyle>;
   /**
    * @optional
@@ -67,6 +71,7 @@ const DrawerItem = ({
   style,
   onPress,
   accessibilityLabel,
+  right,
   ...rest
 }: Props) => {
   const { colors, roundness } = theme;
@@ -101,21 +106,26 @@ const DrawerItem = ({
         accessibilityLabel={accessibilityLabel}
       >
         <View style={styles.wrapper}>
-          {icon ? <Icon source={icon} size={24} color={contentColor} /> : null}
-          <Text
-            selectable={false}
-            numberOfLines={1}
-            style={[
-              styles.label,
-              {
-                color: contentColor,
-                ...font,
-                marginLeft: labelMargin,
-              },
-            ]}
-          >
-            {label}
-          </Text>
+          <View style={styles.content}>
+            {icon ? (
+              <Icon source={icon} size={24} color={contentColor} />
+            ) : null}
+            <Text
+              selectable={false}
+              numberOfLines={1}
+              style={[
+                styles.label,
+                {
+                  color: contentColor,
+                  ...font,
+                  marginLeft: labelMargin,
+                },
+              ]}
+            >
+              {label}
+            </Text>
+          </View>
+          {right?.({ color: contentColor })}
         </View>
       </TouchableRipple>
     </View>
@@ -133,6 +143,10 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     padding: 8,
+  },
+  content: {
+    flex: 1,
+    flexDirection: 'row',
   },
   label: {
     marginRight: 32,

--- a/src/components/__tests__/__snapshots__/DrawerItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DrawerItem.test.js.snap
@@ -52,71 +52,80 @@ exports[`renders DrawerItem with icon 1`] = `
         }
       }
     >
-      <Text
-        accessibilityElementsHidden={true}
-        allowFontScaling={false}
-        importantForAccessibility="no-hide-descendants"
-        pointerEvents="none"
-        selectable={false}
+      <View
         style={
-          Array [
-            Object {
-              "color": "rgba(0, 0, 0, 0.68)",
-              "fontSize": 24,
-            },
-            Array [
-              Object {
-                "lineHeight": 24,
-                "transform": Array [
-                  Object {
-                    "scaleX": 1,
-                  },
-                ],
-              },
-              Object {
-                "backgroundColor": "transparent",
-              },
-            ],
-            Object {
-              "fontFamily": "Material Design Icons",
-              "fontStyle": "normal",
-              "fontWeight": "normal",
-            },
-            Object {},
-          ]
+          Object {
+            "flex": 1,
+            "flexDirection": "row",
+          }
         }
       >
-        
-      </Text>
-      <Text
-        numberOfLines={1}
-        selectable={false}
-        style={
-          Array [
-            Object {
-              "color": "#000000",
-              "fontFamily": "System",
-              "fontWeight": "400",
-            },
-            Object {
-              "textAlign": "left",
-            },
+        <Text
+          accessibilityElementsHidden={true}
+          allowFontScaling={false}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
             Array [
-              Object {
-                "marginRight": 32,
-              },
               Object {
                 "color": "rgba(0, 0, 0, 0.68)",
-                "fontFamily": "System",
-                "fontWeight": "500",
-                "marginLeft": 32,
+                "fontSize": 24,
               },
-            ],
-          ]
-        }
-      >
-        Example item
-      </Text>
+              Array [
+                Object {
+                  "lineHeight": 24,
+                  "transform": Array [
+                    Object {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                Object {
+                  "backgroundColor": "transparent",
+                },
+              ],
+              Object {
+                "fontFamily": "Material Design Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          
+        </Text>
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "color": "#000000",
+                "fontFamily": "System",
+                "fontWeight": "400",
+              },
+              Object {
+                "textAlign": "left",
+              },
+              Array [
+                Object {
+                  "marginRight": 32,
+                },
+                Object {
+                  "color": "rgba(0, 0, 0, 0.68)",
+                  "fontFamily": "System",
+                  "fontWeight": "500",
+                  "marginLeft": 32,
+                },
+              ],
+            ]
+          }
+        >
+          Example item
+        </Text>
+      </View>
     </View>
   </View>
 </View>
@@ -174,71 +183,80 @@ exports[`renders active DrawerItem 1`] = `
         }
       }
     >
-      <Text
-        accessibilityElementsHidden={true}
-        allowFontScaling={false}
-        importantForAccessibility="no-hide-descendants"
-        pointerEvents="none"
-        selectable={false}
+      <View
         style={
-          Array [
-            Object {
-              "color": "#6200ee",
-              "fontSize": 24,
-            },
-            Array [
-              Object {
-                "lineHeight": 24,
-                "transform": Array [
-                  Object {
-                    "scaleX": 1,
-                  },
-                ],
-              },
-              Object {
-                "backgroundColor": "transparent",
-              },
-            ],
-            Object {
-              "fontFamily": "Material Design Icons",
-              "fontStyle": "normal",
-              "fontWeight": "normal",
-            },
-            Object {},
-          ]
+          Object {
+            "flex": 1,
+            "flexDirection": "row",
+          }
         }
       >
-        
-      </Text>
-      <Text
-        numberOfLines={1}
-        selectable={false}
-        style={
-          Array [
-            Object {
-              "color": "#000000",
-              "fontFamily": "System",
-              "fontWeight": "400",
-            },
-            Object {
-              "textAlign": "left",
-            },
+        <Text
+          accessibilityElementsHidden={true}
+          allowFontScaling={false}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
             Array [
-              Object {
-                "marginRight": 32,
-              },
               Object {
                 "color": "#6200ee",
-                "fontFamily": "System",
-                "fontWeight": "500",
-                "marginLeft": 32,
+                "fontSize": 24,
               },
-            ],
-          ]
-        }
-      >
-        Example item
-      </Text>
+              Array [
+                Object {
+                  "lineHeight": 24,
+                  "transform": Array [
+                    Object {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                Object {
+                  "backgroundColor": "transparent",
+                },
+              ],
+              Object {
+                "fontFamily": "Material Design Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          
+        </Text>
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "color": "#000000",
+                "fontFamily": "System",
+                "fontWeight": "400",
+              },
+              Object {
+                "textAlign": "left",
+              },
+              Array [
+                Object {
+                  "marginRight": 32,
+                },
+                Object {
+                  "color": "#6200ee",
+                  "fontFamily": "System",
+                  "fontWeight": "500",
+                  "marginLeft": 32,
+                },
+              ],
+            ]
+          }
+        >
+          Example item
+        </Text>
+      </View>
     </View>
   </View>
 </View>
@@ -296,35 +314,44 @@ exports[`renders basic DrawerItem 1`] = `
         }
       }
     >
-      <Text
-        numberOfLines={1}
-        selectable={false}
+      <View
         style={
-          Array [
-            Object {
-              "color": "#000000",
-              "fontFamily": "System",
-              "fontWeight": "400",
-            },
-            Object {
-              "textAlign": "left",
-            },
-            Array [
-              Object {
-                "marginRight": 32,
-              },
-              Object {
-                "color": "rgba(0, 0, 0, 0.68)",
-                "fontFamily": "System",
-                "fontWeight": "500",
-                "marginLeft": 0,
-              },
-            ],
-          ]
+          Object {
+            "flex": 1,
+            "flexDirection": "row",
+          }
         }
       >
-        Example item
-      </Text>
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "color": "#000000",
+                "fontFamily": "System",
+                "fontWeight": "400",
+              },
+              Object {
+                "textAlign": "left",
+              },
+              Array [
+                Object {
+                  "marginRight": 32,
+                },
+                Object {
+                  "color": "rgba(0, 0, 0, 0.68)",
+                  "fontFamily": "System",
+                  "fontWeight": "500",
+                  "marginLeft": 0,
+                },
+              ],
+            ]
+          }
+        >
+          Example item
+        </Text>
+      </View>
     </View>
   </View>
 </View>


### PR DESCRIPTION
### Summary
It would be nice to be able to render a badge or chip in the Drawer.Item

### Test plan
1. Open the example app and see the Drawer.Item using a badge

![example](https://user-images.githubusercontent.com/6487206/104540868-23c3fb80-55ff-11eb-9a47-f3935de1040f.jpeg)

