### PR TITLE
fix: remove resizeMode style property from CardCover

### DIFF
--- a/src/components/Card/CardCover.tsx
+++ b/src/components/Card/CardCover.tsx
@@ -86,7 +86,6 @@ const styles = StyleSheet.create({
     width: undefined,
     padding: 16,
     justifyContent: 'flex-end',
-    resizeMode: 'cover',
   },
 });
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/2538

### Summary

That PR _unblocks_ the ability to pass the resizeMode to `CardCover`, which was basically not possible before because of no option to override the `resizeMode` value defined in styles.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

1. Add `CardCover` with the image source
2. Specify different `resizeMode`

`cover` (default) | `stretch`
--- | ---
<img width="490" alt="Zrzut ekranu 2021-04-12 o 14 01 27" src="https://user-images.githubusercontent.com/22746080/114392300-dc66f000-9b98-11eb-9e1a-09bb3b57e2fb.png"> | <img width="490" alt="Zrzut ekranu 2021-04-12 o 14 02 10" src="https://user-images.githubusercontent.com/22746080/114392220-c0fbe500-9b98-11eb-8499-93d20d543ea5.png">


<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
