### PR TITLE
fix: correct displaying progress bar on Android

### DIFF
--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -168,55 +168,57 @@ const ProgressBar = ({
           style,
         ]}
       >
-        <Animated.View
-          style={[
-            styles.progressBar,
-            {
-              backgroundColor: tintColor,
-              width,
-              transform: [
-                {
-                  translateX: timer.interpolate(
-                    indeterminate
-                      ? {
-                          inputRange: [0, 0.5, 1],
-                          outputRange: [
-                            (isRTL ? 1 : -1) * 0.5 * width,
-                            (isRTL ? 1 : -1) *
-                              0.5 *
-                              INDETERMINATE_MAX_WIDTH *
-                              width,
-                            (isRTL ? -1 : 1) * 0.7 * width,
-                          ],
-                        }
-                      : {
-                          inputRange: [0, 1],
-                          outputRange: [(isRTL ? 1 : -1) * 0.5 * width, 0],
-                        }
-                  ),
-                },
-                {
-                  // Workaround for workaround for https://github.com/facebook/react-native/issues/6278
-                  scaleX: timer.interpolate(
-                    indeterminate
-                      ? {
-                          inputRange: [0, 0.5, 1],
-                          outputRange: [
-                            0.0001,
-                            INDETERMINATE_MAX_WIDTH,
-                            0.0001,
-                          ],
-                        }
-                      : {
-                          inputRange: [0, 1],
-                          outputRange: [0.0001, 1],
-                        }
-                  ),
-                },
-              ],
-            },
-          ]}
-        />
+        {width ? (
+          <Animated.View
+            style={[
+              styles.progressBar,
+              {
+                width,
+                backgroundColor: tintColor,
+                transform: [
+                  {
+                    translateX: timer.interpolate(
+                      indeterminate
+                        ? {
+                            inputRange: [0, 0.5, 1],
+                            outputRange: [
+                              (isRTL ? 1 : -1) * 0.5 * width,
+                              (isRTL ? 1 : -1) *
+                                0.5 *
+                                INDETERMINATE_MAX_WIDTH *
+                                width,
+                              (isRTL ? -1 : 1) * 0.7 * width,
+                            ],
+                          }
+                        : {
+                            inputRange: [0, 1],
+                            outputRange: [(isRTL ? 1 : -1) * 0.5 * width, 0],
+                          }
+                    ),
+                  },
+                  {
+                    // Workaround for workaround for https://github.com/facebook/react-native/issues/6278
+                    scaleX: timer.interpolate(
+                      indeterminate
+                        ? {
+                            inputRange: [0, 0.5, 1],
+                            outputRange: [
+                              0.0001,
+                              INDETERMINATE_MAX_WIDTH,
+                              0.0001,
+                            ],
+                          }
+                        : {
+                            inputRange: [0, 1],
+                            outputRange: [0.0001, 1],
+                          }
+                    ),
+                  },
+                ],
+              },
+            ]}
+          />
+        ) : null}
       </Animated.View>
     </View>
   );


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Nested `ProgressBar` sometimes has some issues with displaying properly the progress on the `ProgressBar`, because initial width is zero, then it's updated to the real value, however the component does not update itself. Making it conditionally fixes the problem.

On the screenshots you can observe:

* left column presents fixed nested progress bar from the [issue](https://github.com/callstack/react-native-paper/issues/2895)
* right column presents all progressbar examples, to show that nothing breaks

fixed | default progress bar examples
--- | ---
<img width="429" alt="Zrzut ekranu 2021-10-6 o 13 39 45" src="https://user-images.githubusercontent.com/22746080/136201812-cb9de45c-46c4-43e4-81a8-13332a217b3f.png"> | <img width="429" alt="Zrzut ekranu 2021-10-6 o 13 40 13" src="https://user-images.githubusercontent.com/22746080/136201817-b9c0e7b7-cd88-4402-bcc4-79ea287a143f.png">



<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

* Run the example app, open the ProgressBar and observe all the cases are working properly.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
