### PR TITLE
fix: correct Chip touchable style

### DIFF
--- a/example/src/Examples/ChipExample.tsx
+++ b/example/src/Examples/ChipExample.tsx
@@ -216,6 +216,9 @@ const ChipExample = () => {
               With custom close icon
             </Chip>
           </View>
+          <Chip mode="outlined" onPress={() => {}} style={styles.fullWidthChip}>
+            Full width chip
+          </Chip>
         </List.Section>
       </ScreenWrapper>
       <Snackbar
@@ -252,6 +255,10 @@ const styles = StyleSheet.create({
   },
   bigTextStyle: {
     flex: -1,
+  },
+  fullWidthChip: {
+    marginVertical: 4,
+    marginHorizontal: 12,
   },
 });
 

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -391,7 +391,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   touchable: {
-    flex: 1,
+    flexGrow: 1,
   },
 });
 

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -355,6 +355,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingLeft: 4,
     position: 'relative',
+    flexGrow: 1,
   },
   icon: {
     padding: 4,

--- a/src/components/__tests__/__snapshots__/Chip.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.js.snap
@@ -41,7 +41,7 @@ exports[`renders chip with close button 1`] = `
             "borderRadius": 16,
           },
           Object {
-            "flex": 1,
+            "flexGrow": 1,
           },
         ],
       ]
@@ -263,7 +263,7 @@ exports[`renders chip with custom close button 1`] = `
             "borderRadius": 16,
           },
           Object {
-            "flex": 1,
+            "flexGrow": 1,
           },
         ],
       ]
@@ -485,7 +485,7 @@ exports[`renders chip with icon 1`] = `
             "borderRadius": 16,
           },
           Object {
-            "flex": 1,
+            "flexGrow": 1,
           },
         ],
       ]
@@ -634,7 +634,7 @@ exports[`renders chip with onPress 1`] = `
             "borderRadius": 16,
           },
           Object {
-            "flex": 1,
+            "flexGrow": 1,
           },
         ],
       ]
@@ -735,7 +735,7 @@ exports[`renders outlined disabled chip 1`] = `
             "borderRadius": 16,
           },
           Object {
-            "flex": 1,
+            "flexGrow": 1,
           },
         ],
       ]
@@ -836,7 +836,7 @@ exports[`renders selected chip 1`] = `
             "borderRadius": 16,
           },
           Object {
-            "flex": 1,
+            "flexGrow": 1,
           },
         ],
       ]

--- a/src/components/__tests__/__snapshots__/Chip.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.js.snap
@@ -53,6 +53,7 @@ exports[`renders chip with close button 1`] = `
           Object {
             "alignItems": "center",
             "flexDirection": "row",
+            "flexGrow": 1,
             "paddingLeft": 4,
             "position": "relative",
           },
@@ -275,6 +276,7 @@ exports[`renders chip with custom close button 1`] = `
           Object {
             "alignItems": "center",
             "flexDirection": "row",
+            "flexGrow": 1,
             "paddingLeft": 4,
             "position": "relative",
           },
@@ -497,6 +499,7 @@ exports[`renders chip with icon 1`] = `
           Object {
             "alignItems": "center",
             "flexDirection": "row",
+            "flexGrow": 1,
             "paddingLeft": 4,
             "position": "relative",
           },
@@ -646,6 +649,7 @@ exports[`renders chip with onPress 1`] = `
           Object {
             "alignItems": "center",
             "flexDirection": "row",
+            "flexGrow": 1,
             "paddingLeft": 4,
             "position": "relative",
           },
@@ -747,6 +751,7 @@ exports[`renders outlined disabled chip 1`] = `
           Object {
             "alignItems": "center",
             "flexDirection": "row",
+            "flexGrow": 1,
             "paddingLeft": 4,
             "position": "relative",
           },
@@ -848,6 +853,7 @@ exports[`renders selected chip 1`] = `
           Object {
             "alignItems": "center",
             "flexDirection": "row",
+            "flexGrow": 1,
             "paddingLeft": 4,
             "position": "relative",
           },

--- a/src/components/__tests__/__snapshots__/ListItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.js.snap
@@ -124,7 +124,7 @@ exports[`renders list item with custom description 1`] = `
                       "borderRadius": 16,
                     },
                     Object {
-                      "flex": 1,
+                      "flexGrow": 1,
                     },
                   ],
                 ]

--- a/src/components/__tests__/__snapshots__/ListItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.js.snap
@@ -136,6 +136,7 @@ exports[`renders list item with custom description 1`] = `
                     Object {
                       "alignItems": "center",
                       "flexDirection": "row",
+                      "flexGrow": 1,
                       "paddingLeft": 4,
                       "position": "relative",
                     },


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/2972, https://github.com/callstack/react-native-paper/issues/2959

### Summary

Setting the `flexGrow` to `Touchable` within `Chip`

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Android | ios | web
-- | -- | --
![Zrzut ekranu 2021-11-9 o 19 24 33](https://user-images.githubusercontent.com/22746080/140985598-ee43621c-fc73-4a3a-a9e8-6fcd541d9d48.png) | <img width="493" alt="Zrzut ekranu 2021-11-9 o 19 31 52" src="https://user-images.githubusercontent.com/22746080/140985604-538cdf21-2b4f-4269-92e4-aa38dc851dd3.png"> | <img width="957" alt="Zrzut ekranu 2021-11-9 o 19 31 58" src="https://user-images.githubusercontent.com/22746080/140985613-11dae255-64f5-459c-9aba-95d1bdc28d33.png">

at the same time it's not breaking the previous issue: https://github.com/callstack/react-native-paper/issues/2804

Android | ios | web
-- | -- | --
![previous_bug](https://user-images.githubusercontent.com/22746080/140985960-54b6bb82-6291-49b8-8e14-2a2b69e02e0d.gif) | ![bug_prev_ios](https://user-images.githubusercontent.com/22746080/140986061-1eaaa51f-d8fd-41ee-8bdc-d53575ded1f7.gif) | ![bug_prev_web](https://user-images.githubusercontent.com/22746080/140986004-5fd3e05a-9894-45ff-bbb1-3ef31bcbcdc5.gif)




### Test plan

Run the code below from one of the issues and **expect** Chips are displayed properly:

```javascript
import * as React from 'react';
import { View, StyleSheet } from 'react-native';
import { Chip, List } from 'react-native-paper';

const ChipExample = () => {
  return (
    <>
      <List.Section title="Flat chip">
        <View style={styles.row}>
          <Chip selected onPress={() => { }} style={styles.chip}>
            Simple 1
          </Chip>
          <Chip selected onPress={() => { }} style={styles.chip}>
            Simple 2
          </Chip>
          <Chip selected onPress={() => { }} style={styles.chip}>
            Simple 3
          </Chip>
        </View>
      </List.Section>
    </>
  );
};

const styles = StyleSheet.create({
  row: {
    flexDirection: 'row',
    flexWrap: 'wrap',
    paddingHorizontal: 12,
  },
  chip: {
    margin: 4,
  },
});

export default ChipExample;
```

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
