### PR TITLE
fix: correct Button elevation

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -143,8 +143,9 @@ const Button = ({
   ...rest
 }: Props) => {
   const { current: elevation } = React.useRef<Animated.Value>(
-    new Animated.Value(mode === 'contained' ? 2 : 0)
+    new Animated.Value(0)
   );
+  elevation.setValue(mode === 'contained' ? 2 : 0);
 
   const handlePressIn = () => {
     if (mode === 'contained') {

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -145,7 +145,9 @@ const Button = ({
   const { current: elevation } = React.useRef<Animated.Value>(
     new Animated.Value(0)
   );
-  elevation.setValue(mode === 'contained' ? 2 : 0);
+  React.useEffect(() => {
+    elevation.setValue(mode === 'contained' ? 2 : 0);
+  }, [mode, elevation]);
 
   const handlePressIn = () => {
     if (mode === 'contained') {

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -143,7 +143,7 @@ const Button = ({
   ...rest
 }: Props) => {
   const { current: elevation } = React.useRef<Animated.Value>(
-    new Animated.Value(0)
+    new Animated.Value(mode === 'contained' ? 2 : 0)
   );
   React.useEffect(() => {
     elevation.setValue(mode === 'contained' ? 2 : 0);


### PR DESCRIPTION
### Summary

It has a bug that Button elevation is still zero after mode is changed to `contained` from other modes.
This PR fixes this.

### Test plan

1. Render a Button with mode other than `contained`.
2. Change the mode to `contained` mode dynamically(e.g. on button press).
3. Check elevation