### PR TITLE
fix: define a prop as optional

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -10,7 +10,7 @@ type Props = React.ComponentProps<typeof Animated.Text> & {
   /**
    * Whether the badge is visible
    */
-  visible: boolean;
+  visible?: boolean;
   /**
    * Content of the `Badge`.
    */


### PR DESCRIPTION
Same as #2573.

Default value `true` is given for `visible` prop of Badge. But `visible` is defined as mandatory. This prop can be optional.

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
