### PR TITLE
docs: add react-native-collapsible-tab-view to the recommended libraries

### DIFF
--- a/docs/pages/6.recommended-libraries.md
+++ b/docs/pages/6.recommended-libraries.md
@@ -16,6 +16,9 @@ Material Design themed [swipeable tabs](https://material.io/design/components/ta
 [react-native-paper-tabs](https://github.com/web-ridge/react-native-paper-tabs)
 Material Design themed [swipeable tabs](https://material.io/design/components/tabs.html) for React Native Paper, maintained by [@RichardLindhout](https://twitter.com/RichardLindhout)
 
+[react-native-collapsible-tab-view](https://github.com/PedroBern/react-native-collapsible-tab-view)
+Collapsible Material Design themed [swipeable tabs](https://material.io/design/components/tabs.html), maintained by [@PedroBern](https://github.com/PedroBern) and [@andreialecu](https://github.com/andreialecu).
+
 ## Bottom sheet
 
 [osdnk/reanimated-bottom-sheet](https://github.com/osdnk/react-native-reanimated-bottom-sheet)


### PR DESCRIPTION
### Summary

Add [react-native-collapsible-tab-view](https://github.com/PedroBern/react-native-collapsible-tab-view) to the recommended libraries. 

Below is the expo preview of the example app (it uses the [react-native-tab-view](https://github.com/satya164/react-native-tab-view) example app as a template).

- [View it with Expo](https://expo.io/@pedrobern/react-native-collapsible-tab-view-demos).

<a href="https://expo.io/@pedrobern/react-native-collapsible-tab-view-demos"><img src="https://api.qrserver.com/v1/create-qr-code/?size=400x400&data=exp://exp.host/@pedrobern/react-native-collapsible-tab-view-demos" height="200px" width="200px"></a>