### PR TITLE
Allow Interacting with Menu.Items via iOS Voice Command

### DIFF
--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -89,6 +89,7 @@ const MenuItem = ({
   titleStyle,
   accessibilityLabel,
   theme,
+  ...props
 }: Props) => {
   const disabledColor = color(theme.dark ? white : black)
     .alpha(0.32)
@@ -112,6 +113,7 @@ const MenuItem = ({
       accessibilityLabel={accessibilityLabel}
       accessibilityRole="menuitem"
       accessibilityState={{ disabled }}
+      {...props}
     >
       <View style={styles.row}>
         {icon ? (


### PR DESCRIPTION
### Summary

`Menu.Item`s can't be interacted with via iOS Voice Command. To see this, follow these steps:

- In the example app, run `yarn start`
- On a physical iPhone, go to Settings > Accessibility > Voice Control, then set Voice Control to On
- Open the app from Expo Go on a physical iPhone
- Go to the Menu examples screen
- Tap the toggle menu button
- Speak "show names". The Voice Control overlay will appear, showing which buttons can be interacted with via their names. Note that the "Back" and "MENU WITH ICONS" buttons have names, but the menu items in the dropdown menu do not:

![image](https://user-images.githubusercontent.com/15832198/140642849-5f34a0ae-8c92-423b-954a-b3ccb52e6dc9.png)

In investigating a fix, I found that I needed to change the `accessibilityRole` of the `Menu.Item`'s `TouchableRipple` from "menuitem" to "button". This doesn't seem like an ideal fix; maybe this is a limitation of React Native's support for Voice Control. So I didn't want to hard-code this attribute change in `Menu.Item` itself.

Instead, I recommend we keep `accessibilityRole="menuitem"` the default for the `TouchableRipple `, but allow it to be overridden for apps that want this Voice Control functionality. There are two ways we could do this:

1. Add `accessibilityRole` as a prop that `Menu.Item` takes in, or
2. Allow `Menu.Item` to take in arbitrary props, and pass them along to the `TouchableRipple`

This PR takes approach 2, but I would be happy to change this PR to take approach 1 if y'all prefer.

I would also be happy to make any necessary documentation updates before merge, once we settle on an approach.

### Test plan

- In the example app `MenuExample.tsx`, add `accessibilityRole="button"` to the components on lines 73-78:

```jsx
          <Menu.Item onPress={() => {}} title="Undo" accessibilityRole="button" />
          <Menu.Item onPress={() => {}} title="Redo" accessibilityRole="button" />
          <Divider />
          <Menu.Item onPress={() => {}} title="Cut" disabled accessibilityRole="button" />
          <Menu.Item onPress={() => {}} title="Copy" disabled accessibilityRole="button" />
          <Menu.Item onPress={() => {}} title="Paste" accessibilityRole="button" />
```

- In the example app, run `yarn start`
- On a physical iPhone, go to Settings > Accessibility > Voice Control, then set Voice Control to On
- Open the app from Expo Go on a physical iPhone
- Go to the Menu examples screen
- Tap the toggle menu button
- Speak "show names". The Voice Control overlay will appear, showing which buttons can be interacted with via their names. Note that now "Undo", "Redo", and "Paste" all have names and can be interacted with.

![image](https://user-images.githubusercontent.com/15832198/140643034-38b24ffc-f715-410d-8e0c-743604121e9c.png)
