### PR TITLE
feat: Added font weight of value bold to themes

### DIFF
--- a/src/styles/fonts.tsx
+++ b/src/styles/fonts.tsx
@@ -19,6 +19,10 @@ const fontConfig = {
       fontFamily: 'Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif',
       fontWeight: '100' as '100',
     },
+    bold: {
+      fontFamily: 'Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif',
+      fontWeight: '700' as '700',
+    },
   },
   ios: {
     regular: {
@@ -37,6 +41,10 @@ const fontConfig = {
       fontFamily: 'System',
       fontWeight: '100' as '100',
     },
+    bold: {
+      fontFamily: 'Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif',
+      fontWeight: '700' as '700',
+    },
   },
   default: {
     regular: {
@@ -54,6 +62,10 @@ const fontConfig = {
     thin: {
       fontFamily: 'sans-serif-thin',
       fontWeight: 'normal' as 'normal',
+    },
+    bold: {
+      fontFamily: 'Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif',
+      fontWeight: '700' as '700',
     },
   },
 };

--- a/src/styles/fonts.tsx
+++ b/src/styles/fonts.tsx
@@ -42,7 +42,7 @@ const fontConfig = {
       fontWeight: '100' as '100',
     },
     bold: {
-      fontFamily: 'Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif',
+      fontFamily: 'System',
       fontWeight: '700' as '700',
     },
   },
@@ -64,8 +64,8 @@ const fontConfig = {
       fontWeight: 'normal' as 'normal',
     },
     bold: {
-      fontFamily: 'Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif',
-      fontWeight: '700' as '700',
+      fontFamily: 'sans-serif-bold',
+      fontWeight: 'normal' as 'normal',
     },
   },
 };

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -21,6 +21,7 @@ export type Fonts = {
   medium: Font;
   light: Font;
   thin: Font;
+  bold: Font;
 };
 
 type Mode = 'adaptive' | 'exact';
@@ -78,6 +79,7 @@ declare global {
       medium: ThemeFont;
       light: ThemeFont;
       thin: ThemeFont;
+      bold: ThemeFont;
     }
     interface ThemeColors {
       primary: string;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Closes #2917 

Currently there is no `fontWeight` value of `bold` in themes (PaperProvider). This PR adds that style.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

1. Set font weight to bold in your theme.
2. Assign a theme to the component to apply styles.
