### PR TITLE
feat: add Button props to Snackbar action

### DIFF
--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -23,7 +23,7 @@ type Props = React.ComponentProps<typeof Surface> & {
    * - `label` - Label of the action button
    * - `onPress` - Callback that is called when action button is pressed.
    */
-  action?: React.ComponentProps<typeof Button> & {
+  action?: Omit<React.ComponentProps<typeof Button>, 'children'> & {
     label: string;
   };
   /**

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -23,10 +23,8 @@ type Props = React.ComponentProps<typeof Surface> & {
    * - `label` - Label of the action button
    * - `onPress` - Callback that is called when action button is pressed.
    */
-  action?: {
+  action?: React.ComponentProps<typeof Button> & {
     label: string;
-    accessibilityLabel?: string;
-    onPress: () => void;
   };
   /**
    * The duration for which the Snackbar is shown.
@@ -171,6 +169,13 @@ const Snackbar = ({
 
   if (hidden) return null;
 
+  const {
+    style: actionStyle,
+    label: actionLabel,
+    onPress: onPressAction,
+    ...actionProps
+  } = action || {};
+
   return (
     <SafeAreaView
       pointerEvents="box-none"
@@ -212,17 +217,17 @@ const Snackbar = ({
         </Text>
         {action ? (
           <Button
-            accessibilityLabel={action.accessibilityLabel}
             onPress={() => {
-              action.onPress();
+              onPressAction?.();
               onDismiss();
             }}
-            style={styles.button}
+            style={[styles.button, actionStyle]}
             color={colors.accent}
             compact
             mode="text"
+            {...actionProps}
           >
-            {action.label}
+            {actionLabel}
           </Button>
         ) : null}
       </Surface>


### PR DESCRIPTION
### Summary

With this feature you can pass Button props to action, for example, style, testID, icon, etc.

### Test plan

1. Download this branch
2. Create Snackbar
3. Pass other props to action

