### PR TITLE
fix: unified behaviour when `allowFontScaling` is false

### DIFF
--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -27,6 +27,7 @@ const InputLabel = (props: InputLabelProps) => {
     placeholderColor,
     errorColor,
     labelTranslationXOffset,
+    allowFontScaling,
   } = props.labelProps;
 
   const labelTranslationX = {
@@ -112,6 +113,7 @@ const InputLabel = (props: InputLabelProps) => {
           },
         ]}
         numberOfLines={1}
+        allowFontScaling={allowFontScaling}
       >
         {label}
       </AnimatedText>
@@ -129,6 +131,7 @@ const InputLabel = (props: InputLabelProps) => {
           },
         ]}
         numberOfLines={1}
+        allowFontScaling={allowFontScaling}
       >
         {label}
       </AnimatedText>

--- a/src/components/TextInput/Label/LabelBackground.tsx
+++ b/src/components/TextInput/Label/LabelBackground.tsx
@@ -15,6 +15,7 @@ const LabelBackground = ({
     label,
     backgroundColor,
     roundness,
+    allowFontScaling,
   },
   labelStyle,
 }: LabelBackgroundProps) => {
@@ -73,6 +74,7 @@ const LabelBackground = ({
             },
           ]}
           numberOfLines={1}
+          allowFontScaling={allowFontScaling}
         >
           {label}
         </AnimatedText>,

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -122,6 +122,10 @@ export type TextInputProps = React.ComponentPropsWithRef<
    * @optional
    */
   theme: ReactNativePaper.Theme;
+  /**
+   * @optional
+   */
+  allowFontScaling?: boolean;
 };
 
 /**
@@ -183,6 +187,7 @@ class TextInput extends React.Component<TextInputProps, State> {
     error: false,
     multiline: false,
     editable: true,
+    allowFontScaling: true,
     render: (props: RenderProps) => <NativeTextInput {...props} />,
   };
 
@@ -448,6 +453,7 @@ class TextInput extends React.Component<TextInputProps, State> {
         onLayoutAnimatedText={this.handleLayoutAnimatedText}
         onLeftAffixLayoutChange={this.onLeftAffixLayoutChange}
         onRightAffixLayoutChange={this.onRightAffixLayoutChange}
+        allowFontScaling={this.props.allowFontScaling}
       />
     ) : (
       <TextInputFlat
@@ -464,6 +470,7 @@ class TextInput extends React.Component<TextInputProps, State> {
         onLayoutAnimatedText={this.handleLayoutAnimatedText}
         onLeftAffixLayoutChange={this.onLeftAffixLayoutChange}
         onRightAffixLayoutChange={this.onRightAffixLayoutChange}
+        allowFontScaling={!!this.props.allowFontScaling}
       />
     );
   }

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -81,6 +81,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
       left,
       right,
       placeholderTextColor,
+      allowFontScaling,
       ...rest
     } = this.props;
 
@@ -278,6 +279,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
       placeholderColor,
       errorColor,
       roundness: theme.roundness,
+      allowFontScaling,
     };
     const affixTopPosition = {
       [AdornmentSide.Left]: leftAffixTopPosition,
@@ -331,6 +333,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
             ...rest,
             ref: innerRef,
             onChangeText,
+            allowFontScaling: this.props.allowFontScaling,
             placeholder: label
               ? parentState.placeholder
               : this.props.placeholder,

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -80,6 +80,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
       left,
       right,
       placeholderTextColor,
+      allowFontScaling,
       ...rest
     } = this.props;
 
@@ -214,6 +215,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
       errorColor,
       labelTranslationXOffset,
       roundness: theme.roundness,
+      allowFontScaling: allowFontScaling,
     };
 
     const minHeight = (height ||
@@ -316,6 +318,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
               ...rest,
               ref: innerRef,
               onChangeText,
+              allowFontScaling,
               placeholder: label
                 ? parentState.placeholder
                 : this.props.placeholder,

--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -23,6 +23,7 @@ export type RenderProps = {
   numberOfLines?: number;
   value?: string;
   adjustsFontSizeToFit?: boolean;
+  allowFontScaling?: boolean;
 };
 type TextInputTypesWithoutMode = $Omit<TextInputProps, 'mode'>;
 export type State = {
@@ -45,6 +46,7 @@ export type ChildTextInputProps = {
   onLayoutAnimatedText: (args: any) => void;
   onLeftAffixLayoutChange: (event: LayoutChangeEvent) => void;
   onRightAffixLayoutChange: (event: LayoutChangeEvent) => void;
+  allowFontScaling?: boolean;
 } & TextInputTypesWithoutMode;
 export type LabelProps = {
   mode?: 'flat' | 'outlined';
@@ -69,6 +71,7 @@ export type LabelProps = {
   error?: boolean | null;
   onLayoutAnimatedText: (args: any) => void;
   roundness: number;
+  allowFontScaling?: boolean;
 };
 export type InputLabelProps = {
   parentState: State;
@@ -79,4 +82,5 @@ export type LabelBackgroundProps = {
   labelProps: LabelProps;
   labelStyle: any;
   parentState: State;
+  allowFontScaling?: boolean;
 };


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
The problem occurs for `TextInput` component. It concerns `allowFontScaling` props. When `Larger Accessibility Sizes` is turned on in iPhone and `allowFontScaling` is `false`, labels behaviour is wrong (as presented below). Labels should act the same as text in input.

This change fixes the problem, `allowFontScaling` is transferred to the label. Thanks to that, the components work consistently.
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Actual results:
<img width="266" alt="Screenshot 2021-10-21 at 18 12 02" src="https://user-images.githubusercontent.com/22773283/138316504-7cfcd33a-737b-4329-9ba2-eeca7e993705.png">

After my changes: 
<img width="266" alt="Screenshot 2021-10-21 at 14 11 05" src="https://user-images.githubusercontent.com/22773283/138316437-0bc98013-dc97-4514-ad0a-0f22ab16fe03.png">

