### PR TITLE
feat: add loading prop to IconButton

### DIFF
--- a/example/src/Examples/IconButtonExample.tsx
+++ b/example/src/Examples/IconButtonExample.tsx
@@ -21,7 +21,8 @@ const ButtonExample = () => {
         onPress={() => {}}
         style={{ backgroundColor: Colors.lightGreen200 }}
       />
-      <IconButton icon="heart" size={60} onPress={() => {}} />
+      <IconButton icon="heart" size={48} onPress={() => {}} />
+      <IconButton icon="heart" size={48} onPress={() => {}} loading />
     </View>
   );
 };

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -15,6 +15,7 @@ import CrossFadeIcon from './CrossFadeIcon';
 import { withTheme } from '../core/theming';
 
 import type { $RemoveChildren } from '../types';
+import ActivityIndicator from './ActivityIndicator';
 
 type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
@@ -33,6 +34,10 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
    * Whether the button is disabled. A disabled button is greyed out and `onPress` is not called on touch.
    */
   disabled?: boolean;
+  /**
+   * Whether to show a loading indicator.
+   */
+  loading?: boolean;
   /**
    * Whether an icon change is animated.
    */
@@ -93,6 +98,7 @@ const IconButton = ({
   size = 24,
   accessibilityLabel,
   disabled,
+  loading,
   onPress,
   animated = false,
   theme,
@@ -131,7 +137,11 @@ const IconButton = ({
       {...rest}
     >
       <View>
-        <IconComponent color={iconColor} source={icon} size={size} />
+        {loading ? (
+          <ActivityIndicator color={iconColor} size={size} />
+        ) : (
+          <IconComponent color={iconColor} size={size} source={icon} />
+        )}
       </View>
     </TouchableRipple>
   );


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Added a loading prop to the IconButton - related issue https://github.com/callstack/react-native-paper/issues/1112 - if the Button has a loading prop, makes sense the IconButton does as well.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
1. Download this branch 
2. Create IconButton (or take a peak at the example)
3. Pass in loading prop
4. Presto