### PR TITLE
fix: list.accordion onlongpress type

### DIFF
--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -7,6 +7,7 @@ import {
   StyleProp,
   TextStyle,
   I18nManager,
+  GestureResponderEvent,
 } from 'react-native';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
@@ -45,7 +46,7 @@ type Props = {
   /**
    * Function to execute on long press.
    */
-  onLongPress?: () => void;
+  onLongPress?: (e: GestureResponderEvent) => void;
   /**
    * Content of the section.
    */


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Currently List.Accordion onLongPress prop has a type `() => void`.   List.Accordion pasess this to TouchableRipple in which the type of onLongPress is `(e: GestureResponderEvent) => void`.  When using the List.Accordion component it does passes GestureResponderEvent  but since the type does not have any parameters defined the linter complains about it. List.Item uses the same type as TouchableRipple.

The GestureResponderEvent could be used to correclty locate a contextual menu over the Accordion which will be a diferent callback from onPress (expand)

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
Currently this works, is just the linter since it passes the prop but the linter complains about it.

Passes  type-check, lint and tests. Reviewed Docs as well.
