### PR TITLE
feat: pass pointerEvents to the `DataTableRow` view container

### DIFF
--- a/src/components/DataTable/DataTableRow.tsx
+++ b/src/components/DataTable/DataTableRow.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import color from 'color';
-import { StyleSheet, StyleProp, View, ViewStyle } from 'react-native';
+import {
+  StyleSheet,
+  StyleProp,
+  View,
+  ViewStyle,
+  ViewProps,
+} from 'react-native';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { black, white } from '../../styles/colors';
 import { withTheme } from '../../core/theming';
@@ -20,6 +26,10 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
    * @optional
    */
   theme: ReactNativePaper.Theme;
+  /**
+   * `pointerEvents` passed to the `View` container, which is wrapping children within `TouchableRipple`.
+   */
+  pointerEvents?: ViewProps['pointerEvents'];
 };
 
 /**
@@ -50,7 +60,14 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
  * ```
  */
 
-const DataTableRow = ({ onPress, style, theme, children, ...rest }: Props) => {
+const DataTableRow = ({
+  onPress,
+  style,
+  theme,
+  children,
+  pointerEvents,
+  ...rest
+}: Props) => {
   const borderBottomColor = color(theme.dark ? white : black)
     .alpha(0.12)
     .rgb()
@@ -62,7 +79,9 @@ const DataTableRow = ({ onPress, style, theme, children, ...rest }: Props) => {
       onPress={onPress}
       style={[styles.container, { borderBottomColor }, style]}
     >
-      <View style={styles.content}>{children}</View>
+      <View style={styles.content} pointerEvents={pointerEvents}>
+        {children}
+      </View>
     </TouchableRipple>
   );
 };


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes: https://github.com/callstack/react-native-paper/issues/2634

That PR introduces a prop called `pointerEvents` which allows user to specify its value for the `View` container which is wrapping the children within `TouchableRipple` in `DataTableRow` component.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

1. Run the example locally on the web
2. Modify current `DataTableExample` e.g.  in the following way (basically specify `pointerEvents` value and add `onPress`):

```
...
  <DataTable.Row 
    key={item.key} 
    onPress={() => console.log('table row pressed')
    pointerEvents="none"
  >
```
3. Expect onPress is fired on the web

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
![web_table_paper](https://user-images.githubusercontent.com/22746080/112997518-7c6e5380-916d-11eb-894f-6b965f7b8205.gif)

