### PR TITLE
feat: A new feature numberOfLines props added in snackbar

### DIFF
--- a/src/babel/__fixtures__/rewrite-imports/output.js
+++ b/src/babel/__fixtures__/rewrite-imports/output.js
@@ -1,11 +1,11 @@
 /* eslint-disable prettier/prettier */
 import { Text } from 'react-native';
-import PaperProvider from "react-native-paper/lib/module/core/Provider";
-import BottomNavigation from "react-native-paper/lib/module/components/BottomNavigation";
-import Button from "react-native-paper/lib/module/components/Button";
-import FAB from "react-native-paper/lib/module/components/FAB";
-import Appbar from "react-native-paper/lib/module/components/Appbar";
-import * as Colors from "react-native-paper/lib/module/styles/colors";
+import PaperProvider from "react-native-paper/lib\\module\\core\\Provider";
+import BottomNavigation from "react-native-paper/lib\\module\\components\\BottomNavigation";
+import Button from "react-native-paper/lib\\module\\components\\Button";
+import FAB from "react-native-paper/lib\\module\\components\\FAB";
+import Appbar from "react-native-paper/lib\\module\\components\\Appbar";
+import * as Colors from "react-native-paper/lib\\module\\styles\\colors";
 import { NonExistent, NonExistentSecond as Stuff, Theme } from "react-native-paper/lib/module/index.js";
-import { ThemeProvider } from "react-native-paper/lib/module/core/theming";
-import { withTheme } from "react-native-paper/lib/module/core/theming";
+import { ThemeProvider } from "react-native-paper/lib\\module\\core\\theming";
+import { withTheme } from "react-native-paper/lib\\module\\core\\theming";

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -33,6 +33,10 @@ type Props = React.ComponentProps<typeof Surface> & {
    */
   duration?: number;
   /**
+   * When numberOfLines is set, this prop defines how many lines snackbar can show.
+   */
+   numberOfLines?: number;
+  /**
    * Callback called when Snackbar is dismissed. The `visible` prop needs to be updated when this is called.
    */
   onDismiss: () => void;
@@ -113,6 +117,7 @@ const Snackbar = ({
   wrapperStyle,
   style,
   theme,
+  numberOfLines = 0, // 0 represents it can have any number of lines
   ...rest
 }: Props) => {
   const { current: opacity } = React.useRef<Animated.Value>(
@@ -207,6 +212,7 @@ const Snackbar = ({
             styles.content,
             { marginRight: action ? 0 : 16, color: colors.surface },
           ]}
+          numberOfLines={numberOfLines}
         >
           {children}
         </Text>

--- a/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
@@ -46,6 +46,7 @@ exports[`renders snackbar with Text as a child 1`] = `
     }
   >
     <Text
+      numberOfLines={0}
       style={
         Array [
           Object {
@@ -123,6 +124,7 @@ exports[`renders snackbar with action button 1`] = `
     }
   >
     <Text
+      numberOfLines={0}
       style={
         Array [
           Object {
@@ -297,6 +299,7 @@ exports[`renders snackbar with content 1`] = `
     }
   >
     <Text
+      numberOfLines={0}
       style={
         Array [
           Object {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This pull request solves this issue https://github.com/callstack/react-native-paper/issues/2596

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
in your local project which is using `react-native-paper` create a snackbar component and copy the snackbar contents from pull request snackbar file, and if any component is has missing import in snackbar component, then import it from  `react-native-paper`