### PR TITLE
fix: Add displayName attribute to DataTable Row to fix documentation hierarchy

### DIFF
--- a/src/components/DataTable/DataTableRow.tsx
+++ b/src/components/DataTable/DataTableRow.tsx
@@ -67,6 +67,8 @@ const DataTableRow = ({ onPress, style, theme, children, ...rest }: Props) => {
   );
 };
 
+DataTableRow.displayName = 'DataTable.Row';
+
 const styles = StyleSheet.create({
   container: {
     borderStyle: 'solid',


### PR DESCRIPTION
### Summary

Missing DataTable Row displayName attribute is causing the page to appear at a wrong level in the hierarchy of the documentation (child of root, not child of DataTable). I assume setting this attribute to "DataTable.Row" will fix the hierarchy issue, as this is the only difference vs. the other DataTable pages.

[DataTable.Row page in question](https://callstack.github.io/react-native-paper/data-table-row.html)

#### Current

![image](https://user-images.githubusercontent.com/30495990/130368057-3be2f564-aea3-405f-97bc-8744c3a5d3c1.png)

#### Proposed

![image](https://user-images.githubusercontent.com/30495990/130368102-6d1cb428-3456-46a7-b375-adbf337a8c61.png)
