### PR TITLE
feat: add card mode outlined

### DIFF
--- a/example/src/Examples/CardExample.tsx
+++ b/example/src/Examples/CardExample.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Alert, ScrollView, StyleSheet } from 'react-native';
+import { Alert, ScrollView, StyleSheet, View } from 'react-native';
 import {
   Avatar,
   Paragraph,
@@ -7,98 +7,120 @@ import {
   Button,
   IconButton,
   useTheme,
+  Text,
+  Switch,
 } from 'react-native-paper';
 
 const CardExample = () => {
   const {
     colors: { background },
   } = useTheme();
+  const [isOutlined, setIsOutlined] = React.useState(false);
+  const mode = isOutlined ? 'outlined' : 'elevated';
 
   return (
-    <ScrollView
-      style={[styles.container, { backgroundColor: background }]}
-      contentContainerStyle={styles.content}
-    >
-      <Card style={styles.card}>
-        <Card.Cover source={require('../../assets/images/wrecked-ship.jpg')} />
-        <Card.Title title="Abandoned Ship" />
-        <Card.Content>
-          <Paragraph>
-            The Abandoned Ship is a wrecked ship located on Route 108 in Hoenn,
-            originally being a ship named the S.S. Cactus. The second part of
-            the ship can only be accessed by using Dive and contains the
-            Scanner.
-          </Paragraph>
-        </Card.Content>
-      </Card>
-      <Card style={styles.card}>
-        <Card.Cover source={require('../../assets/images/forest.jpg')} />
-        <Card.Actions>
-          <Button onPress={() => {}}>Share</Button>
-          <Button onPress={() => {}}>Explore</Button>
-        </Card.Actions>
-      </Card>
-      <Card style={styles.card}>
-        <Card.Title
-          title="Berries that are trimmed at the end"
-          subtitle="Omega Ruby"
-          left={(props: any) => <Avatar.Icon {...props} icon="folder" />}
-          right={(props: any) => (
-            <IconButton {...props} icon="dots-vertical" onPress={() => {}} />
-          )}
+    <View style={[styles.container, { backgroundColor: background }]}>
+      <View style={styles.preference}>
+        <Text>Outlined</Text>
+        <Switch
+          value={isOutlined}
+          onValueChange={() =>
+            setIsOutlined((prevIsOutlined) => !prevIsOutlined)
+          }
         />
-        <Card.Content>
-          <Paragraph>
-            Dotted around the Hoenn region, you will find loamy soil, many of
-            which are housing berries. Once you have picked the berries, then
-            you have the ability to use that loamy soil to grow your own
-            berries. These can be any berry and will require attention to get
-            the best crop.
-          </Paragraph>
-        </Card.Content>
-      </Card>
-      <Card style={styles.card}>
-        <Card.Cover source={require('../../assets/images/strawberries.jpg')} />
-        <Card.Title
-          title="Just Strawberries"
-          subtitle="... and only Strawberries"
-          right={(props: any) => (
-            <IconButton {...props} icon="chevron-down" onPress={() => {}} />
-          )}
-        />
-      </Card>
-      <Card
-        style={styles.card}
-        onPress={() => {
-          Alert.alert('The Chameleon is Pressed');
-        }}
+      </View>
+      <ScrollView
+        style={[styles.container, { backgroundColor: background }]}
+        contentContainerStyle={styles.content}
       >
-        <Card.Cover source={require('../../assets/images/chameleon.jpg')} />
-        <Card.Title title="Pressable Chameleon" />
-        <Card.Content>
-          <Paragraph>
-            This is a pressable chameleon. If you press me, I will alert.
-          </Paragraph>
-        </Card.Content>
-      </Card>
-      <Card
-        style={styles.card}
-        onLongPress={() => {
-          Alert.alert('The City is Long Pressed');
-        }}
-      >
-        <Card.Cover source={require('../../assets/images/city.jpg')} />
-        <Card.Title
-          title="Long Pressable City"
-          left={(props) => <Avatar.Icon {...props} icon="city" />}
-        />
-        <Card.Content>
-          <Paragraph>
-            This is a long press only city. If you long press me, I will alert.
-          </Paragraph>
-        </Card.Content>
-      </Card>
-    </ScrollView>
+        <Card style={styles.card} mode={mode}>
+          <Card.Cover
+            source={require('../../assets/images/wrecked-ship.jpg')}
+          />
+          <Card.Title title="Abandoned Ship" />
+          <Card.Content>
+            <Paragraph>
+              The Abandoned Ship is a wrecked ship located on Route 108 in
+              Hoenn, originally being a ship named the S.S. Cactus. The second
+              part of the ship can only be accessed by using Dive and contains
+              the Scanner.
+            </Paragraph>
+          </Card.Content>
+        </Card>
+        <Card style={styles.card} mode={mode}>
+          <Card.Cover source={require('../../assets/images/forest.jpg')} />
+          <Card.Actions>
+            <Button onPress={() => {}}>Share</Button>
+            <Button onPress={() => {}}>Explore</Button>
+          </Card.Actions>
+        </Card>
+        <Card style={styles.card} mode={mode}>
+          <Card.Title
+            title="Berries that are trimmed at the end"
+            subtitle="Omega Ruby"
+            left={(props: any) => <Avatar.Icon {...props} icon="folder" />}
+            right={(props: any) => (
+              <IconButton {...props} icon="dots-vertical" onPress={() => {}} />
+            )}
+          />
+          <Card.Content>
+            <Paragraph>
+              Dotted around the Hoenn region, you will find loamy soil, many of
+              which are housing berries. Once you have picked the berries, then
+              you have the ability to use that loamy soil to grow your own
+              berries. These can be any berry and will require attention to get
+              the best crop.
+            </Paragraph>
+          </Card.Content>
+        </Card>
+        <Card style={styles.card} mode={mode}>
+          <Card.Cover
+            source={require('../../assets/images/strawberries.jpg')}
+          />
+          <Card.Title
+            title="Just Strawberries"
+            subtitle="... and only Strawberries"
+            right={(props: any) => (
+              <IconButton {...props} icon="chevron-down" onPress={() => {}} />
+            )}
+          />
+        </Card>
+        <Card
+          style={styles.card}
+          onPress={() => {
+            Alert.alert('The Chameleon is Pressed');
+          }}
+          mode={mode}
+        >
+          <Card.Cover source={require('../../assets/images/chameleon.jpg')} />
+          <Card.Title title="Pressable Chameleon" />
+          <Card.Content>
+            <Paragraph>
+              This is a pressable chameleon. If you press me, I will alert.
+            </Paragraph>
+          </Card.Content>
+        </Card>
+        <Card
+          style={styles.card}
+          onLongPress={() => {
+            Alert.alert('The City is Long Pressed');
+          }}
+          mode={mode}
+        >
+          <Card.Cover source={require('../../assets/images/city.jpg')} />
+          <Card.Title
+            title="Long Pressable City"
+            left={(props) => <Avatar.Icon {...props} icon="city" />}
+          />
+          <Card.Content>
+            <Paragraph>
+              This is a long press only city. If you long press me, I will
+              alert.
+            </Paragraph>
+          </Card.Content>
+        </Card>
+      </ScrollView>
+    </View>
   );
 };
 
@@ -113,6 +135,12 @@ const styles = StyleSheet.create({
   },
   card: {
     margin: 4,
+  },
+  preference: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    paddingVertical: 12,
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@callstack/react-theme-provider": "^3.0.5",
+    "@callstack/react-theme-provider": "^3.0.6",
     "color": "^3.1.2",
     "react-native-iphone-x-helper": "^1.3.1"
   },

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -7,6 +7,8 @@ import {
   View,
   ViewStyle,
 } from 'react-native';
+import color from 'color';
+import { white, black } from '../../styles/colors';
 import CardContent from './CardContent';
 import CardActions from './CardActions';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -16,11 +18,21 @@ import CardTitle, { CardTitle as _CardTitle } from './CardTitle';
 import Surface from '../Surface';
 import { withTheme } from '../../core/theming';
 
+type OutlinedCardProps = {
+  mode: 'outlined';
+  elevation?: never;
+};
+
+type ElevatedCardProps = {
+  mode?: 'elevated';
+  elevation?: number;
+};
+
 type Props = React.ComponentProps<typeof Surface> & {
   /**
    * Resting elevation of the card which controls the drop shadow.
    */
-  elevation?: number;
+  elevation?: never | number;
   /**
    * Function to execute on long press.
    */
@@ -29,6 +41,12 @@ type Props = React.ComponentProps<typeof Surface> & {
    * Function to execute on press.
    */
   onPress?: () => void;
+  /**
+   * Mode of the Card.
+   * - `elevated` - Card with elevation.
+   * - `outlined` - Card with an outline.
+   */
+  mode?: 'elevated' | 'outlined';
   /**
    * Content of the `Card`.
    */
@@ -85,16 +103,18 @@ const Card = ({
   elevation: cardElevation = 1,
   onLongPress,
   onPress,
+  mode: cardMode = 'elevated',
   children,
   style,
   theme,
   testID,
   accessible,
   ...rest
-}: Props) => {
+}: (OutlinedCardProps | ElevatedCardProps) & Props) => {
   const { current: elevation } = React.useRef<Animated.Value>(
     new Animated.Value(cardElevation)
   );
+  const { animation, dark, mode, roundness } = theme;
 
   const handlePressIn = () => {
     const {
@@ -110,27 +130,33 @@ const Card = ({
   };
 
   const handlePressOut = () => {
-    const {
-      dark,
-      mode,
-      animation: { scale },
-    } = theme;
     Animated.timing(elevation, {
       toValue: cardElevation,
-      duration: 150 * scale,
+      duration: 150 * animation.scale,
       useNativeDriver: !dark || mode === 'exact',
     }).start();
   };
 
-  const { roundness } = theme;
   const total = React.Children.count(children);
   const siblings = React.Children.map(children, (child) =>
     React.isValidElement(child) && child.type
       ? (child.type as any).displayName
       : null
   );
+  const borderColor = color(theme.dark ? white : black)
+    .alpha(0.12)
+    .rgb()
+    .string();
+
   return (
-    <Surface style={[{ borderRadius: roundness, elevation }, style]} {...rest}>
+    <Surface
+      style={[
+        { borderRadius: roundness, elevation, borderColor },
+        cardMode === 'outlined' ? styles.outlined : {},
+        style,
+      ]}
+      {...rest}
+    >
       <TouchableWithoutFeedback
         delayPressIn={0}
         disabled={!(onPress || onLongPress)}
@@ -170,6 +196,10 @@ const styles = StyleSheet.create({
   innerContainer: {
     flexGrow: 1,
     flexShrink: 1,
+  },
+  outlined: {
+    elevation: 0,
+    borderWidth: 1,
   },
 });
 

--- a/src/components/__tests__/Card/Card.test.js
+++ b/src/components/__tests__/Card/Card.test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Card from '../../Card/Card';
+
+describe('Card', () => {
+  it('renders an outlined card', () => {
+    const tree = renderer.create(<Card mode="outlined" />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/__tests__/Card/__snapshots__/Card.test.js.snap
+++ b/src/components/__tests__/Card/__snapshots__/Card.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Card renders an outlined card 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#ffffff",
+      "borderColor": "rgba(0, 0, 0, 0.12)",
+      "borderRadius": 4,
+      "borderWidth": 1,
+      "elevation": 0,
+    }
+  }
+>
+  <View
+    accessible={true}
+    focusable={false}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "flexGrow": 1,
+        "flexShrink": 1,
+      }
+    }
+  />
+</View>
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,10 +1806,10 @@
     eslint-restricted-globals "^0.2.0"
     prettier "^1.19.1"
 
-"@callstack/react-theme-provider@^3.0.5":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@callstack/react-theme-provider/-/react-theme-provider-3.0.5.tgz#a173e455e9603c9c45357a3b6ace1273086527ca"
-  integrity sha512-Iec+ybWN0FvNj87sD3oWo/49edGUP0UOSdMnzCJEFJIDYr992ECIuOV89burAAh2/ibPCxgLiK6dmgv2mO/8Tg==
+"@callstack/react-theme-provider@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@callstack/react-theme-provider/-/react-theme-provider-3.0.6.tgz#7dac483037e27e28676bdf1431ba87b88f21118f"
+  integrity sha512-wwKMXfmklfogpalNZT0W+jh76BIquiYUiQHOaPmt/PCyCEP/E6rP+e7Uie6mBZrfkea9WJYJ+mus6r+45JAEhg==
   dependencies:
     deepmerge "^3.2.0"
     hoist-non-react-statics "^3.3.0"


### PR DESCRIPTION
### Summary
Implement MD outlined card.

https://material.io/components/cards

Elevated | Outlined
--- | ---
![light-elevated](https://user-images.githubusercontent.com/6487206/115811833-d2c65f00-a3c6-11eb-915b-801132b9d9a0.jpeg) | ![light-outlined](https://user-images.githubusercontent.com/6487206/115811839-d659e600-a3c6-11eb-9ef1-62ad1e1775e8.jpeg)

Elevated | Outlined
--- | ---
![dark-elevated](https://user-images.githubusercontent.com/6487206/115811935-fbe6ef80-a3c6-11eb-8b1b-6570fb0e82c1.jpeg) | ![dark-outlined](https://user-images.githubusercontent.com/6487206/115811951-ff7a7680-a3c6-11eb-8b1b-75d8afec1bb3.jpeg)

### Test plan
1. Open the example app
2. Check the example showing an outlined card

