### PR TITLE
fix(Card): missing event in typescript definition of onPress and onLongPress

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -24,11 +24,11 @@ type Props = React.ComponentProps<typeof Surface> & {
   /**
    * Function to execute on long press.
    */
-  onLongPress?: () => void;
+  onLongPress?: React.ComponentProps<typeof TouchableWithoutFeedback>['onLongPress'];
   /**
    * Function to execute on press.
    */
-  onPress?: () => void;
+  onPress?: React.ComponentProps<typeof TouchableWithoutFeedback>['onPress'];
   /**
    * Content of the `Card`.
    */

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -24,7 +24,9 @@ type Props = React.ComponentProps<typeof Surface> & {
   /**
    * Function to execute on long press.
    */
-  onLongPress?: React.ComponentProps<typeof TouchableWithoutFeedback>['onLongPress'];
+  onLongPress?: React.ComponentProps<
+    typeof TouchableWithoutFeedback
+  >['onLongPress'];
   /**
    * Function to execute on press.
    */


### PR DESCRIPTION

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

I had an error when trying to access the event in onPress of Card (to call preventDefault() ). I noticed onLongPress also is missing. I used ComponentProps to get them, but maybe you would prefer something else ?

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
