### PR TITLE
fix: useNativeDriver: false

### DIFF
--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -147,13 +147,13 @@ const FAB = ({
       Animated.timing(visibility, {
         toValue: 1,
         duration: 200 * scale,
-        useNativeDriver: true,
+        useNativeDriver: false,
       }).start();
     } else {
       Animated.timing(visibility, {
         toValue: 0,
         duration: 150 * scale,
-        useNativeDriver: true,
+        useNativeDriver: false,
       }).start();
     }
   }, [visible, scale, visibility]);

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -136,7 +136,7 @@ const Snackbar = ({
       Animated.timing(opacity, {
         toValue: 1,
         duration: 200 * scale,
-        useNativeDriver: true,
+        useNativeDriver: false,
       }).start(({ finished }) => {
         if (finished) {
           const isInfinity =
@@ -158,7 +158,7 @@ const Snackbar = ({
       Animated.timing(opacity, {
         toValue: 0,
         duration: 100 * scale,
-        useNativeDriver: true,
+        useNativeDriver: false,
       }).start(({ finished }) => {
         if (finished) setHidden(true);
       });


### PR DESCRIPTION
Add `useNativeDriver: false` to _Snackbar.tsx_  and _FAB.tsx_ silencing the warning:
`
Animated: 'useNativeDriver' is not supported because the native animated module is missing. Falling back to JS-based animation. [...]
`