### PR TITLE
allow disabling anchor-focus after dismissal in Menu

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -45,6 +45,10 @@ type Props = {
    */
   onDismiss: () => void;
   /**
+   * Whether the `anchor` should be focused when `onDimiss` has finished animating
+   */
+  focusAnchorOnDismiss?: boolean;
+  /**
    * Accessibility label for the overlay. This is read by the screen reader when the user taps outside the menu.
    */
   overlayAccessibilityLabel?: string;
@@ -329,7 +333,9 @@ class Menu extends React.Component<Props, State> {
       if (finished) {
         this.setState({ menuLayout: { width: 0, height: 0 }, rendered: false });
         this.state.scaleAnimation.setValue({ x: 0, y: 0 });
-        this.focusFirstDOMNode(this.anchor);
+        if (this.props.focusAnchorOnDismiss ?? true) {
+          this.focusFirstDOMNode(this.anchor);
+        }
       }
     });
   };


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
It's not necessarily always desirable that the anchor be focused when `Menu` `onDismiss`es. This PR allows disabling this behavior by adding a `focusAnchorOnDismiss` prop to `Menu` while preserving the existing behavior as the default

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
Instantiate a `<Menu focusAnchorOnDismiss>` and observe how its `anchor` does not get focused `onDismiss`