### PR TITLE
fix: move outline outside of input view container

### DIFF
--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -291,15 +291,15 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
           This is so that the label can overlap the outline
           Otherwise the border will cut off the label on Android
           */}
+        <Outline
+          theme={theme}
+          hasActiveOutline={hasActiveOutline}
+          focused={parentState.focused}
+          activeColor={activeColor}
+          outlineColor={outlineColor}
+          backgroundColor={backgroundColor}
+        />
         <View>
-          <Outline
-            theme={theme}
-            hasActiveOutline={hasActiveOutline}
-            focused={parentState.focused}
-            activeColor={activeColor}
-            outlineColor={outlineColor}
-            backgroundColor={backgroundColor}
-          />
           <View
             style={[
               styles.labelContainer,

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -376,28 +376,28 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
 <View
   style={Object {}}
 >
+  <View
+    pointerEvents="none"
+    style={
+      Array [
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 6,
+        },
+        Object {
+          "backgroundColor": "#f6f6f6",
+          "borderColor": "rgba(0, 0, 0, 0.54)",
+          "borderRadius": 4,
+          "borderWidth": 1,
+        },
+      ]
+    }
+    testID="text-input-outline"
+  />
   <View>
-    <View
-      pointerEvents="none"
-      style={
-        Array [
-          Object {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 6,
-          },
-          Object {
-            "backgroundColor": "#f6f6f6",
-            "borderColor": "rgba(0, 0, 0, 0.54)",
-            "borderRadius": 4,
-            "borderWidth": 1,
-          },
-        ]
-      }
-      testID="text-input-outline"
-    />
     <View
       style={
         Array [


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->
Fixes: https://github.com/callstack/react-native-paper/issues/2935

### Summary

PR moves the outline outside of `TextInput`, so then it's not affected by input's padding. 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

ios | android | web
--- | --- | --- 
![input_padding_ios](https://user-images.githubusercontent.com/22746080/145412895-a21da47c-309a-48a3-add3-081439551631.gif) | ![Kapture 2021-12-09 at 14 54 54](https://user-images.githubusercontent.com/22746080/145412925-74178bdf-bc41-4674-8081-f07b051bbe00.gif) | ![Kapture 2021-12-09 at 14 57 41](https://user-images.githubusercontent.com/22746080/145412969-8035406e-5df3-491d-aded-d7e8705a8623.gif)


### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

1. To one of TextInput example with `mode="outlined"` add to styles some `paddingRight` or use the following snippet:

```
      <TextInput
        label="Email"
        placeholder="Email"
        value={text}
        multiline={false}
        mode="outlined"
        onChangeText={(text) => setText(text)}
        style={{ backgroundColor: 'aquamarine', paddingRight: 120 }}
      />
```

2. Type some text
3. Expect padding is adjusted properly