### PR TITLE
feat: set default cursor for TouchableRipple to 'pointer'

### DIFF
--- a/src/components/TouchableRipple/TouchableRipple.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.tsx
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   StyleProp,
   GestureResponderEvent,
+  Platform,
 } from 'react-native';
 import color from 'color';
 import { withTheme } from '../../core/theming';
@@ -253,6 +254,7 @@ TouchableRipple.supported = true;
 const styles = StyleSheet.create({
   touchable: {
     position: 'relative',
+    ...(Platform.OS === 'web' && { cursor: 'pointer' }),
   },
   borderless: {
     overflow: 'hidden',


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
While I was working on client's app code I've come to a realisation that in every place where Paper's `<TouchableRipple />` component was used we needed to pass additional style to ensure pointer cursor on the web. After some digging I've found that it's caused because TouchabeRipple is using `<TouchableWithoutFeedback />` under the hood and based on this: https://github.com/necolas/react-native-web/issues/1847#issuecomment-747625960 that's exactly what's causing react-native-web to NOT "inject" `cursor: 'pointer'` style on the web.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
In the example app:
- [x]  on mobile device/simulator everything should work exactly the same as before this change.

- [x] on the web `<TouchableRipple />` component should have `pointer` cursor

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
