### PR TITLE
fix: component BottomNavigation

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -605,10 +605,14 @@ const BottomNavigation = ({
             ? 1
             : 0;
 
-          const top = offsetsAnims[index].interpolate({
-            inputRange: [0, 1],
-            outputRange: [0, FAR_FAR_AWAY],
-          });
+          const top = sceneAnimationEnabled
+            ? offsetsAnims[index].interpolate({
+                inputRange: [0, 1],
+                outputRange: [0, FAR_FAR_AWAY],
+              })
+            : focused
+            ? 0
+            : FAR_FAR_AWAY;
 
           return (
             <Animated.View


### PR DESCRIPTION
Prevent scene blink fix desynchronization between opacity & top

Sometimes the top property is too far and the opacity = 0 so the screen flash.

### Summary

Fix screen flash / blink when switching tabs.

https://github.com/react-navigation/react-navigation/issues/9256

### Test plan

Switch between tabs.
