### PR TITLE
chore: Expose Snackbar props type

### DIFF
--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -13,7 +13,7 @@ import Surface from './Surface';
 import Text from './Typography/Text';
 import { withTheme } from '../core/theming';
 
-type Props = React.ComponentProps<typeof Surface> & {
+export type SnackbarProps = React.ComponentProps<typeof Surface> & {
   /**
    * Whether the Snackbar is currently visible.
    */
@@ -112,7 +112,7 @@ const Snackbar = ({
   style,
   theme,
   ...rest
-}: Props) => {
+}: SnackbarProps) => {
   const { current: opacity } = React.useRef<Animated.Value>(
     new Animated.Value(0.0)
   );


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

Sometimes we need to import the props definition. It is available for TextInput (https://github.com/callstack/react-native-paper/blob/main/src/components/TextInput/TextInput.tsx#L21) but not for the Snackbar.

This very basic change renames the Snackbar props type to `SnackbarProps` and exports it.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

```js
import {SnackbarProps} from 'react-native-paper/lib/typescript/components/Snackbar'

// use it
```


Thank you for your library 👍🏻