### PR TITLE
fix: TextInput border being cut out

### DIFF
--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -116,7 +116,7 @@ const TextInputExample = () => {
   return (
     <TextInputAvoidingView>
       <ScreenWrapper
-        style={styles.container}
+        contentContainerStyle={styles.container}
         keyboardShouldPersistTaps={'always'}
         removeClippedSubviews={false}
       >
@@ -433,6 +433,15 @@ const TextInputExample = () => {
             style={{
               textAlign: 'center',
             }}
+          />
+        </View>
+        <View style={styles.inputContainerStyle}>
+          <TextInput
+            mode="outlined"
+            theme={{
+              roundness: 25,
+            }}
+            label="Custom rounded input"
           />
         </View>
       </ScreenWrapper>

--- a/src/components/TextInput/Label/LabelBackground.tsx
+++ b/src/components/TextInput/Label/LabelBackground.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Animated, StyleSheet } from 'react-native';
 
 import AnimatedText from '../../Typography/AnimatedText';
-import { useTheme } from '../../../core/theming';
 
 import type { LabelBackgroundProps } from '../types';
 
@@ -15,6 +14,7 @@ const LabelBackground = ({
     hasActiveOutline,
     label,
     backgroundColor,
+    roundness,
   },
   labelStyle,
 }: LabelBackgroundProps) => {
@@ -23,7 +23,6 @@ const LabelBackground = ({
     inputRange: [0, 1],
     outputRange: [hasFocus ? 1 : 0, 0],
   });
-  const { roundness } = useTheme();
 
   const labelTranslationX = {
     transform: [

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -277,6 +277,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
       activeColor,
       placeholderColor,
       errorColor,
+      roundness: theme.roundness,
     };
     const affixTopPosition = {
       [AdornmentSide.Left]: leftAffixTopPosition,

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -213,6 +213,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
       backgroundColor: backgroundColor as ColorValue,
       errorColor,
       labelTranslationXOffset,
+      roundness: theme.roundness,
     };
 
     const minHeight = (height ||

--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -68,6 +68,7 @@ export type LabelProps = {
   errorColor?: string;
   error?: boolean | null;
   onLayoutAnimatedText: (args: any) => void;
+  roundness: number;
 };
 export type InputLabelProps = {
   parentState: State;


### PR DESCRIPTION
### Summary

Following up #2678. `useTheme` doesn't work in the component `LabelBackground` when you pass a custom theme to the TextInput as in the example below:

```js
<TextInput
  mode="outlined"
  label="Test"
  theme={{
    roundness: 25,
  }}
  underlineColor="red"
  value="custom rounded input"
/>
```

The solution was to pass the prop `roundness` along under the `labelProps`

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/6487206/123016548-41ad3d80-d3a1-11eb-9578-5057c80b64a3.jpeg) | ![after](https://user-images.githubusercontent.com/6487206/123016580-58539480-d3a1-11eb-9619-a3635c76b665.jpeg)

### Test plan
1. Check it out in the example app