### PR TITLE
test: update test files to comply with eslint rules

### DIFF
--- a/src/components/__tests__/Avatar.test.js
+++ b/src/components/__tests__/Avatar.test.js
@@ -1,6 +1,14 @@
 import * as React from 'react';
+import { StyleSheet } from 'react-native';
 import renderer from 'react-test-renderer';
 import * as Avatar from '../Avatar/Avatar.tsx';
+import { red500 } from '../../styles/colors';
+
+const styles = StyleSheet.create({
+  bgColor: {
+    backgroundColor: red500,
+  },
+});
 
 it('renders avatar with text', () => {
   const tree = renderer.create(<Avatar.Text label="XD" />).toJSON();
@@ -16,7 +24,7 @@ it('renders avatar with text and custom size', () => {
 
 it('renders avatar with text and custom background color', () => {
   const tree = renderer
-    .create(<Avatar.Text style={{ backgroundColor: '#FF0000' }} label="XD" />)
+    .create(<Avatar.Text style={styles.bgColor} label="XD" />)
     .toJSON();
 
   expect(tree).toMatchSnapshot();
@@ -38,9 +46,7 @@ it('renders avatar with icon', () => {
 
 it('renders avatar with icon and custom background color', () => {
   const tree = renderer
-    .create(
-      <Avatar.Icon style={{ backgroundColor: '#FF0000' }} icon="information" />
-    )
+    .create(<Avatar.Icon style={styles.bgColor} icon="information" />)
     .toJSON();
 
   expect(tree).toMatchSnapshot();

--- a/src/components/__tests__/BottomNavigation.test.js
+++ b/src/components/__tests__/BottomNavigation.test.js
@@ -1,6 +1,14 @@
 import * as React from 'react';
+import { StyleSheet } from 'react-native';
 import renderer from 'react-test-renderer';
 import BottomNavigation from '../BottomNavigation.tsx';
+import { red300 } from '../../styles/colors';
+
+const styles = StyleSheet.create({
+  bgColor: {
+    color: red300,
+  },
+});
 
 // Make sure any animation finishes before checking the snapshot results
 jest.mock('react-native', () => {
@@ -109,7 +117,7 @@ it('renders custom icon and label with custom colors in shifting bottom navigati
         renderScene={({ route }) => route.title}
         activeColor="#FBF7DB"
         inactiveColor="#853D4B"
-        barStyle={{ backgroundColor: '#E96A82' }}
+        barStyle={styles.bgColor}
       />
     )
     .toJSON();
@@ -127,7 +135,7 @@ it('renders custom icon and label with custom colors in non-shifting bottom navi
         renderScene={({ route }) => route.title}
         activeColor="#FBF7DB"
         inactiveColor="#853D4B"
-        barStyle={{ backgroundColor: '#E96A82' }}
+        barStyle={styles.bgColor}
       />
     )
     .toJSON();

--- a/src/components/__tests__/Button.test.js
+++ b/src/components/__tests__/Button.test.js
@@ -1,7 +1,14 @@
 import * as React from 'react';
+import { StyleSheet } from 'react-native';
 import renderer from 'react-test-renderer';
 import Button from '../Button.tsx';
 import { pink500 } from '../../styles/colors.tsx';
+
+const styles = StyleSheet.create({
+  flexing: {
+    flexDirection: 'row-reverse',
+  },
+});
 
 it('renders text button by default', () => {
   const tree = renderer.create(<Button>Text Button</Button>).toJSON();
@@ -44,10 +51,7 @@ it('renders button with icon', () => {
 it('renders button with icon in reverse order', () => {
   const tree = renderer
     .create(
-      <Button
-        icon="chevron-right"
-        contentStyle={{ flexDirection: 'row-reverse' }}
-      >
+      <Button icon="chevron-right" contentStyle={styles.flexing}>
         Right Icon
       </Button>
     )

--- a/src/components/__tests__/ListAccordion.test.js
+++ b/src/components/__tests__/ListAccordion.test.js
@@ -1,8 +1,16 @@
 import * as React from 'react';
+import { StyleSheet } from 'react-native';
 import renderer from 'react-test-renderer';
 import ListAccordion from '../List/ListAccordion.tsx';
 import ListItem from '../List/ListItem.tsx';
 import ListIcon from '../List/ListIcon.tsx';
+import { red500 } from '../../styles/colors';
+
+const styles = StyleSheet.create({
+  coloring: {
+    color: red500,
+  },
+});
 
 it('renders list accordion with children', () => {
   const tree = renderer
@@ -70,8 +78,8 @@ it('renders list accordion with custom title and description styles', () => {
       <ListAccordion
         title="Accordion item 1"
         description="Describes the expandable list item"
-        titleStyle={{ color: 'red' }}
-        descriptionStyle={{ color: 'red' }}
+        titleStyle={styles.coloring}
+        descriptionStyle={styles.coloring}
       >
         <ListItem title="List item 1" />
       </ListAccordion>

--- a/src/components/__tests__/ListItem.test.js
+++ b/src/components/__tests__/ListItem.test.js
@@ -1,9 +1,20 @@
 import * as React from 'react';
+import { StyleSheet } from 'react-native';
 import renderer from 'react-test-renderer';
 import { Text, View } from 'react-native';
 import ListItem from '../List/ListItem.tsx';
 import ListIcon from '../List/ListIcon.tsx';
 import Chip from '../Chip';
+import { red500 } from '../../styles/colors';
+
+const styles = StyleSheet.create({
+  title: {
+    fontSize: 20,
+  },
+  description: {
+    color: red500,
+  },
+});
 
 it('renders list item with title and description', () => {
   const tree = renderer
@@ -57,8 +68,8 @@ it('renders list item with custom title and description styles', () => {
       <ListItem
         title="First Item"
         description="Item description"
-        titleStyle={{ fontSize: 20 }}
-        descriptionStyle={{ color: 'red' }}
+        titleStyle={styles.title}
+        descriptionStyle={styles.description}
       />
     )
     .toJSON();
@@ -101,8 +112,8 @@ it('renders with a description with typeof number', () => {
       <ListItem
         title="First Item"
         description={123}
-        titleStyle={{ fontSize: 20 }}
-        descriptionStyle={{ color: 'red' }}
+        titleStyle={styles.title}
+        descriptionStyle={styles.description}
       />
     )
     .toJSON();

--- a/src/components/__tests__/ListSection.test.js
+++ b/src/components/__tests__/ListSection.test.js
@@ -1,9 +1,17 @@
 import * as React from 'react';
+import { StyleSheet } from 'react-native';
 import renderer from 'react-test-renderer';
 import ListSection from '../List/ListSection.tsx';
 import ListItem from '../List/ListItem.tsx';
 import ListIcon from '../List/ListIcon.tsx';
 import ListSubheader from '../List/ListSubheader.tsx';
+import { red500 } from '../../styles/colors';
+
+const styles = StyleSheet.create({
+  itemColor: {
+    color: red500,
+  },
+});
 
 it('renders list section without subheader', () => {
   const tree = renderer
@@ -47,7 +55,7 @@ it('renders list section with subheader', () => {
 it('renders list section with custom title style', () => {
   const tree = renderer
     .create(
-      <ListSection title="Some title" titleStyle={{ color: 'red' }}>
+      <ListSection title="Some title" titleStyle={styles.itemColor}>
         <ListItem
           title="First Item"
           left={(props) => <ListIcon {...props} icon="folder" />}

--- a/src/components/__tests__/Menu.test.js
+++ b/src/components/__tests__/Menu.test.js
@@ -1,7 +1,15 @@
 import * as React from 'react';
+import { StyleSheet } from 'react-native';
 import renderer from 'react-test-renderer';
 import Menu from '../Menu/Menu.tsx';
 import Button from '../Button.tsx';
+
+const styles = StyleSheet.create({
+  contentStyle: {
+    borderTopLeftRadius: 0,
+    borderTopRightRadius: 0,
+  },
+});
 
 it('renders visible menu', () => {
   const tree = renderer
@@ -44,7 +52,7 @@ it('renders menu with content styles', () => {
         visible
         onDismiss={jest.fn()}
         anchor={<Button mode="outlined">Open menu</Button>}
-        contentStyle={{ borderTopLeftRadius: 0, borderTopRightRadius: 0 }}
+        contentStyle={styles.contentStyle}
       >
         <Menu.Item onPress={jest.fn()} title="Undo" />
         <Menu.Item onPress={jest.fn()} title="Redo" />

--- a/src/components/__tests__/TextInput.test.js
+++ b/src/components/__tests__/TextInput.test.js
@@ -1,6 +1,20 @@
 import * as React from 'react';
+import { StyleSheet } from 'react-native';
 import { render } from 'react-native-testing-library';
 import TextInput from '../TextInput/TextInput';
+import { red500 } from '../../styles/colors';
+
+const style = StyleSheet.create({
+  inputStyle: {
+    color: red500,
+  },
+  centered: {
+    textAlign: 'center',
+  },
+  height: {
+    height: 100,
+  },
+});
 
 const affixTextValue = '/100';
 it('correctly renders left-side icon adornment, and right-side affix adornment', () => {
@@ -19,10 +33,7 @@ it('correctly renders left-side icon adornment, and right-side affix adornment',
         />
       }
       right={
-        <TextInput.Affix
-          text={affixTextValue}
-          textStyle={{ color: '#FF0000' }}
-        />
+        <TextInput.Affix text={affixTextValue} textStyle={style.inputStyle} />
       }
     />
   );
@@ -40,10 +51,7 @@ it('correctly renders left-side icon adornment, and right-side affix adornment '
       value={'Some test value'}
       onChangeText={(text) => this.setState({ text })}
       left={
-        <TextInput.Affix
-          text={affixTextValue}
-          textStyle={{ color: '#FF0000' }}
-        />
+        <TextInput.Affix text={affixTextValue} textStyle={style.inputStyle} />
       }
       right={
         <TextInput.Icon
@@ -79,7 +87,7 @@ it('correctly applies textAlign center', () => {
       label="Flat input"
       placeholder="Type something"
       value={'Some test value'}
-      style={{ textAlign: 'center' }}
+      style={style.centered}
     />
   );
 
@@ -93,7 +101,7 @@ it('correctly applies height to multiline Outline TextInput', () => {
       label="Outline Input"
       placeholder="Type Something"
       value={'Some test value'}
-      style={{ height: 100 }}
+      style={style.height}
       multiline
     />
   );

--- a/src/components/__tests__/Typography/Caption.test.js
+++ b/src/components/__tests__/Typography/Caption.test.js
@@ -1,6 +1,15 @@
 import * as React from 'react';
+import { StyleSheet } from 'react-native';
 import renderer from 'react-test-renderer';
 import Caption from '../../Typography/Caption.tsx';
+import { red500 } from '../../../styles/colors';
+
+const style = StyleSheet.create({
+  caption: {
+    fontSize: 20,
+    color: red500,
+  },
+});
 
 it('renders caption with children as content', () => {
   const tree = renderer.create(<Caption>Caption content</Caption>).toJSON();
@@ -10,11 +19,7 @@ it('renders caption with children as content', () => {
 
 it('renders caption applying style', () => {
   const tree = renderer
-    .create(
-      <Caption style={{ fontSize: 20, color: 'red' }}>
-        Big and red caption
-      </Caption>
-    )
+    .create(<Caption style={style.caption}>Big and red caption</Caption>)
     .toJSON();
 
   expect(tree).toMatchSnapshot();

--- a/src/components/__tests__/Typography/__snapshots__/Caption.test.js.snap
+++ b/src/components/__tests__/Typography/__snapshots__/Caption.test.js.snap
@@ -30,7 +30,7 @@ exports[`renders caption applying style 1`] = `
             "marginVertical": 2,
           },
           Object {
-            "color": "red",
+            "color": "#f44336",
             "fontSize": 20,
           },
         ],

--- a/src/components/__tests__/__snapshots__/Avatar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Avatar.test.js.snap
@@ -62,7 +62,7 @@ exports[`renders avatar with icon and custom background color 1`] = `
   style={
     Array [
       Object {
-        "backgroundColor": "#FF0000",
+        "backgroundColor": "#f44336",
         "borderRadius": 32,
         "height": 64,
         "width": 64,
@@ -200,7 +200,7 @@ exports[`renders avatar with text and custom background color 1`] = `
   style={
     Array [
       Object {
-        "backgroundColor": "#FF0000",
+        "backgroundColor": "#f44336",
         "borderRadius": 32,
         "height": 64,
         "width": 64,

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
@@ -2922,8 +2922,9 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
     pointerEvents="none"
     style={
       Object {
-        "backgroundColor": "#E96A82",
+        "backgroundColor": "#ffffff",
         "bottom": 0,
+        "color": "#e57373",
         "elevation": 4,
         "left": 0,
         "position": null,
@@ -2947,7 +2948,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
       style={
         Object {
           "alignItems": "center",
-          "backgroundColor": "#E96A82",
+          "backgroundColor": "#6200ee",
           "overflow": "hidden",
         }
       }
@@ -3856,8 +3857,9 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
     pointerEvents="none"
     style={
       Object {
-        "backgroundColor": "#E96A82",
+        "backgroundColor": "#ffffff",
         "bottom": 0,
+        "color": "#e57373",
         "elevation": 4,
         "left": 0,
         "position": null,
@@ -3881,7 +3883,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
       style={
         Object {
           "alignItems": "center",
-          "backgroundColor": "rgba(233, 106, 130, 1)",
+          "backgroundColor": "rgba(98, 0, 238, 1)",
           "overflow": "hidden",
         }
       }

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.js.snap
@@ -491,7 +491,7 @@ exports[`renders list accordion with custom title and description styles 1`] = `
                     "color": "rgba(0, 0, 0, 0.87)",
                   },
                   Object {
-                    "color": "red",
+                    "color": "#f44336",
                   },
                 ],
               ]
@@ -520,7 +520,7 @@ exports[`renders list accordion with custom title and description styles 1`] = `
                     "color": "rgba(0, 0, 0, 0.54)",
                   },
                   Object {
-                    "color": "red",
+                    "color": "#f44336",
                   },
                 ],
               ]

--- a/src/components/__tests__/__snapshots__/ListItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.js.snap
@@ -331,7 +331,7 @@ exports[`renders list item with custom title and description styles 1`] = `
                 "color": "rgba(0, 0, 0, 0.54)",
               },
               Object {
-                "color": "red",
+                "color": "#f44336",
               },
             ],
           ]
@@ -912,7 +912,7 @@ exports[`renders with a description with typeof number 1`] = `
                 "color": "rgba(0, 0, 0, 0.54)",
               },
               Object {
-                "color": "red",
+                "color": "#f44336",
               },
             ],
           ]

--- a/src/components/__tests__/__snapshots__/ListSection.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.js.snap
@@ -74,7 +74,7 @@ exports[`renders list section with custom title style 1`] = `
             "fontWeight": "500",
           },
           Object {
-            "color": "red",
+            "color": "#f44336",
           },
         ],
       ]

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -779,7 +779,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
             "fontWeight": undefined,
           },
           Object {
-            "color": "#FF0000",
+            "color": "#f44336",
           },
         ]
       }
@@ -1204,7 +1204,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
             "fontWeight": undefined,
           },
           Object {
-            "color": "#FF0000",
+            "color": "#f44336",
           },
         ]
       }


### PR DESCRIPTION
### Summary

I noticed the pre-commit hook indicates 77 warnings, mostly of usage of inline styles.

<img width="856" alt="Zrzut ekranu 2021-10-20 o 00 29 15" src="https://user-images.githubusercontent.com/4152181/137999422-d5073390-01e4-4338-a601-b1d7bf5d595f.png">

This PR fixes warnings in test files. (by "fixes" I mean actually complying to eslint rules 😆 )
And we're down to only 47 warnings 🎉 


<img width="733" alt="Zrzut ekranu 2021-10-20 o 00 31 37" src="https://user-images.githubusercontent.com/4152181/137999722-8912cefc-8eef-41e4-9d5c-a3065336902d.png">


