### PR TITLE
fix: remove additional outline from web inputs

### DIFF
--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -360,6 +360,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
                   ? 'right'
                   : 'left',
               },
+              Platform.OS === 'web' && { outline: 'none' },
               adornmentStyleAdjustmentForNativeInput,
             ],
           })}

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -339,6 +339,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
                     ? 'right'
                     : 'left',
                 },
+                Platform.OS === 'web' && { outline: 'none' },
                 adornmentStyleAdjustmentForNativeInput,
               ],
             } as RenderProps)}

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -164,6 +164,7 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
             "textAlign": "left",
             "textAlignVertical": "center",
           },
+          false,
           Array [
             Object {},
           ],
@@ -340,6 +341,7 @@ exports[`correctly applies textAlign center 1`] = `
             "textAlign": "center",
             "textAlignVertical": "center",
           },
+          false,
           Array [
             Object {},
           ],
@@ -516,6 +518,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
             "textAlign": "left",
             "textAlignVertical": "center",
           },
+          false,
           Object {
             "marginLeft": 0,
             "marginRight": 36,
@@ -834,6 +837,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
             "textAlign": "left",
             "textAlignVertical": "center",
           },
+          false,
           Object {
             "marginLeft": 36,
             "marginRight": 0,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/2598

### Summary

That PR is removing the outline from web text input which is overlapping with component border. 
**NOTE**: we are providing the visual indicator/effect when input if focused, so there is no regression in terms of accessibility.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

1. Use text input on the web
2. Focus the text input
3. Expect there is additional `outline`

before | after
--- | ---
![image](https://user-images.githubusercontent.com/22746080/114157875-678b8000-9924-11eb-921e-edabec3a9048.png) | ![image](https://user-images.githubusercontent.com/22746080/114157828-56427380-9924-11eb-8e6f-b6603c570590.png)


<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
