### PR TITLE
Add custom close icon for the Chip component

### DIFF
--- a/example/src/Examples/ChipExample.tsx
+++ b/example/src/Examples/ChipExample.tsx
@@ -25,6 +25,15 @@ const ChipExample = () => {
               Close button
             </Chip>
             <Chip
+              onPress={() => {}}
+              onClose={() => {}}
+              closeIcon="arrow-down"
+              style={styles.chip}
+              closeIconAccessibilityLabel="Custom Close icon accessibility label"
+            >
+              Custom Close button
+            </Chip>
+            <Chip
               icon="heart"
               onPress={() => {}}
               onClose={() => {}}

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -40,6 +40,10 @@ type Props = React.ComponentProps<typeof Surface> & {
    */
   avatar?: React.ReactNode;
   /**
+   * Icon to display as the close button for the `Chip`. The icon appears only when the onClose prop is specified.
+   */
+  closeIcon?: IconSource;
+  /**
    * Whether chip is selected.
    */
   selected?: boolean;
@@ -129,6 +133,7 @@ const Chip = ({
   onPress,
   onLongPress,
   onClose,
+  closeIcon,
   textStyle,
   style,
   theme,
@@ -320,12 +325,16 @@ const Chip = ({
             accessibilityLabel={closeIconAccessibilityLabel}
           >
             <View style={[styles.icon, styles.closeIcon]}>
-              <MaterialCommunityIcon
-                name="close-circle"
-                size={16}
-                color={iconColor}
-                direction="ltr"
-              />
+              {closeIcon ? (
+                <Icon source={closeIcon} color={iconColor} size={16} />
+              ) : (
+                <MaterialCommunityIcon
+                  name="close-circle"
+                  size={16}
+                  color={iconColor}
+                  direction="ltr"
+                />
+              )}
             </View>
           </TouchableWithoutFeedback>
         </View>

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -5,6 +5,7 @@ import {
   Platform,
   StyleProp,
   StyleSheet,
+  TextStyle,
   TouchableWithoutFeedback,
   View,
   ViewStyle,
@@ -78,7 +79,7 @@ type Props = React.ComponentProps<typeof Surface> & {
   /**
    * Style of chip's text
    */
-  textStyle?: any;
+  textStyle?: StyleProp<TextStyle>;
   style?: StyleProp<ViewStyle>;
 
   /**

--- a/src/components/__tests__/Chip.test.js
+++ b/src/components/__tests__/Chip.test.js
@@ -30,6 +30,18 @@ it('renders chip with close button', () => {
   expect(tree).toMatchSnapshot();
 });
 
+it('renders chip with custom close button', () => {
+  const tree = renderer
+    .create(
+      <Chip icon="information" onClose={() => {}} closeIcon="arrow-down">
+        Example Chip
+      </Chip>
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
 it('renders outlined disabled chip', () => {
   const tree = renderer
     .create(

--- a/src/components/__tests__/__snapshots__/Chip.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.js.snap
@@ -222,6 +222,228 @@ exports[`renders chip with close button 1`] = `
 </View>
 `;
 
+exports[`renders chip with custom close button 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#ebebeb",
+      "borderColor": "#ebebeb",
+      "borderRadius": 16,
+      "borderStyle": "solid",
+      "borderWidth": 0.5,
+      "elevation": 0,
+      "flexDirection": "column",
+    }
+  }
+>
+  <View
+    accessibilityRole="button"
+    accessibilityState={
+      Object {
+        "disabled": false,
+        "selected": false,
+      }
+    }
+    accessible={true}
+    focusable={false}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "overflow": "hidden",
+        },
+        Array [
+          Object {
+            "borderRadius": 16,
+          },
+          Object {
+            "flex": 1,
+          },
+        ],
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "paddingLeft": 4,
+            "position": "relative",
+          },
+          Object {
+            "paddingRight": 32,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignSelf": "center",
+              "padding": 4,
+            },
+            null,
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          allowFontScaling={false}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "color": "rgba(0, 0, 0, 0.54)",
+                "fontSize": 18,
+              },
+              Array [
+                Object {
+                  "lineHeight": 18,
+                  "transform": Array [
+                    Object {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                Object {
+                  "backgroundColor": "transparent",
+                },
+              ],
+              Object {
+                "fontFamily": "Material Design Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+      <Text
+        numberOfLines={1}
+        selectable={false}
+        style={
+          Array [
+            Object {
+              "color": "#000000",
+              "fontFamily": "System",
+              "fontWeight": "400",
+            },
+            Object {
+              "textAlign": "left",
+            },
+            Array [
+              Object {
+                "lineHeight": 24,
+                "marginVertical": 4,
+                "minHeight": 24,
+                "textAlignVertical": "center",
+              },
+              Object {
+                "color": "rgba(0, 0, 0, 0.87)",
+                "fontFamily": "System",
+                "fontWeight": "400",
+                "marginLeft": 4,
+                "marginRight": 0,
+              },
+              undefined,
+            ],
+          ]
+        }
+      >
+        Example Chip
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "height": "100%",
+        "justifyContent": "center",
+        "position": "absolute",
+        "right": 0,
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Close"
+      accessibilityRole="button"
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "alignSelf": "center",
+            "padding": 4,
+          },
+          Object {
+            "marginRight": 4,
+          },
+        ]
+      }
+    >
+      <Text
+        accessibilityElementsHidden={true}
+        allowFontScaling={false}
+        importantForAccessibility="no-hide-descendants"
+        pointerEvents="none"
+        selectable={false}
+        style={
+          Array [
+            Object {
+              "color": "rgba(0, 0, 0, 0.54)",
+              "fontSize": 16,
+            },
+            Array [
+              Object {
+                "lineHeight": 16,
+                "transform": Array [
+                  Object {
+                    "scaleX": 1,
+                  },
+                ],
+              },
+              Object {
+                "backgroundColor": "transparent",
+              },
+            ],
+            Object {
+              "fontFamily": "Material Design Icons",
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {},
+          ]
+        }
+      >
+        
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
 exports[`renders chip with icon 1`] = `
 <View
   style={


### PR DESCRIPTION
### Summary
The close button icon in the Chip is currently hard-coded to the MaterialCommunityIcon "close-circle" which is might be undesirable to users who prefer to use their own icon sets.
The PR below adds a **closeIcon** prop which when specified replaces the default "close-circle" icon.
