### PR TITLE
Docs: React Navigation Integration - update previous prop to back for 6.x

### DIFF
--- a/docs/pages/9.react-navigation.md
+++ b/docs/pages/9.react-navigation.md
@@ -176,7 +176,7 @@ Another interesting pattern that can be implemented with `react-native-paper` an
 - Pass `Appbar.Action` to the anchor prop
 - Add a state to control `Menu` visibility
 
-We also want the menu to appear only on `HomeScreen`, which means we will render it conditionally based on the `previous` prop.
+We also want the menu to appear only on `HomeScreen`, which means we will render it conditionally based on the `back` prop.
 
 ```js
 function CustomNavigationBar({ navigation, back }) {

--- a/docs/pages/9.react-navigation.md
+++ b/docs/pages/9.react-navigation.md
@@ -155,7 +155,7 @@ export default function App() {
 }
 ```
 
-Secondly, we check if the navigation bar receives a `back` prop. If it has, it means there is another screen on the stack beneath the current screen and we should render the back arrow button in such a case.
+Secondly, we check if the navigation bar receives a `back` prop. If it has, it means there is another screen on the stack beneath the current screen and we should render the back arrow button in such a case. (The `back` prop is sent in React Navigation 6.x; in 5.x a prop named `previous` is sent and can be checked for instead.)
 
 ```js
 function CustomNavigationBar({ navigation, back }) {

--- a/docs/pages/9.react-navigation.md
+++ b/docs/pages/9.react-navigation.md
@@ -155,13 +155,13 @@ export default function App() {
 }
 ```
 
-Secondly, we check if navigation has previous state. If it has, it means there is another screen on the stack beneath the current screen and we should render the back arrow button in such a case.
+Secondly, we check if the navigation bar receives a `back` prop. If it has, it means there is another screen on the stack beneath the current screen and we should render the back arrow button in such a case.
 
 ```js
-function CustomNavigationBar({ navigation, previous }) {
+function CustomNavigationBar({ navigation, back }) {
   return (
     <Appbar.Header>
-      {previous ? <Appbar.BackAction onPress={navigation.goBack} /> : null}
+      {back ? <Appbar.BackAction onPress={navigation.goBack} /> : null}
       <Appbar.Content title="My awesome app" />
     </Appbar.Header>
   );
@@ -179,16 +179,16 @@ Another interesting pattern that can be implemented with `react-native-paper` an
 We also want the menu to appear only on `HomeScreen`, which means we will render it conditionally based on the `previous` prop.
 
 ```js
-function CustomNavigationBar({ navigation, previous }) {
+function CustomNavigationBar({ navigation, back }) {
   const [visible, setVisible] = React.useState(false);
   const openMenu = () => setVisible(true);
   const closeMenu = () => setVisible(false);
 
   return (
     <Appbar.Header>
-      {previous ? <Appbar.BackAction onPress={navigation.goBack} /> : null}
+      {back ? <Appbar.BackAction onPress={navigation.goBack} /> : null}
       <Appbar.Content title="My awesome app" />
-      {!previous ? (
+      {!back ? (
         <Menu
           visible={visible}
           onDismiss={closeMenu}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

The docs page [Integrate AppBar with react-navigation](https://callstack.github.io/react-native-paper/integrate-app-bar-with-react-navigation.html#adding-appbar) describes using the `previous` prop to detect if a back button should be shown. This is correct for React Navigation 5.x as described here: <https://reactnavigation.org/docs/5.x/stack-navigator/#header>

But in React Navigation 6.x, there is no longer a `previous` prop; instead, there is a `back` prop, as described here: <https://reactnavigation.org/docs/stack-navigator/#header>

As a result, when using React Navigation 6.x with the current instructions, the back button never appears. If you switch to using the `back` prop, the back button starts working again. Repro: <https://github.com/CodingItWrong/rn-paper-navigation>

This PR currently updates the instruction page to be correct for React Navigation 6.x

Additional changes I would be happy to make if you'd like:

- I could specify that these instructions are for React Navigation 6.x
- I could add a note that `previous` should be used instead for React Navigation 5.x (and I could investigate if it would work in 4.x and below as well, and note that)

### Test plan

Can be manually tested in the repro repo: <https://github.com/CodingItWrong/rn-paper-navigation>
