### PR TITLE
updated textinput.tsx

### DIFF
--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -337,7 +337,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
                 !multiline || (multiline && height)
                   ? { height: inputHeight }
                   : {},
-                paddingOut,
+                 // paddingOut,
                 {
                   ...font,
                   fontSize,


### PR DESCRIPTION
As outlined textinput after decreacing height makes the text inside it scrollable it can be removed using removing paddingout from the style

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
