### PR TITLE
fix(android): add importantForAccessibility in Modal component

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -215,6 +215,7 @@ class Modal extends React.Component<Props, State> {
           accessibilityRole="button"
           disabled={!dismissable}
           onPress={dismissable ? this.hideModal : undefined}
+          importantForAccessibility="no"
         >
           <Animated.View
             style={[


### PR DESCRIPTION
### Summary
It wasn't being possible to focus on the content under the dialog.

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/6487206/119429630-921f7580-bce5-11eb-9d8b-a0d25c681a72.jpeg) | ![after](https://user-images.githubusercontent.com/6487206/119429639-95b2fc80-bce5-11eb-94a0-4fc97c390fcd.jpeg)


### Test plan
1. Open the dialog example
2. Focus on the dialog content using TalkBack
