### PR TITLE
fix: Making `theme` prop optional for the `TextInput` component

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -130,7 +130,7 @@ export type TextInputProps = React.ComponentPropsWithRef<
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme?: ReactNativePaper.Theme;
 };
 
 /**


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Changing the `Theme` props attribute in the `TextInput` component to optional.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
This PR resolves the issue mentioned in [Issue/3013](https://github.com/callstack/react-native-paper/issues/3013)
### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
Calling the `TestInput` component and ensure that it doesn't require a `theme` props