### PR TITLE
fix: upgrade ts types to latest version

### DIFF
--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -98,7 +98,7 @@ const TextInputExample = () => {
     colors: { background, accent },
   } = useTheme();
 
-  const inputActionHandler = (type: string, payload: string) =>
+  const inputActionHandler = (type: keyof State, payload: string) =>
     dispatch({
       type: type,
       payload: payload,

--- a/example/utils/index.ts
+++ b/example/utils/index.ts
@@ -1,6 +1,6 @@
-type ReducerAction = {
-  payload: string | boolean | IconsColor;
-  type: string;
+type ReducerAction<T extends keyof State> = {
+  payload: State[T];
+  type: T;
 };
 
 type IconsColor = {
@@ -35,10 +35,12 @@ export type State = {
   iconsColor: IconsColor;
 };
 
-export function inputReducer(state: State, action: ReducerAction) {
+export function inputReducer<T extends keyof State>(
+  state: State,
+  action: ReducerAction<T>
+) {
   switch (action.type) {
     case action.type:
-      //@ts-ignore
       state[action.type] = action.payload;
       return { ...state };
     default:

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/jest": "^24.0.13",
     "@types/node": "^13.1.0",
     "@types/react-dom": "^16.8.4",
-    "@types/react-native": "^0.62.0",
+    "@types/react-native": "^0.63.0",
     "@types/react-native-vector-icons": "^6.4.1",
     "@typescript-eslint/eslint-plugin": "^2.12.0",
     "@typescript-eslint/parser": "^2.12.0",

--- a/src/components/ActivityIndicator.tsx
+++ b/src/components/ActivityIndicator.tsx
@@ -146,7 +146,7 @@ const ActivityIndicator = ({
   const containerStyle = {
     width: size,
     height: size / 2,
-    overflow: 'hidden' as ViewStyle['overflow'],
+    overflow: 'hidden' as const,
   };
 
   return (

--- a/src/components/ActivityIndicator.tsx
+++ b/src/components/ActivityIndicator.tsx
@@ -146,7 +146,7 @@ const ActivityIndicator = ({
   const containerStyle = {
     width: size,
     height: size / 2,
-    overflow: 'hidden',
+    overflow: 'hidden' as ViewStyle['overflow'],
   };
 
   return (

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -94,8 +94,9 @@ const Appbar = ({ children, dark, style, theme, ...rest }: Props) => {
     isDark =
       backgroundColor === 'transparent'
         ? false
-        : // @ts-ignore
-          !color(backgroundColor).isLight();
+        : typeof backgroundColor === 'string'
+        ? !color(backgroundColor).isLight()
+        : true;
   }
 
   let shouldCenterContent = false;
@@ -125,7 +126,6 @@ const Appbar = ({ children, dark, style, theme, ...rest }: Props) => {
   }
   return (
     <Surface
-      //@ts-ignore Types of property 'backgroundColor' are incompatible.
       style={[{ backgroundColor }, styles.appbar, { elevation }, restStyle]}
       {...rest}
     >
@@ -135,12 +135,10 @@ const Appbar = ({ children, dark, style, theme, ...rest }: Props) => {
         .map((child, i) => {
           if (
             !React.isValidElement(child) ||
-            ![
-              AppbarContent,
-              AppbarAction,
-              AppbarBackAction,
-              // @ts-ignore Type 'string' is not assignable to type
-            ].includes(child.type)
+            ![AppbarContent, AppbarAction, AppbarBackAction].includes(
+              // @ts-expect-error: TypeScript complains about the type of type but it doesn't matter
+              child.type
+            )
           ) {
             return child;
           }

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -94,7 +94,8 @@ const Appbar = ({ children, dark, style, theme, ...rest }: Props) => {
     isDark =
       backgroundColor === 'transparent'
         ? false
-        : !color(backgroundColor).isLight();
+        : // @ts-ignore
+          !color(backgroundColor).isLight();
   }
 
   let shouldCenterContent = false;

--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -108,7 +108,7 @@ const AppbarContent = ({
           numberOfLines={1}
           accessible
           accessibilityTraits="header"
-          // @ts-ignore Type '"heading"' is not assignable to type ...
+          // @ts-expect-error React Native doesn't accept 'heading' as it's web-only
           accessibilityRole={Platform.OS === 'web' ? 'heading' : 'header'}
         >
           {title}

--- a/src/components/Appbar/AppbarHeader.tsx
+++ b/src/components/Appbar/AppbarHeader.tsx
@@ -111,7 +111,6 @@ const AppbarHeader = (props: Props) => {
     >
       <Appbar
         style={[
-          //@ts-ignore Types of property 'backgroundColor' are incompatible.
           { height, backgroundColor, marginTop: statusBarHeight },
           styles.appbar,
           restStyle,

--- a/src/components/Avatar/AvatarIcon.tsx
+++ b/src/components/Avatar/AvatarIcon.tsx
@@ -52,7 +52,7 @@ const Avatar = ({ icon, size = defaultSize, style, theme, ...rest }: Props) => {
     StyleSheet.flatten(style) || {};
   const textColor =
     rest.color ||
-    (color(backgroundColor).isLight() ? 'rgba(0, 0, 0, .54)' : white);
+    (color(backgroundColor as string).isLight() ? 'rgba(0, 0, 0, .54)' : white);
 
   return (
     <View

--- a/src/components/Avatar/AvatarIcon.tsx
+++ b/src/components/Avatar/AvatarIcon.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import { View, ViewStyle, StyleSheet, StyleProp } from 'react-native';
-import color from 'color';
-import Icon from '../Icon';
+import Icon, { IconSource } from '../Icon';
 import { withTheme } from '../../core/theming';
 import { white } from '../../styles/colors';
-import type { IconSource } from './../Icon';
+import getContrastingColor from '../../utils/getContrastingColor';
 
 const defaultSize = 64;
 
@@ -51,8 +50,8 @@ const Avatar = ({ icon, size = defaultSize, style, theme, ...rest }: Props) => {
   const { backgroundColor = theme.colors.primary, ...restStyle } =
     StyleSheet.flatten(style) || {};
   const textColor =
-    rest.color ||
-    (color(backgroundColor as string).isLight() ? 'rgba(0, 0, 0, .54)' : white);
+    rest.color ??
+    getContrastingColor(backgroundColor, white, 'rgba(0, 0, 0, .54)');
 
   return (
     <View

--- a/src/components/Avatar/AvatarText.tsx
+++ b/src/components/Avatar/AvatarText.tsx
@@ -71,7 +71,8 @@ const AvatarText = ({
   const { backgroundColor = theme.colors.primary, ...restStyle } =
     StyleSheet.flatten(style) || {};
   const textColor =
-    color || (Color(backgroundColor).isLight() ? 'rgba(0, 0, 0, .54)' : white);
+    color ||
+    (Color(backgroundColor as string).isLight() ? 'rgba(0, 0, 0, .54)' : white);
 
   return (
     <View

--- a/src/components/Avatar/AvatarText.tsx
+++ b/src/components/Avatar/AvatarText.tsx
@@ -6,10 +6,10 @@ import {
   StyleProp,
   TextStyle,
 } from 'react-native';
-import Color from 'color';
 import Text from '../Typography/Text';
 import { withTheme } from '../../core/theming';
 import { white } from '../../styles/colors';
+import getContrastingColor from '../../utils/getContrastingColor';
 
 const defaultSize = 64;
 
@@ -65,14 +65,14 @@ const AvatarText = ({
   style,
   theme,
   labelStyle,
-  color,
+  color: customColor,
   ...rest
 }: Props) => {
   const { backgroundColor = theme.colors.primary, ...restStyle } =
     StyleSheet.flatten(style) || {};
   const textColor =
-    color ||
-    (Color(backgroundColor as string).isLight() ? 'rgba(0, 0, 0, .54)' : white);
+    customColor ??
+    getContrastingColor(backgroundColor, white, 'rgba(0, 0, 0, .54)');
 
   return (
     <View

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { Animated, StyleSheet, StyleProp, TextStyle } from 'react-native';
-import color from 'color';
-import { black, white } from '../styles/colors';
+import { white, black } from '../styles/colors';
 import { withTheme } from '../core/theming';
+import getContrastingColor from '../utils/getContrastingColor';
 
 const defaultSize = 20;
 
@@ -85,10 +85,12 @@ const Badge = ({
     }).start();
   }, [visible, opacity, scale]);
 
-  // @ts-ignore
-  const { backgroundColor = theme.colors.notification, ...restStyle } =
-    StyleSheet.flatten(style) || {};
-  const textColor = color(backgroundColor).isLight() ? black : white;
+  const {
+    backgroundColor = theme.colors.notification,
+    ...restStyle
+  } = (StyleSheet.flatten(style) || {}) as TextStyle;
+
+  const textColor = getContrastingColor(backgroundColor, white, black);
 
   const borderRadius = size / 2;
 

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -85,6 +85,7 @@ const Badge = ({
     }).start();
   }, [visible, opacity, scale]);
 
+  // @ts-ignore
   const { backgroundColor = theme.colors.notification, ...restStyle } =
     StyleSheet.flatten(style) || {};
   const textColor = color(backgroundColor).isLight() ? black : white;
@@ -92,7 +93,6 @@ const Badge = ({
   const borderRadius = size / 2;
 
   return (
-    // @ts-ignore
     <Animated.Text
       numberOfLines={1}
       style={[

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -750,7 +750,7 @@ const BottomNavigation = ({
                 onPress: () => handleTabPress(index),
                 testID: getTestID({ route }),
                 accessibilityLabel: getAccessibilityLabel({ route }),
-                // @ts-ignore
+                // @ts-ignore We keep old a11y props for backwards compat with old RN versions
                 accessibilityTraits: focused
                   ? ['button', 'selected']
                   : 'button',

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -559,14 +559,18 @@ const BottomNavigation = ({
   const backgroundColor = shifting
     ? indexAnim.interpolate({
         inputRange: routes.map((_, i) => i),
-        //@ts-ignore
+        // FIXME: does outputRange support ColorValue or just strings?
+        // @ts-expect-error
         outputRange: routes.map(
           (route) => getColor({ route }) || approxBackgroundColor
         ),
       })
     : approxBackgroundColor;
 
-  const isDark = !color(approxBackgroundColor as string).isLight();
+  const isDark =
+    typeof approxBackgroundColor === 'string'
+      ? !color(approxBackgroundColor).isLight()
+      : true;
 
   const textColor = isDark ? white : black;
   const activeTintColor =
@@ -750,7 +754,7 @@ const BottomNavigation = ({
                 onPress: () => handleTabPress(index),
                 testID: getTestID({ route }),
                 accessibilityLabel: getAccessibilityLabel({ route }),
-                // @ts-ignore We keep old a11y props for backwards compat with old RN versions
+                // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
                 accessibilityTraits: focused
                   ? ['button', 'selected']
                   : 'button',

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -247,6 +247,7 @@ const Touchable = ({
   TouchableRipple.supported ? (
     <TouchableRipple
       {...rest}
+      disabled={rest.disabled || undefined}
       borderless={borderless}
       centered={centered}
       rippleColor={rippleColor}
@@ -565,7 +566,7 @@ const BottomNavigation = ({
       })
     : approxBackgroundColor;
 
-  const isDark = !color(approxBackgroundColor).isLight();
+  const isDark = !color(approxBackgroundColor as string).isLight();
 
   const textColor = isDark ? white : black;
   const activeTintColor =
@@ -749,6 +750,7 @@ const BottomNavigation = ({
                 onPress: () => handleTabPress(index),
                 testID: getTestID({ route }),
                 accessibilityLabel: getAccessibilityLabel({ route }),
+                // @ts-ignore
                 accessibilityTraits: focused
                   ? ['button', 'selected']
                   : 'button',

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -265,6 +265,7 @@ const Button = ({
         onPressIn={handlePressIn}
         onPressOut={handlePressOut}
         accessibilityLabel={accessibilityLabel}
+        // @ts-ignore
         accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
         accessibilityComponentType="button"
         accessibilityRole="button"
@@ -281,14 +282,14 @@ const Button = ({
               <Icon
                 source={icon}
                 size={customLabelSize || 16}
-                color={customLabelColor || textColor}
+                color={(customLabelColor || textColor) as string}
               />
             </View>
           ) : null}
           {loading ? (
             <ActivityIndicator
               size={customLabelSize || 16}
-              color={customLabelColor || textColor}
+              color={(customLabelColor || textColor) as string}
               style={iconStyle}
             />
           ) : null}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -171,7 +171,10 @@ const Button = ({
   const { colors, roundness } = theme;
   const font = theme.fonts.medium;
 
-  let backgroundColor, borderColor, textColor, borderWidth;
+  let backgroundColor: string,
+    borderColor: string,
+    textColor: string,
+    borderWidth: number;
 
   if (mode === 'contained') {
     if (disabled) {
@@ -232,7 +235,8 @@ const Button = ({
   };
   const touchableStyle = {
     borderRadius: style
-      ? StyleSheet.flatten(style).borderRadius || roundness
+      ? ((StyleSheet.flatten(style) || {}) as ViewStyle).borderRadius ||
+        roundness
       : roundness,
   };
 
@@ -265,7 +269,7 @@ const Button = ({
         onPressIn={handlePressIn}
         onPressOut={handlePressOut}
         accessibilityLabel={accessibilityLabel}
-        // @ts-ignore We keep old a11y props for backwards compat with old RN versions
+        // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
         accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
         accessibilityComponentType="button"
         accessibilityRole="button"
@@ -281,15 +285,23 @@ const Button = ({
             <View style={iconStyle}>
               <Icon
                 source={icon}
-                size={customLabelSize || 16}
-                color={(customLabelColor || textColor) as string}
+                size={customLabelSize ?? 16}
+                color={
+                  typeof customLabelColor === 'string'
+                    ? customLabelColor
+                    : textColor
+                }
               />
             </View>
           ) : null}
           {loading ? (
             <ActivityIndicator
-              size={customLabelSize || 16}
-              color={(customLabelColor || textColor) as string}
+              size={customLabelSize ?? 16}
+              color={
+                typeof customLabelColor === 'string'
+                  ? customLabelColor
+                  : textColor
+              }
               style={iconStyle}
             />
           ) : null}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -265,7 +265,7 @@ const Button = ({
         onPressIn={handlePressIn}
         onPressOut={handlePressOut}
         accessibilityLabel={accessibilityLabel}
-        // @ts-ignore
+        // @ts-ignore We keep old a11y props for backwards compat with old RN versions
         accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
         accessibilityComponentType="button"
         accessibilityRole="button"

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -130,11 +130,7 @@ const Card = ({
       : null
   );
   return (
-    <Surface
-      // @ts-ignore
-      style={[{ borderRadius: roundness, elevation }, style]}
-      {...rest}
-    >
+    <Surface style={[{ borderRadius: roundness, elevation }, style]} {...rest}>
       <TouchableWithoutFeedback
         delayPressIn={0}
         disabled={!(onPress || onLongPress)}

--- a/src/components/Checkbox/CheckboxAndroid.tsx
+++ b/src/components/Checkbox/CheckboxAndroid.tsx
@@ -136,7 +136,7 @@ const CheckboxAndroid = ({
       rippleColor={rippleColor}
       onPress={onPress}
       disabled={disabled}
-      // @ts-ignore We keep old a11y props for backwards compat with old RN versions
+      // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
       accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
       accessibilityComponentType="button"
       accessibilityRole="checkbox"

--- a/src/components/Checkbox/CheckboxAndroid.tsx
+++ b/src/components/Checkbox/CheckboxAndroid.tsx
@@ -136,7 +136,7 @@ const CheckboxAndroid = ({
       rippleColor={rippleColor}
       onPress={onPress}
       disabled={disabled}
-      // @ts-ignore
+      // @ts-ignore We keep old a11y props for backwards compat with old RN versions
       accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
       accessibilityComponentType="button"
       accessibilityRole="checkbox"

--- a/src/components/Checkbox/CheckboxAndroid.tsx
+++ b/src/components/Checkbox/CheckboxAndroid.tsx
@@ -136,6 +136,7 @@ const CheckboxAndroid = ({
       rippleColor={rippleColor}
       onPress={onPress}
       disabled={disabled}
+      // @ts-ignore
       accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
       accessibilityComponentType="button"
       accessibilityRole="checkbox"

--- a/src/components/Checkbox/CheckboxIOS.tsx
+++ b/src/components/Checkbox/CheckboxIOS.tsx
@@ -81,7 +81,7 @@ const CheckboxIOS = ({
       rippleColor={rippleColor}
       onPress={onPress}
       disabled={disabled}
-      // @ts-ignore We keep old a11y props for backwards compat with old RN versions
+      // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
       accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
       accessibilityComponentType="button"
       accessibilityRole="checkbox"

--- a/src/components/Checkbox/CheckboxIOS.tsx
+++ b/src/components/Checkbox/CheckboxIOS.tsx
@@ -81,7 +81,7 @@ const CheckboxIOS = ({
       rippleColor={rippleColor}
       onPress={onPress}
       disabled={disabled}
-      // @ts-ignore
+      // @ts-ignore We keep old a11y props for backwards compat with old RN versions
       accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
       accessibilityComponentType="button"
       accessibilityRole="checkbox"

--- a/src/components/Checkbox/CheckboxIOS.tsx
+++ b/src/components/Checkbox/CheckboxIOS.tsx
@@ -81,6 +81,7 @@ const CheckboxIOS = ({
       rippleColor={rippleColor}
       onPress={onPress}
       disabled={disabled}
+      // @ts-ignore
       accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
       accessibilityComponentType="button"
       accessibilityRole="checkbox"

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -249,7 +249,7 @@ const Chip = ({
         underlayColor={underlayColor}
         disabled={disabled}
         accessibilityLabel={accessibilityLabel}
-        // @ts-ignore
+        // @ts-ignore We keep old a11y props for backwards compat with old RN versions
         accessibilityTraits={accessibilityTraits}
         accessibilityComponentType="button"
         accessibilityRole="button"
@@ -312,7 +312,7 @@ const Chip = ({
         <View style={styles.closeButtonStyle}>
           <TouchableWithoutFeedback
             onPress={onClose}
-            // @ts-ignore
+            // @ts-ignore We keep old a11y props for backwards compat with old RN versions
             accessibilityTraits="button"
             accessibilityComponentType="button"
             accessibilityRole="button"

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   AccessibilityState,
+  // @ts-ignore
   AccessibilityTrait,
   Animated,
   Platform,
@@ -195,8 +196,8 @@ const Chip = ({
         .rgb()
         .string();
   const selectedBackgroundColor = (dark
-    ? color(backgroundColor).lighten(mode === 'outlined' ? 0.2 : 0.4)
-    : color(backgroundColor).darken(mode === 'outlined' ? 0.08 : 0.2)
+    ? color(backgroundColor as string).lighten(mode === 'outlined' ? 0.2 : 0.4)
+    : color(backgroundColor as string).darken(mode === 'outlined' ? 0.08 : 0.2)
   )
     .rgb()
     .string();
@@ -248,6 +249,7 @@ const Chip = ({
         underlayColor={underlayColor}
         disabled={disabled}
         accessibilityLabel={accessibilityLabel}
+        // @ts-ignore
         accessibilityTraits={accessibilityTraits}
         accessibilityComponentType="button"
         accessibilityRole="button"
@@ -310,6 +312,7 @@ const Chip = ({
         <View style={styles.closeButtonStyle}>
           <TouchableWithoutFeedback
             onPress={onClose}
+            // @ts-ignore
             accessibilityTraits="button"
             accessibilityComponentType="button"
             accessibilityRole="button"

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import {
   AccessibilityState,
-  // @ts-ignore
-  AccessibilityTrait,
   Animated,
   Platform,
   StyleProp,
@@ -162,15 +160,13 @@ const Chip = ({
   };
 
   const { dark, colors } = theme;
+  const defaultBackgroundColor =
+    mode === 'outlined' ? colors.surface : dark ? '#383838' : '#ebebeb';
 
   const {
-    backgroundColor = mode === 'outlined'
-      ? colors.surface
-      : dark
-      ? '#383838'
-      : '#ebebeb',
+    backgroundColor = defaultBackgroundColor,
     borderRadius = 16,
-  } = StyleSheet.flatten(style) || {};
+  } = (StyleSheet.flatten(style) || {}) as ViewStyle;
 
   const borderColor =
     mode === 'outlined'
@@ -195,9 +191,14 @@ const Chip = ({
         .alpha(0.54)
         .rgb()
         .string();
+
+  const backgroundColorString =
+    typeof backgroundColor === 'string'
+      ? backgroundColor
+      : defaultBackgroundColor;
   const selectedBackgroundColor = (dark
-    ? color(backgroundColor as string).lighten(mode === 'outlined' ? 0.2 : 0.4)
-    : color(backgroundColor as string).darken(mode === 'outlined' ? 0.08 : 0.2)
+    ? color(backgroundColorString).lighten(mode === 'outlined' ? 0.2 : 0.4)
+    : color(backgroundColorString).darken(mode === 'outlined' ? 0.08 : 0.2)
   )
     .rgb()
     .string();
@@ -206,7 +207,7 @@ const Chip = ({
     ? color(selectedColor).fade(0.5).rgb().string()
     : selectedBackgroundColor;
 
-  const accessibilityTraits: AccessibilityTrait[] = ['button'];
+  const accessibilityTraits = ['button'];
   const accessibilityState: AccessibilityState = {
     selected,
     disabled,
@@ -249,7 +250,7 @@ const Chip = ({
         underlayColor={underlayColor}
         disabled={disabled}
         accessibilityLabel={accessibilityLabel}
-        // @ts-ignore We keep old a11y props for backwards compat with old RN versions
+        // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
         accessibilityTraits={accessibilityTraits}
         accessibilityComponentType="button"
         accessibilityRole="button"
@@ -312,7 +313,7 @@ const Chip = ({
         <View style={styles.closeButtonStyle}>
           <TouchableWithoutFeedback
             onPress={onClose}
-            // @ts-ignore We keep old a11y props for backwards compat with old RN versions
+            // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
             accessibilityTraits="button"
             accessibilityComponentType="button"
             accessibilityRole="button"

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -95,7 +95,7 @@ const Dialog = ({
         borderRadius: theme.roundness,
         backgroundColor:
           theme.dark && theme.mode === 'adaptive'
-            ? (overlay(DIALOG_ELEVATION, theme.colors.surface) as string)
+            ? overlay(DIALOG_ELEVATION, theme.colors.surface)
             : theme.colors.surface,
       },
       styles.container,

--- a/src/components/Dialog/DialogTitle.tsx
+++ b/src/components/Dialog/DialogTitle.tsx
@@ -51,7 +51,7 @@ type Props = React.ComponentPropsWithRef<typeof Title> & {
  */
 const DialogTitle = ({ children, theme, style, ...rest }: Props) => (
   <Title
-    // @ts-ignore
+    // @ts-ignore We keep old a11y props for backwards compat with old RN versions
     accessibilityTraits="header"
     accessibilityRole="header"
     style={[styles.text, { color: theme.colors.text }, style]}

--- a/src/components/Dialog/DialogTitle.tsx
+++ b/src/components/Dialog/DialogTitle.tsx
@@ -51,6 +51,7 @@ type Props = React.ComponentPropsWithRef<typeof Title> & {
  */
 const DialogTitle = ({ children, theme, style, ...rest }: Props) => (
   <Title
+    // @ts-ignore
     accessibilityTraits="header"
     accessibilityRole="header"
     style={[styles.text, { color: theme.colors.text }, style]}

--- a/src/components/Dialog/DialogTitle.tsx
+++ b/src/components/Dialog/DialogTitle.tsx
@@ -51,7 +51,7 @@ type Props = React.ComponentPropsWithRef<typeof Title> & {
  */
 const DialogTitle = ({ children, theme, style, ...rest }: Props) => (
   <Title
-    // @ts-ignore We keep old a11y props for backwards compat with old RN versions
+    // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
     accessibilityTraits="header"
     accessibilityRole="header"
     style={[styles.text, { color: theme.colors.text }, style]}

--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -93,6 +93,7 @@ const DrawerItem = ({
         delayPressIn={0}
         onPress={onPress}
         style={{ borderRadius: roundness }}
+        // @ts-ignore
         accessibilityTraits={active ? ['button', 'selected'] : 'button'}
         accessibilityComponentType="button"
         accessibilityRole="button"

--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -93,7 +93,7 @@ const DrawerItem = ({
         delayPressIn={0}
         onPress={onPress}
         style={{ borderRadius: roundness }}
-        // @ts-ignore
+        // @ts-ignore We keep old a11y props for backwards compat with old RN versions
         accessibilityTraits={active ? ['button', 'selected'] : 'button'}
         accessibilityComponentType="button"
         accessibilityRole="button"

--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -93,7 +93,7 @@ const DrawerItem = ({
         delayPressIn={0}
         onPress={onPress}
         style={{ borderRadius: roundness }}
-        // @ts-ignore We keep old a11y props for backwards compat with old RN versions
+        // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
         accessibilityTraits={active ? ['button', 'selected'] : 'button'}
         accessibilityComponentType="button"
         accessibilityRole="button"

--- a/src/components/Drawer/DrawerSection.tsx
+++ b/src/components/Drawer/DrawerSection.tsx
@@ -69,7 +69,7 @@ const DrawerSection = ({ children, title, theme, style, ...rest }: Props) => {
         <View style={styles.titleContainer}>
           <Text
             numberOfLines={1}
-            style={{ color: titleColor, ...font, marginLeft: 16 }}
+            style={[{ color: titleColor, ...font }, styles.title]}
           >
             {title}
           </Text>
@@ -90,6 +90,9 @@ const styles = StyleSheet.create({
   titleContainer: {
     height: 40,
     justifyContent: 'center',
+  },
+  title: {
+    marginLeft: 16,
   },
   divider: {
     marginTop: 4,

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -170,7 +170,7 @@ const FAB = ({
       .rgb()
       .string();
   } else {
-    foregroundColor = !color(backgroundColor).isLight()
+    foregroundColor = !color(backgroundColor as string).isLight()
       ? white
       : 'rgba(0, 0, 0, .54)';
   }
@@ -205,6 +205,7 @@ const FAB = ({
         rippleColor={rippleColor}
         disabled={disabled}
         accessibilityLabel={accessibilityLabel}
+        // @ts-ignore
         accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
         accessibilityComponentType="button"
         accessibilityRole="button"

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -1,17 +1,25 @@
 import color from 'color';
 import * as React from 'react';
-import { Animated, View, ViewStyle, StyleSheet, StyleProp } from 'react-native';
+import {
+  Animated,
+  View,
+  ViewStyle,
+  StyleSheet,
+  StyleProp,
+  AccessibilityState,
+} from 'react-native';
 import ActivityIndicator from '../ActivityIndicator';
 import Surface from '../Surface';
 import CrossFadeIcon from '../CrossFadeIcon';
-import Icon from '../Icon';
+import Icon, { IconSource } from '../Icon';
 import Text from '../Typography/Text';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { black, white } from '../../styles/colors';
 import { withTheme } from '../../core/theming';
+import getContrastingColor from '../../utils/getContrastingColor';
 import type { $RemoveChildren } from '../../types';
-import type { IconSource } from './../Icon';
-import type { AccessibilityState } from 'react-native';
+
+getContrastingColor;
 
 type Props = $RemoveChildren<typeof Surface> & {
   /**
@@ -157,8 +165,9 @@ const FAB = ({
     .rgb()
     .string();
 
-  const { backgroundColor = disabled ? disabledColor : theme.colors.accent } =
-    StyleSheet.flatten(style) || {};
+  const {
+    backgroundColor = disabled ? disabledColor : theme.colors.accent,
+  } = (StyleSheet.flatten(style) || {}) as ViewStyle;
 
   let foregroundColor;
 
@@ -170,9 +179,11 @@ const FAB = ({
       .rgb()
       .string();
   } else {
-    foregroundColor = !color(backgroundColor as string).isLight()
-      ? white
-      : 'rgba(0, 0, 0, .54)';
+    foregroundColor = getContrastingColor(
+      backgroundColor,
+      white,
+      'rgba(0, 0, 0, .54)'
+    );
   }
 
   const rippleColor = color(foregroundColor).alpha(0.32).rgb().string();
@@ -205,7 +216,7 @@ const FAB = ({
         rippleColor={rippleColor}
         disabled={disabled}
         accessibilityLabel={accessibilityLabel}
-        // @ts-ignore We keep old a11y props for backwards compat with old RN versions
+        // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
         accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
         accessibilityComponentType="button"
         accessibilityRole="button"

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -205,7 +205,7 @@ const FAB = ({
         rippleColor={rippleColor}
         disabled={disabled}
         accessibilityLabel={accessibilityLabel}
-        // @ts-ignore
+        // @ts-ignore We keep old a11y props for backwards compat with old RN versions
         accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
         accessibilityComponentType="button"
         accessibilityRole="button"

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -303,6 +303,7 @@ const FABGroup = ({
                         ? it.accessibilityLabel
                         : it.label
                     }
+                    // @ts-ignore
                     accessibilityTraits="button"
                     accessibilityComponentType="button"
                     accessibilityRole="button"
@@ -334,6 +335,7 @@ const FABGroup = ({
                     ? it.accessibilityLabel
                     : it.label
                 }
+                // @ts-ignore
                 accessibilityTraits="button"
                 accessibilityComponentType="button"
                 accessibilityRole="button"
@@ -351,6 +353,7 @@ const FABGroup = ({
           icon={icon}
           color={colorProp}
           accessibilityLabel={accessibilityLabel}
+          // @ts-ignore
           accessibilityTraits="button"
           accessibilityComponentType="button"
           accessibilityRole="button"

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -303,7 +303,7 @@ const FABGroup = ({
                         ? it.accessibilityLabel
                         : it.label
                     }
-                    // @ts-ignore We keep old a11y props for backwards compat with old RN versions
+                    // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
                     accessibilityTraits="button"
                     accessibilityComponentType="button"
                     accessibilityRole="button"
@@ -335,7 +335,7 @@ const FABGroup = ({
                     ? it.accessibilityLabel
                     : it.label
                 }
-                // @ts-ignore We keep old a11y props for backwards compat with old RN versions
+                // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
                 accessibilityTraits="button"
                 accessibilityComponentType="button"
                 accessibilityRole="button"
@@ -353,7 +353,7 @@ const FABGroup = ({
           icon={icon}
           color={colorProp}
           accessibilityLabel={accessibilityLabel}
-          // @ts-ignore We keep old a11y props for backwards compat with old RN versions
+          // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
           accessibilityTraits="button"
           accessibilityComponentType="button"
           accessibilityRole="button"

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -303,7 +303,7 @@ const FABGroup = ({
                         ? it.accessibilityLabel
                         : it.label
                     }
-                    // @ts-ignore
+                    // @ts-ignore We keep old a11y props for backwards compat with old RN versions
                     accessibilityTraits="button"
                     accessibilityComponentType="button"
                     accessibilityRole="button"
@@ -335,7 +335,7 @@ const FABGroup = ({
                     ? it.accessibilityLabel
                     : it.label
                 }
-                // @ts-ignore
+                // @ts-ignore We keep old a11y props for backwards compat with old RN versions
                 accessibilityTraits="button"
                 accessibilityComponentType="button"
                 accessibilityRole="button"
@@ -353,7 +353,7 @@ const FABGroup = ({
           icon={icon}
           color={colorProp}
           accessibilityLabel={accessibilityLabel}
-          // @ts-ignore
+          // @ts-ignore We keep old a11y props for backwards compat with old RN versions
           accessibilityTraits="button"
           accessibilityComponentType="button"
           accessibilityRole="button"

--- a/src/components/HelperText.tsx
+++ b/src/components/HelperText.tsx
@@ -113,7 +113,6 @@ const HelperText = ({
   }, [visible, scale, shown]);
 
   const handleTextLayout = (e: LayoutChangeEvent) => {
-    //@ts-ignore Animated.Text typings are improved but something is still broken. It thinks onLayout is not callable.
     onLayout?.(e);
     textHeight = e.nativeEvent.layout.height;
   };
@@ -129,7 +128,6 @@ const HelperText = ({
           .string();
 
   return (
-    // @ts-ignore
     <AnimatedText
       onLayout={handleTextLayout}
       style={[

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -67,7 +67,6 @@ export const isEqualIcon = (a: any, b: any) =>
 
 const Icon = ({ source, color, size, theme, ...rest }: Props) => {
   const direction =
-    // @ts-ignore
     typeof source === 'object' && source.direction && source.source
       ? source.direction === 'auto'
         ? I18nManager.isRTL
@@ -76,7 +75,6 @@ const Icon = ({ source, color, size, theme, ...rest }: Props) => {
         : source.direction
       : null;
   const s =
-    // @ts-ignore
     typeof source === 'object' && source.direction && source.source
       ? source.source
       : source;

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -117,14 +117,13 @@ const IconButton = ({
         style,
       ]}
       accessibilityLabel={accessibilityLabel}
-      // @ts-ignore
+      // @ts-ignore We keep old a11y props for backwards compat with old RN versions
       accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
       accessibilityComponentType="button"
       accessibilityRole="button"
       accessibilityState={{ disabled }}
       disabled={disabled}
       hitSlop={
-        // @ts-ignore - this should be fixed in react-theme-providersince withTheme() is not forwarding static property types
         TouchableRipple.supported
           ? { top: 10, left: 10, bottom: 10, right: 10 }
           : { top: 6, left: 6, bottom: 6, right: 6 }
@@ -139,7 +138,6 @@ const IconButton = ({
 };
 
 const styles = StyleSheet.create({
-  // @ts-ignore - this should be fixed in react-theme-providersince withTheme() is not forwarding static property types
   container: {
     alignItems: 'center',
     justifyContent: 'center',

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -117,7 +117,7 @@ const IconButton = ({
         style,
       ]}
       accessibilityLabel={accessibilityLabel}
-      // @ts-ignore We keep old a11y props for backwards compat with old RN versions
+      // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
       accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
       accessibilityComponentType="button"
       accessibilityRole="button"

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -117,6 +117,7 @@ const IconButton = ({
         style,
       ]}
       accessibilityLabel={accessibilityLabel}
+      // @ts-ignore
       accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
       accessibilityComponentType="button"
       accessibilityRole="button"

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -180,6 +180,7 @@ const ListAccordion = ({
         style={[styles.container, style]}
         onPress={handlePress}
         onLongPress={onLongPress}
+        // @ts-ignore
         accessibilityTraits="button"
         accessibilityComponentType="button"
         accessibilityRole="button"

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -180,7 +180,7 @@ const ListAccordion = ({
         style={[styles.container, style]}
         onPress={handlePress}
         onLongPress={onLongPress}
-        // @ts-ignore
+        // @ts-ignore We keep old a11y props for backwards compat with old RN versions
         accessibilityTraits="button"
         accessibilityComponentType="button"
         accessibilityRole="button"

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -180,7 +180,7 @@ const ListAccordion = ({
         style={[styles.container, style]}
         onPress={handlePress}
         onLongPress={onLongPress}
-        // @ts-ignore We keep old a11y props for backwards compat with old RN versions
+        // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
         accessibilityTraits="button"
         accessibilityComponentType="button"
         accessibilityRole="button"

--- a/src/components/MaterialCommunityIcon.tsx
+++ b/src/components/MaterialCommunityIcon.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleSheet, Text, Platform } from 'react-native';
+import { StyleSheet, Text, Platform, TextProps, ViewProps } from 'react-native';
 
 export type IconProps = {
   name: string;
@@ -9,7 +9,14 @@ export type IconProps = {
   allowFontScaling?: boolean;
 };
 
-let MaterialCommunityIcons: any;
+let MaterialCommunityIcons: React.ComponentType<
+  TextProps & {
+    name: string;
+    color: string;
+    size: number;
+    pointerEvents?: ViewProps['pointerEvents'];
+  }
+>;
 
 try {
   // Optionally require vector-icons
@@ -19,7 +26,6 @@ try {
   let isErrorLogged = false;
 
   // Fallback component for icons
-  // @ts-ignore
   MaterialCommunityIcons = ({ name, color, size, ...rest }) => {
     /* eslint-disable no-console */
     if (!isErrorLogged) {
@@ -43,7 +49,7 @@ try {
       <Text
         {...rest}
         style={[styles.icon, { color, fontSize: size }]}
-        // @ts-ignore
+        // @ts-expect-error: Text doesn't support this, but it seems to affect TouchableNativeFeedback
         pointerEvents="none"
         selectable={false}
       >

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -168,7 +168,10 @@ class Menu extends React.Component<Props, State> {
   private anchor?: View | null = null;
   private menu?: View | null = null;
 
-  private isAnchorCoord = () => !React.isValidElement(this.props.anchor);
+  private isCoordinate = (anchor: any): anchor is { x: number; y: number } =>
+    !React.isValidElement(anchor) &&
+    typeof anchor?.x === 'number' &&
+    typeof anchor?.y === 'number';
 
   private measureMenuLayout = () =>
     new Promise<LayoutRectangle>((resolve) => {
@@ -182,8 +185,7 @@ class Menu extends React.Component<Props, State> {
   private measureAnchorLayout = () =>
     new Promise<LayoutRectangle>((resolve) => {
       const { anchor } = this.props;
-      if (this.isAnchorCoord()) {
-        // @ts-ignore
+      if (this.isCoordinate(anchor)) {
         resolve({ x: anchor.x, y: anchor.y, width: 0, height: 0 });
         return;
       }
@@ -270,8 +272,8 @@ class Menu extends React.Component<Props, State> {
       !windowLayout.height ||
       !menuLayout.width ||
       !menuLayout.height ||
-      (!anchorLayout.width && !this.isAnchorCoord()) ||
-      (!anchorLayout.height && !this.isAnchorCoord())
+      (!anchorLayout.width && !this.isCoordinate(this.props.anchor)) ||
+      (!anchorLayout.height && !this.isCoordinate(this.props.anchor))
     ) {
       requestAnimationFrame(this.show);
       return;
@@ -522,7 +524,7 @@ class Menu extends React.Component<Props, State> {
     };
 
     const positionStyle = {
-      top: this.isAnchorCoord() ? top : top + additionalVerticalValue,
+      top: this.isCoordinate(anchor) ? top : top + additionalVerticalValue,
       ...(I18nManager.isRTL ? { right: left } : { left }),
     };
 
@@ -533,7 +535,7 @@ class Menu extends React.Component<Props, State> {
         }}
         collapsable={false}
       >
-        {this.isAnchorCoord() ? null : anchor}
+        {this.isCoordinate(anchor) ? null : anchor}
         {rendered ? (
           <Portal>
             <TouchableWithoutFeedback

--- a/src/components/Portal/PortalHost.tsx
+++ b/src/components/Portal/PortalHost.tsx
@@ -87,13 +87,12 @@ export default class PortalHost extends React.Component<Props> {
     if (this.manager) {
       this.manager.update(key, children);
     } else {
-      const op = { type: 'mount', key, children };
+      const op: Operation = { type: 'mount', key, children };
       const index = this.queue.findIndex(
         (o) => o.type === 'mount' || (o.type === 'update' && o.key === key)
       );
 
       if (index > -1) {
-        // @ts-ignore
         this.queue[index] = op;
       } else {
         this.queue.push(op as Operation);

--- a/src/components/RadioButton/RadioButtonAndroid.tsx
+++ b/src/components/RadioButton/RadioButtonAndroid.tsx
@@ -151,6 +151,7 @@ const RadioButtonAndroid = ({
                     });
                   }
             }
+            // @ts-ignore
             accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
             accessibilityComponentType={
               checked ? 'radiobutton_checked' : 'radiobutton_unchecked'

--- a/src/components/RadioButton/RadioButtonAndroid.tsx
+++ b/src/components/RadioButton/RadioButtonAndroid.tsx
@@ -151,7 +151,7 @@ const RadioButtonAndroid = ({
                     });
                   }
             }
-            // @ts-ignore
+            // @ts-ignore We keep old a11y props for backwards compat with old RN versions
             accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
             accessibilityComponentType={
               checked ? 'radiobutton_checked' : 'radiobutton_unchecked'

--- a/src/components/RadioButton/RadioButtonAndroid.tsx
+++ b/src/components/RadioButton/RadioButtonAndroid.tsx
@@ -151,7 +151,7 @@ const RadioButtonAndroid = ({
                     });
                   }
             }
-            // @ts-ignore We keep old a11y props for backwards compat with old RN versions
+            // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
             accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
             accessibilityComponentType={
               checked ? 'radiobutton_checked' : 'radiobutton_unchecked'

--- a/src/components/RadioButton/RadioButtonIOS.tsx
+++ b/src/components/RadioButton/RadioButtonIOS.tsx
@@ -102,6 +102,7 @@ const RadioButtonIOS = ({
                     });
                   }
             }
+            // @ts-ignore
             accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
             accessibilityComponentType={
               checked ? 'radiobutton_checked' : 'radiobutton_unchecked'

--- a/src/components/RadioButton/RadioButtonIOS.tsx
+++ b/src/components/RadioButton/RadioButtonIOS.tsx
@@ -102,7 +102,7 @@ const RadioButtonIOS = ({
                     });
                   }
             }
-            // @ts-ignore We keep old a11y props for backwards compat with old RN versions
+            // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
             accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
             accessibilityComponentType={
               checked ? 'radiobutton_checked' : 'radiobutton_unchecked'

--- a/src/components/RadioButton/RadioButtonIOS.tsx
+++ b/src/components/RadioButton/RadioButtonIOS.tsx
@@ -102,7 +102,7 @@ const RadioButtonIOS = ({
                     });
                   }
             }
-            // @ts-ignore
+            // @ts-ignore We keep old a11y props for backwards compat with old RN versions
             accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
             accessibilityComponentType={
               checked ? 'radiobutton_checked' : 'radiobutton_unchecked'

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -4,6 +4,7 @@ import {
   StyleProp,
   TextInput,
   I18nManager,
+  TextInputProps,
   ViewStyle,
   TextStyle,
 } from 'react-native';
@@ -119,17 +120,31 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
   ) => {
     const root = React.useRef<TextInput>(null);
 
-    React.useImperativeHandle(ref, () => ({
-      // @ts-ignore
-      focus: root.current?.focus,
-      // @ts-ignore
-      clear: root.current?.clear,
-      setNativeProps: (args: Object) => root.current?.setNativeProps(args),
-      // @ts-ignore
-      isFocused: root.current?.isFocused,
-      // @ts-ignore
-      blur: root.current?.blur,
-    }));
+    React.useImperativeHandle(ref, () => {
+      const input = root.current;
+
+      if (input) {
+        return {
+          focus: input.focus,
+          clear: input.clear,
+          setNativeProps: (args: TextInputProps) => input.setNativeProps(args),
+          isFocused: input.isFocused,
+          blur: input.blur,
+        };
+      }
+
+      const noop = () => {
+        throw new Error('TextInput is not available');
+      };
+
+      return {
+        focus: noop,
+        clear: noop,
+        setNativeProps: noop,
+        isFocused: noop,
+        blur: noop,
+      };
+    });
 
     const handleClearPress = () => {
       root.current?.clear();
@@ -153,7 +168,7 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
         ]}
       >
         <IconButton
-          // @ts-ignore We keep old a11y props for backwards compat with old RN versions
+          // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
           accessibilityTraits="button"
           accessibilityComponentType="button"
           accessibilityRole="button"
@@ -182,7 +197,7 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
           underlineColorAndroid="transparent"
           returnKeyType="search"
           keyboardAppearance={dark ? 'dark' : 'light'}
-          // @ts-ignore We keep old a11y props for backwards compat with old RN versions
+          // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
           accessibilityTraits="search"
           accessibilityRole="search"
           ref={root}
@@ -207,7 +222,7 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
               />
             ))
           }
-          // @ts-ignore We keep old a11y props for backwards compat with old RN versions
+          // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
           accessibilityTraits="button"
           accessibilityComponentType="button"
           accessibilityRole="button"

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -153,6 +153,7 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
         ]}
       >
         <IconButton
+          // @ts-ignore
           accessibilityTraits="button"
           accessibilityComponentType="button"
           accessibilityRole="button"
@@ -181,6 +182,7 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
           underlineColorAndroid="transparent"
           returnKeyType="search"
           keyboardAppearance={dark ? 'dark' : 'light'}
+          // @ts-ignore
           accessibilityTraits="search"
           accessibilityRole="search"
           ref={root}
@@ -205,6 +207,7 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
               />
             ))
           }
+          // @ts-ignore
           accessibilityTraits="button"
           accessibilityComponentType="button"
           accessibilityRole="button"

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -153,7 +153,7 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
         ]}
       >
         <IconButton
-          // @ts-ignore
+          // @ts-ignore We keep old a11y props for backwards compat with old RN versions
           accessibilityTraits="button"
           accessibilityComponentType="button"
           accessibilityRole="button"
@@ -182,7 +182,7 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
           underlineColorAndroid="transparent"
           returnKeyType="search"
           keyboardAppearance={dark ? 'dark' : 'light'}
-          // @ts-ignore
+          // @ts-ignore We keep old a11y props for backwards compat with old RN versions
           accessibilityTraits="search"
           accessibilityRole="search"
           ref={root}
@@ -207,7 +207,7 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
               />
             ))
           }
-          // @ts-ignore
+          // @ts-ignore We keep old a11y props for backwards compat with old RN versions
           accessibilityTraits="button"
           accessibilityComponentType="button"
           accessibilityRole="button"

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -146,6 +146,7 @@ const Snackbar = ({
             duration === Number.NEGATIVE_INFINITY;
 
           if (finished && !isInfinity) {
+            // @ts-ignore setTimeout incompatible with clearTimeout
             hideTimeout.current = setTimeout(onDismiss, duration);
           }
         }

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -146,8 +146,10 @@ const Snackbar = ({
             duration === Number.NEGATIVE_INFINITY;
 
           if (finished && !isInfinity) {
-            // @ts-ignore setTimeout incompatible with clearTimeout
-            hideTimeout.current = setTimeout(onDismiss, duration);
+            hideTimeout.current = (setTimeout(
+              onDismiss,
+              duration
+            ) as unknown) as NodeJS.Timeout;
           }
         }
       });

--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -64,7 +64,6 @@ const Surface = ({ style, theme, ...rest }: Props) => {
   const { elevation = 4 }: ViewStyle = flattenedStyles;
   const { dark: isDarkTheme, mode, colors } = theme;
   return (
-    // @ts-ignore
     <Animated.View
       {...rest}
       style={[
@@ -74,7 +73,7 @@ const Surface = ({ style, theme, ...rest }: Props) => {
               ? overlay(elevation, colors.surface)
               : colors.surface,
         },
-        elevation && shadow(elevation),
+        elevation ? shadow(elevation) : null,
         style,
       ]}
     />

--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -9,7 +9,7 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
    * Content of the `Surface`.
    */
   children: React.ReactNode;
-  style?: StyleProp<ViewStyle>;
+  style?: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
   /**
    * @optional
    */
@@ -60,8 +60,7 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
  * ```
  */
 const Surface = ({ style, theme, ...rest }: Props) => {
-  const flattenedStyles = StyleSheet.flatten(style) || {};
-  const { elevation = 4 }: ViewStyle = flattenedStyles;
+  const { elevation = 4 } = (StyleSheet.flatten(style) || {}) as ViewStyle;
   const { dark: isDarkTheme, mode, colors } = theme;
   return (
     <Animated.View

--- a/src/components/TextInput/Adornment/TextInputAffix.tsx
+++ b/src/components/TextInput/Adornment/TextInputAffix.tsx
@@ -7,6 +7,7 @@ import {
   TextStyle,
   LayoutChangeEvent,
   Animated,
+  ViewStyle,
 } from 'react-native';
 
 import { withTheme } from '../../../core/theming';
@@ -89,7 +90,7 @@ const TextInputAffix = ({ text, textStyle: labelStyle, theme }: Props) => {
   const style = {
     top: topPosition,
     [side]: offset,
-  };
+  } as ViewStyle;
 
   return (
     <Animated.View

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -275,14 +275,13 @@ class TextInput extends React.Component<TextInputProps, State> {
 
     // Set the placeholder in a delay to offset the label animation
     // If we show it immediately, they'll overlap and look ugly
-    // @ts-ignore
-    this.timer = setTimeout(
+    this.timer = (setTimeout(
       () =>
         this.setState({
           placeholder: this.props.placeholder,
         }),
       50
-    );
+    ) as unknown) as NodeJS.Timeout;
   };
 
   private hidePlaceholder = () =>
@@ -290,7 +289,7 @@ class TextInput extends React.Component<TextInputProps, State> {
       placeholder: '',
     });
 
-  private timer?: number;
+  private timer?: NodeJS.Timeout;
   private root: NativeTextInput | undefined | null;
 
   private showError = () => {

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -330,12 +330,10 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
             ...rest,
             ref: innerRef,
             onChangeText,
-            // @ts-ignore
             placeholder: label
               ? parentState.placeholder
               : this.props.placeholder,
-            placeholderTextColor: (placeholderTextColor ||
-              placeholderColor) as string,
+            placeholderTextColor: placeholderTextColor ?? placeholderColor,
             editable: !disabled && editable,
             selectionColor:
               typeof selectionColor === 'undefined'

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -318,11 +318,12 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
           activeColor={activeColor}
         />
         <View
-          style={{
-            paddingTop: 0,
-            paddingBottom: 0,
-            minHeight,
-          }}
+          style={[
+            styles.labelContainer,
+            {
+              minHeight,
+            },
+          ]}
         >
           <InputLabel parentState={parentState} labelProps={labelProps} />
           {render?.({
@@ -333,7 +334,8 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
             placeholder: label
               ? parentState.placeholder
               : this.props.placeholder,
-            placeholderTextColor: placeholderTextColor || placeholderColor,
+            placeholderTextColor: (placeholderTextColor ||
+              placeholderColor) as string,
             editable: !disabled && editable,
             selectionColor:
               typeof selectionColor === 'undefined'
@@ -420,6 +422,10 @@ const styles = StyleSheet.create({
     right: 0,
     bottom: 0,
     height: 2,
+  },
+  labelContainer: {
+    paddingTop: 0,
+    paddingBottom: 0,
   },
   input: {
     flexGrow: 1,

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -287,17 +287,20 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
             hasActiveOutline={hasActiveOutline}
             activeColor={activeColor}
             outlineColor={outlineColor}
-            backgroundColor={backgroundColor}
+            backgroundColor={backgroundColor as string}
           />
           <View
-            style={{
-              paddingTop: LABEL_PADDING_TOP,
-              paddingBottom: 0,
-              minHeight,
-            }}
+            style={[
+              styles.labelContainer,
+              {
+                paddingTop: LABEL_PADDING_TOP,
+                minHeight,
+              },
+            ]}
           >
             <InputLabel
               parentState={parentState}
+              // @ts-ignore
               labelProps={labelProps}
               labelBackground={LabelBackground}
             />
@@ -391,6 +394,9 @@ const styles = StyleSheet.create({
     right: 0,
     top: 6,
     bottom: 0,
+  },
+  labelContainer: {
+    paddingBottom: 0,
   },
   input: {
     flexGrow: 1,

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -6,6 +6,7 @@ import {
   I18nManager,
   Platform,
   TextStyle,
+  ColorValue,
 } from 'react-native';
 import color from 'color';
 import TextInputAdornment, {
@@ -202,7 +203,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
       hasActiveOutline,
       activeColor,
       placeholderColor,
-      backgroundColor,
+      backgroundColor: backgroundColor as ColorValue,
       errorColor,
       labelTranslationXOffset,
     };
@@ -287,7 +288,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
             hasActiveOutline={hasActiveOutline}
             activeColor={activeColor}
             outlineColor={outlineColor}
-            backgroundColor={backgroundColor as string}
+            backgroundColor={backgroundColor}
           />
           <View
             style={[
@@ -300,7 +301,6 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
           >
             <InputLabel
               parentState={parentState}
-              // @ts-ignore
               labelProps={labelProps}
               labelBackground={LabelBackground}
             />
@@ -352,11 +352,11 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
 
 export default TextInputOutlined;
 
-type OutlineType = {
+type OutlineProps = {
   activeColor: string;
-  hasActiveOutline: boolean | undefined;
-  outlineColor: string | undefined;
-  backgroundColor: string | undefined;
+  hasActiveOutline?: boolean;
+  outlineColor?: string;
+  backgroundColor: ColorValue;
   theme: ReactNativePaper.Theme;
 };
 
@@ -366,7 +366,7 @@ const Outline = ({
   activeColor,
   outlineColor,
   backgroundColor,
-}: OutlineType) => (
+}: OutlineProps) => (
   <View
     pointerEvents="none"
     style={[

--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -8,7 +8,7 @@ import type { TextInputProps } from './TextInput';
 import type { $Omit } from './../../types';
 
 export type RenderProps = {
-  ref: (a: NativeTextInput | null | undefined) => void;
+  ref: (a?: NativeTextInput | null) => void;
   onChangeText?: (a: string) => void;
   placeholder?: string;
   placeholderTextColor?: string;
@@ -28,15 +28,15 @@ export type State = {
   labeled: Animated.Value;
   error: Animated.Value;
   focused: boolean;
-  placeholder: string | null | undefined;
-  value: string | null | undefined;
+  placeholder?: string | null;
+  value?: string | null;
   labelLayout: { measured: boolean; width: number; height: number };
   leftLayout: { height: number | null; width: number | null };
   rightLayout: { height: number | null; width: number | null };
 };
 export type ChildTextInputProps = {
   parentState: State;
-  innerRef: (ref: NativeTextInput | null | undefined) => void;
+  innerRef: (ref?: NativeTextInput | null) => void;
   onFocus?: (args: any) => void;
   onBlur?: (args: any) => void;
   forceFocus: () => void;
@@ -57,18 +57,15 @@ export type LabelProps = {
   fontWeight: TextStyle['fontWeight'];
   font: any;
   topPosition: number;
-  paddingOffset?:
-    | { paddingLeft: number; paddingRight: number }
-    | null
-    | undefined;
+  paddingOffset?: { paddingLeft: number; paddingRight: number } | null;
   labelTranslationXOffset?: number;
-  placeholderColor: string | null | undefined;
-  backgroundColor?: string | null | undefined;
-  label?: string | null | undefined;
-  hasActiveOutline: boolean | null | undefined;
+  placeholderColor: string | null;
+  backgroundColor?: TextStyle['backgroundColor'];
+  label?: string | null;
+  hasActiveOutline?: boolean | null;
   activeColor: string;
   errorColor?: string;
-  error: boolean | null | undefined;
+  error?: boolean | null;
   onLayoutAnimatedText: (args: any) => void;
 };
 export type InputLabelProps = {

--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -3,6 +3,7 @@ import type {
   Animated,
   TextStyle,
   LayoutChangeEvent,
+  ColorValue,
 } from 'react-native';
 import type { TextInputProps } from './TextInput';
 import type { $Omit } from './../../types';
@@ -11,7 +12,7 @@ export type RenderProps = {
   ref: (a?: NativeTextInput | null) => void;
   onChangeText?: (a: string) => void;
   placeholder?: string;
-  placeholderTextColor?: string;
+  placeholderTextColor?: ColorValue;
   editable?: boolean;
   selectionColor?: string;
   onFocus?: (args: any) => void;
@@ -28,8 +29,8 @@ export type State = {
   labeled: Animated.Value;
   error: Animated.Value;
   focused: boolean;
-  placeholder?: string | null;
-  value?: string | null;
+  placeholder?: string;
+  value?: string;
   labelLayout: { measured: boolean; width: number; height: number };
   leftLayout: { height: number | null; width: number | null };
   rightLayout: { height: number | null; width: number | null };
@@ -60,7 +61,7 @@ export type LabelProps = {
   paddingOffset?: { paddingLeft: number; paddingRight: number } | null;
   labelTranslationXOffset?: number;
   placeholderColor: string | null;
-  backgroundColor?: TextStyle['backgroundColor'];
+  backgroundColor?: ColorValue;
   label?: string | null;
   hasActiveOutline?: boolean | null;
   activeColor: string;

--- a/src/components/ToggleButton/ToggleButtonRow.tsx
+++ b/src/components/ToggleButton/ToggleButtonRow.tsx
@@ -55,9 +55,9 @@ const ToggleButtonRow = ({ value, onValueChange, children, style }: Props) => {
     <ToggleButtonGroup value={value} onValueChange={onValueChange}>
       <View style={[styles.row, style]}>
         {React.Children.map(children, (child, i) => {
-          // @ts-ignore
+          // @ts-expect-error: TypeScript complains about child.type but it doesn't matter
           if (child && child.type === ToggleButton) {
-            // @ts-ignore
+            // @ts-expect-error: We're sure that child is a React Element
             return React.cloneElement(child, {
               style: [
                 styles.button,
@@ -66,7 +66,7 @@ const ToggleButtonRow = ({ value, onValueChange, children, style }: Props) => {
                   : i === count - 1
                   ? styles.last
                   : styles.middle,
-                // @ts-ignore
+                // @ts-expect-error: We're sure that child is a React Element
                 child.props.style,
               ],
             });

--- a/src/components/TouchableRipple/TouchableRipple.native.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.native.tsx
@@ -8,6 +8,7 @@ import {
   TouchableWithoutFeedback,
   View,
   ViewStyle,
+  StyleSheet,
 } from 'react-native';
 import color from 'color';
 import { withTheme } from '../../core/theming';
@@ -66,7 +67,7 @@ const TouchableRipple = ({
             : TouchableNativeFeedback.Ripple(calculatedRippleColor, borderless)
         }
       >
-        <View style={[borderless && { overflow: 'hidden' }, style]}>
+        <View style={[borderless && styles.overflowHidden, style]}>
           {React.Children.only(children)}
         </View>
       </TouchableNativeFeedback>
@@ -77,7 +78,7 @@ const TouchableRipple = ({
     <TouchableHighlight
       {...rest}
       disabled={disabled}
-      style={[borderless && { overflow: 'hidden' }, style]}
+      style={[borderless && styles.overflowHidden, style]}
       underlayColor={
         underlayColor != null
           ? underlayColor
@@ -91,5 +92,11 @@ const TouchableRipple = ({
 
 TouchableRipple.supported =
   Platform.OS === 'android' && Platform.Version >= ANDROID_VERSION_LOLLIPOP;
+
+const styles = StyleSheet.create({
+  overflowHidden: {
+    overflow: 'hidden',
+  },
+});
 
 export default withTheme(TouchableRipple);

--- a/src/components/TouchableRipple/TouchableRipple.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.tsx
@@ -209,9 +209,8 @@ const TouchableRipple = ({
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         containers.forEach((container) => {
-          const ripple = container.firstChild;
+          const ripple = container.firstChild as HTMLSpanElement;
 
-          // @ts-ignore
           Object.assign(ripple.style, {
             transitionDuration: '250ms',
             opacity: 0,

--- a/src/components/Typography/AnimatedText.tsx
+++ b/src/components/Typography/AnimatedText.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { Animated, TextStyle, I18nManager, StyleProp } from 'react-native';
+import {
+  Animated,
+  TextStyle,
+  I18nManager,
+  StyleProp,
+  StyleSheet,
+} from 'react-native';
 import { withTheme } from '../../core/theming';
 
 type Props = React.ComponentPropsWithRef<typeof Animated.Text> & {
@@ -23,10 +29,10 @@ function AnimatedText({ style, theme, ...rest }: Props) {
     <Animated.Text
       {...rest}
       style={[
+        styles.text,
         {
           ...theme.fonts.regular,
           color: theme.colors.text,
-          textAlign: 'left',
           writingDirection,
         },
         style,
@@ -34,5 +40,11 @@ function AnimatedText({ style, theme, ...rest }: Props) {
     />
   );
 }
+
+const styles = StyleSheet.create({
+  text: {
+    textAlign: 'left',
+  },
+});
 
 export default withTheme(AnimatedText);

--- a/src/components/Typography/AnimatedText.tsx
+++ b/src/components/Typography/AnimatedText.tsx
@@ -25,7 +25,6 @@ function AnimatedText({ style, theme, ...rest }: Props) {
   const writingDirection = I18nManager.isRTL ? 'rtl' : 'ltr';
 
   return (
-    //@ts-ignore
     <Animated.Text
       {...rest}
       style={[

--- a/src/components/Typography/StyledText.tsx
+++ b/src/components/Typography/StyledText.tsx
@@ -1,6 +1,6 @@
 import color from 'color';
 import * as React from 'react';
-import { I18nManager, StyleProp, TextStyle } from 'react-native';
+import { I18nManager, StyleProp, TextStyle, StyleSheet } from 'react-native';
 
 import Text from './Text';
 import { withTheme } from '../../core/theming';
@@ -21,11 +21,18 @@ const StyledText = ({ theme, alpha, family, style, ...rest }: Props) => {
     <Text
       {...rest}
       style={[
-        { color: textColor, ...font, textAlign: 'left', writingDirection },
+        styles.text,
+        { color: textColor, ...font, writingDirection },
         style,
       ]}
     />
   );
 };
+
+const styles = StyleSheet.create({
+  text: {
+    textAlign: 'left',
+  },
+});
 
 export default withTheme(StyledText);

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { Text as NativeText, TextStyle, StyleProp } from 'react-native';
+import {
+  Text as NativeText,
+  TextStyle,
+  StyleProp,
+  StyleSheet,
+} from 'react-native';
 import { withTheme } from '../../core/theming';
 
 type Props = React.ComponentProps<typeof NativeText> & {
@@ -35,12 +40,18 @@ const Text: React.RefForwardingComponent<{}, Props> = (
         {
           ...theme.fonts.regular,
           color: theme.colors.text,
-          textAlign: 'left',
         },
+        styles.text,
         style,
       ]}
     />
   );
 };
+
+const styles = StyleSheet.create({
+  text: {
+    textAlign: 'left',
+  },
+});
 
 export default withTheme(React.forwardRef(Text));

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
@@ -430,6 +430,8 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             "color": "#000000",
             "fontFamily": "System",
             "fontWeight": "400",
+          },
+          Object {
             "textAlign": "left",
           },
           Array [

--- a/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.js.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.js.snap
@@ -40,6 +40,8 @@ exports[`can render the Android checkbox on different platforms 1`] = `
             "color": "#000000",
             "fontFamily": "System",
             "fontWeight": "400",
+          },
+          Object {
             "textAlign": "left",
           },
           Array [
@@ -210,6 +212,8 @@ exports[`can render the iOS checkbox on different platforms 1`] = `
             "color": "#000000",
             "fontFamily": "System",
             "fontWeight": "400",
+          },
+          Object {
             "textAlign": "left",
           },
           Array [
@@ -346,6 +350,8 @@ exports[`renders unchecked 1`] = `
             "color": "#000000",
             "fontFamily": "System",
             "fontWeight": "400",
+          },
+          Object {
             "textAlign": "left",
           },
           Array [

--- a/src/components/__tests__/RadioButton/__snapshots__/RadioButtonItem.test.js.snap
+++ b/src/components/__tests__/RadioButton/__snapshots__/RadioButtonItem.test.js.snap
@@ -40,6 +40,8 @@ exports[`can render the Android radio button on different platforms 1`] = `
             "color": "#000000",
             "fontFamily": "System",
             "fontWeight": "400",
+          },
+          Object {
             "textAlign": "left",
           },
           Array [
@@ -143,6 +145,8 @@ exports[`can render the iOS radio button on different platforms 1`] = `
             "color": "#000000",
             "fontFamily": "System",
             "fontWeight": "400",
+          },
+          Object {
             "textAlign": "left",
           },
           Array [
@@ -279,6 +283,8 @@ exports[`renders unchecked 1`] = `
             "color": "#000000",
             "fontFamily": "System",
             "fontWeight": "400",
+          },
+          Object {
             "textAlign": "left",
           },
           Array [

--- a/src/components/__tests__/Typography/__snapshots__/Caption.test.js.snap
+++ b/src/components/__tests__/Typography/__snapshots__/Caption.test.js.snap
@@ -8,14 +8,18 @@ exports[`renders caption applying style 1`] = `
         "color": "#000000",
         "fontFamily": "System",
         "fontWeight": "400",
+      },
+      Object {
         "textAlign": "left",
       },
       Array [
         Object {
+          "textAlign": "left",
+        },
+        Object {
           "color": "rgba(0, 0, 0, 0.54)",
           "fontFamily": "System",
           "fontWeight": "400",
-          "textAlign": "left",
           "writingDirection": "ltr",
         },
         Array [
@@ -46,14 +50,18 @@ exports[`renders caption with children as content 1`] = `
         "color": "#000000",
         "fontFamily": "System",
         "fontWeight": "400",
+      },
+      Object {
         "textAlign": "left",
       },
       Array [
         Object {
+          "textAlign": "left",
+        },
+        Object {
           "color": "rgba(0, 0, 0, 0.54)",
           "fontFamily": "System",
           "fontWeight": "400",
-          "textAlign": "left",
           "writingDirection": "ltr",
         },
         Array [

--- a/src/components/__tests__/__snapshots__/Avatar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Avatar.test.js.snap
@@ -171,6 +171,8 @@ exports[`renders avatar with text 1`] = `
           "color": "#000000",
           "fontFamily": "System",
           "fontWeight": "400",
+        },
+        Object {
           "textAlign": "left",
         },
         Array [
@@ -219,6 +221,8 @@ exports[`renders avatar with text and custom background color 1`] = `
           "color": "#000000",
           "fontFamily": "System",
           "fontWeight": "400",
+        },
+        Object {
           "textAlign": "left",
         },
         Array [
@@ -267,6 +271,8 @@ exports[`renders avatar with text and custom colors 1`] = `
           "color": "#000000",
           "fontFamily": "System",
           "fontWeight": "400",
+        },
+        Object {
           "textAlign": "left",
         },
         Array [
@@ -315,6 +321,8 @@ exports[`renders avatar with text and custom size 1`] = `
           "color": "#000000",
           "fontFamily": "System",
           "fontWeight": "400",
+        },
+        Object {
           "textAlign": "left",
         },
         Array [

--- a/src/components/__tests__/__snapshots__/Banner.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.js.snap
@@ -70,6 +70,8 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Object {
@@ -155,6 +157,8 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Object {
@@ -238,6 +242,8 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                       "color": "#000000",
                       "fontFamily": "System",
                       "fontWeight": "400",
+                    },
+                    Object {
                       "textAlign": "left",
                     },
                     Array [
@@ -336,6 +342,8 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Object {
@@ -419,6 +427,8 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                       "color": "#000000",
                       "fontFamily": "System",
                       "fontWeight": "400",
+                    },
+                    Object {
                       "textAlign": "left",
                     },
                     Array [
@@ -515,6 +525,8 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                       "color": "#000000",
                       "fontFamily": "System",
                       "fontWeight": "400",
+                    },
+                    Object {
                       "textAlign": "left",
                     },
                     Array [
@@ -614,6 +626,8 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Object {
@@ -698,6 +712,8 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Object {

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
@@ -3174,6 +3174,8 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                         "color": "#000000",
                         "fontFamily": "System",
                         "fontWeight": "400",
+                      },
+                      Object {
                         "textAlign": "left",
                       },
                       Array [
@@ -3212,6 +3214,8 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                         "color": "#000000",
                         "fontFamily": "System",
                         "fontWeight": "400",
+                      },
+                      Object {
                         "textAlign": "left",
                       },
                       Array [
@@ -3445,6 +3449,8 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                         "color": "#000000",
                         "fontFamily": "System",
                         "fontWeight": "400",
+                      },
+                      Object {
                         "textAlign": "left",
                       },
                       Array [
@@ -3483,6 +3489,8 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                         "color": "#000000",
                         "fontFamily": "System",
                         "fontWeight": "400",
+                      },
+                      Object {
                         "textAlign": "left",
                       },
                       Array [
@@ -3716,6 +3724,8 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                         "color": "#000000",
                         "fontFamily": "System",
                         "fontWeight": "400",
+                      },
+                      Object {
                         "textAlign": "left",
                       },
                       Array [
@@ -3754,6 +3764,8 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                         "color": "#000000",
                         "fontFamily": "System",
                         "fontWeight": "400",
+                      },
+                      Object {
                         "textAlign": "left",
                       },
                       Array [
@@ -4115,6 +4127,8 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                         "color": "#000000",
                         "fontFamily": "System",
                         "fontWeight": "400",
+                      },
+                      Object {
                         "textAlign": "left",
                       },
                       Array [
@@ -4348,6 +4362,8 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                         "color": "#000000",
                         "fontFamily": "System",
                         "fontWeight": "400",
+                      },
+                      Object {
                         "textAlign": "left",
                       },
                       Array [
@@ -4581,6 +4597,8 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                         "color": "#000000",
                         "fontFamily": "System",
                         "fontWeight": "400",
+                      },
+                      Object {
                         "textAlign": "left",
                       },
                       Array [
@@ -4922,6 +4940,8 @@ exports[`renders non-shifting bottom navigation 1`] = `
                         "color": "#000000",
                         "fontFamily": "System",
                         "fontWeight": "400",
+                      },
+                      Object {
                         "textAlign": "left",
                       },
                       Array [
@@ -4960,6 +4980,8 @@ exports[`renders non-shifting bottom navigation 1`] = `
                         "color": "#000000",
                         "fontFamily": "System",
                         "fontWeight": "400",
+                      },
+                      Object {
                         "textAlign": "left",
                       },
                       Array [
@@ -5193,6 +5215,8 @@ exports[`renders non-shifting bottom navigation 1`] = `
                         "color": "#000000",
                         "fontFamily": "System",
                         "fontWeight": "400",
+                      },
+                      Object {
                         "textAlign": "left",
                       },
                       Array [
@@ -5231,6 +5255,8 @@ exports[`renders non-shifting bottom navigation 1`] = `
                         "color": "#000000",
                         "fontFamily": "System",
                         "fontWeight": "400",
+                      },
+                      Object {
                         "textAlign": "left",
                       },
                       Array [
@@ -5464,6 +5490,8 @@ exports[`renders non-shifting bottom navigation 1`] = `
                         "color": "#000000",
                         "fontFamily": "System",
                         "fontWeight": "400",
+                      },
+                      Object {
                         "textAlign": "left",
                       },
                       Array [
@@ -5502,6 +5530,8 @@ exports[`renders non-shifting bottom navigation 1`] = `
                         "color": "#000000",
                         "fontFamily": "System",
                         "fontWeight": "400",
+                      },
+                      Object {
                         "textAlign": "left",
                       },
                       Array [
@@ -5863,6 +5893,8 @@ exports[`renders shifting bottom navigation 1`] = `
                         "color": "#000000",
                         "fontFamily": "System",
                         "fontWeight": "400",
+                      },
+                      Object {
                         "textAlign": "left",
                       },
                       Array [
@@ -6096,6 +6128,8 @@ exports[`renders shifting bottom navigation 1`] = `
                         "color": "#000000",
                         "fontFamily": "System",
                         "fontWeight": "400",
+                      },
+                      Object {
                         "textAlign": "left",
                       },
                       Array [
@@ -6329,6 +6363,8 @@ exports[`renders shifting bottom navigation 1`] = `
                         "color": "#000000",
                         "fontFamily": "System",
                         "fontWeight": "400",
+                      },
+                      Object {
                         "textAlign": "left",
                       },
                       Array [
@@ -6562,6 +6598,8 @@ exports[`renders shifting bottom navigation 1`] = `
                         "color": "#000000",
                         "fontFamily": "System",
                         "fontWeight": "400",
+                      },
+                      Object {
                         "textAlign": "left",
                       },
                       Array [
@@ -6795,6 +6833,8 @@ exports[`renders shifting bottom navigation 1`] = `
                         "color": "#000000",
                         "fontFamily": "System",
                         "fontWeight": "400",
+                      },
+                      Object {
                         "textAlign": "left",
                       },
                       Array [

--- a/src/components/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.js.snap
@@ -62,6 +62,8 @@ exports[`renders button with color 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -159,6 +161,8 @@ exports[`renders button with custom testID 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -300,6 +304,8 @@ exports[`renders button with icon 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -443,6 +449,8 @@ exports[`renders button with icon in reverse order 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -546,6 +554,8 @@ exports[`renders contained contained with mode 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -642,6 +652,8 @@ exports[`renders disabled button 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -923,6 +935,8 @@ exports[`renders loading button 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -1019,6 +1033,8 @@ exports[`renders outlined button with mode 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -1115,6 +1131,8 @@ exports[`renders text button by default 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -1211,6 +1229,8 @@ exports[`renders text button with mode 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [

--- a/src/components/__tests__/__snapshots__/Chip.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.js.snap
@@ -114,6 +114,8 @@ exports[`renders chip with close button 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -329,6 +331,8 @@ exports[`renders chip with icon 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -423,6 +427,8 @@ exports[`renders chip with onPress 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -517,6 +523,8 @@ exports[`renders outlined disabled chip 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -659,6 +667,8 @@ exports[`renders selected chip 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [

--- a/src/components/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.js.snap
@@ -34,6 +34,8 @@ exports[`renders data table cell 1`] = `
           "color": "#000000",
           "fontFamily": "System",
           "fontWeight": "400",
+        },
+        Object {
           "textAlign": "left",
         },
         undefined,
@@ -93,6 +95,8 @@ exports[`renders data table header 1`] = `
             "color": "#000000",
             "fontFamily": "System",
             "fontWeight": "400",
+          },
+          Object {
             "textAlign": "left",
           },
           Array [
@@ -144,6 +148,8 @@ exports[`renders data table header 1`] = `
             "color": "#000000",
             "fontFamily": "System",
             "fontWeight": "400",
+          },
+          Object {
             "textAlign": "left",
           },
           Array [
@@ -189,6 +195,8 @@ exports[`renders data table pagination 1`] = `
           "color": "#000000",
           "fontFamily": "System",
           "fontWeight": "400",
+        },
+        Object {
           "textAlign": "left",
         },
         Array [
@@ -400,6 +408,8 @@ exports[`renders data table pagination with label 1`] = `
           "color": "#000000",
           "fontFamily": "System",
           "fontWeight": "400",
+        },
+        Object {
           "textAlign": "left",
         },
         Array [
@@ -673,6 +683,8 @@ exports[`renders data table title with press handler 1`] = `
           "color": "#000000",
           "fontFamily": "System",
           "fontWeight": "400",
+        },
+        Object {
           "textAlign": "left",
         },
         Array [
@@ -777,6 +789,8 @@ exports[`renders data table title with sort icon 1`] = `
           "color": "#000000",
           "fontFamily": "System",
           "fontWeight": "400",
+        },
+        Object {
           "textAlign": "left",
         },
         Array [
@@ -835,6 +849,8 @@ exports[`renders right aligned data table cell 1`] = `
           "color": "#000000",
           "fontFamily": "System",
           "fontWeight": "400",
+        },
+        Object {
           "textAlign": "left",
         },
         undefined,
@@ -880,6 +896,8 @@ exports[`renders right aligned data table title 1`] = `
           "color": "#000000",
           "fontFamily": "System",
           "fontWeight": "400",
+        },
+        Object {
           "textAlign": "left",
         },
         Array [

--- a/src/components/__tests__/__snapshots__/DrawerItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DrawerItem.test.js.snap
@@ -97,6 +97,8 @@ exports[`renders DrawerItem with icon 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -217,6 +219,8 @@ exports[`renders active DrawerItem 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -301,6 +305,8 @@ exports[`renders basic DrawerItem 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [

--- a/src/components/__tests__/__snapshots__/FAB.test.js.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.js.snap
@@ -420,6 +420,8 @@ exports[`renders extended FAB 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.js.snap
@@ -56,6 +56,8 @@ exports[`renders expanded accordion 1`] = `
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Array [
@@ -174,6 +176,8 @@ exports[`renders expanded accordion 1`] = `
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Array [
@@ -304,6 +308,8 @@ exports[`renders list accordion with children 1`] = `
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Array [
@@ -429,6 +435,8 @@ exports[`renders list accordion with custom title and description styles 1`] = `
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Array [
@@ -456,6 +464,8 @@ exports[`renders list accordion with custom title and description styles 1`] = `
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Array [
@@ -639,6 +649,8 @@ exports[`renders list accordion with left items 1`] = `
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Array [
@@ -764,6 +776,8 @@ exports[`renders multiline list accordion 1`] = `
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Array [
@@ -789,6 +803,8 @@ exports[`renders multiline list accordion 1`] = `
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Array [

--- a/src/components/__tests__/__snapshots__/ListItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.js.snap
@@ -53,6 +53,8 @@ exports[`renders list item with custom description 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -195,6 +197,8 @@ exports[`renders list item with custom description 1`] = `
                         "color": "#000000",
                         "fontFamily": "System",
                         "fontWeight": "400",
+                      },
+                      Object {
                         "textAlign": "left",
                       },
                       Array [
@@ -281,6 +285,8 @@ exports[`renders list item with custom title and description styles 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -308,6 +314,8 @@ exports[`renders list item with custom title and description styles 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -387,6 +395,8 @@ exports[`renders list item with left and right items 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -412,6 +422,8 @@ exports[`renders list item with left and right items 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -596,6 +608,8 @@ exports[`renders list item with left item 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -670,6 +684,8 @@ exports[`renders list item with right item 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -747,6 +763,8 @@ exports[`renders list item with title and description 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -772,6 +790,8 @@ exports[`renders list item with title and description 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -846,6 +866,8 @@ exports[`renders with a description with typeof number 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [
@@ -873,6 +895,8 @@ exports[`renders with a description with typeof number 1`] = `
               "color": "#000000",
               "fontFamily": "System",
               "fontWeight": "400",
+            },
+            Object {
               "textAlign": "left",
             },
             Array [

--- a/src/components/__tests__/__snapshots__/ListSection.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.js.snap
@@ -60,6 +60,8 @@ exports[`renders list section with custom title style 1`] = `
           "color": "#000000",
           "fontFamily": "System",
           "fontWeight": "400",
+        },
+        Object {
           "textAlign": "left",
         },
         Array [
@@ -189,6 +191,8 @@ exports[`renders list section with custom title style 1`] = `
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Array [
@@ -316,6 +320,8 @@ exports[`renders list section with custom title style 1`] = `
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Array [
@@ -398,6 +404,8 @@ exports[`renders list section with subheader 1`] = `
           "color": "#000000",
           "fontFamily": "System",
           "fontWeight": "400",
+        },
+        Object {
           "textAlign": "left",
         },
         Array [
@@ -525,6 +533,8 @@ exports[`renders list section with subheader 1`] = `
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Array [
@@ -652,6 +662,8 @@ exports[`renders list section with subheader 1`] = `
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Array [
@@ -834,6 +846,8 @@ exports[`renders list section without subheader 1`] = `
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Array [
@@ -961,6 +975,8 @@ exports[`renders list section without subheader 1`] = `
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Array [

--- a/src/components/__tests__/__snapshots__/Menu.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.js.snap
@@ -65,6 +65,8 @@ exports[`renders menu with content styles 1`] = `
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Array [
@@ -165,6 +167,8 @@ exports[`renders not visible menu 1`] = `
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Array [
@@ -265,6 +269,8 @@ exports[`renders visible menu 1`] = `
                 "color": "#000000",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "textAlign": "left",
               },
               Array [

--- a/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
@@ -52,6 +52,8 @@ exports[`renders snackbar with Text as a child 1`] = `
             "color": "#000000",
             "fontFamily": "System",
             "fontWeight": "400",
+          },
+          Object {
             "textAlign": "left",
           },
           Array [
@@ -127,6 +129,8 @@ exports[`renders snackbar with action button 1`] = `
             "color": "#000000",
             "fontFamily": "System",
             "fontWeight": "400",
+          },
+          Object {
             "textAlign": "left",
           },
           Array [
@@ -209,6 +213,8 @@ exports[`renders snackbar with action button 1`] = `
                   "color": "#000000",
                   "fontFamily": "System",
                   "fontWeight": "400",
+                },
+                Object {
                   "textAlign": "left",
                 },
                 Array [
@@ -297,6 +303,8 @@ exports[`renders snackbar with content 1`] = `
             "color": "#000000",
             "fontFamily": "System",
             "fontWeight": "400",
+          },
+          Object {
             "textAlign": "left",
           },
           Array [

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -32,11 +32,15 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
   />
   <View
     style={
-      Object {
-        "minHeight": 64,
-        "paddingBottom": 0,
-        "paddingTop": 0,
-      }
+      Array [
+        Object {
+          "paddingBottom": 0,
+          "paddingTop": 0,
+        },
+        Object {
+          "minHeight": 64,
+        },
+      ]
     }
   >
     <View
@@ -204,11 +208,15 @@ exports[`correctly applies textAlign center 1`] = `
   />
   <View
     style={
-      Object {
-        "minHeight": 64,
-        "paddingBottom": 0,
-        "paddingTop": 0,
-      }
+      Array [
+        Object {
+          "paddingBottom": 0,
+          "paddingTop": 0,
+        },
+        Object {
+          "minHeight": 64,
+        },
+      ]
     }
   >
     <View
@@ -376,11 +384,15 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
   />
   <View
     style={
-      Object {
-        "minHeight": 64,
-        "paddingBottom": 0,
-        "paddingTop": 0,
-      }
+      Array [
+        Object {
+          "paddingBottom": 0,
+          "paddingTop": 0,
+        },
+        Object {
+          "minHeight": 64,
+        },
+      ]
     }
   >
     <View
@@ -690,11 +702,15 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
   />
   <View
     style={
-      Object {
-        "minHeight": 64,
-        "paddingBottom": 0,
-        "paddingTop": 0,
-      }
+      Array [
+        Object {
+          "paddingBottom": 0,
+          "paddingTop": 0,
+        },
+        Object {
+          "minHeight": 64,
+        },
+      ]
     }
   >
     <View

--- a/src/utils/getContrastingColor.tsx
+++ b/src/utils/getContrastingColor.tsx
@@ -1,0 +1,14 @@
+import type { ColorValue } from 'react-native';
+import color from 'color';
+
+export default function getContrastingColor(
+  input: ColorValue,
+  light: string,
+  dark: string
+): string {
+  if (typeof input === 'string') {
+    return color(input).isLight() ? dark : light;
+  }
+
+  return light;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2742,10 +2742,17 @@
     "@types/react" "*"
     "@types/react-native" "*"
 
-"@types/react-native@*", "@types/react-native@^0.62.0":
+"@types/react-native@*":
   version "0.62.14"
   resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.62.14.tgz#13ce7dab136bb124b6f394fe7510442557b16d29"
   integrity sha512-ItBgiEQks2Mid6GsiLBx75grNH0glaKemTK9V7G+vSnvP+Zk3x1Wr+aTy4dJxRPPMg14DAJyYePLZwj2cigXbw==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-native@^0.63.0":
+  version "0.63.46"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.46.tgz#942df5af29046c6f22227495e00d5297cc1cea73"
+  integrity sha512-SnBnWRErpISIaWk4K8kAfIKqSPdZ8fdH6HIw7kVdz6jMl/5FAf6iXeIwRfVZg1bCMh+ymNPCpSENNNEVprxj/w==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
### Summary

This PR upgrades react native types to v0.63 and fixes few eslint warnings.

### Test plan

Reinstall node_modules and run `yarn typescript`