### PR TITLE
fix: override Card surface colors with theme

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -155,6 +155,7 @@ const Card = ({
         cardMode === 'outlined' ? styles.outlined : {},
         style,
       ]}
+      theme={theme}
       {...rest}
     >
       <TouchableWithoutFeedback

--- a/src/components/__tests__/Card/Card.test.js
+++ b/src/components/__tests__/Card/Card.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { render } from 'react-native-testing-library';
 import Card from '../../Card/Card';
 
 describe('Card', () => {
@@ -7,5 +8,19 @@ describe('Card', () => {
     const tree = renderer.create(<Card mode="outlined" />).toJSON();
 
     expect(tree).toMatchSnapshot();
+  });
+
+  it('renders with a custom theme', () => {
+    const { getByA11yLabel } = render(
+      <Card
+        mode="outlined"
+        accessibilityLabel="card"
+        theme={{ colors: { surface: '#0000FF' } }}
+      />
+    );
+
+    expect(getByA11yLabel('card').props.style.backgroundColor).toEqual(
+      '#0000FF'
+    );
   });
 });


### PR DESCRIPTION
### Summary
Resolve #2937

### Test plan
```js
<Card theme={{ colors: { surface: '#0000FF' } }}>
  <Card.Title title="Card Title" subtitle="Card Subtitle" />
  <Card.Cover source={{ uri: 'https://picsum.photos/700' }} />
  <Card.Actions>
    <Button>Cancel</Button>
    <Button>Ok</Button>
   </Card.Actions>
</Card>
```
![after](https://user-images.githubusercontent.com/6487206/138473093-215826a7-71e6-416d-87dd-f7a9cf73a1e6.jpeg)


