### PR TITLE
Fix: Prevent font scaling in bottom nav

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -10,7 +10,7 @@ type Props = React.ComponentProps<typeof Animated.Text> & {
   /**
    * Whether the badge is visible
    */
-  visible: boolean;
+  visible?: boolean;
   /**
    * Content of the `Badge`.
    */

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -835,6 +835,7 @@ const BottomNavigation = ({
                             })
                           ) : (
                             <Text
+                              allowFontScaling={false}
                               style={[styles.label, { color: activeTintColor }]}
                             >
                               {getLabelText({ route })}
@@ -856,6 +857,7 @@ const BottomNavigation = ({
                               })
                             ) : (
                               <Text
+                                allowFontScaling={false}
                                 selectable={false}
                                 style={[
                                   styles.label,

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
@@ -3154,6 +3154,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                 }
               >
                 <Text
+                  allowFontScaling={false}
                   style={
                     Array [
                       Object {
@@ -3191,6 +3192,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                 }
               >
                 <Text
+                  allowFontScaling={false}
                   selectable={false}
                   style={
                     Array [
@@ -3423,6 +3425,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                 }
               >
                 <Text
+                  allowFontScaling={false}
                   style={
                     Array [
                       Object {
@@ -3460,6 +3463,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                 }
               >
                 <Text
+                  allowFontScaling={false}
                   selectable={false}
                   style={
                     Array [
@@ -3692,6 +3696,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                 }
               >
                 <Text
+                  allowFontScaling={false}
                   style={
                     Array [
                       Object {
@@ -3729,6 +3734,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                 }
               >
                 <Text
+                  allowFontScaling={false}
                   selectable={false}
                   style={
                     Array [
@@ -4089,6 +4095,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                 }
               >
                 <Text
+                  allowFontScaling={false}
                   style={
                     Array [
                       Object {
@@ -4320,6 +4327,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                 }
               >
                 <Text
+                  allowFontScaling={false}
                   style={
                     Array [
                       Object {
@@ -4551,6 +4559,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                 }
               >
                 <Text
+                  allowFontScaling={false}
                   style={
                     Array [
                       Object {
@@ -4890,6 +4899,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  allowFontScaling={false}
                   style={
                     Array [
                       Object {
@@ -4927,6 +4937,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  allowFontScaling={false}
                   selectable={false}
                   style={
                     Array [
@@ -5159,6 +5170,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  allowFontScaling={false}
                   style={
                     Array [
                       Object {
@@ -5196,6 +5208,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  allowFontScaling={false}
                   selectable={false}
                   style={
                     Array [
@@ -5428,6 +5441,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  allowFontScaling={false}
                   style={
                     Array [
                       Object {
@@ -5465,6 +5479,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  allowFontScaling={false}
                   selectable={false}
                   style={
                     Array [
@@ -5825,6 +5840,7 @@ exports[`renders shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  allowFontScaling={false}
                   style={
                     Array [
                       Object {
@@ -6056,6 +6072,7 @@ exports[`renders shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  allowFontScaling={false}
                   style={
                     Array [
                       Object {
@@ -6287,6 +6304,7 @@ exports[`renders shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  allowFontScaling={false}
                   style={
                     Array [
                       Object {
@@ -6518,6 +6536,7 @@ exports[`renders shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  allowFontScaling={false}
                   style={
                     Array [
                       Object {
@@ -6749,6 +6768,7 @@ exports[`renders shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  allowFontScaling={false}
                   style={
                     Array [
                       Object {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

If the user has dynamic font scaling turned up on their device, the bottom navigation's text labels are not visible as they don't have the space to grow.
I believe it's not really of interest to increase the size of the tab bar to accomodate larger font sizes as it would encroach on the app's main screen real estate. As such, I suggest preventing tab bar labels from being scaled.

### Test plan

[Before change](https://user-images.githubusercontent.com/30954044/127580484-3b88071c-3f25-43ca-8d7b-90888c30e078.mov)
[After change](https://user-images.githubusercontent.com/30954044/127580521-425b7439-72f7-44d8-982f-4bd0e8a133f6.mov)

