### PR TITLE
chore(TextInput): run animations using native driver on iOS

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {
   Animated,
   TextInput as NativeTextInput,
-  Platform,
   LayoutChangeEvent,
   StyleProp,
   TextStyle,
@@ -298,11 +297,7 @@ class TextInput extends React.Component<TextInputProps, State> {
     Animated.timing(this.state.error, {
       toValue: 1,
       duration: FOCUS_ANIMATION_DURATION * scale,
-      // To prevent this - https://github.com/callstack/react-native-paper/issues/941
-      useNativeDriver: Platform.select({
-        ios: false,
-        default: true,
-      }),
+      useNativeDriver: true,
     }).start();
   };
 
@@ -311,11 +306,7 @@ class TextInput extends React.Component<TextInputProps, State> {
     Animated.timing(this.state.error, {
       toValue: 0,
       duration: BLUR_ANIMATION_DURATION * scale,
-      // To prevent this - https://github.com/callstack/react-native-paper/issues/941
-      useNativeDriver: Platform.select({
-        ios: false,
-        default: true,
-      }),
+      useNativeDriver: true,
     }).start();
   };
 
@@ -324,11 +315,7 @@ class TextInput extends React.Component<TextInputProps, State> {
     Animated.timing(this.state.labeled, {
       toValue: 1,
       duration: FOCUS_ANIMATION_DURATION * scale,
-      // To prevent this - https://github.com/callstack/react-native-paper/issues/941
-      useNativeDriver: Platform.select({
-        ios: false,
-        default: true,
-      }),
+      useNativeDriver: true,
     }).start();
   };
 
@@ -337,11 +324,7 @@ class TextInput extends React.Component<TextInputProps, State> {
     Animated.timing(this.state.labeled, {
       toValue: 0,
       duration: BLUR_ANIMATION_DURATION * scale,
-      // To prevent this - https://github.com/callstack/react-native-paper/issues/941
-      useNativeDriver: Platform.select({
-        ios: false,
-        default: true,
-      }),
+      useNativeDriver: true,
     }).start();
   };
 


### PR DESCRIPTION
### Summary
This PR is a proposal to run animations using the native driver on the iOS platform. It's a little laggy in old devices such as an iPhone 5s  when you have some inputs in a form. It's noticeable in the example app as well.

This was removed in this issue #941 demoed in this snack https://snack.expo.io/ryoVI7WuV
However, I couldn't reproduce this issue anymore either in the snack or on a phone (iPhone 5s). Maybe it was fixed in the newer versions of react-native?

### Test plan
1. Open the example app and goes to the TextInput section
2. Check if the label animations are running smoothly
3. Try to reproduce the problem reported in issue  #941