### PR TITLE
feat: Added new prop (iconRight) to drawer item

### DIFF
--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -73,7 +73,7 @@ const DrawerItem = ({
   onPress,
   accessibilityLabel,
   right,
-  iconRight=false
+  iconRight=false,
   ...rest
 }: Props) => {
   const { colors, roundness } = theme;

--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -73,7 +73,7 @@ const DrawerItem = ({
   onPress,
   accessibilityLabel,
   right,
-  iconRight=false,
+  iconRight = false,
   ...rest
 }: Props) => {
   const { colors, roundness } = theme;
@@ -84,9 +84,7 @@ const DrawerItem = ({
     ? colors.primary
     : color(colors.text).alpha(0.68).rgb().string();
   const font = theme.fonts.medium;
-  const labelMargin = icon  ? 32 : 0;
-  
-
+  const labelMargin = icon ? 32 : 0;
   return (
     <View
       {...rest}
@@ -121,8 +119,8 @@ const DrawerItem = ({
                 {
                   color: contentColor,
                   ...font,
-                  marginLeft:!iconRight? labelMargin:0,
-                  marginRight:iconRight?labelMargin:0,
+                  marginLeft: !iconRight ? labelMargin : 0,
+                  marginRight: iconRight ? labelMargin : 0,
                 },
               ]}
             >

--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -31,6 +31,7 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
    * Callback which returns a React element to display on the right side. For instance a Badge.
    */
   right?: (props: { color: string }) => React.ReactNode;
+  iconRight?: boolean;
   style?: StyleProp<ViewStyle>;
   /**
    * @optional
@@ -72,6 +73,7 @@ const DrawerItem = ({
   onPress,
   accessibilityLabel,
   right,
+  iconRight=false
   ...rest
 }: Props) => {
   const { colors, roundness } = theme;
@@ -82,7 +84,8 @@ const DrawerItem = ({
     ? colors.primary
     : color(colors.text).alpha(0.68).rgb().string();
   const font = theme.fonts.medium;
-  const labelMargin = icon ? 32 : 0;
+  const labelMargin = icon  ? 32 : 0;
+  
 
   return (
     <View
@@ -107,7 +110,7 @@ const DrawerItem = ({
       >
         <View style={styles.wrapper}>
           <View style={styles.content}>
-            {icon ? (
+            {!iconRight && icon ? (
               <Icon source={icon} size={24} color={contentColor} />
             ) : null}
             <Text
@@ -118,12 +121,16 @@ const DrawerItem = ({
                 {
                   color: contentColor,
                   ...font,
-                  marginLeft: labelMargin,
+                  marginLeft:!iconRight? labelMargin:0,
+                  marginRight:iconRight?labelMargin:0,
                 },
               ]}
             >
               {label}
             </Text>
+            {iconRight && icon ? (
+              <Icon source={icon} size={24} color={contentColor} />
+            ) : null}
           </View>
           {right?.({ color: contentColor })}
         </View>

--- a/src/components/__tests__/__snapshots__/DrawerItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DrawerItem.test.js.snap
@@ -118,6 +118,7 @@ exports[`renders DrawerItem with icon 1`] = `
                   "fontFamily": "System",
                   "fontWeight": "500",
                   "marginLeft": 32,
+                  "marginRight": 0,
                 },
               ],
             ]
@@ -249,6 +250,7 @@ exports[`renders active DrawerItem 1`] = `
                   "fontFamily": "System",
                   "fontWeight": "500",
                   "marginLeft": 32,
+                  "marginRight": 0,
                 },
               ],
             ]
@@ -344,6 +346,7 @@ exports[`renders basic DrawerItem 1`] = `
                   "fontFamily": "System",
                   "fontWeight": "500",
                   "marginLeft": 0,
+                  "marginRight": 0,
                 },
               ],
             ]


### PR DESCRIPTION

### Summary

This pull request adds iconRight prop to drawer item, so that the users can have the option of placing an icon to right of text instead of only left.
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
