### PR TITLE
feat(menu): overlay, surfaceProps, focusAnchorOnDismiss, focusSurfaceOnShown

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -577,8 +577,12 @@ class Menu extends React.Component<Props, State> {
               pointerEvents={visible ? 'box-none' : 'none'}
               onAccessibilityEscape={onDismiss}
             >
-              <Animated.View style={{ transform: positionTransforms }}>
+              <Animated.View
+                pointerEvents="none"
+                style={{ transform: positionTransforms }}
+              >
                 <Surface
+                  pointerEvents="auto"
                   {...this.props.surfaceProps}
                   style={
                     [

--- a/src/components/TextInput/Adornment/TextInputAffix.tsx
+++ b/src/components/TextInput/Adornment/TextInputAffix.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import color from 'color';
 import {
   Text,
@@ -14,15 +14,15 @@ import { AdornmentSide } from './enums';
 
 const AFFIX_OFFSET = 12;
 
-type Props = {
-  text: string;
+type Props = PropsWithChildren<{
+  text?: string;
   onLayout?: (event: LayoutChangeEvent) => void;
   textStyle?: StyleProp<TextStyle>;
   /**
    * @optional
    */
   theme: ReactNativePaper.Theme;
-};
+}>;
 
 type ContextState = {
   topPosition: number | null;
@@ -69,7 +69,12 @@ const AffixAdornment: React.FunctionComponent<
   );
 };
 
-const TextInputAffix = ({ text, textStyle: labelStyle, theme }: Props) => {
+const TextInputAffix = ({
+  text = '',
+  textStyle: labelStyle,
+  theme,
+  children,
+}: Props) => {
   const {
     textStyle,
     onLayout,
@@ -106,7 +111,11 @@ const TextInputAffix = ({ text, textStyle: labelStyle, theme }: Props) => {
       ]}
       onLayout={onLayout}
     >
-      <Text style={[{ color: textColor }, textStyle, labelStyle]}>{text}</Text>
+      {children ?? (
+        <Text style={[{ color: textColor }, textStyle, labelStyle]}>
+          {text}
+        </Text>
+      )}
     </Animated.View>
   );
 };


### PR DESCRIPTION
### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

Adds the following props to `Menu`:
```typescript
  /**
   * Whether the `anchor` should be focused when `onDimiss` has finished animating
   */
  focusAnchorOnDismiss?: boolean;
  /**
   * Whether the `anchor` should be focused when `onDimiss` has finished animating
   */
  focusSurfaceOnShown?: boolean;
  /**
   * Whether to use the overlay that is rendered behind the Surface and dismisses the Surface `onPress`
   */
  overlay?: boolean;
  /**
   * Additional props to add to the `Surface`
   */
  surfaceProps?: Partial<ComponentProps<typeof Surface>>;
```
