### PR TITLE
fix: interpolate shadowOpacity to correct its value for the elevation equal zero

### DIFF
--- a/src/styles/shadow.tsx
+++ b/src/styles/shadow.tsx
@@ -17,7 +17,11 @@ export default function shadow(elevation: number | Animated.Value = 0) {
           outputRange: [0, 0.5, 0.75, 2, 7, 23],
         }),
       },
-      shadowOpacity: new Animated.Value(SHADOW_OPACITY),
+      shadowOpacity: elevation.interpolate({
+        inputRange: [0, 1],
+        outputRange: [0, SHADOW_OPACITY],
+        extrapolate: 'clamp',
+      }),
       shadowRadius: elevation.interpolate({
         inputRange,
         outputRange: [0, 0.75, 1.5, 3, 8, 24],


### PR DESCRIPTION
Fixes: https://github.com/callstack/react-native-paper/issues/2733

### Summary

Fixes the shadow which remains even if the elevation was set to 0.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

1. Run the app
2. Set `elevation={0}` on Card component
**3. Expect there is no shadow**

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
