### PR TITLE
feat: improve ListAccordion accessibility

### DIFF
--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -84,6 +84,10 @@ type Props = {
    * TestID used for testing purposes
    */
   testID?: string;
+  /**
+   * Accessibility label for the TouchableRipple. This is read by the screen reader when the user taps the touchable.
+   */
+  accessibilityLabel?: string;
 };
 
 /**
@@ -146,6 +150,7 @@ const ListAccordion = ({
   onPress,
   onLongPress,
   expanded: expandedProp,
+  accessibilityLabel,
 }: Props) => {
   const [expanded, setExpanded] = React.useState<boolean>(
     expandedProp || false
@@ -190,6 +195,8 @@ const ListAccordion = ({
           accessibilityTraits="button"
           accessibilityComponentType="button"
           accessibilityRole="button"
+          accessibilityState={{ expanded: isExpanded }}
+          accessibilityLabel={accessibilityLabel}
           testID={testID}
           delayPressIn={0}
           borderless

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.js.snap
@@ -11,6 +11,11 @@ exports[`renders expanded accordion 1`] = `
   >
     <View
       accessibilityRole="button"
+      accessibilityState={
+        Object {
+          "expanded": true,
+        }
+      }
       accessible={true}
       focusable={true}
       onClick={[Function]}
@@ -221,6 +226,11 @@ exports[`renders list accordion with children 1`] = `
   >
     <View
       accessibilityRole="button"
+      accessibilityState={
+        Object {
+          "expanded": false,
+        }
+      }
       accessible={true}
       focusable={true}
       onClick={[Function]}
@@ -410,6 +420,11 @@ exports[`renders list accordion with custom title and description styles 1`] = `
   >
     <View
       accessibilityRole="button"
+      accessibilityState={
+        Object {
+          "expanded": false,
+        }
+      }
       accessible={true}
       focusable={true}
       onClick={[Function]}
@@ -582,6 +597,11 @@ exports[`renders list accordion with left items 1`] = `
   >
     <View
       accessibilityRole="button"
+      accessibilityState={
+        Object {
+          "expanded": false,
+        }
+      }
       accessible={true}
       focusable={true}
       onClick={[Function]}
@@ -771,6 +791,11 @@ exports[`renders multiline list accordion 1`] = `
   >
     <View
       accessibilityRole="button"
+      accessibilityState={
+        Object {
+          "expanded": false,
+        }
+      }
       accessible={true}
       focusable={true}
       onClick={[Function]}


### PR DESCRIPTION
### Summary
1. Add prop `accessibilityLabel` to ListAccordion
2. Pass the key `expanded` under `accessibilityState`  to the `TouchableRipple`

### Test plan
1. Test it using TalkBack or VoiceOver 