### PR TITLE
fix: correct example list background color

### DIFF
--- a/example/src/ExampleList.tsx
+++ b/example/src/ExampleList.tsx
@@ -109,6 +109,7 @@ export default function ExampleList({ navigation }: Props) {
         backgroundColor: colors.background,
         paddingBottom: safeArea.bottom,
       }}
+      style={{ backgroundColor: colors.background }}
       ItemSeparatorComponent={Divider}
       renderItem={renderItem}
       keyExtractor={keyExtractor}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

That PR corrects background color on example list.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

1. Open example app
2. Switch mode to `dark`
3. Expect example list has correct bg color when bounces

before | after
--- | ---
![wrong](https://user-images.githubusercontent.com/22746080/114547812-34682a00-9c5f-11eb-8212-228720161294.gif) | ![correct](https://user-images.githubusercontent.com/22746080/114547806-316d3980-9c5f-11eb-8760-83a83762ce59.gif)
 

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
