### PR TITLE
fix: define a prop as optional

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -10,7 +10,7 @@ type Props = React.ComponentProps<typeof Animated.Text> & {
   /**
    * Whether the badge is visible
    */
-  visible: boolean;
+  visible?: boolean;
   /**
    * Content of the `Badge`.
    */


### PR DESCRIPTION
Thanks all contributors!

I found inconsistency between type definition and implementation.

Default value `true` is given for `visible` prop of Badge. But `visible` is defined as mandatory. This prop can be optional.
