### PR TITLE
Fixed documentation

### DIFF
--- a/src/components/DataTable/DataTablePagination.tsx
+++ b/src/components/DataTable/DataTablePagination.tsx
@@ -77,7 +77,7 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
  *     <DataTable>
  *       <DataTable.Pagination
  *         page={page}
- *         numberOfPages={Math.floor(items.length / itemsPerPage)}
+ *         numberOfPages={Math.ceil(items.length / itemsPerPage)}
  *         onPageChange={page => setPage(page)}
  *         label={`${from + 1}-${to} of ${items.length}`}
  *       />


### PR DESCRIPTION
Number of pages was Math.floor() causing component not to work, changed to Math.ceil() which corrects malfunction