### PR TITLE
fix(2928): Radio Button (RadioButton) onPress Bug

### DIFF
--- a/src/components/RadioButton/utils.ts
+++ b/src/components/RadioButton/utils.ts
@@ -12,7 +12,7 @@ export const handlePress = ({
       `onPress in the scope of RadioButtonGroup will not be executed, use onValueChange instead`
     );
   }
-  
+
   onValueChange ? onValueChange(value) : onPress?.();
 };
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
When using `RadioButtonItem` with onPress that is within the scope of  `RadioButtonGroup` the onPress callback will not take effect because onValueChange takes precedence. This is desired behaviour, however in some cases might be confusing, thus the warning approach

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
https://github.com/callstack/react-native-paper/issues/2928

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
