### PR TITLE
chore: fix flat Chip example

### DIFF
--- a/example/src/Examples/ChipExample.tsx
+++ b/example/src/Examples/ChipExample.tsx
@@ -14,12 +14,7 @@ const ChipExample = () => {
       >
         <List.Section title="Flat chip">
           <View style={styles.row}>
-            <Chip
-              mode="outlined"
-              selected
-              onPress={() => {}}
-              style={styles.chip}
-            >
+            <Chip selected onPress={() => {}} style={styles.chip}>
               Simple
             </Chip>
             <Chip


### PR DESCRIPTION
### Summary
The first Chip in the "flat" example is actually outlined instead of flat. This PR fixes that :) 

Before:
![chipbefore](https://user-images.githubusercontent.com/28541613/105255518-073a3d00-5b84-11eb-82b4-5d9ad1351013.png)

After:
![chipafter](https://user-images.githubusercontent.com/28541613/105255497-fc7fa800-5b83-11eb-884c-f330069c323e.png)
