### PR TITLE
fix: add missing padding to CardTitle

### DIFF
--- a/src/components/Card/CardTitle.tsx
+++ b/src/components/Card/CardTitle.tsx
@@ -176,11 +176,13 @@ const styles = StyleSheet.create({
 
   title: {
     minHeight: 30,
+    paddingRight: 16,
   },
 
   subtitle: {
     minHeight: 20,
     marginVertical: 0,
+    paddingRight: 16,
   },
 });
 


### PR DESCRIPTION
### Summary
I just realized that in the Card.Title paddingRight was missing. So the title was a little bit off when centered.

### Test plan

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/6487206/126874993-12449f3e-c9f0-4f77-aba1-954083424cda.jpeg) | ![after](https://user-images.githubusercontent.com/6487206/126875000-b3d0523d-bfa1-49de-b8c1-78ed09444b67.jpeg)

