### PR TITLE
fix: do not render empty string as section title

### DIFF
--- a/src/components/List/ListSection.tsx
+++ b/src/components/List/ListSection.tsx
@@ -63,7 +63,7 @@ const ListSection = ({
   ...rest
 }: Props) => (
   <View {...rest} style={[styles.container, style]}>
-    {title && <ListSubheader style={titleStyle}>{title}</ListSubheader>}
+    {title ? <ListSubheader style={titleStyle}>{title}</ListSubheader> : null}
     {children}
   </View>
 );


### PR DESCRIPTION
## Summary

List.Section tries to render empty string without `Text` when `""` is passed to `title` prop and causes an error:

![image](https://user-images.githubusercontent.com/1257695/113236776-82387600-92e0-11eb-926c-0b5128e44d24.png)

## Test plan

Render this:

```
<List.Section title="" />
```
