### PR TITLE
feat: customize top padding of a flat TextInput

### DIFF
--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -440,6 +440,18 @@ const TextInputExample = () => {
             }}
           />
         </View>
+        <View style={styles.inputContainerStyle}>
+          <TextInput
+            mode="flat"
+            label="Very dense flat input"
+            dense
+            style={{
+              height: 40,
+              paddingTop: 4,
+              paddingHorizontal: 4,
+            }}
+          />
+        </View>
       </ScrollView>
     </TextInputAvoidingView>
   );

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -131,7 +131,7 @@ type Props = {
    * ```
    *
    * Specifying the components this way is easier and takes care of implementing a `shouldComponentUpdate` method.
-   * Each component will receive the current route and a `jumpTo` method as it's props.
+   * Each component will receive the current route and a `jumpTo` method as its props.
    * The `jumpTo` method can be used to navigate to other tabs programmatically:
    *
    * ```js
@@ -377,7 +377,7 @@ const BottomNavigation = ({
   const indexAnim = useAnimatedValue(navigationState.index);
 
   /**
-   * Animation for the background color ripple, used to determine it's scale and opacity.
+   * Animation for the background color ripple, used to determine its scale and opacity.
    */
   const rippleAnim = useAnimatedValue(MIN_RIPPLE_SCALE);
 

--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -79,7 +79,7 @@ const InputLabel = (props: InputLabelProps) => {
         StyleSheet.absoluteFill,
         {
           opacity:
-            // Hide the label in minimized state until we measure it's width
+            // Hide the label in minimized state until we measure its width
             parentState.value || parentState.focused
               ? parentState.labelLayout.measured
                 ? 1

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -39,13 +39,20 @@ import {
 } from './Adornment/TextInputAdornment';
 import { AdornmentSide, AdornmentType, InputMode } from './Adornment/enums';
 
-const MINIMIZED_LABEL_Y_OFFSET = -18;
-
-const LABEL_PADDING_TOP = 30;
-const LABEL_PADDING_TOP_DENSE = 24;
 const MIN_HEIGHT = 64;
 const MIN_DENSE_HEIGHT_WL = 52;
 const MIN_DENSE_HEIGHT = 40;
+
+const MINIMIZED_LABEL_LOGICAL_MARGIN_TOP = 12;
+const MINIMIZED_LABEL_LOGICAL_MARGIN_BOTTOM = 6;
+
+const MINIMIZED_LABEL_RESERVED_HEIGHT_DENSE =
+  MINIMIZED_LABEL_LOGICAL_MARGIN_TOP + MINIMIZED_LABEL_FONT_SIZE;
+const MINIMIZED_LABEL_RESERVED_HEIGHT =
+  MINIMIZED_LABEL_RESERVED_HEIGHT_DENSE + MINIMIZED_LABEL_LOGICAL_MARGIN_BOTTOM;
+
+const MINIMIZED_LABEL_BASE_Y_OFFSET_FROM_TOP =
+  MINIMIZED_LABEL_LOGICAL_MARGIN_TOP + MINIMIZED_LABEL_FONT_SIZE / 2;
 
 class TextInputFlat extends React.Component<ChildTextInputProps> {
   static defaultProps = {
@@ -180,8 +187,8 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
 
     const minInputHeight = dense
       ? (label ? MIN_DENSE_HEIGHT_WL : MIN_DENSE_HEIGHT) -
-        LABEL_PADDING_TOP_DENSE
-      : MIN_HEIGHT - LABEL_PADDING_TOP;
+        MINIMIZED_LABEL_RESERVED_HEIGHT_DENSE
+      : MIN_HEIGHT - MINIMIZED_LABEL_RESERVED_HEIGHT;
 
     const inputHeight = calculateInputHeight(
       labelHeight,
@@ -224,7 +231,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
     });
 
     const baseLabelTranslateY =
-      -labelHalfHeight - (topPosition + MINIMIZED_LABEL_Y_OFFSET);
+      -topPosition - labelHalfHeight + MINIMIZED_LABEL_BASE_Y_OFFSET_FROM_TOP;
 
     const placeholderOpacity = hasActiveOutline
       ? interpolatePlaceholder(parentState.labeled, hasActiveOutline)
@@ -238,7 +245,11 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
 
     const flatHeight =
       inputHeight +
-      (!height ? (dense ? LABEL_PADDING_TOP_DENSE : LABEL_PADDING_TOP) : 0);
+      (height
+        ? 0
+        : dense
+        ? MINIMIZED_LABEL_RESERVED_HEIGHT_DENSE
+        : MINIMIZED_LABEL_RESERVED_HEIGHT);
 
     const iconTopPosition = (flatHeight - ADORNMENT_SIZE) / 2;
 
@@ -432,11 +443,11 @@ const styles = StyleSheet.create({
     zIndex: 1,
   },
   inputFlat: {
-    paddingTop: 24,
+    paddingTop: 12 + MINIMIZED_LABEL_LOGICAL_MARGIN_TOP,
     paddingBottom: 4,
   },
   inputFlatDense: {
-    paddingTop: 22,
+    paddingTop: 10 + MINIMIZED_LABEL_LOGICAL_MARGIN_TOP,
     paddingBottom: 2,
   },
 });

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -199,7 +199,13 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
     const topPosition = calculateLabelTopPosition(
       labelHeight,
       inputHeight,
-      multiline && height ? 0 : !height ? minInputHeight / 2 : 0
+      height
+        ? 0
+        : (dense
+            ? MINIMIZED_LABEL_RESERVED_HEIGHT_DENSE
+            : MINIMIZED_LABEL_RESERVED_HEIGHT) /
+            2 +
+            2
     );
 
     if (height && typeof height !== 'number') {

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -28,7 +28,6 @@ import {
   calculateInputHeight,
   calculatePadding,
   adjustPaddingFlat,
-  Padding,
   interpolatePlaceholder,
   calculateFlatAffixTopPosition,
   calculateFlatInputHorizontalPadding,
@@ -43,16 +42,8 @@ const MIN_HEIGHT = 64;
 const MIN_DENSE_HEIGHT_WL = 52;
 const MIN_DENSE_HEIGHT = 40;
 
-const MINIMIZED_LABEL_LOGICAL_MARGIN_TOP = 12;
+const MINIMIZED_LABEL_DEFAULT_LOGICAL_MARGIN_BOTTOM = 12;
 const MINIMIZED_LABEL_LOGICAL_MARGIN_BOTTOM = 6;
-
-const MINIMIZED_LABEL_RESERVED_HEIGHT_DENSE =
-  MINIMIZED_LABEL_LOGICAL_MARGIN_TOP + MINIMIZED_LABEL_FONT_SIZE;
-const MINIMIZED_LABEL_RESERVED_HEIGHT =
-  MINIMIZED_LABEL_RESERVED_HEIGHT_DENSE + MINIMIZED_LABEL_LOGICAL_MARGIN_BOTTOM;
-
-const MINIMIZED_LABEL_BASE_Y_OFFSET_FROM_TOP =
-  MINIMIZED_LABEL_LOGICAL_MARGIN_TOP + MINIMIZED_LABEL_FONT_SIZE / 2;
 
 class TextInputFlat extends React.Component<ChildTextInputProps> {
   static defaultProps = {
@@ -99,11 +90,17 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
       fontSize: fontSizeStyle,
       fontWeight,
       height,
+      paddingTop: paddingTopStyle,
       paddingHorizontal,
       textAlign,
       ...viewStyle
     } = (StyleSheet.flatten(style) || {}) as TextStyle;
     const fontSize = fontSizeStyle || MAXIMIZED_LABEL_FONT_SIZE;
+
+    const minimizedLabelLogicalMarginTop =
+      typeof paddingTopStyle === 'number'
+        ? paddingTopStyle
+        : MINIMIZED_LABEL_DEFAULT_LOGICAL_MARGIN_BOTTOM;
 
     const isPaddingHorizontalPassed =
       paddingHorizontal !== undefined && typeof paddingHorizontal === 'number';
@@ -185,10 +182,14 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
         (labelHalfWidth - (labelScale * labelWidth) / 2) +
       (1 - labelScale) * (I18nManager.isRTL ? -1 : 1) * paddingLeft;
 
-    const minInputHeight = dense
-      ? (label ? MIN_DENSE_HEIGHT_WL : MIN_DENSE_HEIGHT) -
-        MINIMIZED_LABEL_RESERVED_HEIGHT_DENSE
-      : MIN_HEIGHT - MINIMIZED_LABEL_RESERVED_HEIGHT;
+    const minimizeLabelReservedHeight =
+      minimizedLabelLogicalMarginTop +
+      MINIMIZED_LABEL_FONT_SIZE +
+      (dense ? 0 : MINIMIZED_LABEL_LOGICAL_MARGIN_BOTTOM);
+
+    const minInputHeight =
+      (dense ? (label ? MIN_DENSE_HEIGHT_WL : MIN_DENSE_HEIGHT) : MIN_HEIGHT) -
+      minimizeLabelReservedHeight;
 
     const inputHeight = calculateInputHeight(
       labelHeight,
@@ -199,13 +200,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
     const topPosition = calculateLabelTopPosition(
       labelHeight,
       inputHeight,
-      height
-        ? 0
-        : (dense
-            ? MINIMIZED_LABEL_RESERVED_HEIGHT_DENSE
-            : MINIMIZED_LABEL_RESERVED_HEIGHT) /
-            2 +
-            2
+      height ? 0 : minimizeLabelReservedHeight / 2 + 2
     );
 
     if (height && typeof height !== 'number') {
@@ -224,9 +219,15 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
       label,
       scale: fontScale,
       isAndroid: Platform.OS === 'android',
-      styles: StyleSheet.flatten(
-        dense ? styles.inputFlatDense : styles.inputFlat
-      ) as Padding,
+      styles: dense
+        ? {
+            paddingTop: 10 + minimizedLabelLogicalMarginTop,
+            paddingBottom: 2,
+          }
+        : {
+            paddingTop: 12 + minimizedLabelLogicalMarginTop,
+            paddingBottom: 4,
+          },
     };
 
     const pad = calculatePadding(paddingSettings);
@@ -237,7 +238,10 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
     });
 
     const baseLabelTranslateY =
-      -topPosition - labelHalfHeight + MINIMIZED_LABEL_BASE_Y_OFFSET_FROM_TOP;
+      -topPosition -
+      labelHalfHeight +
+      minimizedLabelLogicalMarginTop +
+      MINIMIZED_LABEL_FONT_SIZE / 2;
 
     const placeholderOpacity = hasActiveOutline
       ? interpolatePlaceholder(parentState.labeled, hasActiveOutline)
@@ -249,13 +253,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
       height ||
       (dense ? (label ? MIN_DENSE_HEIGHT_WL : MIN_DENSE_HEIGHT) : MIN_HEIGHT);
 
-    const flatHeight =
-      inputHeight +
-      (height
-        ? 0
-        : dense
-        ? MINIMIZED_LABEL_RESERVED_HEIGHT_DENSE
-        : MINIMIZED_LABEL_RESERVED_HEIGHT);
+    const flatHeight = inputHeight + (height ? 0 : minimizeLabelReservedHeight);
 
     const iconTopPosition = (flatHeight - ADORNMENT_SIZE) / 2;
 
@@ -447,13 +445,5 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     margin: 0,
     zIndex: 1,
-  },
-  inputFlat: {
-    paddingTop: 12 + MINIMIZED_LABEL_LOGICAL_MARGIN_TOP,
-    paddingBottom: 4,
-  },
-  inputFlatDense: {
-    paddingTop: 10 + MINIMIZED_LABEL_LOGICAL_MARGIN_TOP,
-    paddingBottom: 2,
   },
 });

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -402,7 +402,7 @@ const Underline = ({
         styles.underline,
         {
           backgroundColor,
-          // Underlines is thinner when input is not focused
+          // Underline is thinner when input is not focused
           transform: [{ scaleY: parentState.focused ? 1 : 0.5 }],
         },
       ]}

--- a/src/components/__tests__/TextInput.test.js
+++ b/src/components/__tests__/TextInput.test.js
@@ -85,3 +85,21 @@ it('correctly applies textAlign center', () => {
 
   expect(toJSON()).toMatchSnapshot();
 });
+
+it('uses paddingTop to position minimized label', () => {
+  const { toJSON } = render(
+    <TextInput
+      label="Flat input"
+      placeholder="Type something"
+      value={'Some test value'}
+      dense
+      style={{
+        height: 40,
+        paddingTop: 4,
+        paddingHorizontal: 4,
+      }}
+    />
+  );
+
+  expect(toJSON()).toMatchSnapshot();
+});

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -991,3 +991,180 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
   </View>
 </View>
 `;
+
+exports[`uses paddingTop to position minimized label 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "rgb(231, 231, 231)",
+        "borderTopLeftRadius": 4,
+        "borderTopRightRadius": 4,
+      },
+      Object {},
+    ]
+  }
+>
+  <View
+    style={
+      Object {
+        "backgroundColor": "rgba(0, 0, 0, 0.26)",
+        "bottom": 0,
+        "height": 2,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "transform": Array [
+          Object {
+            "scaleY": 0.5,
+          },
+        ],
+      }
+    }
+  />
+  <View
+    style={
+      Array [
+        Object {
+          "paddingBottom": 0,
+          "paddingTop": 0,
+        },
+        Object {
+          "minHeight": 40,
+        },
+      ]
+    }
+  >
+    <View
+      pointerEvents="none"
+      style={
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "transform": Array [
+            Object {
+              "translateX": 1,
+            },
+          ],
+        }
+      }
+    >
+      <Text
+        numberOfLines={1}
+        onLayout={[Function]}
+        style={
+          Object {
+            "color": "#6200ee",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": undefined,
+            "left": 0,
+            "opacity": 0,
+            "paddingLeft": 4,
+            "paddingRight": 4,
+            "position": "absolute",
+            "textAlign": "left",
+            "top": 20,
+            "transform": Array [
+              Object {
+                "translateX": 0,
+              },
+              Object {
+                "translateY": -10,
+              },
+              Object {
+                "scale": 0.75,
+              },
+            ],
+            "writingDirection": "ltr",
+          }
+        }
+      >
+        Flat input
+      </Text>
+      <Text
+        numberOfLines={1}
+        style={
+          Object {
+            "color": "rgba(0, 0, 0, 0.54)",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": undefined,
+            "left": 0,
+            "opacity": 0,
+            "paddingLeft": 4,
+            "paddingRight": 4,
+            "position": "absolute",
+            "textAlign": "left",
+            "top": 20,
+            "transform": Array [
+              Object {
+                "translateX": 0,
+              },
+              Object {
+                "translateY": -10,
+              },
+              Object {
+                "scale": 0.75,
+              },
+            ],
+            "writingDirection": "ltr",
+          }
+        }
+      >
+        Flat input
+      </Text>
+    </View>
+    <TextInput
+      allowFontScaling={true}
+      editable={true}
+      multiline={false}
+      onBlur={[Function]}
+      onChangeText={[Function]}
+      onFocus={[Function]}
+      placeholder=""
+      placeholderTextColor="rgba(0, 0, 0, 0.54)"
+      rejectResponderTermination={true}
+      selectionColor="#6200ee"
+      style={
+        Array [
+          Object {
+            "flexGrow": 1,
+            "margin": 0,
+            "zIndex": 1,
+          },
+          Object {
+            "paddingLeft": 4,
+            "paddingRight": 4,
+          },
+          Object {
+            "height": 40,
+          },
+          Object {
+            "paddingBottom": 2,
+            "paddingTop": 14,
+          },
+          Object {
+            "color": "#000000",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": undefined,
+            "textAlign": "left",
+            "textAlignVertical": "center",
+          },
+          false,
+          Array [
+            Object {},
+          ],
+        ]
+      }
+      underlineColorAndroid="transparent"
+      value="Some test value"
+    />
+  </View>
+</View>
+`;


### PR DESCRIPTION
### Summary

A `paddingTop` value in a TextInput's style now controls the spacing
between the top of a flat TextInput and the top of its minimized label,
which defaults to 12.

Previously this was hardcoded to 12, even when setting dense to true,
which makes it difficult to style flat TextInputs so that they take up
minimal vertical space. Dense could be used and a small height given,
but 12 pixels would always be frustratingly reserved above the minimized
label. Now the paddingTop can be set to smaller value to get a more
pleasing vertically compact view.

The use of the style's paddingTop feels appropriate given the effect of
value and the use of other style properties to control the internal
layout of TextInputFlat, but I'm open to suggestions of alternative
approaches to exposing this.

The individual commits may be helpful to understand how the changes
came about.

Partially addresses #2700.

### Test plan

1. I ran the tests to ensure no snapshots changed.

2. I added a "Very dense flat input" example to the bottom of TextInputExample and verified it (and the existing examples) renders correctly:
- In Chrome on MacOS: ![image](https://user-images.githubusercontent.com/151714/119393572-6c887100-bcd1-11eb-97de-a48effebbd53.png)
- In the iOS Simulator: ![image](https://user-images.githubusercontent.com/151714/119393287-069be980-bcd1-11eb-9f63-fbfc74ca7651.png)
- In the Android emulator: ![image](https://user-images.githubusercontent.com/151714/119394354-5cbd5c80-bcd2-11eb-8b65-674a794ecd9f.png)

3. I ran the tests to ensure there are no regressions.

4. I added a test for this use case to capture future regressions.