### PR TITLE
fix: switch ref forwarding

### DIFF
--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -76,67 +76,63 @@ type Props = React.ComponentPropsWithRef<typeof NativeSwitch> & {
  * export default MyComponent;
  * ```
  */
-const Switch = ({
-  value,
-  disabled,
-  onValueChange,
-  color,
-  theme,
-  ...rest
-}: Props) => {
-  const checkedColor = color || theme.colors.accent;
+const Switch = React.forwardRef<NativeSwitch, Props>(
+  ({ value, disabled, onValueChange, color, theme, ...rest }: Props, ref) => {
+    const checkedColor = color || theme.colors.accent;
 
-  const onTintColor =
-    Platform.OS === 'ios'
-      ? checkedColor
-      : disabled
-      ? theme.dark
-        ? setColor(white).alpha(0.1).rgb().string()
-        : setColor(black).alpha(0.12).rgb().string()
-      : setColor(checkedColor).alpha(0.5).rgb().string();
+    const onTintColor =
+      Platform.OS === 'ios'
+        ? checkedColor
+        : disabled
+        ? theme.dark
+          ? setColor(white).alpha(0.1).rgb().string()
+          : setColor(black).alpha(0.12).rgb().string()
+        : setColor(checkedColor).alpha(0.5).rgb().string();
 
-  const thumbTintColor =
-    Platform.OS === 'ios'
-      ? undefined
-      : disabled
-      ? theme.dark
-        ? grey800
-        : grey400
-      : value
-      ? checkedColor
-      : theme.dark
-      ? grey400
-      : grey50;
+    const thumbTintColor =
+      Platform.OS === 'ios'
+        ? undefined
+        : disabled
+        ? theme.dark
+          ? grey800
+          : grey400
+        : value
+        ? checkedColor
+        : theme.dark
+        ? grey400
+        : grey50;
 
-  const props =
-    version && version.major === 0 && version.minor <= 56
-      ? {
-          onTintColor,
-          thumbTintColor,
-        }
-      : Platform.OS === 'web'
-      ? {
-          activeTrackColor: onTintColor,
-          thumbColor: thumbTintColor,
-          activeThumbColor: checkedColor,
-        }
-      : {
-          thumbColor: thumbTintColor,
-          trackColor: {
-            true: onTintColor,
-            false: '',
-          },
-        };
+    const props =
+      version && version.major === 0 && version.minor <= 56
+        ? {
+            onTintColor,
+            thumbTintColor,
+          }
+        : Platform.OS === 'web'
+        ? {
+            activeTrackColor: onTintColor,
+            thumbColor: thumbTintColor,
+            activeThumbColor: checkedColor,
+          }
+        : {
+            thumbColor: thumbTintColor,
+            trackColor: {
+              true: onTintColor,
+              false: '',
+            },
+          };
 
-  return (
-    <NativeSwitch
-      value={value}
-      disabled={disabled}
-      onValueChange={disabled ? undefined : onValueChange}
-      {...props}
-      {...rest}
-    />
-  );
-};
+    return (
+      <NativeSwitch
+        value={value}
+        disabled={disabled}
+        onValueChange={disabled ? undefined : onValueChange}
+        ref={ref}
+        {...props}
+        {...rest}
+      />
+    );
+  }
+);
 
 export default withTheme(Switch);


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
The `Switch` component was converted from a React class component to a functional component between v3 and v4, but was not converted to use `React.forwardRef()`. Because of this, `Switch` components do not accept refs in v4.

Here is a bug for the same issue that got closed in December due to inactivity: https://github.com/callstack/react-native-paper/issues/2408

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
1. Create a `Switch` component and provide a ref as a prop
2. Call a native function on the ref like `.focus()`
3. Verify the native function is successful and no React warnings/errors are thrown
