### PR TITLE
fix: run animation on card long press

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -136,8 +136,8 @@ const Card = ({
         disabled={!(onPress || onLongPress)}
         onLongPress={onLongPress}
         onPress={onPress}
-        onPressIn={onPress ? handlePressIn : undefined}
-        onPressOut={onPress ? handlePressOut : undefined}
+        onPressIn={onPress || onLongPress ? handlePressIn : undefined}
+        onPressOut={onPress || onLongPress ? handlePressOut : undefined}
         testID={testID}
         accessible={accessible}
       >


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/2656

### Summary

That PR fixing the issue with missing animation when `onLongPress` is called.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

![fixlongpress](https://user-images.githubusercontent.com/22746080/117285317-2e352a00-ae68-11eb-8e0e-e9d16a7db90b.gif)


### Test plan

1. Scan the QR code
2. Run the app and open Card example
3. Scroll to the last example
4. Long press the card and observe the shadow animation

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
