### PR TITLE
fix: correct flex values in checkbox item label

### DIFF
--- a/src/components/Checkbox/CheckboxItem.tsx
+++ b/src/components/Checkbox/CheckboxItem.tsx
@@ -135,6 +135,7 @@ const styles = StyleSheet.create({
   },
   label: {
     fontSize: 16,
-    flex: 1,
+    flexShrink: 1,
+    flexGrow: 1,
   },
 });

--- a/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.js.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.js.snap
@@ -46,7 +46,8 @@ exports[`can render the Android checkbox on different platforms 1`] = `
           },
           Array [
             Object {
-              "flex": 1,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "fontSize": 16,
             },
             Object {
@@ -218,7 +219,8 @@ exports[`can render the iOS checkbox on different platforms 1`] = `
           },
           Array [
             Object {
-              "flex": 1,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "fontSize": 16,
             },
             Object {
@@ -356,7 +358,8 @@ exports[`renders unchecked 1`] = `
           },
           Array [
             Object {
-              "flex": 1,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "fontSize": 16,
             },
             Object {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/2542

### Summary

`flexShrink` on mobile defaults to `0` that's why we need to specify it separately with the value `1`.
It corrects the behavior with missing label in some cases.


<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
