### PR TITLE
fix: correct long label in outlined text input

### DIFF
--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -28,6 +28,7 @@ const initialState: State = {
   outlinedMultiline: '',
   outlinedTextArea: '',
   outlinedColors: '',
+  outlinedLongLabel: '',
   maxLengthName: '',
   flatTextSecureEntry: true,
   outlineTextSecureEntry: true,
@@ -390,6 +391,15 @@ const TextInputExample = () => {
           }
           outlineColor={pink400}
           activeOutlineColor={amber900}
+        />
+        <TextInput
+          mode="outlined"
+          style={styles.inputContainerStyle}
+          label="Outlined with super long label which is truncating at some point"
+          placeholder="Type something"
+          onChangeText={(outlinedLongLabel) =>
+            inputActionHandler('outlinedLongLabel', outlinedLongLabel)
+          }
         />
         <View style={styles.inputContainerStyle}>
           <TextInput

--- a/example/utils/index.ts
+++ b/example/utils/index.ts
@@ -31,6 +31,7 @@ export type State = {
   outlinedMultiline: string;
   outlinedTextArea: string;
   outlinedColors: string;
+  outlinedLongLabel: string;
   maxLengthName: string;
   flatTextSecureEntry: boolean;
   outlineTextSecureEntry: boolean;

--- a/src/components/TextInput/Label/LabelBackground.tsx
+++ b/src/components/TextInput/Label/LabelBackground.tsx
@@ -70,6 +70,9 @@ const LabelBackground = ({
                   }),
                 },
               ],
+              maxWidth:
+                parentState.labelLayout.width -
+                2 * placeholderStyle.paddingHorizontal,
             },
           ]}
           numberOfLines={1}
@@ -87,7 +90,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 6,
     left: 10,
-    width: 8,
+    width: 12,
   },
   outlinedLabel: {
     position: 'absolute',

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -249,7 +249,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
                   "translateX": -3,
                 },
               ],
-              "width": 8,
+              "width": 12,
             }
           }
         />
@@ -263,6 +263,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
               "fontSize": 16,
               "fontWeight": undefined,
               "left": 18,
+              "maxWidth": -28,
               "opacity": 1,
               "paddingHorizontal": 0,
               "position": "absolute",


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes: #2954 

PR adding a `maxWidth` for the `label` to correct the spacings after truncating and avoid displaying border.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

Android | iOS | web
| - | - | - |
<img width="429" alt="Zrzut ekranu 2021-11-5 o 13 41 10" src="https://user-images.githubusercontent.com/22746080/140513365-42fe45c4-01bd-4761-9099-e0efb87ecfc3.png"> | <img width="493" alt="Zrzut ekranu 2021-11-5 o 13 37 59" src="https://user-images.githubusercontent.com/22746080/140513350-9be64d88-3a10-4667-8603-4d98113694b6.png" /> | <img width="612" alt="Zrzut ekranu 2021-11-5 o 13 44 22" src="https://user-images.githubusercontent.com/22746080/140513393-a547eb75-a672-499b-9c8b-c60587543c05.png">
> 

### Test plan

1. Open the app
2. Go to TextInput example
3. Scroll to the example: `Outlined with super long label which is truncating at some point`
4. Expect there is no border 

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
