### PR TITLE
chore: change MenuItem to function component

### DIFF
--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -1,17 +1,17 @@
 import color from 'color';
 import * as React from 'react';
 import {
-  View,
+  StyleProp,
   StyleSheet,
   TextStyle,
+  View,
   ViewStyle,
-  StyleProp,
 } from 'react-native';
 import Icon, { IconSource } from '../Icon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import Text from '../Typography/Text';
-import { withTheme } from '../../core/theming';
 import { black, white } from '../../styles/colors';
+import { useTheme } from '../../core/theming';
 
 type Props = {
   /**
@@ -33,7 +33,6 @@ type Props = {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
   style?: StyleProp<ViewStyle>;
   contentStyle?: StyleProp<ViewStyle>;
   titleStyle?: StyleProp<TextStyle>;
@@ -71,73 +70,69 @@ type Props = {
  * export default MyComponent;
  * ```
  */
+function MenuItem({
+  icon,
+  title,
+  disabled,
+  onPress,
+  style,
+  contentStyle,
+  testID,
+  titleStyle,
+}: Props) {
+  const theme = useTheme();
 
-class MenuItem extends React.Component<Props> {
-  static displayName = 'Menu.Item';
+  const disabledColor = color(theme.dark ? white : black)
+    .alpha(0.32)
+    .rgb()
+    .string();
 
-  render() {
-    const {
-      icon,
-      title,
-      disabled,
-      onPress,
-      theme,
-      style,
-      contentStyle,
-      testID,
-      titleStyle,
-    } = this.props;
+  const titleColor = disabled
+    ? disabledColor
+    : color(theme.colors.text).alpha(0.87).rgb().string();
 
-    const disabledColor = color(theme.dark ? white : black)
-      .alpha(0.32)
-      .rgb()
-      .string();
+  const iconColor = disabled
+    ? disabledColor
+    : color(theme.colors.text).alpha(0.54).rgb().string();
 
-    const titleColor = disabled
-      ? disabledColor
-      : color(theme.colors.text).alpha(0.87).rgb().string();
-
-    const iconColor = disabled
-      ? disabledColor
-      : color(theme.colors.text).alpha(0.54).rgb().string();
-
-    return (
-      <TouchableRipple
-        style={[styles.container, style]}
-        onPress={onPress}
-        disabled={disabled}
-        testID={testID}
-        accessibilityRole="menuitem"
-        accessibilityState={{ disabled }}
-      >
-        <View style={styles.row}>
-          {icon ? (
-            <View style={[styles.item, styles.icon]} pointerEvents="box-none">
-              <Icon source={icon} size={24} color={iconColor} />
-            </View>
-          ) : null}
-          <View
-            style={[
-              styles.item,
-              styles.content,
-              icon ? styles.widthWithIcon : null,
-              contentStyle,
-            ]}
-            pointerEvents="none"
-          >
-            <Text
-              selectable={false}
-              numberOfLines={1}
-              style={[styles.title, { color: titleColor }, titleStyle]}
-            >
-              {title}
-            </Text>
+  return (
+    <TouchableRipple
+      style={[styles.container, style]}
+      onPress={onPress}
+      disabled={disabled}
+      testID={testID}
+      accessibilityRole="menuitem"
+      accessibilityState={{ disabled }}
+    >
+      <View style={styles.row}>
+        {icon ? (
+          <View style={[styles.item, styles.icon]} pointerEvents="box-none">
+            <Icon source={icon} size={24} color={iconColor} />
           </View>
+        ) : null}
+        <View
+          style={[
+            styles.item,
+            styles.content,
+            icon ? styles.widthWithIcon : null,
+            contentStyle,
+          ]}
+          pointerEvents="none"
+        >
+          <Text
+            selectable={false}
+            numberOfLines={1}
+            style={[styles.title, { color: titleColor }, titleStyle]}
+          >
+            {title}
+          </Text>
         </View>
-      </TouchableRipple>
-    );
-  }
+      </View>
+    </TouchableRipple>
+  );
 }
+
+MenuItem.displayName = 'Menu.Item';
 
 const minWidth = 112;
 const maxWidth = 280;
@@ -173,7 +168,7 @@ const styles = StyleSheet.create({
   },
 });
 
-export default withTheme(MenuItem);
+export default MenuItem;
 
 // @component-docs ignore-next-line
 export { MenuItem };


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

The only thing this does is that it changes MenuItem to be a fn component. I replaced withTheme() by useTheme() too

You're probably wondering why I did this, well, it's nicer this way, and secondly, I maintain something like a copy of this in another project, where I changed it into a fn component and I'd like the two implementations to stay similar.


### Test plan

Tested with the example app on ios simulator and android device, all is good.

Thank you!