### PR TITLE
feat: banner, add optional callback for on animation complete

### DIFF
--- a/example/src/Examples/BannerExample.tsx
+++ b/example/src/Examples/BannerExample.tsx
@@ -26,6 +26,8 @@ const BannerExample = () => {
           ]}
           icon={require('../../assets/images/email-icon.png')}
           visible={visible}
+          onAnimateShowFinish={() => console.log('Completed opening animation')}
+          onAnimateHideFinish={() => console.log('Completed closing animation')}
         >
           Two line text string with two actions. One to two lines is preferable
           on mobile.

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -48,6 +48,16 @@ type Props = $RemoveChildren<typeof Surface> & {
    * @optional
    */
   theme: ReactNativePaper.Theme;
+  /**
+   * @optional
+   * Optional function that will be called after the open animation finished running normally
+   */
+  onAnimateShowFinish?: Animated.EndCallback;
+  /**
+   * @optional
+   * Optional function that will be called after the open animation finished running normally
+   */
+  onAnimateHideFinish?: Animated.EndCallback;
 };
 
 type NativeEvent = {
@@ -117,6 +127,8 @@ const Banner = ({
   contentStyle,
   style,
   theme,
+  onAnimateShowFinish = () => {},
+  onAnimateHideFinish = () => {},
   ...rest
 }: Props) => {
   const { current: position } = React.useRef<Animated.Value>(
@@ -139,14 +151,14 @@ const Banner = ({
         duration: 250 * scale,
         toValue: 1,
         useNativeDriver: false,
-      }).start();
+      }).start(onAnimateShowFinish);
     } else {
       // hide
       Animated.timing(position, {
         duration: 200 * scale,
         toValue: 0,
         useNativeDriver: false,
-      }).start();
+      }).start(onAnimateHideFinish);
     }
   }, [visible, position, scale]);
 

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -55,7 +55,7 @@ type Props = $RemoveChildren<typeof Surface> & {
   onAnimateShowFinish?: Animated.EndCallback;
   /**
    * @optional
-   * Optional function that will be called after the open animation finished running normally
+   * Optional function that will be called after the close animation finished running normally
    */
   onAnimateHideFinish?: Animated.EndCallback;
 };


### PR DESCRIPTION
### Summary

After using the Banner component, for better flexibility for customization, I find that it could be useful for consumers to hook into the callback for when the default animation completes.
i.e doing some action after the banner is completely gone as opposed to during animation after setting `visible=false`

### Test plan

I've modified the Banner example to log out whenever it completes the `open/close` animation. If that is not a preferred modification to examples then you can test by:
1. modifying `BannerExample.tsx` for `onAnimateShowFinish` and/or `onAnimateHideFinish` callbacks

```
        <Banner
          ...otherprops
          onAnimateShowFinish={() => console.log('Completed opening animation')}
          onAnimateHideFinish={() => console.log('Completed closing animation')}
        >

      </Banner>
```
2. Run the example app
3. toggle the Banner show/hide
4. see that it logs out at the appropriate time
