### PR TITLE
feat: add prop color to TextInputIcon

### DIFF
--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -95,7 +95,7 @@ const TextInputExample = () => {
   const _isUsernameValid = (name: string) => /^[a-zA-Z]*$/.test(name);
 
   const {
-    colors: { background, accent },
+    colors: { background, accent, primary },
   } = useTheme();
 
   const inputActionHandler = (type: keyof State, payload: string) =>
@@ -215,6 +215,12 @@ const TextInputExample = () => {
             inputActionHandler('flatDenseText', flatDenseText)
           }
           left={<TextInput.Affix text="#" />}
+          right={
+            <TextInput.Icon
+              name="chevron-up"
+              color={(focused) => (focused ? primary : undefined)}
+            />
+          }
         />
         <TextInput
           style={styles.inputContainerStyle}

--- a/src/components/TextInput/Adornment/TextInputIcon.tsx
+++ b/src/components/TextInput/Adornment/TextInputIcon.tsx
@@ -7,11 +7,12 @@ import type { IconSource } from '../../Icon';
 
 type Props = $Omit<
   React.ComponentProps<typeof IconButton>,
-  'icon' | 'theme'
+  'icon' | 'theme' | 'color'
 > & {
   name: IconSource;
   onPress?: () => void;
   forceTextInputFocus?: boolean;
+  color?: ((isTextInputFocused: boolean) => string | undefined) | string;
   style?: StyleProp<ViewStyle>;
   theme?: ReactNativePaper.Theme;
 };
@@ -54,6 +55,7 @@ const TextInputIcon = ({
   name,
   onPress,
   forceTextInputFocus,
+  color,
   ...rest
 }: Props) => {
   const { style, isTextInputFocused, forceFocus } = React.useContext(
@@ -74,6 +76,7 @@ const TextInputIcon = ({
         style={styles.iconButton}
         size={ICON_SIZE}
         onPress={onPressWithFocusControl}
+        color={typeof color === 'function' ? color(isTextInputFocused) : color}
         {...rest}
       />
     </View>


### PR DESCRIPTION
### Summary
This PR adds a new prop `color` to the component `TextInputIcon`. It accepts whether a function or a string, making it easier to change the icon color when the input is focused as in the MD example below.

![Screenshot from 2021-04-12 23-09-41](https://user-images.githubusercontent.com/6487206/114486407-37720480-9be4-11eb-9e39-47b87c55fe16.png)

### Test plan
Check the example app