### PR TITLE
fix: datatable.title numberOfLines > 1 height + wrapped text align

### DIFF
--- a/src/components/DataTable/DataTableTitle.tsx
+++ b/src/components/DataTable/DataTableTitle.tsx
@@ -128,6 +128,16 @@ const DataTableTitle = ({
         <Text
           style={[
             styles.cell,
+            // height must scale with numberOfLines
+            { height: 24 * numberOfLines },
+            // if numberOfLines causes wrap, center is lost. Align directly, sensitive to numeric and RTL
+            numberOfLines > 1
+              ? numeric
+                ? I18nManager.isRTL
+                  ? styles.leftText
+                  : styles.rightText
+                : styles.centerText
+              : {},
             sortDirection ? styles.sorted : { color: textColor },
             textStyle,
           ]}
@@ -150,12 +160,23 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
   },
 
+  rightText: {
+    textAlign: 'right',
+  },
+
+  leftText: {
+    textAlign: 'left',
+  },
+
+  centerText: {
+    textAlign: 'center',
+  },
+
   right: {
     justifyContent: 'flex-end',
   },
 
   cell: {
-    height: 24,
     lineHeight: 24,
     fontSize: 12,
     fontWeight: '500',

--- a/src/components/DataTable/DataTableTitle.tsx
+++ b/src/components/DataTable/DataTableTitle.tsx
@@ -129,7 +129,7 @@ const DataTableTitle = ({
           style={[
             styles.cell,
             // height must scale with numberOfLines
-            { height: 24 * numberOfLines },
+            { maxHeight: 24 * numberOfLines },
             // if numberOfLines causes wrap, center is lost. Align directly, sensitive to numeric and RTL
             numberOfLines > 1
               ? numeric

--- a/src/components/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.js.snap
@@ -107,7 +107,7 @@ exports[`renders data table header 1`] = `
               "lineHeight": 24,
             },
             Object {
-              "height": 24,
+              "maxHeight": 24,
             },
             Object {},
             Object {
@@ -164,7 +164,7 @@ exports[`renders data table header 1`] = `
               "lineHeight": 24,
             },
             Object {
-              "height": 24,
+              "maxHeight": 24,
             },
             Object {},
             Object {
@@ -1481,7 +1481,7 @@ exports[`renders data table title with press handler 1`] = `
             "lineHeight": 24,
           },
           Object {
-            "height": 24,
+            "maxHeight": 24,
           },
           Object {},
           Object {
@@ -1574,7 +1574,7 @@ exports[`renders data table title with sort icon 1`] = `
             "lineHeight": 24,
           },
           Object {
-            "height": 24,
+            "maxHeight": 24,
           },
           Object {},
           Object {
@@ -1685,7 +1685,7 @@ exports[`renders right aligned data table title 1`] = `
             "lineHeight": 24,
           },
           Object {
-            "height": 24,
+            "maxHeight": 24,
           },
           Object {},
           Object {

--- a/src/components/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.js.snap
@@ -104,9 +104,12 @@ exports[`renders data table header 1`] = `
               "alignItems": "center",
               "fontSize": 12,
               "fontWeight": "500",
-              "height": 24,
               "lineHeight": 24,
             },
+            Object {
+              "height": 24,
+            },
+            Object {},
             Object {
               "color": "rgba(0, 0, 0, 0.6)",
             },
@@ -158,9 +161,12 @@ exports[`renders data table header 1`] = `
               "alignItems": "center",
               "fontSize": 12,
               "fontWeight": "500",
-              "height": 24,
               "lineHeight": 24,
             },
+            Object {
+              "height": 24,
+            },
+            Object {},
             Object {
               "color": "rgba(0, 0, 0, 0.6)",
             },
@@ -1472,9 +1478,12 @@ exports[`renders data table title with press handler 1`] = `
             "alignItems": "center",
             "fontSize": 12,
             "fontWeight": "500",
-            "height": 24,
             "lineHeight": 24,
           },
+          Object {
+            "height": 24,
+          },
+          Object {},
           Object {
             "marginLeft": 8,
           },
@@ -1562,9 +1571,12 @@ exports[`renders data table title with sort icon 1`] = `
             "alignItems": "center",
             "fontSize": 12,
             "fontWeight": "500",
-            "height": 24,
             "lineHeight": 24,
           },
+          Object {
+            "height": 24,
+          },
+          Object {},
           Object {
             "marginLeft": 8,
           },
@@ -1670,9 +1682,12 @@ exports[`renders right aligned data table title 1`] = `
             "alignItems": "center",
             "fontSize": 12,
             "fontWeight": "500",
-            "height": 24,
             "lineHeight": 24,
           },
+          Object {
+            "height": 24,
+          },
+          Object {},
           Object {
             "color": "rgba(0, 0, 0, 0.6)",
           },


### PR DESCRIPTION
### Summary

Thanks for react-native-paper you all, it's fantastic.

The DataTable.Title component takes a numberOfLines prop

However, the internal / wrapped Text component has a style applied with height *and* lineHeight fixed at 24.
So it appears that even with numberOfLines > 1, the height of the Text will be fixed and not allow multiple lines.

So without this, it does not appear the numberOfLines prop has an effect, as noticed in #848 and #863

With this, it appears to work exactly as expected.

Text components require special alignment treatment with word wrapping. Normally a word wrap will force text alignment to flex-start. So we align directly when number of lines is > 1, while respecting the numeric property and it's interaction with RTL languages

It's entirely possible I'm missing something, there was one success report in comments of #848, and the PR author must have made it work, but I just could not see how to make it work without this? And neither could others.

### Test plan

I went right into node_modules and made the edits to test it. I also ran it in the example app and updated the jest snapshots. The jest tests show that my change is backwards-compatible - it has no effect when numberOfLines === 1 other than to move where height prop is set

I'm using patch-package to use this change right now.