### PR TITLE
feat: introduce prop for defining control position (leading/trailing) fo RadioButton.Item

### DIFF
--- a/example/src/Examples/RadioButtonItemExample.tsx
+++ b/example/src/Examples/RadioButtonItemExample.tsx
@@ -6,6 +6,10 @@ const RadioButtonItemExample = () => {
   const [checkedDefault, setCheckedDefault] = React.useState<boolean>(true);
   const [checkedAndroid, setCheckedAndroid] = React.useState<boolean>(true);
   const [checkedIOS, setCheckedIOS] = React.useState<boolean>(true);
+  const [checkedLeadingControl, setCheckedLeadingControl] = React.useState<
+    boolean
+  >(true);
+
   const {
     colors: { background },
   } = useTheme();
@@ -38,6 +42,13 @@ const RadioButtonItemExample = () => {
         status={checkedIOS ? 'checked' : 'unchecked'}
         onPress={() => setCheckedIOS(!checkedIOS)}
         value="iOS"
+      />
+      <RadioButton.Item
+        label="Default with leading control"
+        status={checkedLeadingControl ? 'checked' : 'unchecked'}
+        onPress={() => setCheckedLeadingControl(!checkedLeadingControl)}
+        value="iOS"
+        position="leading"
       />
     </View>
   );

--- a/src/components/RadioButton/RadioButtonItem.tsx
+++ b/src/components/RadioButton/RadioButtonItem.tsx
@@ -69,6 +69,10 @@ export type Props = {
    * Left undefined `<RadioButton />` will be used.
    */
   mode?: 'android' | 'ios';
+  /**
+   * Radio button control position. Default is `leading`.
+   */
+  position?: 'leading' | 'trailing';
 };
 
 /**
@@ -114,8 +118,10 @@ const RadioButtonItem = ({
   accessibilityLabel,
   testID,
   mode,
+  position = 'trailing',
 }: Props) => {
   const radioButtonProps = { value, disabled, status, color, uncheckedColor };
+  const isLeading = position === 'leading';
   let radioButton: any;
 
   if (mode === 'android') {
@@ -145,10 +151,20 @@ const RadioButtonItem = ({
             testID={testID}
           >
             <View style={[styles.container, style]} pointerEvents="none">
-              <Text style={[styles.label, { color: colors.text }, labelStyle]}>
+              {isLeading && radioButton}
+              <Text
+                style={[
+                  styles.label,
+                  {
+                    color: colors.text,
+                    textAlign: isLeading ? 'right' : 'left',
+                  },
+                  labelStyle,
+                ]}
+              >
                 {label}
               </Text>
-              {radioButton}
+              {!isLeading && radioButton}
             </View>
           </TouchableRipple>
         );

--- a/src/components/__tests__/RadioButton/RadioButtonItem.test.js
+++ b/src/components/__tests__/RadioButton/RadioButtonItem.test.js
@@ -48,3 +48,19 @@ it('can render the Android radio button on different platforms', () => {
 
   expect(tree).toMatchSnapshot();
 });
+
+it('can render leading radio button control', () => {
+  Platform.OS = 'ios';
+  const tree = renderer
+    .create(
+      <RadioButton.Item
+        label="Default with leading control"
+        status={'unchecked'}
+        value="iOS"
+        position="leading"
+      />
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/__tests__/RadioButton/__snapshots__/RadioButtonItem.test.js.snap
+++ b/src/components/__tests__/RadioButton/__snapshots__/RadioButtonItem.test.js.snap
@@ -1,5 +1,144 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`can render leading radio button control 1`] = `
+<View
+  accessible={true}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      false,
+      undefined,
+    ]
+  }
+>
+  <View
+    pointerEvents="none"
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+          "paddingHorizontal": 16,
+          "paddingVertical": 8,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      accessibilityLiveRegion="polite"
+      accessibilityRole="radio"
+      accessibilityState={
+        Object {
+          "checked": false,
+          "disabled": undefined,
+        }
+      }
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          Object {
+            "borderRadius": 18,
+            "padding": 6,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Object {
+            "opacity": 0,
+          }
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          allowFontScaling={false}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "color": "#03dac4",
+                "fontSize": 24,
+              },
+              Array [
+                Object {
+                  "lineHeight": 24,
+                  "transform": Array [
+                    Object {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                Object {
+                  "backgroundColor": "transparent",
+                },
+              ],
+              Object {
+                "fontFamily": "Material Design Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+    <Text
+      style={
+        Array [
+          Object {
+            "color": "#000000",
+            "fontFamily": "System",
+            "fontWeight": "400",
+          },
+          Object {
+            "textAlign": "left",
+          },
+          Array [
+            Object {
+              "flex": 1,
+              "fontSize": 16,
+            },
+            Object {
+              "color": "#000000",
+              "textAlign": "right",
+            },
+            undefined,
+          ],
+        ]
+      }
+    >
+      Default with leading control
+    </Text>
+  </View>
+</View>
+`;
+
 exports[`can render the Android radio button on different platforms 1`] = `
 <View
   accessible={true}

--- a/src/components/__tests__/RadioButton/__snapshots__/RadioButtonItem.test.js.snap
+++ b/src/components/__tests__/RadioButton/__snapshots__/RadioButtonItem.test.js.snap
@@ -51,6 +51,7 @@ exports[`can render the Android radio button on different platforms 1`] = `
             },
             Object {
               "color": "#000000",
+              "textAlign": "left",
             },
             undefined,
           ],
@@ -156,6 +157,7 @@ exports[`can render the iOS radio button on different platforms 1`] = `
             },
             Object {
               "color": "#000000",
+              "textAlign": "left",
             },
             undefined,
           ],
@@ -294,6 +296,7 @@ exports[`renders unchecked 1`] = `
             },
             Object {
               "color": "#000000",
+              "textAlign": "left",
             },
             undefined,
           ],


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/2704

### Summary

This PR extends `RadioButton.Item` component and introduces new prop to define radio button control position - `leading/trailing`

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

#### iOS

ltr | rtl
--- | ---
![ios_ltr](https://user-images.githubusercontent.com/22746080/117630576-a0b14d00-b17b-11eb-86c7-e332a1e11714.gif) | ![ios_rtl](https://user-images.githubusercontent.com/22746080/117630588-a3ac3d80-b17b-11eb-96c4-ace78db396e5.gif)

#### Android

ltr | rtl
--- | ---
![a_ltr](https://user-images.githubusercontent.com/22746080/117630694-bde61b80-b17b-11eb-86cc-bc799c5d1301.gif) | ![a_rtl_2](https://user-images.githubusercontent.com/22746080/117630928-fbe33f80-b17b-11eb-8da6-6a90af4c328c.gif)



### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
