### PR TITLE
fix!: fix TextInput paddingOut not based on lineHeight when provided

### DIFF
--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -91,6 +91,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
     const {
       fontSize: fontSizeStyle,
       fontWeight,
+      lineHeight,
       height,
       backgroundColor = colors.background,
       textAlign,
@@ -165,6 +166,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
       dense: dense ? dense : null,
       topPosition,
       fontSize,
+      lineHeight,
       label,
       scale: fontScale,
       isAndroid: Platform.OS === 'android',

--- a/src/components/TextInput/helpers.tsx
+++ b/src/components/TextInput/helpers.tsx
@@ -15,6 +15,7 @@ type PaddingProps = {
   dense: boolean | null;
   topPosition: number;
   fontSize: number;
+  lineHeight?: number;
   label?: string | null;
   scale: number;
   offset: number;
@@ -101,23 +102,25 @@ export const adjustPaddingOut = ({
   scale,
   height,
   fontSize,
+  lineHeight,
   dense,
   offset,
   isAndroid,
 }: AdjProps): Padding => {
-  const refFontSize = scale * fontSize;
+  const fontHeight = lineHeight ?? fontSize;
+  const refFontHeight = scale * fontSize;
   let result = pad;
 
   if (height) {
     return {
-      paddingTop: Math.max(0, (height - fontSize) / 2),
-      paddingBottom: Math.max(0, (height - fontSize) / 2),
+      paddingTop: Math.max(0, (height - fontHeight) / 2),
+      paddingBottom: Math.max(0, (height - fontHeight) / 2),
     };
   }
   if (!isAndroid && multiline) {
     if (dense) {
       if (label) {
-        result += scale < 1 ? Math.min(offset, (refFontSize / 2) * scale) : 0;
+        result += scale < 1 ? Math.min(offset, (refFontHeight / 2) * scale) : 0;
       } else {
         result += 0;
       }
@@ -126,10 +129,10 @@ export const adjustPaddingOut = ({
       if (label) {
         result +=
           scale < 1
-            ? Math.min(offset, refFontSize * scale)
-            : Math.min(offset / 2, refFontSize * scale);
+            ? Math.min(offset, refFontHeight * scale)
+            : Math.min(offset / 2, refFontHeight * scale);
       } else {
-        result += scale < 1 ? Math.min(offset / 2, refFontSize * scale) : 0;
+        result += scale < 1 ? Math.min(offset / 2, refFontHeight * scale) : 0;
       }
     }
     result = Math.floor(result);


### PR DESCRIPTION
### Summary

When using a `TextInput` in `outlined` mode text can be cut on some device, especially on Android.
This is due to the fact that `adjustPaddingOut` is only based on `fontSize`, and even if you pass `lineHeight` in the style to avoid this, this one is not used.
So, to prevent this issue `adjustPaddingOut` is now based on `lineHeight` when this one is provided.

### Test plan

Before:
![Screenshot_20210324-124148](https://user-images.githubusercontent.com/3551795/112349070-cb644680-8c9e-11eb-9d21-73186d9937a1.png)

After:
![Screenshot_20210324-123253](https://user-images.githubusercontent.com/3551795/112349077-ce5f3700-8c9e-11eb-8b69-767b305d0975.png)

