### PR TITLE
fix: BottomNavigation clickthrough in tabs on web

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -610,6 +610,11 @@ const BottomNavigation = ({
             outputRange: [0, FAR_FAR_AWAY],
           });
 
+          const web =
+            Platform.OS === 'web'
+              ? { display: focused ? 'flex' : 'none' }
+              : undefined;
+
           return (
             <Animated.View
               key={route.key}
@@ -618,7 +623,7 @@ const BottomNavigation = ({
               importantForAccessibility={
                 focused ? 'auto' : 'no-hide-descendants'
               }
-              style={[StyleSheet.absoluteFill, { opacity }]}
+              style={[StyleSheet.absoluteFill, { opacity }, web]}
               collapsable={false}
               removeClippedSubviews={
                 // On iOS, set removeClippedSubviews to true only when not focused


### PR DESCRIPTION
Fixes https://github.com/callstack/react-native-paper/issues/2366

### Summary

Fixes #2366 by setting `display: none` on the tab when it's not focused. Continuation of broken pull request: https://github.com/callstack/react-native-paper/pull/2370. The commit just uses the already-existing "focused" attribute that the rest of the code uses. I tested it in my own application and the branch works (with `yarn link`)

### Test plan

Clone the branch, install dependencies with `yarn bootstrap` and `yarn link`. Test expo snack online with instructions in the app and see the issue. Download expo snack to a folder (https://snack.expo.io/@jasperro/react-native-paper-tab-clickthrough-test) and run `yarn` and `yarn link react-native-paper`, and it should be fixed.