### PR TITLE
feat: add prop right to List Accordion

### DIFF
--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -29,6 +29,10 @@ type Props = {
    */
   left?: (props: { color: string }) => React.ReactNode;
   /**
+   * Callback which returns a React element to display on the right side.
+   */
+  right?: (props: { isExpanded: boolean }) => React.ReactNode;
+  /**
    * Whether the accordion is expanded
    * If this prop is provided, the accordion will behave as a "controlled component".
    * You'll need to update this prop when you want to toggle the component or on `onPress`.
@@ -127,6 +131,7 @@ type Props = {
  */
 const ListAccordion = ({
   left,
+  right,
   title,
   description,
   children,
@@ -224,12 +229,18 @@ const ListAccordion = ({
           <View
             style={[styles.item, description ? styles.multiline : undefined]}
           >
-            <MaterialCommunityIcon
-              name={isExpanded ? 'chevron-up' : 'chevron-down'}
-              color={titleColor}
-              size={24}
-              direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
-            />
+            {right ? (
+              right({
+                isExpanded: isExpanded,
+              })
+            ) : (
+              <MaterialCommunityIcon
+                name={isExpanded ? 'chevron-up' : 'chevron-down'}
+                color={titleColor}
+                size={24}
+                direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
+              />
+            )}
           </View>
         </View>
       </TouchableRipple>


### PR DESCRIPTION
### Summary
This pull request addresses issue https://github.com/callstack/react-native-paper/issues/2150. It gives users the flexibility to replace what's rendered on the right-hand-side of the accordion with their own component. The expanded state is passed back to the user so that they can render based on this value.

This feature draws inspiration from the `left` prop on the same component. Instead, this could have been addressed similarly to how Fab Icon is implemented, however the drawback is that the implementation of Fab Icon is a bit more complex when compared to the `left` prop of this component.

### Test plan

Render a `List.Accordion` component and pass in a separate component as the `right` prop. E.g.

Omitting this prop results in the default `MaterialCommunityIcon` element being rendered.
