### PR TITLE
feat: add event listeners for Avatar.Image

### DIFF
--- a/src/components/Avatar/AvatarImage.tsx
+++ b/src/components/Avatar/AvatarImage.tsx
@@ -18,18 +18,6 @@ export type AvatarImageSource =
 
 type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
-   * Event Listeners of standard React Native Image - `onError`, `onLayout`, `onLoad`, `onLoadEnd`, `onLoadStart`, `onProgress`
-   */
-  listeners?: Pick<
-    ImageProps,
-    | 'onError'
-    | 'onLayout'
-    | 'onLoad'
-    | 'onLoadEnd'
-    | 'onLoadStart'
-    | 'onProgress'
-  >;
-  /**
    * Image to display for the `Avatar`.
    * It accepts a standard React Native Image `source` prop
    * Or a function that returns an `Image`.
@@ -40,6 +28,30 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
    */
   size?: number;
   style?: StyleProp<ViewStyle>;
+  /**
+   * Invoked on load error.
+   */
+  onError?: ImageProps['onError'];
+  /**
+   * Invoked on mount and on layout changes.
+   */
+  onLayout?: ImageProps['onLayout'];
+  /**
+   * Invoked when load completes successfully.
+   */
+  onLoad?: ImageProps['onLoad'];
+  /**
+   * Invoked when load either succeeds or fails.
+   */
+  onLoadEnd?: ImageProps['onLoadEnd'];
+  /**
+   * Invoked on load start.
+   */
+  onLoadStart?: ImageProps['onLoadStart'];
+  /**
+   * Invoked on download progress.
+   */
+  onProgress?: ImageProps['onProgress'];
   /**
    * @optional
    */
@@ -67,10 +79,15 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
  * ```
  */
 const AvatarImage = ({
-  listeners,
   size = defaultSize,
   source,
   style,
+  onError,
+  onLayout,
+  onLoad,
+  onLoadEnd,
+  onLoadStart,
+  onProgress,
   theme,
   ...rest
 }: Props) => {
@@ -96,12 +113,12 @@ const AvatarImage = ({
         <Image
           source={source}
           style={{ width: size, height: size, borderRadius: size / 2 }}
-          onError={listeners?.onError}
-          onLayout={listeners?.onLayout}
-          onLoad={listeners?.onLoad}
-          onLoadEnd={listeners?.onLoadEnd}
-          onLoadStart={listeners?.onLoadStart}
-          onProgress={listeners?.onProgress}
+          onError={onError}
+          onLayout={onLayout}
+          onLoad={onLoad}
+          onLoadEnd={onLoadEnd}
+          onLoadStart={onLoadStart}
+          onProgress={onProgress}
         />
       )}
     </View>

--- a/src/components/Avatar/AvatarImage.tsx
+++ b/src/components/Avatar/AvatarImage.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {
   Image,
   ImageSourcePropType,
+  ImageProps,
   StyleSheet,
   View,
   ViewStyle,
@@ -16,6 +17,18 @@ export type AvatarImageSource =
   | ((props: { size: number }) => React.ReactNode);
 
 type Props = React.ComponentPropsWithRef<typeof View> & {
+  /**
+   * Event Listeners of standard React Native Image - `onError`, `onLayout`, `onLoad`, `onLoadEnd`, `onLoadStart`, `onProgress`
+   */
+  listeners?: Pick<
+    ImageProps,
+    | 'onError'
+    | 'onLayout'
+    | 'onLoad'
+    | 'onLoadEnd'
+    | 'onLoadStart'
+    | 'onProgress'
+  >;
   /**
    * Image to display for the `Avatar`.
    * It accepts a standard React Native Image `source` prop
@@ -54,6 +67,7 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
  * ```
  */
 const AvatarImage = ({
+  listeners,
   size = defaultSize,
   source,
   style,
@@ -82,6 +96,12 @@ const AvatarImage = ({
         <Image
           source={source}
           style={{ width: size, height: size, borderRadius: size / 2 }}
+          onError={listeners?.onError}
+          onLayout={listeners?.onLayout}
+          onLoad={listeners?.onLoad}
+          onLoadEnd={listeners?.onLoadEnd}
+          onLoadStart={listeners?.onLoadStart}
+          onProgress={listeners?.onProgress}
         />
       )}
     </View>

--- a/src/components/__tests__/Avatar.test.js
+++ b/src/components/__tests__/Avatar.test.js
@@ -59,3 +59,21 @@ it('renders avatar with image', () => {
 
   expect(tree).toMatchSnapshot();
 });
+
+it('renders avatar with event listeners', () => {
+  const tree = renderer
+    .create(
+      <Avatar.Image
+        source={{ src: 'avatar.png' }}
+        onError={() => {}}
+        onLayout={() => {}}
+        onLoad={() => {}}
+        onLoadEnd={() => {}}
+        onLoadStart={() => {}}
+        onProgress={() => {}}
+      />
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/__tests__/Avatar.test.js
+++ b/src/components/__tests__/Avatar.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { StyleSheet } from 'react-native';
 import renderer from 'react-test-renderer';
+import { fireEvent, render } from 'react-native-testing-library';
 import * as Avatar from '../Avatar/Avatar.tsx';
 import { red500 } from '../../styles/colors';
 
@@ -60,20 +61,47 @@ it('renders avatar with image', () => {
   expect(tree).toMatchSnapshot();
 });
 
-it('renders avatar with event listeners', () => {
-  const tree = renderer
-    .create(
-      <Avatar.Image
-        source={{ src: 'avatar.png' }}
-        onError={() => {}}
-        onLayout={() => {}}
-        onLoad={() => {}}
-        onLoadEnd={() => {}}
-        onLoadStart={() => {}}
-        onProgress={() => {}}
-      />
-    )
-    .toJSON();
+describe('AvatarImage listener', () => {
+  const onListenerMock = jest.fn();
+  const { getByTestId } = render(
+    <Avatar.Image
+      testID={'avatar-image'}
+      onError={onListenerMock}
+      onLayout={onListenerMock}
+      onLoad={onListenerMock}
+      onLoadEnd={onListenerMock}
+      onLoadStart={onListenerMock}
+      onProgress={onListenerMock}
+    />
+  );
 
-  expect(tree).toMatchSnapshot();
+  it('onError should be called', () => {
+    fireEvent(getByTestId('avatar-image'), 'onError');
+    expect(onListenerMock).toHaveBeenCalled();
+  });
+
+  it('onLayout should be called', () => {
+    fireEvent(getByTestId('avatar-image'), 'onLayout');
+    expect(onListenerMock).toHaveBeenCalled();
+  });
+
+  it('onLoad should be called', () => {
+    fireEvent(getByTestId('avatar-image'), 'onLoad');
+    expect(onListenerMock).toHaveBeenCalled();
+  });
+
+  it('onLoadEnd should be called', () => {
+    fireEvent(getByTestId('avatar-image'), 'onLoadEnd');
+    expect(onListenerMock).toHaveBeenCalled();
+  });
+
+  it('onLoadStart should be called', () => {
+    fireEvent(getByTestId('avatar-image'), 'onLoadStart');
+    expect(onListenerMock).toHaveBeenCalled();
+  });
+
+  it('onProgress should be called', () => {
+    fireEvent(getByTestId('avatar-image'), 'onProgress');
+    expect(onListenerMock).toHaveBeenCalled();
+  });
 });

--- a/src/components/__tests__/__snapshots__/Avatar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Avatar.test.js.snap
@@ -1,5 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders avatar with event listeners 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#6200ee",
+        "borderRadius": 32,
+        "height": 64,
+        "width": 64,
+      },
+      undefined,
+    ]
+  }
+>
+  <Image
+    onError={[Function]}
+    onLayout={[Function]}
+    onLoad={[Function]}
+    onLoadEnd={[Function]}
+    onLoadStart={[Function]}
+    onProgress={[Function]}
+    source={
+      Object {
+        "src": "avatar.png",
+      }
+    }
+    style={
+      Object {
+        "borderRadius": 32,
+        "height": 64,
+        "width": 64,
+      }
+    }
+  />
+</View>
+`;
+
 exports[`renders avatar with icon 1`] = `
 <View
   style={

--- a/src/components/__tests__/__snapshots__/Avatar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Avatar.test.js.snap
@@ -1,42 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders avatar with event listeners 1`] = `
-<View
-  style={
-    Array [
-      Object {
-        "backgroundColor": "#6200ee",
-        "borderRadius": 32,
-        "height": 64,
-        "width": 64,
-      },
-      undefined,
-    ]
-  }
->
-  <Image
-    onError={[Function]}
-    onLayout={[Function]}
-    onLoad={[Function]}
-    onLoadEnd={[Function]}
-    onLoadStart={[Function]}
-    onProgress={[Function]}
-    source={
-      Object {
-        "src": "avatar.png",
-      }
-    }
-    style={
-      Object {
-        "borderRadius": 32,
-        "height": 64,
-        "width": 64,
-      }
-    }
-  />
-</View>
-`;
-
 exports[`renders avatar with icon 1`] = `
 <View
   style={


### PR DESCRIPTION
This PR adds necessary event listeners that was missing in `Avatar.Image`.


_Generally I was trying to add all props of standard React Native Image component but then thought that they are unnecessary for Avatar Image. If you guys prefer that then I can make a PR for that too_

_I was confused if I should make one `listener` prop or add them separately for each of them and decided to make one prop, If this is also not recommended then I will update_