### PR TITLE
fix: type error for error argument

### DIFF
--- a/src/components/MaterialCommunityIcon.tsx
+++ b/src/components/MaterialCommunityIcon.tsx
@@ -22,7 +22,7 @@ try {
   // Optionally require vector-icons
   MaterialCommunityIcons = require('react-native-vector-icons/MaterialCommunityIcons')
     .default;
-} catch (e) {
+} catch (e: any) {
   let isErrorLogged = false;
 
   // Fallback component for icons


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Using Typescript v4.4.4+


> tsc --build .
> node_modules/react-native-paper/src/components/MaterialCommunityIcon.tsx:34:11 - error TS2571: Object is of type 'unknown'.


### Test plan

Added any type to catch argument
