### PR TITLE
Fix: Pagination Datatable example

### DIFF
--- a/example/src/Examples/DataTableExample.tsx
+++ b/example/src/Examples/DataTableExample.tsx
@@ -93,7 +93,7 @@ const DataTableExample = () => {
 
           <DataTable.Pagination
             page={page}
-            numberOfPages={Math.floor(sortedItems.length / itemsPerPage)}
+            numberOfPages={Math.round(sortedItems.length / itemsPerPage)}
             onPageChange={(page) => setPage(page)}
             label={`${from + 1}-${to} of ${sortedItems.length}`}
           />


### PR DESCRIPTION
Noticed this while I was attempting to create a table using this as my example to reference. You are flooring the page numbers, which is wrong. Changing this to round up using `.round` instead would give you the desired usage.


