### PR TITLE
chore: set peer dependencies versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,8 +97,8 @@
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
-    "react": "*",
-    "react-native": "*",
+    "react": ">=16.8.0",
+    "react-native": ">=0.59.0",
     "react-native-vector-icons": "*"
   },
   "husky": {


### PR DESCRIPTION
Update peer dependencies in `package.json` to correct minimal versions, so users with older versions are not surprised that `react-native-paper` does not work for them.

### Summary

`react-native-paper` uses React Hooks in the code. This sets minimum versions of React to `16.8.0` and React Native to `0.59.0`

https://reactjs.org/blog/2019/02/06/react-v16.8.0.html

https://reactnative.dev/blog/2019/03/12/releasing-react-native-059

### Test plan

Verify that set peer dependencies versions do not create conflicts.