### PR TITLE
RadioButtonItem label fix

### DIFF
--- a/src/components/RadioButton/RadioButtonItem.tsx
+++ b/src/components/RadioButton/RadioButtonItem.tsx
@@ -176,6 +176,7 @@ const styles = StyleSheet.create({
   },
   label: {
     fontSize: 16,
-    flex: 1,
+    flexShrink: 1,
+    flexGrow: 1,
   },
 });

--- a/src/components/__tests__/RadioButton/__snapshots__/RadioButtonItem.test.js.snap
+++ b/src/components/__tests__/RadioButton/__snapshots__/RadioButtonItem.test.js.snap
@@ -46,7 +46,8 @@ exports[`can render the Android radio button on different platforms 1`] = `
           },
           Array [
             Object {
-              "flex": 1,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "fontSize": 16,
             },
             Object {
@@ -151,7 +152,8 @@ exports[`can render the iOS radio button on different platforms 1`] = `
           },
           Array [
             Object {
-              "flex": 1,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "fontSize": 16,
             },
             Object {
@@ -289,7 +291,8 @@ exports[`renders unchecked 1`] = `
           },
           Array [
             Object {
-              "flex": 1,
+              "flexGrow": 1,
+              "flexShrink": 1,
               "fontSize": 16,
             },
             Object {


### PR DESCRIPTION
Closes #2688

### Summary

An issue where Checkbox.Item labels were invisible #2542.  Is also the same issue for 
RadioButtonItem labels.  The following fix was for Checkbox.Item labels being invisible was merged with this pull request https://github.com/callstack/react-native-paper/pull/2659.

This PR is the same fix for RadioButtonItem 


### Test plan
1. create a project using radio button items with a label prop
2. replace the `react-native-paper` version number in your package.json with my fork and branch:
`"react-native-paper": "git://github.com/conor909/react-native-paper.git#2659-radio-button-label-fix"`
3. then run `yarn` / `npm install`
4. The labels should now be showing for RadioButtonItems:
![Screenshot 2021-04-27 at 10 47 06](https://user-images.githubusercontent.com/2417359/116222066-2083f400-a746-11eb-9514-497be4abfbcf.png)