### PR TITLE
fix: patch for text input label

### DIFF
--- a/src/components/TextInput/Label/LabelBackground.tsx
+++ b/src/components/TextInput/Label/LabelBackground.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Animated, StyleSheet } from 'react-native';
 
 import AnimatedText from '../../Typography/AnimatedText';
+import { useTheme } from '../../../core/theming';
 
 import type { LabelBackgroundProps } from '../types';
 
@@ -22,6 +23,7 @@ const LabelBackground = ({
     inputRange: [0, 1],
     outputRange: [hasFocus ? 1 : 0, 0],
   });
+  const { roundness } = useTheme();
 
   const labelTranslationX = {
     transform: [
@@ -45,6 +47,7 @@ const LabelBackground = ({
             {
               backgroundColor,
               opacity,
+              bottom: Math.max(roundness, 2),
             },
             labelTranslationX,
           ]}
@@ -86,7 +89,6 @@ const styles = StyleSheet.create({
     top: 6,
     left: 10,
     width: 8,
-    bottom: 2,
   },
   outlinedLabel: {
     position: 'absolute',


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fix the regression introduced in: https://github.com/callstack/react-native-paper/pull/2672

### Summary

before | after
--- | ---
<img width="704" alt="Zrzut ekranu 2021-04-23 o 14 36 32" src="https://user-images.githubusercontent.com/22746080/115871822-56bd2d00-a441-11eb-8e47-6eb89176cf14.png"> | <img width="704" alt="Zrzut ekranu 2021-04-23 o 14 36 19" src="https://user-images.githubusercontent.com/22746080/115871823-5886f080-a441-11eb-921d-960a129aa24c.png">


<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

1. Set in theme `roundess: 25`
2. Focus outlined text input with label
Expect: there are no bug related to bottom border

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
