### PR TITLE
Chip - optional icon 

### DIFF
--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -34,7 +34,7 @@ type Props = React.ComponentProps<typeof Surface> & {
   /**
    * Icon to display for the `Chip`. Both icon and avatar cannot be specified.
    */
-  icon?: IconSource;
+  icon?: IconSource|null;
   /**
    * Avatar to display for the `Chip`. Both icon and avatar cannot be specified.
    */
@@ -267,14 +267,14 @@ const Chip = ({
                 : avatar}
             </View>
           ) : null}
-          {icon || selected ? (
+          {icon !== null ? (
             <View
               style={[
                 styles.icon,
                 avatar ? [styles.avatar, styles.avatarSelected] : null,
               ]}
             >
-              {icon ? (
+              {typeof icon === 'string' ? (
                 <Icon
                   source={icon}
                   color={avatar ? white : iconColor}

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -34,7 +34,7 @@ type Props = React.ComponentProps<typeof Surface> & {
   /**
    * Icon to display for the `Chip`. Both icon and avatar cannot be specified.
    */
-  icon?: IconSource|null;
+  icon?: IconSource | null;
   /**
    * Avatar to display for the `Chip`. Both icon and avatar cannot be specified.
    */

--- a/src/components/__tests__/Chip.test.js
+++ b/src/components/__tests__/Chip.test.js
@@ -18,6 +18,12 @@ it('renders chip with icon', () => {
   expect(tree).toMatchSnapshot();
 });
 
+it('renders chip without icon', () => {
+  const tree = renderer.create(<Chip icon={null}>Example Chip</Chip>).toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
 it('renders chip with close button', () => {
   const tree = renderer
     .create(

--- a/src/components/__tests__/__snapshots__/Chip.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.js.snap
@@ -418,6 +418,150 @@ exports[`renders chip with onPress 1`] = `
         ]
       }
     >
+      <View
+        style={
+          Array [
+            Object {
+              "alignSelf": "center",
+              "padding": 4,
+            },
+            null,
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          allowFontScaling={false}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "color": "rgba(0, 0, 0, 0.54)",
+                "fontSize": 18,
+              },
+              Array [
+                Object {
+                  "lineHeight": 18,
+                  "transform": Array [
+                    Object {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                Object {
+                  "backgroundColor": "transparent",
+                },
+              ],
+              Object {
+                "fontFamily": "Material Design Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+      <Text
+        numberOfLines={1}
+        selectable={false}
+        style={
+          Array [
+            Object {
+              "color": "#000000",
+              "fontFamily": "System",
+              "fontWeight": "400",
+            },
+            Object {
+              "textAlign": "left",
+            },
+            Array [
+              Object {
+                "lineHeight": 24,
+                "marginVertical": 4,
+                "minHeight": 24,
+                "textAlignVertical": "center",
+              },
+              Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "System",
+                "fontWeight": "400",
+                "marginLeft": 8,
+                "marginRight": 8,
+              },
+              undefined,
+            ],
+          ]
+        }
+      >
+        Example Chip
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`renders chip without icon 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#ebebeb",
+      "borderColor": "#ebebeb",
+      "borderRadius": 16,
+      "borderStyle": "solid",
+      "borderWidth": 0.5,
+      "elevation": 0,
+      "flexDirection": "row",
+    }
+  }
+>
+  <View
+    accessibilityRole="button"
+    accessibilityState={
+      Object {
+        "disabled": false,
+        "selected": false,
+      }
+    }
+    accessible={true}
+    focusable={false}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "overflow": "hidden",
+        },
+        Object {
+          "borderRadius": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "paddingLeft": 4,
+            "position": "relative",
+          },
+          Object {
+            "paddingRight": 4,
+          },
+        ]
+      }
+    >
       <Text
         numberOfLines={1}
         selectable={false}
@@ -514,6 +658,54 @@ exports[`renders outlined disabled chip 1`] = `
         ]
       }
     >
+      <View
+        style={
+          Array [
+            Object {
+              "alignSelf": "center",
+              "padding": 4,
+            },
+            null,
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          allowFontScaling={false}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "color": "rgba(0, 0, 0, 0.26)",
+                "fontSize": 18,
+              },
+              Array [
+                Object {
+                  "lineHeight": 18,
+                  "transform": Array [
+                    Object {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                Object {
+                  "backgroundColor": "transparent",
+                },
+              ],
+              Object {
+                "fontFamily": "Material Design Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
       <Text
         numberOfLines={1}
         selectable={false}


### PR DESCRIPTION
### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
The `Chip` component has some undesired internal padding when the icon is removed. It looks like this is because the icon was not designed to be optional.

Currently, we can do this (among other methods) to render the chip without an icon:
```
const emptyIcon = () => null

const MyComponent = () => (
  <Chip icon={emptyIcon}
)
```

However, as seen in this screenshot, there is some leftover padding inside the chip that is designed to create space between the icon and the text - even when the icon is not there.

<img width="1047" alt="Screen Shot 2021-05-31 at 7 39 35 AM" src="https://user-images.githubusercontent.com/32719539/120202142-78999480-c1e3-11eb-8965-36e5c956189e.png">




### Test plan

- render a chip component and pass `null` as the icon, notice that the padding is now gone
- render a chip with an icon and notice that the padding is there
- render a chip with an avatar and notice that the padding is still there


Relates to: https://github.com/callstack/react-native-paper/issues/1852
