### PR TITLE
fix: Ripple effect on DrawerItem

### DIFF
--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -85,19 +85,16 @@ const DrawerItem = ({
   const labelMargin = icon ? 32 : 0;
 
   return (
-    <View
-      {...rest}
-      style={[
-        styles.container,
-        { backgroundColor, borderRadius: roundness },
-        style,
-      ]}
-    >
+    <View {...rest}>
       <TouchableRipple
         borderless
         delayPressIn={0}
         onPress={onPress}
-        style={{ borderRadius: roundness }}
+        style={[
+          styles.container,
+          { backgroundColor, borderRadius: roundness },
+          style,
+        ]}
         // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
         accessibilityTraits={active ? ['button', 'selected'] : 'button'}
         accessibilityComponentType="button"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->


### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
This pull request solves issue #2878, by passing the `style` prop directly to `TouchableRipple`


### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
You can add `padding` or change `height` of `DrawerItem` and the ripple effect won't break
Also, other behaviors are still the same (changing `width` or `alignSelf` for example) since `TouchableRipple` itself is a `View`
