### PR TITLE
fix: cleanup modal backhandler listener on unmount

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -148,13 +148,16 @@ export default function Modal({
     }).start();
   };
 
-  const hideModal = () => {
+  const removeListeners = () => {
     if (subscription.current?.remove) {
       subscription.current?.remove();
     } else {
       BackHandler.removeEventListener('hardwareBackPress', handleBack);
     }
+  }
 
+  const hideModal = () => {
+    removeListeners();
     const { scale } = animation;
 
     Animated.timing(opacity, {
@@ -191,6 +194,10 @@ export default function Modal({
     }
     prevVisible.current = visible;
   });
+
+  React.useEffect(() => {
+    return removeListeners;
+  }, []);
 
   if (!rendered) return null;
 

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -154,7 +154,7 @@ export default function Modal({
     } else {
       BackHandler.removeEventListener('hardwareBackPress', handleBack);
     }
-  }
+  };
 
   const hideModal = () => {
     removeListeners();


### PR DESCRIPTION
### Summary

If a modal is getting unmounted and the visible prop is not changed to false beforehand, the hardwareBackPress listener is not getting removed.
This bug was introduced in version 3.10.0, when the change to the functional component happened (#2557). 

### Test plan

1. Show the modal
2. Unmount component
3. The hardwareBackPress is still listening, you can add another hardwareBackPress listener in your parent component to see if it is getting called.
