### PR TITLE
feat: Support lineHeight prop on flat and outlined InputLabel

### DIFF
--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -19,6 +19,7 @@ const InputLabel = (props: InputLabelProps) => {
     font,
     fontSize,
     fontWeight,
+    lineHeight,
     placeholderOpacity,
     wiggleOffsetX,
     labelScale,
@@ -45,6 +46,7 @@ const InputLabel = (props: InputLabelProps) => {
     ...font,
     fontSize,
     fontWeight,
+    lineHeight,
     transform: [
       {
         // Wiggle the label when there's an error

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -91,6 +91,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
     const {
       fontSize: fontSizeStyle,
       fontWeight,
+      lineHeight,
       height,
       paddingHorizontal,
       textAlign,
@@ -269,6 +270,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
       font,
       fontSize,
       fontWeight,
+      lineHeight,
       labelScale,
       wiggleOffsetX: LABEL_WIGGLE_X_OFFSET,
       topPosition,

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -92,6 +92,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
     const {
       fontSize: fontSizeStyle,
       fontWeight,
+      lineHeight,
       height,
       backgroundColor = colors.background,
       textAlign,
@@ -202,6 +203,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
       font,
       fontSize,
       fontWeight,
+      lineHeight,
       labelScale,
       wiggleOffsetX: LABEL_WIGGLE_X_OFFSET,
       topPosition,

--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -56,6 +56,7 @@ export type LabelProps = {
   labelScale: number;
   fontSize: number;
   fontWeight: TextStyle['fontWeight'];
+  lineHeight: number,
   font: any;
   topPosition: number;
   paddingOffset?: { paddingLeft: number; paddingRight: number } | null;


### PR DESCRIPTION

### Summary
Line height style not working on InputLabel when we add lineHeight to TextInput style props

### Test plan

 Add lineHeight to flat and outlined TextInput, lineHeight  must be applied to TextInput and InputLabel.

