### PR TITLE
Fix: Updated documentation for Webpack 5

### DIFF
--- a/docs/pages/5.react-native-web.md
+++ b/docs/pages/5.react-native-web.md
@@ -200,7 +200,9 @@ Now, add the following in the `module.rules` array in your webpack config:
 },
 ```
 
-### 3. Configure `file-loader` (Webpack < 5)
+### 3. Configure `file-loader`
+
+#### webpack < 5.0
 
 To be able to import images and other assets using `require`, we need to configure `file-loader`. Let's install it:
 

--- a/docs/pages/5.react-native-web.md
+++ b/docs/pages/5.react-native-web.md
@@ -200,7 +200,7 @@ Now, add the following in the `module.rules` array in your webpack config:
 },
 ```
 
-### 3. Configure `file-loader`
+### 3. Configure `file-loader` (Webpack < 5)
 
 To be able to import images and other assets using `require`, we need to configure `file-loader`. Let's install it:
 
@@ -214,6 +214,17 @@ To configure it, add the following in the `module.rules` array in your webpack c
 {
   test: /\.(jpg|png|woff|woff2|eot|ttf|svg)$/,
   loader: 'file-loader',
+}
+```
+
+### 3.bis Or if you use webpack >= 5
+
+Then it is not necessary to install the `file-loader`
+
+```js
+{
+  test: /\.(jpg|png|woff|woff2|eot|ttf|svg)$/,
+  type: 'asset/resource'
 }
 ```
 

--- a/docs/pages/5.react-native-web.md
+++ b/docs/pages/5.react-native-web.md
@@ -219,16 +219,15 @@ To configure it, add the following in the `module.rules` array in your webpack c
 }
 ```
 
-### 3.bis Or if you use webpack >= 5
+##### webpack >= 5.0
 
-Then it is not necessary to install the `file-loader`
+Use `asset/resource`, since `file-loader` was deprecated in webpack v5.
 
 ```js
 {
   test: /\.(jpg|png|woff|woff2|eot|ttf|svg)$/,
   type: 'asset/resource'
 }
-```
 
 ## Load the Material Community Icons
 

--- a/docs/pages/5.react-native-web.md
+++ b/docs/pages/5.react-native-web.md
@@ -228,6 +228,7 @@ Use `asset/resource`, since `file-loader` was deprecated in webpack v5.
   test: /\.(jpg|png|woff|woff2|eot|ttf|svg)$/,
   type: 'asset/resource'
 }
+```
 
 ## Load the Material Community Icons
 


### PR DESCRIPTION
### Summary
file-loader is deprecated in Webpack 5 and outputs loader files as JS modules
Using the new Webpack 5 [asset modules](https://webpack.js.org/guides/asset-modules/) feature did the trick
