### PR TITLE
fix: outlined TexInput adjustPaddingOut (#2740)

### DIFF
--- a/src/components/TextInput/helpers.tsx
+++ b/src/components/TextInput/helpers.tsx
@@ -111,7 +111,7 @@ export const adjustPaddingOut = ({
   const refFontHeight = scale * fontSize;
   let result = pad;
 
-  if (height) {
+  if (height && !multiline) {
     return {
       paddingTop: Math.max(0, (height - fontHeight) / 2),
       paddingBottom: Math.max(0, (height - fontHeight) / 2),

--- a/src/components/__tests__/TextInput.test.js
+++ b/src/components/__tests__/TextInput.test.js
@@ -85,3 +85,17 @@ it('correctly applies textAlign center', () => {
 
   expect(toJSON()).toMatchSnapshot();
 });
+
+it('correctly applies heigh to mutline Outline TextInput', () => {
+  const { toJSON } = render(
+    <TextInput
+      label="Outline Input"
+      placeholder="Type Something"
+      value={'Some test value'}
+      style={{ height: 100 }}
+      multiline
+    />
+  );
+
+  expect(toJSON()).toMatchSnapshot();
+});

--- a/src/components/__tests__/TextInput.test.js
+++ b/src/components/__tests__/TextInput.test.js
@@ -86,7 +86,7 @@ it('correctly applies textAlign center', () => {
   expect(toJSON()).toMatchSnapshot();
 });
 
-it('correctly applies heigh to mutline Outline TextInput', () => {
+it('correctly applies height to multiline Outline TextInput', () => {
   const { toJSON } = render(
     <TextInput
       mode="outlined"

--- a/src/components/__tests__/TextInput.test.js
+++ b/src/components/__tests__/TextInput.test.js
@@ -89,6 +89,7 @@ it('correctly applies textAlign center', () => {
 it('correctly applies heigh to mutline Outline TextInput', () => {
   const { toJSON } = render(
     <TextInput
+      mode="outlined"
       label="Outline Input"
       placeholder="Type Something"
       value={'Some test value'}

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -177,6 +177,183 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
 </View>
 `;
 
+exports[`correctly applies heigh to mutline Outline TextInput 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "rgb(231, 231, 231)",
+        "borderTopLeftRadius": 4,
+        "borderTopRightRadius": 4,
+      },
+      Object {},
+    ]
+  }
+>
+  <View
+    style={
+      Object {
+        "backgroundColor": "rgba(0, 0, 0, 0.26)",
+        "bottom": 0,
+        "height": 2,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "transform": Array [
+          Object {
+            "scaleY": 0.5,
+          },
+        ],
+      }
+    }
+  />
+  <View
+    style={
+      Array [
+        Object {
+          "paddingBottom": 0,
+          "paddingTop": 0,
+        },
+        Object {
+          "minHeight": 100,
+        },
+      ]
+    }
+  >
+    <View
+      pointerEvents="none"
+      style={
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "transform": Array [
+            Object {
+              "translateX": 3,
+            },
+          ],
+        }
+      }
+    >
+      <Text
+        numberOfLines={1}
+        onLayout={[Function]}
+        style={
+          Object {
+            "color": "#6200ee",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": undefined,
+            "left": 0,
+            "opacity": 0,
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "position": "absolute",
+            "textAlign": "left",
+            "top": 50,
+            "transform": Array [
+              Object {
+                "translateX": 0,
+              },
+              Object {
+                "translateY": -32,
+              },
+              Object {
+                "scale": 0.75,
+              },
+            ],
+            "writingDirection": "ltr",
+          }
+        }
+      >
+        Outline Input
+      </Text>
+      <Text
+        numberOfLines={1}
+        style={
+          Object {
+            "color": "rgba(0, 0, 0, 0.54)",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": undefined,
+            "left": 0,
+            "opacity": 0,
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "position": "absolute",
+            "textAlign": "left",
+            "top": 50,
+            "transform": Array [
+              Object {
+                "translateX": 0,
+              },
+              Object {
+                "translateY": -32,
+              },
+              Object {
+                "scale": 0.75,
+              },
+            ],
+            "writingDirection": "ltr",
+          }
+        }
+      >
+        Outline Input
+      </Text>
+    </View>
+    <TextInput
+      allowFontScaling={true}
+      editable={true}
+      multiline={true}
+      onBlur={[Function]}
+      onChangeText={[Function]}
+      onFocus={[Function]}
+      placeholder=""
+      placeholderTextColor="rgba(0, 0, 0, 0.54)"
+      rejectResponderTermination={true}
+      selectionColor="#6200ee"
+      style={
+        Array [
+          Object {
+            "flexGrow": 1,
+            "margin": 0,
+            "zIndex": 1,
+          },
+          Object {
+            "paddingLeft": 12,
+            "paddingRight": 12,
+          },
+          Object {
+            "height": 100,
+          },
+          Object {
+            "paddingBottom": 4,
+            "paddingTop": 36,
+          },
+          Object {
+            "color": "#000000",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": undefined,
+            "textAlign": "left",
+            "textAlignVertical": "top",
+          },
+          false,
+          Array [
+            Object {},
+          ],
+        ]
+      }
+      underlineColorAndroid="transparent"
+      value="Some test value"
+    />
+  </View>
+</View>
+`;
+
 exports[`correctly applies textAlign center 1`] = `
 <View
   style={

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -177,7 +177,7 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
 </View>
 `;
 
-exports[`correctly applies heigh to mutline Outline TextInput 1`] = `
+exports[`correctly applies height to multiline Outline TextInput 1`] = `
 <View
   style={Object {}}
 >

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -179,177 +179,223 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
 
 exports[`correctly applies heigh to mutline Outline TextInput 1`] = `
 <View
-  style={
-    Array [
-      Object {
-        "backgroundColor": "rgb(231, 231, 231)",
-        "borderTopLeftRadius": 4,
-        "borderTopRightRadius": 4,
-      },
-      Object {},
-    ]
-  }
+  style={Object {}}
 >
-  <View
-    style={
-      Object {
-        "backgroundColor": "rgba(0, 0, 0, 0.26)",
-        "bottom": 0,
-        "height": 2,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "transform": Array [
-          Object {
-            "scaleY": 0.5,
-          },
-        ],
-      }
-    }
-  />
-  <View
-    style={
-      Array [
-        Object {
-          "paddingBottom": 0,
-          "paddingTop": 0,
-        },
-        Object {
-          "minHeight": 100,
-        },
-      ]
-    }
-  >
+  <View>
     <View
       pointerEvents="none"
       style={
-        Object {
-          "bottom": 0,
-          "left": 0,
-          "opacity": 0,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-          "transform": Array [
-            Object {
-              "translateX": 3,
-            },
-          ],
-        }
+        Array [
+          Object {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 6,
+          },
+          Object {
+            "backgroundColor": "#f6f6f6",
+            "borderColor": "rgba(0, 0, 0, 0.54)",
+            "borderRadius": 4,
+            "borderWidth": 1,
+          },
+        ]
       }
-    >
-      <Text
-        numberOfLines={1}
-        onLayout={[Function]}
-        style={
-          Object {
-            "color": "#6200ee",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
-            "left": 0,
-            "opacity": 0,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "position": "absolute",
-            "textAlign": "left",
-            "top": 50,
-            "transform": Array [
-              Object {
-                "translateX": 0,
-              },
-              Object {
-                "translateY": -32,
-              },
-              Object {
-                "scale": 0.75,
-              },
-            ],
-            "writingDirection": "ltr",
-          }
-        }
-      >
-        Outline Input
-      </Text>
-      <Text
-        numberOfLines={1}
-        style={
-          Object {
-            "color": "rgba(0, 0, 0, 0.54)",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
-            "left": 0,
-            "opacity": 0,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "position": "absolute",
-            "textAlign": "left",
-            "top": 50,
-            "transform": Array [
-              Object {
-                "translateX": 0,
-              },
-              Object {
-                "translateY": -32,
-              },
-              Object {
-                "scale": 0.75,
-              },
-            ],
-            "writingDirection": "ltr",
-          }
-        }
-      >
-        Outline Input
-      </Text>
-    </View>
-    <TextInput
-      allowFontScaling={true}
-      editable={true}
-      multiline={true}
-      onBlur={[Function]}
-      onChangeText={[Function]}
-      onFocus={[Function]}
-      placeholder=""
-      placeholderTextColor="rgba(0, 0, 0, 0.54)"
-      rejectResponderTermination={true}
-      selectionColor="#6200ee"
+    />
+    <View
       style={
         Array [
           Object {
-            "flexGrow": 1,
-            "margin": 0,
-            "zIndex": 1,
+            "paddingBottom": 0,
           },
           Object {
-            "paddingLeft": 12,
-            "paddingRight": 12,
+            "minHeight": 100,
+            "paddingTop": 8,
           },
-          Object {
-            "height": 100,
-          },
-          Object {
-            "paddingBottom": 4,
-            "paddingTop": 36,
-          },
-          Object {
-            "color": "#000000",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
-            "textAlign": "left",
-            "textAlignVertical": "top",
-          },
-          false,
-          Array [
-            Object {},
-          ],
         ]
       }
-      underlineColorAndroid="transparent"
-      value="Some test value"
-    />
+    >
+      <View
+        pointerEvents="none"
+        style={
+          Object {
+            "bottom": 0,
+            "left": 0,
+            "opacity": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "transform": Array [
+              Object {
+                "translateX": 3,
+              },
+            ],
+          }
+        }
+      >
+        <View
+          pointerEvents="none"
+          style={
+            Object {
+              "backgroundColor": "#f6f6f6",
+              "bottom": 4,
+              "left": 10,
+              "opacity": 1,
+              "position": "absolute",
+              "right": 0,
+              "top": 6,
+              "transform": Array [
+                Object {
+                  "translateX": -3,
+                },
+              ],
+              "width": 8,
+            }
+          }
+        />
+        <Text
+          numberOfLines={1}
+          style={
+            Object {
+              "backgroundColor": "#f6f6f6",
+              "color": "transparent",
+              "fontFamily": "System",
+              "fontSize": 16,
+              "fontWeight": undefined,
+              "left": 18,
+              "opacity": 1,
+              "paddingHorizontal": 0,
+              "position": "absolute",
+              "textAlign": "left",
+              "top": 59,
+              "transform": Array [
+                Object {
+                  "translateX": 0,
+                },
+                Object {
+                  "translateY": -52,
+                },
+                Object {
+                  "scale": 0.75,
+                },
+                Object {
+                  "scaleY": 0.2,
+                },
+              ],
+              "writingDirection": "ltr",
+            }
+          }
+        >
+          Outline Input
+        </Text>
+        <Text
+          numberOfLines={1}
+          onLayout={[Function]}
+          style={
+            Object {
+              "color": "#6200ee",
+              "fontFamily": "System",
+              "fontSize": 16,
+              "fontWeight": undefined,
+              "left": 0,
+              "opacity": 0,
+              "paddingHorizontal": 14,
+              "position": "absolute",
+              "textAlign": "left",
+              "top": 58,
+              "transform": Array [
+                Object {
+                  "translateX": 0,
+                },
+                Object {
+                  "translateY": -52,
+                },
+                Object {
+                  "scale": 0.75,
+                },
+              ],
+              "writingDirection": "ltr",
+            }
+          }
+        >
+          Outline Input
+        </Text>
+        <Text
+          numberOfLines={1}
+          style={
+            Object {
+              "color": "rgba(0, 0, 0, 0.54)",
+              "fontFamily": "System",
+              "fontSize": 16,
+              "fontWeight": undefined,
+              "left": 0,
+              "opacity": 0,
+              "paddingHorizontal": 14,
+              "position": "absolute",
+              "textAlign": "left",
+              "top": 58,
+              "transform": Array [
+                Object {
+                  "translateX": 0,
+                },
+                Object {
+                  "translateY": -52,
+                },
+                Object {
+                  "scale": 0.75,
+                },
+              ],
+              "writingDirection": "ltr",
+            }
+          }
+        >
+          Outline Input
+        </Text>
+      </View>
+      <TextInput
+        allowFontScaling={true}
+        editable={true}
+        multiline={true}
+        onBlur={[Function]}
+        onChangeText={[Function]}
+        onFocus={[Function]}
+        placeholder=""
+        placeholderTextColor="rgba(0, 0, 0, 0.54)"
+        rejectResponderTermination={true}
+        selectionColor="#6200ee"
+        style={
+          Array [
+            Object {
+              "flexGrow": 1,
+              "margin": 0,
+              "paddingHorizontal": 14,
+              "zIndex": 1,
+            },
+            Object {
+              "height": 100,
+            },
+            Object {
+              "paddingBottom": 24,
+              "paddingTop": 24,
+            },
+            Object {
+              "color": "#000000",
+              "fontFamily": "System",
+              "fontSize": 16,
+              "fontWeight": undefined,
+              "textAlign": "left",
+              "textAlignVertical": "top",
+            },
+            false,
+            Array [
+              Object {},
+            ],
+          ]
+        }
+        underlineColorAndroid="transparent"
+        value="Some test value"
+      />
+    </View>
   </View>
 </View>
 `;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Fixes issue [2740](https://github.com/callstack/react-native-paper/issues/2740). The issue happens to be when we calculate the adjustPaddingOut. 

The change is to not return the centering paddingTop, and paddingBottom in case it is multiline.

### Test plan

![Screen Shot 2021-06-30 at 23 10 26](https://user-images.githubusercontent.com/12810203/124006920-713ef400-d9f8-11eb-929f-b68d0f511c27.png)

