### PR TITLE
fix: correct Card animation drivers related to elevation

### DIFF
--- a/example/src/Examples/CardExample.tsx
+++ b/example/src/Examples/CardExample.tsx
@@ -10,6 +10,7 @@ import {
   Text,
   Switch,
 } from 'react-native-paper';
+import { PreferencesContext } from '..';
 import ScreenWrapper from '../ScreenWrapper';
 
 const CardExample = () => {
@@ -18,6 +19,8 @@ const CardExample = () => {
   } = useTheme();
   const [isOutlined, setIsOutlined] = React.useState(false);
   const mode = isOutlined ? 'outlined' : 'elevated';
+
+  const preferences = React.useContext(PreferencesContext);
 
   return (
     <ScreenWrapper contentContainerStyle={styles.content}>
@@ -117,6 +120,23 @@ const CardExample = () => {
             <Paragraph>
               This is a long press only city. If you long press me, I will
               alert.
+            </Paragraph>
+          </Card.Content>
+        </Card>
+        <Card
+          style={styles.card}
+          onPress={() => {
+            preferences.toggleTheme();
+          }}
+          mode={mode}
+        >
+          <Card.Title
+            title="Pressable Theme Change"
+            left={(props) => <Avatar.Icon {...props} icon="format-paint" />}
+          />
+          <Card.Content>
+            <Paragraph>
+              This is pressable card. If you press me, I will switch the theme.
             </Paragraph>
           </Card.Content>
         </Card>

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -70,7 +70,7 @@ const CustomDefaultTheme = {
   },
 };
 
-const PreferencesContext = React.createContext<any>(null);
+export const PreferencesContext = React.createContext<any>(null);
 
 const DrawerContent = () => {
   return (

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -28,6 +28,8 @@ type ElevatedCardProps = {
   elevation?: number;
 };
 
+type HandlePressType = 'in' | 'out';
+
 type Props = React.ComponentProps<typeof Surface> & {
   /**
    * Resting elevation of the card which controls the drop shadow.
@@ -151,38 +153,29 @@ const Card = ({
     elevationDarkAdaptive,
   ]);
 
-  const handlePressIn = () => {
+  const runElevationAnimation = (pressType: HandlePressType) => {
+    const isPressTypeIn = pressType === 'in';
     if (dark && isAdaptiveMode) {
       Animated.timing(elevationDarkAdaptive, {
-        toValue: 8,
+        toValue: isPressTypeIn ? 8 : cardElevation,
         duration: animationDuration,
         useNativeDriver: false,
       }).start();
     } else {
       Animated.timing(elevation, {
-        toValue: 8,
+        toValue: isPressTypeIn ? 8 : cardElevation,
         duration: animationDuration,
         useNativeDriver: true,
       }).start();
     }
   };
 
+  const handlePressIn = () => {
+    runElevationAnimation('in');
+  };
+
   const handlePressOut = () => {
-    if (dark && isAdaptiveMode) {
-      Animated.timing(elevationDarkAdaptive, {
-        // @ts-ignore
-        toValue: cardElevation,
-        duration: animationDuration,
-        useNativeDriver: false,
-      }).start();
-    } else {
-      Animated.timing(elevation, {
-        // @ts-ignore
-        toValue: cardElevation,
-        duration: animationDuration,
-        useNativeDriver: true,
-      }).start();
-    }
+    runElevationAnimation('out');
   };
 
   const total = React.Children.count(children);

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -111,30 +111,78 @@ const Card = ({
   accessible,
   ...rest
 }: (OutlinedCardProps | ElevatedCardProps) & Props) => {
+  // Default animated value
   const { current: elevation } = React.useRef<Animated.Value>(
+    new Animated.Value(cardElevation)
+  );
+  // Dark adaptive animated value, used in case of toggling the theme,
+  // it prevents animating the background with native drivers inside Surface
+  const { current: elevationDarkAdaptive } = React.useRef<Animated.Value>(
     new Animated.Value(cardElevation)
   );
   const { animation, dark, mode, roundness } = theme;
 
+  const prevDarkRef = React.useRef<boolean>(dark);
+  React.useEffect(() => {
+    prevDarkRef.current = dark;
+  });
+
+  const prevDark = prevDarkRef.current;
+  const isAdaptiveMode = mode === 'adaptive';
+  const animationDuration = 150 * animation.scale;
+
+  React.useEffect(() => {
+    /**
+     * Resets animations values if updating to dark adaptive mode,
+     * otherwise, any card that is in the middle of animation while
+     * toggling the theme will stay at that animated value until
+     * the next press-in
+     */
+    if (dark && isAdaptiveMode && !prevDark) {
+      elevation.setValue(cardElevation);
+      elevationDarkAdaptive.setValue(cardElevation);
+    }
+  }, [
+    prevDark,
+    dark,
+    isAdaptiveMode,
+    cardElevation,
+    elevation,
+    elevationDarkAdaptive,
+  ]);
+
   const handlePressIn = () => {
-    const {
-      dark,
-      mode,
-      animation: { scale },
-    } = theme;
-    Animated.timing(elevation, {
-      toValue: 8,
-      duration: 150 * scale,
-      useNativeDriver: !dark || mode === 'exact',
-    }).start();
+    if (dark && isAdaptiveMode) {
+      Animated.timing(elevationDarkAdaptive, {
+        toValue: 8,
+        duration: animationDuration,
+        useNativeDriver: false,
+      }).start();
+    } else {
+      Animated.timing(elevation, {
+        toValue: 8,
+        duration: animationDuration,
+        useNativeDriver: true,
+      }).start();
+    }
   };
 
   const handlePressOut = () => {
-    Animated.timing(elevation, {
-      toValue: cardElevation,
-      duration: 150 * animation.scale,
-      useNativeDriver: !dark || mode === 'exact',
-    }).start();
+    if (dark && isAdaptiveMode) {
+      Animated.timing(elevationDarkAdaptive, {
+        // @ts-ignore
+        toValue: cardElevation,
+        duration: animationDuration,
+        useNativeDriver: false,
+      }).start();
+    } else {
+      Animated.timing(elevation, {
+        // @ts-ignore
+        toValue: cardElevation,
+        duration: animationDuration,
+        useNativeDriver: true,
+      }).start();
+    }
   };
 
   const total = React.Children.count(children);
@@ -143,15 +191,17 @@ const Card = ({
       ? (child.type as any).displayName
       : null
   );
-  const borderColor = color(theme.dark ? white : black)
+  const borderColor = color(dark ? white : black)
     .alpha(0.12)
     .rgb()
     .string();
+  const computedElevation =
+    dark && isAdaptiveMode ? elevationDarkAdaptive : elevation;
 
   return (
     <Surface
       style={[
-        { borderRadius: roundness, elevation, borderColor },
+        { borderRadius: roundness, elevation: computedElevation, borderColor },
         cardMode === 'outlined' ? styles.outlined : {},
         style,
       ]}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->
Refreshing the [PR](https://github.com/callstack/react-native-paper/pull/2113) made by @PedroBern fixing the `Card` issue: https://github.com/callstack/react-native-paper/issues/3009
### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

1. Open the example app
2. Go to card examples
3. Scroll to card which switching the theme on pressing it
4. Press it
5. Expect: app mustn't crash

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
