### PR TITLE
fix: add bg color to list accordion to limit ripple area

### DIFF
--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -181,71 +181,75 @@ const ListAccordion = ({
       : handlePressAction;
   return (
     <View>
-      <TouchableRipple
-        style={[styles.container, style]}
-        onPress={handlePress}
-        onLongPress={onLongPress}
-        // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
-        accessibilityTraits="button"
-        accessibilityComponentType="button"
-        accessibilityRole="button"
-        testID={testID}
-        borderless
-      >
-        <View style={styles.row} pointerEvents="none">
-          {left
-            ? left({
-                color: isExpanded ? theme.colors.primary : descriptionColor,
-              })
-            : null}
-          <View style={[styles.item, styles.content]}>
-            <Text
-              selectable={false}
-              numberOfLines={titleNumberOfLines}
-              style={[
-                styles.title,
-                {
-                  color: isExpanded ? theme.colors.primary : titleColor,
-                },
-                titleStyle,
-              ]}
-            >
-              {title}
-            </Text>
-            {description && (
+      <View style={{ backgroundColor: theme.colors.background }}>
+        <TouchableRipple
+          style={[styles.container, style]}
+          onPress={handlePress}
+          onLongPress={onLongPress}
+          // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
+          accessibilityTraits="button"
+          accessibilityComponentType="button"
+          accessibilityRole="button"
+          testID={testID}
+          delayPressIn={0}
+          borderless
+        >
+          <View style={styles.row} pointerEvents="none">
+            {left
+              ? left({
+                  color: isExpanded ? theme.colors.primary : descriptionColor,
+                })
+              : null}
+            <View style={[styles.item, styles.content]}>
               <Text
                 selectable={false}
-                numberOfLines={descriptionNumberOfLines}
+                numberOfLines={titleNumberOfLines}
                 style={[
-                  styles.description,
+                  styles.title,
                   {
-                    color: descriptionColor,
+                    color: isExpanded ? theme.colors.primary : titleColor,
                   },
-                  descriptionStyle,
+                  titleStyle,
                 ]}
               >
-                {description}
+                {title}
               </Text>
-            )}
+              {description && (
+                <Text
+                  selectable={false}
+                  numberOfLines={descriptionNumberOfLines}
+                  style={[
+                    styles.description,
+                    {
+                      color: descriptionColor,
+                    },
+                    descriptionStyle,
+                  ]}
+                >
+                  {description}
+                </Text>
+              )}
+            </View>
+            <View
+              style={[styles.item, description ? styles.multiline : undefined]}
+            >
+              {right ? (
+                right({
+                  isExpanded: isExpanded,
+                })
+              ) : (
+                <MaterialCommunityIcon
+                  name={isExpanded ? 'chevron-up' : 'chevron-down'}
+                  color={titleColor}
+                  size={24}
+                  direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
+                />
+              )}
+            </View>
           </View>
-          <View
-            style={[styles.item, description ? styles.multiline : undefined]}
-          >
-            {right ? (
-              right({
-                isExpanded: isExpanded,
-              })
-            ) : (
-              <MaterialCommunityIcon
-                name={isExpanded ? 'chevron-up' : 'chevron-down'}
-                color={titleColor}
-                size={24}
-                direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
-              />
-            )}
-          </View>
-        </View>
-      </TouchableRipple>
+        </TouchableRipple>
+      </View>
+
       {isExpanded
         ? React.Children.map(children, (child) => {
             if (

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.js.snap
@@ -3,126 +3,134 @@
 exports[`renders expanded accordion 1`] = `
 <View>
   <View
-    accessibilityRole="button"
-    accessible={true}
-    focusable={true}
-    onClick={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
     style={
-      Array [
-        Object {
-          "overflow": "hidden",
-        },
-        Array [
-          Object {
-            "padding": 8,
-          },
-          undefined,
-        ],
-      ]
+      Object {
+        "backgroundColor": "#f6f6f6",
+      }
     }
   >
     <View
-      pointerEvents="none"
+      accessibilityRole="button"
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
-        Object {
-          "alignItems": "center",
-          "flexDirection": "row",
-        }
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          Array [
+            Object {
+              "padding": 8,
+            },
+            undefined,
+          ],
+        ]
       }
     >
       <View
+        pointerEvents="none"
         style={
-          Array [
-            Object {
-              "margin": 8,
-            },
-            Object {
-              "flex": 1,
-              "justifyContent": "center",
-            },
-          ]
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+          }
         }
       >
-        <Text
-          numberOfLines={1}
-          selectable={false}
+        <View
           style={
             Array [
               Object {
-                "color": "#000000",
-                "fontFamily": "System",
-                "fontWeight": "400",
+                "margin": 8,
               },
               Object {
-                "textAlign": "left",
+                "flex": 1,
+                "justifyContent": "center",
               },
-              Array [
-                Object {
-                  "fontSize": 16,
-                },
-                Object {
-                  "color": "#6200ee",
-                },
-                undefined,
-              ],
             ]
           }
         >
-          Accordion item 1
-        </Text>
-      </View>
-      <View
-        style={
-          Array [
-            Object {
-              "margin": 8,
-            },
-            undefined,
-          ]
-        }
-      >
-        <Text
-          accessibilityElementsHidden={true}
-          allowFontScaling={false}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
+          <Text
+            numberOfLines={1}
+            selectable={false}
+            style={
+              Array [
+                Object {
+                  "color": "#000000",
+                  "fontFamily": "System",
+                  "fontWeight": "400",
+                },
+                Object {
+                  "textAlign": "left",
+                },
+                Array [
+                  Object {
+                    "fontSize": 16,
+                  },
+                  Object {
+                    "color": "#6200ee",
+                  },
+                  undefined,
+                ],
+              ]
+            }
+          >
+            Accordion item 1
+          </Text>
+        </View>
+        <View
           style={
             Array [
               Object {
-                "color": "rgba(0, 0, 0, 0.87)",
-                "fontSize": 24,
+                "margin": 8,
               },
-              Array [
-                Object {
-                  "lineHeight": 24,
-                  "transform": Array [
-                    Object {
-                      "scaleX": 1,
-                    },
-                  ],
-                },
-                Object {
-                  "backgroundColor": "transparent",
-                },
-              ],
-              Object {
-                "fontFamily": "Material Design Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
+              undefined,
             ]
           }
         >
-          
-        </Text>
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
+            style={
+              Array [
+                Object {
+                  "color": "rgba(0, 0, 0, 0.87)",
+                  "fontSize": 24,
+                },
+                Array [
+                  Object {
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  Object {
+                    "backgroundColor": "transparent",
+                  },
+                ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+        </View>
       </View>
     </View>
   </View>
@@ -205,178 +213,186 @@ exports[`renders expanded accordion 1`] = `
 exports[`renders list accordion with children 1`] = `
 <View>
   <View
-    accessibilityRole="button"
-    accessible={true}
-    focusable={true}
-    onClick={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
     style={
-      Array [
-        Object {
-          "overflow": "hidden",
-        },
-        Array [
-          Object {
-            "padding": 8,
-          },
-          undefined,
-        ],
-      ]
+      Object {
+        "backgroundColor": "#f6f6f6",
+      }
     }
   >
     <View
-      pointerEvents="none"
+      accessibilityRole="button"
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
-        Object {
-          "alignItems": "center",
-          "flexDirection": "row",
-        }
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          Array [
+            Object {
+              "padding": 8,
+            },
+            undefined,
+          ],
+        ]
       }
     >
       <View
-        pointerEvents="box-none"
+        pointerEvents="none"
         style={
-          Array [
-            Object {
-              "alignItems": "center",
-              "height": 40,
-              "justifyContent": "center",
-              "margin": 8,
-              "width": 40,
-            },
-            undefined,
-          ]
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+          }
         }
       >
-        <Text
-          accessibilityElementsHidden={true}
-          allowFontScaling={false}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
+        <View
+          pointerEvents="box-none"
           style={
             Array [
               Object {
-                "color": "rgba(0, 0, 0, 0.54)",
-                "fontSize": 24,
+                "alignItems": "center",
+                "height": 40,
+                "justifyContent": "center",
+                "margin": 8,
+                "width": 40,
               },
-              Array [
-                Object {
-                  "lineHeight": 24,
-                  "transform": Array [
-                    Object {
-                      "scaleX": 1,
-                    },
-                  ],
-                },
-                Object {
-                  "backgroundColor": "transparent",
-                },
-              ],
-              Object {
-                "fontFamily": "Material Design Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
+              undefined,
             ]
           }
         >
-          
-        </Text>
-      </View>
-      <View
-        style={
-          Array [
-            Object {
-              "margin": 8,
-            },
-            Object {
-              "flex": 1,
-              "justifyContent": "center",
-            },
-          ]
-        }
-      >
-        <Text
-          numberOfLines={1}
-          selectable={false}
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
+            style={
+              Array [
+                Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontSize": 24,
+                },
+                Array [
+                  Object {
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  Object {
+                    "backgroundColor": "transparent",
+                  },
+                ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+        </View>
+        <View
           style={
             Array [
               Object {
-                "color": "#000000",
-                "fontFamily": "System",
-                "fontWeight": "400",
+                "margin": 8,
               },
               Object {
-                "textAlign": "left",
+                "flex": 1,
+                "justifyContent": "center",
               },
+            ]
+          }
+        >
+          <Text
+            numberOfLines={1}
+            selectable={false}
+            style={
               Array [
                 Object {
-                  "fontSize": 16,
+                  "color": "#000000",
+                  "fontFamily": "System",
+                  "fontWeight": "400",
                 },
+                Object {
+                  "textAlign": "left",
+                },
+                Array [
+                  Object {
+                    "fontSize": 16,
+                  },
+                  Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                  },
+                  undefined,
+                ],
+              ]
+            }
+          >
+            Expandable list item
+          </Text>
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "margin": 8,
+              },
+              undefined,
+            ]
+          }
+        >
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
+            style={
+              Array [
                 Object {
                   "color": "rgba(0, 0, 0, 0.87)",
+                  "fontSize": 24,
                 },
-                undefined,
-              ],
-            ]
-          }
-        >
-          Expandable list item
-        </Text>
-      </View>
-      <View
-        style={
-          Array [
-            Object {
-              "margin": 8,
-            },
-            undefined,
-          ]
-        }
-      >
-        <Text
-          accessibilityElementsHidden={true}
-          allowFontScaling={false}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "rgba(0, 0, 0, 0.87)",
-                "fontSize": 24,
-              },
-              Array [
+                Array [
+                  Object {
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  Object {
+                    "backgroundColor": "transparent",
+                  },
+                ],
                 Object {
-                  "lineHeight": 24,
-                  "transform": Array [
-                    Object {
-                      "scaleX": 1,
-                    },
-                  ],
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
                 },
-                Object {
-                  "backgroundColor": "transparent",
-                },
-              ],
-              Object {
-                "fontFamily": "Material Design Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          
-        </Text>
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+        </View>
       </View>
     </View>
   </View>
@@ -386,161 +402,169 @@ exports[`renders list accordion with children 1`] = `
 exports[`renders list accordion with custom title and description styles 1`] = `
 <View>
   <View
-    accessibilityRole="button"
-    accessible={true}
-    focusable={true}
-    onClick={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
     style={
-      Array [
-        Object {
-          "overflow": "hidden",
-        },
-        Array [
-          Object {
-            "padding": 8,
-          },
-          undefined,
-        ],
-      ]
+      Object {
+        "backgroundColor": "#f6f6f6",
+      }
     }
   >
     <View
-      pointerEvents="none"
+      accessibilityRole="button"
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
-        Object {
-          "alignItems": "center",
-          "flexDirection": "row",
-        }
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          Array [
+            Object {
+              "padding": 8,
+            },
+            undefined,
+          ],
+        ]
       }
     >
       <View
+        pointerEvents="none"
         style={
-          Array [
-            Object {
-              "margin": 8,
-            },
-            Object {
-              "flex": 1,
-              "justifyContent": "center",
-            },
-          ]
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+          }
         }
       >
-        <Text
-          numberOfLines={1}
-          selectable={false}
+        <View
           style={
             Array [
               Object {
-                "color": "#000000",
-                "fontFamily": "System",
-                "fontWeight": "400",
+                "margin": 8,
               },
               Object {
-                "textAlign": "left",
+                "flex": 1,
+                "justifyContent": "center",
               },
+            ]
+          }
+        >
+          <Text
+            numberOfLines={1}
+            selectable={false}
+            style={
               Array [
                 Object {
-                  "fontSize": 16,
+                  "color": "#000000",
+                  "fontFamily": "System",
+                  "fontWeight": "400",
                 },
+                Object {
+                  "textAlign": "left",
+                },
+                Array [
+                  Object {
+                    "fontSize": 16,
+                  },
+                  Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                  },
+                  Object {
+                    "color": "red",
+                  },
+                ],
+              ]
+            }
+          >
+            Accordion item 1
+          </Text>
+          <Text
+            numberOfLines={2}
+            selectable={false}
+            style={
+              Array [
+                Object {
+                  "color": "#000000",
+                  "fontFamily": "System",
+                  "fontWeight": "400",
+                },
+                Object {
+                  "textAlign": "left",
+                },
+                Array [
+                  Object {
+                    "fontSize": 14,
+                  },
+                  Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                  },
+                  Object {
+                    "color": "red",
+                  },
+                ],
+              ]
+            }
+          >
+            Describes the expandable list item
+          </Text>
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "margin": 8,
+              },
+              Object {
+                "alignItems": "center",
+                "height": 40,
+                "justifyContent": "center",
+              },
+            ]
+          }
+        >
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
+            style={
+              Array [
                 Object {
                   "color": "rgba(0, 0, 0, 0.87)",
+                  "fontSize": 24,
                 },
+                Array [
+                  Object {
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  Object {
+                    "backgroundColor": "transparent",
+                  },
+                ],
                 Object {
-                  "color": "red",
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
                 },
-              ],
-            ]
-          }
-        >
-          Accordion item 1
-        </Text>
-        <Text
-          numberOfLines={2}
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "#000000",
-                "fontFamily": "System",
-                "fontWeight": "400",
-              },
-              Object {
-                "textAlign": "left",
-              },
-              Array [
-                Object {
-                  "fontSize": 14,
-                },
-                Object {
-                  "color": "rgba(0, 0, 0, 0.54)",
-                },
-                Object {
-                  "color": "red",
-                },
-              ],
-            ]
-          }
-        >
-          Describes the expandable list item
-        </Text>
-      </View>
-      <View
-        style={
-          Array [
-            Object {
-              "margin": 8,
-            },
-            Object {
-              "alignItems": "center",
-              "height": 40,
-              "justifyContent": "center",
-            },
-          ]
-        }
-      >
-        <Text
-          accessibilityElementsHidden={true}
-          allowFontScaling={false}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "rgba(0, 0, 0, 0.87)",
-                "fontSize": 24,
-              },
-              Array [
-                Object {
-                  "lineHeight": 24,
-                  "transform": Array [
-                    Object {
-                      "scaleX": 1,
-                    },
-                  ],
-                },
-                Object {
-                  "backgroundColor": "transparent",
-                },
-              ],
-              Object {
-                "fontFamily": "Material Design Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          
-        </Text>
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+        </View>
       </View>
     </View>
   </View>
@@ -550,178 +574,186 @@ exports[`renders list accordion with custom title and description styles 1`] = `
 exports[`renders list accordion with left items 1`] = `
 <View>
   <View
-    accessibilityRole="button"
-    accessible={true}
-    focusable={true}
-    onClick={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
     style={
-      Array [
-        Object {
-          "overflow": "hidden",
-        },
-        Array [
-          Object {
-            "padding": 8,
-          },
-          undefined,
-        ],
-      ]
+      Object {
+        "backgroundColor": "#f6f6f6",
+      }
     }
   >
     <View
-      pointerEvents="none"
+      accessibilityRole="button"
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
-        Object {
-          "alignItems": "center",
-          "flexDirection": "row",
-        }
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          Array [
+            Object {
+              "padding": 8,
+            },
+            undefined,
+          ],
+        ]
       }
     >
       <View
-        pointerEvents="box-none"
+        pointerEvents="none"
         style={
-          Array [
-            Object {
-              "alignItems": "center",
-              "height": 40,
-              "justifyContent": "center",
-              "margin": 8,
-              "width": 40,
-            },
-            undefined,
-          ]
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+          }
         }
       >
-        <Text
-          accessibilityElementsHidden={true}
-          allowFontScaling={false}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
+        <View
+          pointerEvents="box-none"
           style={
             Array [
               Object {
-                "color": "rgba(0, 0, 0, 0.54)",
-                "fontSize": 24,
+                "alignItems": "center",
+                "height": 40,
+                "justifyContent": "center",
+                "margin": 8,
+                "width": 40,
               },
-              Array [
-                Object {
-                  "lineHeight": 24,
-                  "transform": Array [
-                    Object {
-                      "scaleX": 1,
-                    },
-                  ],
-                },
-                Object {
-                  "backgroundColor": "transparent",
-                },
-              ],
-              Object {
-                "fontFamily": "Material Design Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
+              undefined,
             ]
           }
         >
-          
-        </Text>
-      </View>
-      <View
-        style={
-          Array [
-            Object {
-              "margin": 8,
-            },
-            Object {
-              "flex": 1,
-              "justifyContent": "center",
-            },
-          ]
-        }
-      >
-        <Text
-          numberOfLines={1}
-          selectable={false}
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
+            style={
+              Array [
+                Object {
+                  "color": "rgba(0, 0, 0, 0.54)",
+                  "fontSize": 24,
+                },
+                Array [
+                  Object {
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  Object {
+                    "backgroundColor": "transparent",
+                  },
+                ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+        </View>
+        <View
           style={
             Array [
               Object {
-                "color": "#000000",
-                "fontFamily": "System",
-                "fontWeight": "400",
+                "margin": 8,
               },
               Object {
-                "textAlign": "left",
+                "flex": 1,
+                "justifyContent": "center",
               },
+            ]
+          }
+        >
+          <Text
+            numberOfLines={1}
+            selectable={false}
+            style={
               Array [
                 Object {
-                  "fontSize": 16,
+                  "color": "#000000",
+                  "fontFamily": "System",
+                  "fontWeight": "400",
                 },
+                Object {
+                  "textAlign": "left",
+                },
+                Array [
+                  Object {
+                    "fontSize": 16,
+                  },
+                  Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                  },
+                  undefined,
+                ],
+              ]
+            }
+          >
+            Accordion item 1
+          </Text>
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "margin": 8,
+              },
+              undefined,
+            ]
+          }
+        >
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
+            style={
+              Array [
                 Object {
                   "color": "rgba(0, 0, 0, 0.87)",
+                  "fontSize": 24,
                 },
-                undefined,
-              ],
-            ]
-          }
-        >
-          Accordion item 1
-        </Text>
-      </View>
-      <View
-        style={
-          Array [
-            Object {
-              "margin": 8,
-            },
-            undefined,
-          ]
-        }
-      >
-        <Text
-          accessibilityElementsHidden={true}
-          allowFontScaling={false}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "rgba(0, 0, 0, 0.87)",
-                "fontSize": 24,
-              },
-              Array [
+                Array [
+                  Object {
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  Object {
+                    "backgroundColor": "transparent",
+                  },
+                ],
                 Object {
-                  "lineHeight": 24,
-                  "transform": Array [
-                    Object {
-                      "scaleX": 1,
-                    },
-                  ],
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
                 },
-                Object {
-                  "backgroundColor": "transparent",
-                },
-              ],
-              Object {
-                "fontFamily": "Material Design Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          
-        </Text>
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+        </View>
       </View>
     </View>
   </View>
@@ -731,157 +763,165 @@ exports[`renders list accordion with left items 1`] = `
 exports[`renders multiline list accordion 1`] = `
 <View>
   <View
-    accessibilityRole="button"
-    accessible={true}
-    focusable={true}
-    onClick={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
     style={
-      Array [
-        Object {
-          "overflow": "hidden",
-        },
-        Array [
-          Object {
-            "padding": 8,
-          },
-          undefined,
-        ],
-      ]
+      Object {
+        "backgroundColor": "#f6f6f6",
+      }
     }
   >
     <View
-      pointerEvents="none"
+      accessibilityRole="button"
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
-        Object {
-          "alignItems": "center",
-          "flexDirection": "row",
-        }
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          Array [
+            Object {
+              "padding": 8,
+            },
+            undefined,
+          ],
+        ]
       }
     >
       <View
+        pointerEvents="none"
         style={
-          Array [
-            Object {
-              "margin": 8,
-            },
-            Object {
-              "flex": 1,
-              "justifyContent": "center",
-            },
-          ]
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+          }
         }
       >
-        <Text
-          numberOfLines={1}
-          selectable={false}
+        <View
           style={
             Array [
               Object {
-                "color": "#000000",
-                "fontFamily": "System",
-                "fontWeight": "400",
+                "margin": 8,
               },
               Object {
-                "textAlign": "left",
+                "flex": 1,
+                "justifyContent": "center",
               },
+            ]
+          }
+        >
+          <Text
+            numberOfLines={1}
+            selectable={false}
+            style={
               Array [
                 Object {
-                  "fontSize": 16,
+                  "color": "#000000",
+                  "fontFamily": "System",
+                  "fontWeight": "400",
                 },
+                Object {
+                  "textAlign": "left",
+                },
+                Array [
+                  Object {
+                    "fontSize": 16,
+                  },
+                  Object {
+                    "color": "rgba(0, 0, 0, 0.87)",
+                  },
+                  undefined,
+                ],
+              ]
+            }
+          >
+            Expandable list item
+          </Text>
+          <Text
+            numberOfLines={2}
+            selectable={false}
+            style={
+              Array [
+                Object {
+                  "color": "#000000",
+                  "fontFamily": "System",
+                  "fontWeight": "400",
+                },
+                Object {
+                  "textAlign": "left",
+                },
+                Array [
+                  Object {
+                    "fontSize": 14,
+                  },
+                  Object {
+                    "color": "rgba(0, 0, 0, 0.54)",
+                  },
+                  undefined,
+                ],
+              ]
+            }
+          >
+            Describes the expandable list item
+          </Text>
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "margin": 8,
+              },
+              Object {
+                "alignItems": "center",
+                "height": 40,
+                "justifyContent": "center",
+              },
+            ]
+          }
+        >
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
+            style={
+              Array [
                 Object {
                   "color": "rgba(0, 0, 0, 0.87)",
+                  "fontSize": 24,
                 },
-                undefined,
-              ],
-            ]
-          }
-        >
-          Expandable list item
-        </Text>
-        <Text
-          numberOfLines={2}
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "#000000",
-                "fontFamily": "System",
-                "fontWeight": "400",
-              },
-              Object {
-                "textAlign": "left",
-              },
-              Array [
+                Array [
+                  Object {
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  Object {
+                    "backgroundColor": "transparent",
+                  },
+                ],
                 Object {
-                  "fontSize": 14,
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
                 },
-                Object {
-                  "color": "rgba(0, 0, 0, 0.54)",
-                },
-                undefined,
-              ],
-            ]
-          }
-        >
-          Describes the expandable list item
-        </Text>
-      </View>
-      <View
-        style={
-          Array [
-            Object {
-              "margin": 8,
-            },
-            Object {
-              "alignItems": "center",
-              "height": 40,
-              "justifyContent": "center",
-            },
-          ]
-        }
-      >
-        <Text
-          accessibilityElementsHidden={true}
-          allowFontScaling={false}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "rgba(0, 0, 0, 0.87)",
-                "fontSize": 24,
-              },
-              Array [
-                Object {
-                  "lineHeight": 24,
-                  "transform": Array [
-                    Object {
-                      "scaleX": 1,
-                    },
-                  ],
-                },
-                Object {
-                  "backgroundColor": "transparent",
-                },
-              ],
-              Object {
-                "fontFamily": "Material Design Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          
-        </Text>
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+        </View>
       </View>
     </View>
   </View>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/2683

### Summary

It turns out there is need to wrap `TouchableRipple` within `View` with specified background color to prevent ripple effect from spreading outside the component area. 

NOTE: the similar approach is applied in Button component, however `Surface` component is used there, which we don't need there. 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

1. Run the example app on Android 7
2. Go to list component
3. Press the list item and observe the ripple

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
