### PR TITLE
chore: upgrade node version on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   default:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:14
     working_directory: ~/react-native-paper
 
 commands:


### PR DESCRIPTION
Upgrade Node version used on CI from 10 to 14. Node 10 is EOL and Node 14 is latest LTS release.

### Summary

This is a maintenance change. It might also help with #2942 not passing on CI.

### Test plan

All pipelines should be passing.