### PR TITLE
header goback button fix

### DIFF
--- a/docs/pages/9.react-navigation.md
+++ b/docs/pages/9.react-navigation.md
@@ -158,10 +158,10 @@ export default function App() {
 Secondly, we check if navigation has previous state. If it has, it means there is another screen on the stack beneath the current screen and we should render the back arrow button in such a case.
 
 ```js
-function CustomNavigationBar({ navigation, previous }) {
+function CustomNavigationBar({ navigation, back }) {
   return (
     <Appbar.Header>
-      {previous ? <Appbar.BackAction onPress={navigation.goBack} /> : null}
+      {back ? <Appbar.BackAction onPress={navigation.goBack} /> : null}
       <Appbar.Content title="My awesome app" />
     </Appbar.Header>
   );
@@ -179,16 +179,16 @@ Another interesting pattern that can be implemented with `react-native-paper` an
 We also want the menu to appear only on `HomeScreen`, which means we will render it conditionally based on the `previous` prop.
 
 ```js
-function CustomNavigationBar({ navigation, previous }) {
+function CustomNavigationBar({ navigation, back }) {
   const [visible, setVisible] = React.useState(false);
   const openMenu = () => setVisible(true);
   const closeMenu = () => setVisible(false);
 
   return (
     <Appbar.Header>
-      {previous ? <Appbar.BackAction onPress={navigation.goBack} /> : null}
+      {back ? <Appbar.BackAction onPress={navigation.goBack} /> : null}
       <Appbar.Content title="My awesome app" />
-      {!previous ? (
+      {!back ? (
         <Menu
           visible={visible}
           onDismiss={closeMenu}


### PR DESCRIPTION
### Summary

There was old property named `previous`, for `AppBar` header goBack button which is deprecated. 

### Test plan
Localhost, chrome
