### PR TITLE
fix: correct displaying text in outlined text input

### DIFF
--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -507,7 +507,14 @@ const TextInputExample = () => {
             theme={{
               roundness: 25,
             }}
-            label="Custom rounded input"
+            label="Outlined text input with custom roundness"
+          />
+        </View>
+        <View style={styles.inputContainerStyle}>
+          <TextInput
+            mode="outlined"
+            label="Outlined text input without roundness"
+            theme={{ roundness: 0 }}
           />
         </View>
         <View style={styles.inputContainerStyle}>
@@ -515,6 +522,22 @@ const TextInputExample = () => {
             mode="outlined"
             label="Outlined text input with error"
             error
+          />
+        </View>
+        <View style={styles.inputContainerStyle}>
+          <TextInput
+            mode="outlined"
+            label="Outlined multiline text input with fixed height"
+            multiline
+            style={styles.fixedHeight}
+          />
+        </View>
+        <View style={styles.inputContainerStyle}>
+          <TextInput
+            mode="flat"
+            label="Flat multiline text input with fixed height"
+            multiline
+            style={styles.fixedHeight}
           />
         </View>
       </ScreenWrapper>
@@ -556,6 +579,9 @@ const styles = StyleSheet.create({
   },
   centeredText: {
     textAlign: 'center',
+  },
+  fixedHeight: {
+    height: 100,
   },
 });
 

--- a/src/components/TextInput/Label/LabelBackground.tsx
+++ b/src/components/TextInput/Label/LabelBackground.tsx
@@ -45,6 +45,7 @@ const LabelBackground = ({
             styles.view,
             {
               backgroundColor,
+              maxHeight: Math.max(roundness / 3, 2),
               opacity,
               bottom: Math.max(roundness, 2),
             },

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -437,6 +437,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
               "backgroundColor": "#f6f6f6",
               "bottom": 4,
               "left": 10,
+              "maxHeight": 2,
               "opacity": 1,
               "position": "absolute",
               "right": 0,


### PR DESCRIPTION
Fixes: https://github.com/callstack/react-native-paper/issues/3003

### Summary

Setting a height of the masking label spacing.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

1. Run the app
2. Type something in outlined input
3. Expect the whole text is displayed properly

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
