### PR TITLE
fix(BottomNavigation): selected state now reads properly on voiceover

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -760,7 +760,7 @@ const BottomNavigation = ({
                   : 'button',
                 accessibilityComponentType: 'button',
                 accessibilityRole: 'button',
-                accessibilityState: { selected: true },
+                accessibilityState: { selected: focused },
                 style: styles.item,
                 children: (
                   <View pointerEvents="none">

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
@@ -296,7 +296,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
           accessibilityRole="button"
           accessibilityState={
             Object {
-              "selected": true,
+              "selected": false,
             }
           }
           accessible={true}
@@ -486,7 +486,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
           accessibilityRole="button"
           accessibilityState={
             Object {
-              "selected": true,
+              "selected": false,
             }
           }
           accessible={true}
@@ -994,7 +994,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
           accessibilityRole="button"
           accessibilityState={
             Object {
-              "selected": true,
+              "selected": false,
             }
           }
           accessible={true}
@@ -1184,7 +1184,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
           accessibilityRole="button"
           accessibilityState={
             Object {
-              "selected": true,
+              "selected": false,
             }
           }
           accessible={true}
@@ -1648,7 +1648,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
           accessibilityRole="button"
           accessibilityState={
             Object {
-              "selected": true,
+              "selected": false,
             }
           }
           accessible={true}
@@ -1814,7 +1814,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
           accessibilityRole="button"
           accessibilityState={
             Object {
-              "selected": true,
+              "selected": false,
             }
           }
           accessible={true}
@@ -2258,7 +2258,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
           accessibilityRole="button"
           accessibilityState={
             Object {
-              "selected": true,
+              "selected": false,
             }
           }
           accessible={true}
@@ -2408,7 +2408,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
           accessibilityRole="button"
           accessibilityState={
             Object {
-              "selected": true,
+              "selected": false,
             }
           }
           accessible={true}
@@ -2558,7 +2558,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
           accessibilityRole="button"
           accessibilityState={
             Object {
-              "selected": true,
+              "selected": false,
             }
           }
           accessible={true}
@@ -2708,7 +2708,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
           accessibilityRole="button"
           accessibilityState={
             Object {
-              "selected": true,
+              "selected": false,
             }
           }
           accessible={true}
@@ -3241,7 +3241,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
           accessibilityRole="button"
           accessibilityState={
             Object {
-              "selected": true,
+              "selected": false,
             }
           }
           accessible={true}
@@ -3516,7 +3516,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
           accessibilityRole="button"
           accessibilityState={
             Object {
-              "selected": true,
+              "selected": false,
             }
           }
           accessible={true}
@@ -4154,7 +4154,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
           accessibilityRole="button"
           accessibilityState={
             Object {
-              "selected": true,
+              "selected": false,
             }
           }
           accessible={true}
@@ -4389,7 +4389,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
           accessibilityRole="button"
           accessibilityState={
             Object {
-              "selected": true,
+              "selected": false,
             }
           }
           accessible={true}
@@ -5007,7 +5007,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
           accessibilityRole="button"
           accessibilityState={
             Object {
-              "selected": true,
+              "selected": false,
             }
           }
           accessible={true}
@@ -5282,7 +5282,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
           accessibilityRole="button"
           accessibilityState={
             Object {
-              "selected": true,
+              "selected": false,
             }
           }
           accessible={true}
@@ -5920,7 +5920,7 @@ exports[`renders shifting bottom navigation 1`] = `
           accessibilityRole="button"
           accessibilityState={
             Object {
-              "selected": true,
+              "selected": false,
             }
           }
           accessible={true}
@@ -6155,7 +6155,7 @@ exports[`renders shifting bottom navigation 1`] = `
           accessibilityRole="button"
           accessibilityState={
             Object {
-              "selected": true,
+              "selected": false,
             }
           }
           accessible={true}
@@ -6390,7 +6390,7 @@ exports[`renders shifting bottom navigation 1`] = `
           accessibilityRole="button"
           accessibilityState={
             Object {
-              "selected": true,
+              "selected": false,
             }
           }
           accessible={true}
@@ -6625,7 +6625,7 @@ exports[`renders shifting bottom navigation 1`] = `
           accessibilityRole="button"
           accessibilityState={
             Object {
-              "selected": true,
+              "selected": false,
             }
           }
           accessible={true}


### PR DESCRIPTION
### Summary

Originally, when using TalkBack to read through the bottom nav, it would tell me a tab was selected, even when it was not. This PR fixes that, and matches the older behavior that is still in place with `accessibilityTraits`

### Test plan

Open app that utilized bottom nav, turn on screenreader (I'm using TalkBack on Android to test)