### PR TITLE
fix: correct toggle button type

### DIFF
--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -102,7 +102,7 @@ const ToggleButton = ({
 
   return (
     <ToggleButtonGroupContext.Consumer>
-      {(context: { value: string; onValueChange: Function } | null) => {
+      {(context: { value: string | null; onValueChange: Function } | null) => {
         let backgroundColor;
 
         const checked: boolean | null =

--- a/src/components/ToggleButton/ToggleButtonGroup.tsx
+++ b/src/components/ToggleButton/ToggleButtonGroup.tsx
@@ -4,11 +4,11 @@ type Props = {
   /**
    * Function to execute on selection change.
    */
-  onValueChange: (value: string) => void;
+  onValueChange: (value: string) => void | null;
   /**
    * Value of the currently selected toggle button.
    */
-  value: string;
+  value: string | null;
   /**
    * React elements containing toggle buttons.
    */
@@ -16,8 +16,8 @@ type Props = {
 };
 
 type ToggleButtonContextType = {
-  value: string;
-  onValueChange: (item: string) => void;
+  value: string | null;
+  onValueChange: (item: string) => void | null;
 };
 
 export const ToggleButtonGroupContext = React.createContext<


### PR DESCRIPTION
Fixes: https://github.com/callstack/react-native-paper/issues/2578

### Summary

Correct types in `ToggleButton.Group` where the value can be `null` e.g. when neither option is selected.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

CI should pass.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
