### PR TITLE
fix: comply to eslint warnings in example files

### DIFF
--- a/example/src/Examples/AppbarExample.tsx
+++ b/example/src/Examples/AppbarExample.tsx
@@ -3,6 +3,7 @@ import { View, Platform, StyleSheet } from 'react-native';
 import type { StackNavigationProp } from '@react-navigation/stack';
 import { Appbar, FAB, Switch, Paragraph } from 'react-native-paper';
 import ScreenWrapper from '../ScreenWrapper';
+import { yellowA200 } from '../../../src/styles/colors';
 
 type Props = {
   navigation: StackNavigationProp<{}>;
@@ -22,7 +23,7 @@ const AppbarExample = ({ navigation }: Props) => {
     navigation.setOptions({
       header: () => (
         <Appbar.Header
-          style={showCustomColor ? { backgroundColor: '#ffff00' } : null}
+          style={showCustomColor ? styles.customColor : null}
           theme={{
             mode: showExactTheme ? 'exact' : 'adaptive',
           }}
@@ -126,5 +127,8 @@ const styles = StyleSheet.create({
     position: 'absolute',
     right: 16,
     bottom: 28,
+  },
+  customColor: {
+    backgroundColor: yellowA200,
   },
 });

--- a/example/src/Examples/ButtonExample.tsx
+++ b/example/src/Examples/ButtonExample.tsx
@@ -33,7 +33,7 @@ const ButtonExample = () => {
             icon="camera"
             onPress={() => {}}
             style={styles.button}
-            contentStyle={{ flexDirection: 'row-reverse' }}
+            contentStyle={styles.flexReverse}
           >
             Icon right
           </Button>
@@ -81,10 +81,7 @@ const ButtonExample = () => {
             mode="outlined"
             onPress={() => {}}
             style={styles.button}
-            labelStyle={{
-              fontWeight: '800',
-              fontSize: 24,
-            }}
+            labelStyle={styles.fontStyles}
           >
             Custom Font
           </Button>
@@ -179,6 +176,13 @@ const styles = StyleSheet.create({
   },
   button: {
     margin: 4,
+  },
+  flexReverse: {
+    flexDirection: 'row-reverse',
+  },
+  fontStyles: {
+    fontWeight: '800',
+    fontSize: 24,
   },
 });
 

--- a/example/src/Examples/ChipExample.tsx
+++ b/example/src/Examples/ChipExample.tsx
@@ -199,8 +199,8 @@ const ChipExample = () => {
             <Chip
               onPress={() => {}}
               onClose={() => {}}
-              style={{ flex: 1 }}
-              textStyle={{ flex: -1 }}
+              style={styles.bigTextFlex}
+              textStyle={styles.bigTextStyle}
               ellipsizeMode="middle"
             >
               With a very big text: React Native Paper is a high-quality,
@@ -238,6 +238,12 @@ const styles = StyleSheet.create({
     marginLeft: 2,
     minHeight: 19,
     lineHeight: 19,
+  },
+  bigTextFlex: {
+    flex: 1,
+  },
+  bigTextStyle: {
+    flex: -1,
   },
 });
 

--- a/example/src/Examples/Dialogs/DialogWithLoadingIndicator.tsx
+++ b/example/src/Examples/Dialogs/DialogWithLoadingIndicator.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ActivityIndicator, Platform, View } from 'react-native';
+import { ActivityIndicator, Platform, View, StyleSheet } from 'react-native';
 import { Paragraph, Colors, Portal, Dialog } from 'react-native-paper';
 
 const isIOS = Platform.OS === 'ios';
@@ -15,11 +15,11 @@ const DialogWithLoadingIndicator = ({
     <Dialog onDismiss={close} visible={visible}>
       <Dialog.Title>Progress Dialog</Dialog.Title>
       <Dialog.Content>
-        <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+        <View style={styles.flexing}>
           <ActivityIndicator
             color={Colors.indigo500}
             size={isIOS ? 'large' : 48}
-            style={{ marginRight: 16 }}
+            style={styles.marginRight}
           />
           <Paragraph>Loading.....</Paragraph>
         </View>
@@ -27,5 +27,15 @@ const DialogWithLoadingIndicator = ({
     </Dialog>
   </Portal>
 );
+
+const styles = StyleSheet.create({
+  flexing: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  marginRight: {
+    marginRight: 16,
+  },
+});
 
 export default DialogWithLoadingIndicator;

--- a/example/src/Examples/Dialogs/DialogWithLongText.tsx
+++ b/example/src/Examples/Dialogs/DialogWithLongText.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Dimensions, ScrollView } from 'react-native';
+import { Dimensions, ScrollView, StyleSheet } from 'react-native';
 import { Paragraph, Button, Portal, Dialog } from 'react-native-paper';
 
 const DialogWithLongText = ({
@@ -16,8 +16,8 @@ const DialogWithLongText = ({
       style={{ maxHeight: 0.6 * Dimensions.get('window').height }}
     >
       <Dialog.Title>Alert</Dialog.Title>
-      <Dialog.ScrollArea style={{ paddingHorizontal: 0 }}>
-        <ScrollView contentContainerStyle={{ paddingHorizontal: 24 }}>
+      <Dialog.ScrollArea style={styles.smallPadding}>
+        <ScrollView contentContainerStyle={styles.biggerPadding}>
           <Paragraph>
             Material is the metaphor
             {'\n'}
@@ -65,5 +65,14 @@ const DialogWithLongText = ({
     </Dialog>
   </Portal>
 );
+
+const styles = StyleSheet.create({
+  smallPadding: {
+    paddingHorizontal: 0,
+  },
+  biggerPadding: {
+    paddingHorizontal: 24,
+  },
+});
 
 export default DialogWithLongText;

--- a/example/src/Examples/Dialogs/DialogWithRadioBtns.tsx
+++ b/example/src/Examples/Dialogs/DialogWithRadioBtns.tsx
@@ -23,7 +23,7 @@ const DialogWithRadioBtns = ({ visible, close }: Props) => {
     <Portal>
       <Dialog onDismiss={close} visible={visible}>
         <Dialog.Title>Choose an option</Dialog.Title>
-        <Dialog.ScrollArea style={{ maxHeight: 170, paddingHorizontal: 0 }}>
+        <Dialog.ScrollArea style={styles.container}>
           <ScrollView>
             <View>
               <TouchableRipple onPress={() => setChecked('normal')}>
@@ -85,6 +85,10 @@ const DialogWithRadioBtns = ({ visible, close }: Props) => {
 export default DialogWithRadioBtns;
 
 const styles = StyleSheet.create({
+  container: {
+    maxHeight: 170,
+    paddingHorizontal: 0,
+  },
   row: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/example/src/Examples/ListSectionExample.tsx
+++ b/example/src/Examples/ListSectionExample.tsx
@@ -98,7 +98,9 @@ const ListSectionExample = () => {
                 Material Design library that has you covered in all major
                 use-cases.
               </Text>
-              <View style={[styles.container, styles.row, { paddingTop: 8 }]}>
+              <View
+                style={[styles.container, styles.row, styles.additionalPadding]}
+              >
                 <Chip icon="file-pdf" onPress={() => {}}>
                   DOCS.pdf
                 </Chip>
@@ -127,6 +129,9 @@ const styles = StyleSheet.create({
   },
   column: {
     flexDirection: 'column',
+  },
+  additionalPadding: {
+    paddingTop: 8,
   },
 });
 

--- a/example/src/Examples/ProgressBarExample.tsx
+++ b/example/src/Examples/ProgressBarExample.tsx
@@ -48,7 +48,7 @@ const ProgressBarExample = () => {
         <ProgressBar
           progress={progress}
           visible={visible}
-          style={{ height: 20 }}
+          style={styles.customHeight}
         />
       </View>
     </ScreenWrapper>
@@ -63,6 +63,9 @@ const styles = StyleSheet.create({
   },
   row: {
     marginVertical: 10,
+  },
+  customHeight: {
+    height: 20,
   },
 });
 

--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -4,6 +4,7 @@ import { TextInput, HelperText, useTheme } from 'react-native-paper';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import { inputReducer, State } from '../../utils';
 import ScreenWrapper from '../ScreenWrapper';
+import { transparent } from '../../../src/styles/colors';
 
 const MAX_LENGTH = 20;
 
@@ -402,7 +403,7 @@ const TextInputExample = () => {
         <View style={styles.inputContainerStyle}>
           <TextInput
             label="Input with no padding"
-            style={{ backgroundColor: 'transparent', paddingHorizontal: 0 }}
+            style={styles.noPaddingInput}
             placeholder="Enter username, only letters"
             value={nameNoPadding}
             error={!_isUsernameValid(nameNoPadding)}
@@ -421,18 +422,14 @@ const TextInputExample = () => {
         <View style={styles.inputContainerStyle}>
           <TextInput
             label="Input with text align center"
-            style={{
-              textAlign: 'center',
-            }}
+            style={styles.centeredText}
           />
         </View>
         <View style={styles.inputContainerStyle}>
           <TextInput
             mode="outlined"
             label="Outlined input with text align center"
-            style={{
-              textAlign: 'center',
-            }}
+            style={styles.centeredText}
           />
         </View>
         <View style={styles.inputContainerStyle}>
@@ -476,6 +473,13 @@ const styles = StyleSheet.create({
   },
   textArea: {
     height: 80,
+  },
+  noPaddingInput: {
+    backgroundColor: transparent,
+    paddingHorizontal: 0,
+  },
+  centeredText: {
+    textAlign: 'center',
   },
 });
 

--- a/example/src/Examples/ToggleButtonExample.tsx
+++ b/example/src/Examples/ToggleButtonExample.tsx
@@ -43,11 +43,7 @@ const ToggleButtonExample = () => {
             onValueChange={(value: string) => setFruit(value)}
           >
             <ImageBackground
-              style={{
-                width: 143,
-                height: 153,
-                margin: 2,
-              }}
+              style={styles.customImage}
               source={{
                 uri:
                   'https://images.pexels.com/photos/1068534/pexels-photo-1068534.jpeg?auto=compress&cs=tinysrgb&h=750&w=1260',
@@ -56,20 +52,13 @@ const ToggleButtonExample = () => {
               <ToggleButton
                 value="watermelon"
                 size={24}
-                style={{
-                  position: 'absolute',
-                  right: 0,
-                }}
+                style={styles.customButton}
                 color="white"
                 icon={fruit === 'watermelon' ? 'heart' : 'heart-outline'}
               />
             </ImageBackground>
             <ImageBackground
-              style={{
-                width: 143,
-                height: 153,
-                margin: 2,
-              }}
+              style={styles.customImage}
               source={{
                 uri:
                   'https://images.pexels.com/photos/46174/strawberries-berries-fruit-freshness-46174.jpeg?auto=compress&cs=tinysrgb&h=750&w=1260',
@@ -78,10 +67,7 @@ const ToggleButtonExample = () => {
               <ToggleButton
                 value="strawberries"
                 size={24}
-                style={{
-                  position: 'absolute',
-                  right: 0,
-                }}
+                style={styles.customButton}
                 color="white"
                 icon={fruit === 'strawberries' ? 'heart' : 'heart-outline'}
               />
@@ -101,6 +87,15 @@ const styles = StyleSheet.create({
   },
   row: {
     flexDirection: 'row',
+  },
+  customImage: {
+    width: 143,
+    height: 153,
+    margin: 2,
+  },
+  customButton: {
+    position: 'absolute',
+    right: 0,
   },
 });
 

--- a/src/styles/colors.tsx
+++ b/src/styles/colors.tsx
@@ -1,3 +1,5 @@
+export const transparent = 'rgba(255, 255, 255, 0)';
+
 export const red50 = '#ffebee';
 export const red100 = '#ffcdd2';
 export const red200 = '#ef9a9a';


### PR DESCRIPTION
### Summary

This is a continuation of efforts to remove eslint warnings, started in PR #2941.
This specific PR tackles example files.
I also changed [styles/colors.tsx](https://github.com/callstack/react-native-paper/blob/main/src/styles/colors.tsx) in order to add a `transparent` color. I went with a white with 100% opacity (in the form of `rgba(255,255,255,0)`).

The current state of eslint warnings on the `main` branch:
<img width="856" alt="Zrzut ekranu 2021-10-20 o 00 29 15" src="https://user-images.githubusercontent.com/4152181/138361083-5a98ba7b-9b21-4f71-be27-388501ef84b6.png">

This PR fixes 21 warnings 🎉 

