### PR TITLE
fix: Searchbar focus()

### DIFF
--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -125,11 +125,11 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
 
       if (input) {
         return {
-          focus: input.focus,
-          clear: input.clear,
+          focus: () => input.focus(),
+          clear: () => input.clear(),
           setNativeProps: (args: TextInputProps) => input.setNativeProps(args),
-          isFocused: input.isFocused,
-          blur: input.blur,
+          isFocused: () => input.isFocused(),
+          blur: () => input.blur(),
         };
       }
 


### PR DESCRIPTION
Closes #2393; Closes #2394

### Summary

For some reason, returning the reference to underlying method raises `dispatchCommand was called with a ref that isn't a native component` error and doesn't actually focus the input.

Returning new proxy method works as expected (and allows us to remove @ts-ignore too).

### Test plan

Not sure about testing, just wanted to get things moving.