### PR TITLE
EventEmitter.removeListener('change', ...): Method has been deprecate…

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -258,13 +258,13 @@ class Menu extends React.Component<Props, State> {
     if (this.backHandlerSubscription?.remove) {
       this.backHandlerSubscription.remove();
     } else {
-      BackHandler.removeEventListener('hardwareBackPress', this.handleDismiss);
+      this.handleDismiss;
     }
 
     if (this.dimensionsSubscription?.remove) {
       this.dimensionsSubscription.remove();
     } else {
-      Dimensions.removeEventListener('change', this.handleDismiss);
+      this.handleDismiss;
     }
 
     this.isBrowser() &&


### PR DESCRIPTION
…d Issue Fixed

https://github.com/callstack/react-native-paper/issues/2984

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

if (this.backHandlerSubscription?.remove) {
      this.backHandlerSubscription.remove();
    } else {
      BackHandler.removeEventListener('hardwareBackPress', this.handleDismiss);    <----   this event trigger when the user does not click on the menu option and the user press Hardware Back Button so no need to do this because BackHandler Listener is not subscribed.
    }

    if (this.dimensionsSubscription?.remove) {
      this.dimensionsSubscription.remove();
    } else {
      Dimensions.removeEventListener('change', this.handleDismiss);     <----   this event trigger when the user does not click on the menu option and the user press Hardware Back Button so no need to do this because BackHandler Listener is not subscribed.
    }

If you wanna see whole process recording click below links:
https://user-images.githubusercontent.com/73298854/145720046-2e3628d5-d94c-409d-9785-287d8432cd87.mp4

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
