### PR TITLE
fix: fixed backgroundColor of textinput label #3020

### DIFF
--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -331,7 +331,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
             },
           ]}
         >
-          {!isAndroid && multiline && (
+          {!isAndroid && multiline && label && (
             // Workaround for: https://github.com/callstack/react-native-paper/issues/2799
             // Patch for a multiline TextInput with fixed height, which allow to avoid covering input label with its value.
             <View
@@ -341,7 +341,7 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
                 StyleSheet.absoluteFill,
                 dense ? styles.densePatchContainer : styles.patchContainer,
                 {
-                  backgroundColor: containerStyle.backgroundColor,
+                  backgroundColor: viewStyle.backgroundColor || containerStyle.backgroundColor,
                   left: paddingLeft,
                   right: paddingRight,
                 },

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -341,7 +341,8 @@ class TextInputFlat extends React.Component<ChildTextInputProps> {
                 StyleSheet.absoluteFill,
                 dense ? styles.densePatchContainer : styles.patchContainer,
                 {
-                  backgroundColor: viewStyle.backgroundColor || containerStyle.backgroundColor,
+                  backgroundColor:
+                    viewStyle.backgroundColor || containerStyle.backgroundColor,
                   left: paddingLeft,
                   right: paddingRight,
                 },


### PR DESCRIPTION
### Summary

This PR fixes issue #3020 , to ensure that the label in TextinputFlat aligns with the backgroundColor of the TextInput AND to not show the label if there is no label specified for the textInput.

### Test plan

See issue, @lukewalczak ran tests and advised on this PR.
