### PR TITLE
fix: Add displayName attribute to DataTable Row

### DIFF
--- a/src/components/DataTable/DataTableRow.tsx
+++ b/src/components/DataTable/DataTableRow.tsx
@@ -86,6 +86,8 @@ const DataTableRow = ({
   );
 };
 
+DataTableRow.displayName = 'DataTable.Row';
+
 const styles = StyleSheet.create({
   container: {
     borderStyle: 'solid',


### PR DESCRIPTION
Add displayName attribute to DataTable Row to fix documentation hierarchy in the documentation.

This is a republish of #2869, pointing to the correct main branch.