### PR TITLE
fix: Drawer.Item content not center aligned

### DIFF
--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -147,7 +147,7 @@ const styles = StyleSheet.create({
   content: {
     flex: 1,
     flexDirection: 'row',
-    alignItems: 'center'
+    alignItems: 'center',
   },
   label: {
     marginRight: 32,

--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -147,6 +147,7 @@ const styles = StyleSheet.create({
   content: {
     flex: 1,
     flexDirection: 'row',
+    alignItems: 'center'
   },
   label: {
     marginRight: 32,

--- a/src/components/__tests__/__snapshots__/DrawerItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DrawerItem.test.js.snap
@@ -55,6 +55,7 @@ exports[`renders DrawerItem with icon 1`] = `
       <View
         style={
           Object {
+            "alignItems": "center",
             "flex": 1,
             "flexDirection": "row",
           }
@@ -186,6 +187,7 @@ exports[`renders active DrawerItem 1`] = `
       <View
         style={
           Object {
+            "alignItems": "center",
             "flex": 1,
             "flexDirection": "row",
           }
@@ -317,6 +319,7 @@ exports[`renders basic DrawerItem 1`] = `
       <View
         style={
           Object {
+            "alignItems": "center",
             "flex": 1,
             "flexDirection": "row",
           }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Fixes Drawer.Item content not being center aligned
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
Prior to change:
![image](https://user-images.githubusercontent.com/11355096/120248477-3e75d480-c26f-11eb-8b48-6fd7dae15a7c.png)

After change: 
![image](https://user-images.githubusercontent.com/11355096/120248684-1d61b380-c270-11eb-997c-2ca88463e5b2.png)

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
