### PR TITLE
fix: chrome autofill in flat TextInput on web

### DIFF
--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -422,6 +422,7 @@ const styles = StyleSheet.create({
     right: 0,
     bottom: 0,
     height: 2,
+    zIndex: 1,
   },
   labelContainer: {
     paddingTop: 0,
@@ -430,7 +431,6 @@ const styles = StyleSheet.create({
   input: {
     flexGrow: 1,
     margin: 0,
-    zIndex: 1,
   },
   inputFlat: {
     paddingTop: 24,

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -27,6 +27,7 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
             "scaleY": 0.5,
           },
         ],
+        "zIndex": 1,
       }
     }
   />
@@ -143,7 +144,6 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
           Object {
             "flexGrow": 1,
             "margin": 0,
-            "zIndex": 1,
           },
           Object {
             "paddingLeft": 12,
@@ -427,6 +427,7 @@ exports[`correctly applies textAlign center 1`] = `
             "scaleY": 0.5,
           },
         ],
+        "zIndex": 1,
       }
     }
   />
@@ -543,7 +544,6 @@ exports[`correctly applies textAlign center 1`] = `
           Object {
             "flexGrow": 1,
             "margin": 0,
-            "zIndex": 1,
           },
           Object {
             "paddingLeft": 12,
@@ -604,6 +604,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
             "scaleY": 0.5,
           },
         ],
+        "zIndex": 1,
       }
     }
   />
@@ -720,7 +721,6 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
           Object {
             "flexGrow": 1,
             "margin": 0,
-            "zIndex": 1,
           },
           Object {
             "paddingLeft": 12,
@@ -923,6 +923,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
             "scaleY": 0.5,
           },
         ],
+        "zIndex": 1,
       }
     }
   />
@@ -1039,7 +1040,6 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
           Object {
             "flexGrow": 1,
             "margin": 0,
-            "zIndex": 1,
           },
           Object {
             "paddingLeft": 44,


### PR DESCRIPTION
### Summary
Both flat and outlined Textinput is broken when using the chrome autofill. This PR fixes this issue in the flat mode.
Related to #2764

Changing the zIndex order did the trick and it still works on both Android and iOS

### Test plan

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/6487206/128958710-484a4561-6f4b-49e6-bd0d-fc69f764ce84.png) | ![after](https://user-images.githubusercontent.com/6487206/128958738-6d45df40-5df2-4a32-8f44-e5e6393714a1.png)

