### PR TITLE
feat: replace old variable references

### DIFF
--- a/example/src/DrawerItems.tsx
+++ b/example/src/DrawerItems.tsx
@@ -54,7 +54,7 @@ const DrawerItems = ({ toggleTheme, toggleRTL, isRTL, isDarkTheme }: Props) => {
   return (
     <DrawerContentScrollView
       alwaysBounceVertical={false}
-      style={[styles.drawerContent, { backgroundColor: colors.surface }]}
+      style={[styles.drawerContent, { backgroundColor: colors?.surface }]}
     >
       <Drawer.Section title="Example items">
         {DrawerItemsData.map((props, index) => (

--- a/example/src/ExampleList.tsx
+++ b/example/src/ExampleList.tsx
@@ -108,7 +108,7 @@ export default function ExampleList({ navigation }: Props) {
   return (
     <FlatList
       contentContainerStyle={{
-        backgroundColor: colors.background,
+        backgroundColor: colors?.background,
         paddingBottom: safeArea.bottom,
         paddingLeft: safeArea.left,
         paddingRight: safeArea.right,

--- a/example/src/Examples/AnimatedFABExample/AnimatedFABExample.tsx
+++ b/example/src/Examples/AnimatedFABExample/AnimatedFABExample.tsx
@@ -23,9 +23,7 @@ type Item = {
 };
 
 const AnimatedFABExample = () => {
-  const {
-    colors: { background },
-  } = useTheme();
+  const { colors } = useTheme();
 
   const isIOS = Platform.OS === 'ios';
 
@@ -117,10 +115,10 @@ const AnimatedFABExample = () => {
         keyExtractor={_keyExtractor}
         onEndReachedThreshold={0}
         scrollEventThrottle={16}
-        style={[styles.flex, { backgroundColor: background }]}
+        style={[styles.flex, { backgroundColor: colors?.background || '#000' }]}
         contentContainerStyle={[
           styles.container,
-          { backgroundColor: background },
+          { backgroundColor: colors?.background || '#000' },
         ]}
         onScroll={onScroll}
       />

--- a/example/src/Examples/BannerExample.tsx
+++ b/example/src/Examples/BannerExample.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { View, StyleSheet, Image, Dimensions, Platform } from 'react-native';
-import { Banner, FAB, useTheme } from 'react-native-paper';
+import { Banner, FAB, useTheme, Theme } from 'react-native-paper';
 import ScreenWrapper from '../ScreenWrapper';
 
 const PHOTOS = Array.from({ length: 24 }).map(
@@ -18,7 +18,7 @@ const BannerExample = () => {
       surface: '#09c8e5',
       primary: '#121330',
     },
-  };
+  } as Theme;
 
   return (
     <>

--- a/example/src/Examples/ButtonExample.tsx
+++ b/example/src/Examples/ButtonExample.tsx
@@ -14,7 +14,7 @@ const ButtonExample = () => {
             Default
           </Button>
           <Button
-            color={colors.accent}
+            color={colors?.accent}
             onPress={() => {}}
             style={styles.button}
           >
@@ -46,7 +46,7 @@ const ButtonExample = () => {
           </Button>
           <Button
             mode="outlined"
-            color={colors.accent}
+            color={colors?.accent}
             onPress={() => {}}
             style={styles.button}
           >
@@ -94,7 +94,7 @@ const ButtonExample = () => {
           </Button>
           <Button
             mode="contained"
-            color={colors.accent}
+            color={colors?.accent}
             onPress={() => {}}
             style={styles.button}
           >

--- a/example/src/Examples/CardExample.tsx
+++ b/example/src/Examples/CardExample.tsx
@@ -14,9 +14,7 @@ import { PreferencesContext } from '..';
 import ScreenWrapper from '../ScreenWrapper';
 
 const CardExample = () => {
-  const {
-    colors: { background },
-  } = useTheme();
+  const { colors } = useTheme();
   const [isOutlined, setIsOutlined] = React.useState(false);
   const mode = isOutlined ? 'outlined' : 'elevated';
 
@@ -34,7 +32,7 @@ const CardExample = () => {
         />
       </View>
       <ScrollView
-        style={[styles.container, { backgroundColor: background }]}
+        style={[styles.container, { backgroundColor: colors?.background }]}
         contentContainerStyle={styles.content}
       >
         <Card style={styles.card} mode={mode}>

--- a/example/src/Examples/ChipExample.tsx
+++ b/example/src/Examples/ChipExample.tsx
@@ -146,20 +146,20 @@ const ChipExample = () => {
               style={[
                 styles.chip,
                 {
-                  backgroundColor: color(colors.primary)
+                  backgroundColor: color(colors?.primary)
                     .alpha(0.2)
                     .rgb()
                     .string(),
                 },
               ]}
-              selectedColor={colors.primary}
+              selectedColor={colors?.primary}
             >
               Flat selected chip with custom color
             </Chip>
             <Chip
               onPress={() => {}}
               style={styles.chip}
-              selectedColor={colors.primary}
+              selectedColor={colors?.primary}
             >
               Flat unselected chip with custom color
             </Chip>
@@ -170,13 +170,13 @@ const ChipExample = () => {
               style={[
                 styles.chip,
                 {
-                  backgroundColor: color(colors.primary)
+                  backgroundColor: color(colors?.primary)
                     .alpha(0.2)
                     .rgb()
                     .string(),
                 },
               ]}
-              selectedColor={colors.primary}
+              selectedColor={colors?.primary}
             >
               Outlined selected chip with custom color
             </Chip>
@@ -184,7 +184,7 @@ const ChipExample = () => {
               mode="outlined"
               onPress={() => {}}
               style={styles.chip}
-              selectedColor={colors.primary}
+              selectedColor={colors?.primary}
             >
               Outlined unselected chip with custom color
             </Chip>

--- a/example/src/Examples/DividerExample.tsx
+++ b/example/src/Examples/DividerExample.tsx
@@ -6,14 +6,12 @@ import ScreenWrapper from '../ScreenWrapper';
 const items = ['Apple', 'Banana', 'Coconut', 'Lemon', 'Mango', 'Peach'];
 
 const DividerExample = () => {
-  const {
-    colors: { background },
-  } = useTheme();
+  const { colors } = useTheme();
 
   return (
     <ScreenWrapper withScrollView={false}>
       <FlatList
-        style={{ backgroundColor: background }}
+        style={{ backgroundColor: colors?.background }}
         renderItem={({ item }) => <List.Item title={item} />}
         keyExtractor={(item) => item}
         ItemSeparatorComponent={Divider}

--- a/example/src/Examples/RadioButtonGroupExample.tsx
+++ b/example/src/Examples/RadioButtonGroupExample.tsx
@@ -7,9 +7,7 @@ const RadioButtonGroupExample = () => {
   const [value, setValue] = React.useState<string>('first');
   const [value2, setValue2] = React.useState<string>('first');
 
-  const {
-    colors: { primary },
-  } = useTheme();
+  const { colors } = useTheme();
   return (
     <ScreenWrapper>
       <List.Section title="With RadioButton">
@@ -41,7 +39,7 @@ const RadioButtonGroupExample = () => {
           <RadioButton.Item
             label="Third item"
             value="third"
-            labelStyle={{ color: primary }}
+            labelStyle={{ color: colors?.primary }}
           />
         </RadioButton.Group>
       </List.Section>

--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -108,9 +108,7 @@ const TextInputExample = () => {
 
   const _isUsernameValid = (name: string) => /^[a-zA-Z]*$/.test(name);
 
-  const {
-    colors: { accent, primary },
-  } = useTheme();
+  const { colors } = useTheme();
 
   const inputActionHandler = (type: keyof State, payload: string) =>
     dispatch({
@@ -121,14 +119,14 @@ const TextInputExample = () => {
   const changeIconColor = (name: keyof State['iconsColor']) => {
     const color = state.iconsColor[name];
 
-    const colors = {
+    const newColors = {
       ...state.iconsColor,
-      [name]: !color ? accent : undefined,
+      [name]: !color ? colors?.accent : undefined,
     };
 
     dispatch({
       type: 'iconsColor',
-      payload: colors,
+      payload: newColors,
     });
   };
 
@@ -232,7 +230,7 @@ const TextInputExample = () => {
           right={
             <TextInput.Icon
               name="chevron-up"
-              color={(focused) => (focused ? primary : undefined)}
+              color={(focused) => (focused ? colors?.primary : undefined)}
             />
           }
         />

--- a/example/src/ScreenWrapper.tsx
+++ b/example/src/ScreenWrapper.tsx
@@ -24,16 +24,14 @@ export default function ScreenWrapper({
   contentContainerStyle,
   ...rest
 }: Props) {
-  const {
-    colors: { background },
-  } = useTheme();
+  const { colors } = useTheme();
 
   const insets = useSafeAreaInsets();
 
   const containerStyle = [
     styles.container,
     {
-      backgroundColor: background,
+      backgroundColor: colors?.background,
       paddingBottom: insets.bottom,
       paddingLeft: insets.left,
       paddingRight: insets.left,

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -10,6 +10,7 @@ import {
   Provider as PaperProvider,
   DarkTheme,
   DefaultTheme,
+  Theme,
 } from 'react-native-paper';
 import App from './RootNavigator';
 import DrawerItems from './DrawerItems';
@@ -27,16 +28,13 @@ declare global {
     interface ThemeAnimation {
       customProperty: number;
     }
-    interface Theme {
-      userDefinedThemeProperty: string;
-    }
   }
 }
 
 const PERSISTENCE_KEY = 'NAVIGATION_STATE';
 const PREFERENCES_KEY = 'APP_PREFERENCES';
 
-const CustomDarkTheme: ReactNativePaper.Theme = {
+const CustomDarkTheme = {
   ...DarkTheme,
   colors: {
     ...DarkTheme.colors,
@@ -46,7 +44,6 @@ const CustomDarkTheme: ReactNativePaper.Theme = {
     ...DarkTheme.fonts,
     superLight: { ...DarkTheme.fonts['light'] },
   },
-  userDefinedThemeProperty: '',
   animation: {
     ...DarkTheme.animation,
     customProperty: 1,
@@ -97,8 +94,7 @@ export default function PaperExample() {
     InitialState | undefined
   >();
 
-  const [theme, setTheme] =
-    React.useState<ReactNativePaper.Theme>(CustomDefaultTheme);
+  const [theme, setTheme] = React.useState<Theme>(CustomDefaultTheme);
   const [rtl, setRtl] = React.useState<boolean>(I18nManager.isRTL);
 
   React.useEffect(() => {

--- a/src/babel/__fixtures__/rewrite-imports/output.js
+++ b/src/babel/__fixtures__/rewrite-imports/output.js
@@ -6,6 +6,7 @@ import Button from "react-native-paper/lib/module/components/Button";
 import FAB from "react-native-paper/lib/module/components/FAB";
 import Appbar from "react-native-paper/lib/module/components/Appbar";
 import * as Colors from "react-native-paper/lib/module/styles/themes/v2/colors";
-import { NonExistent, NonExistentSecond as Stuff, Theme } from "react-native-paper/lib/module/index.js";
+import { NonExistent, NonExistentSecond as Stuff } from "react-native-paper/lib/module/index.js";
 import { ThemeProvider } from "react-native-paper/lib/module/core/theming";
 import { withTheme } from "react-native-paper/lib/module/core/theming";
+import { Theme } from "react-native-paper/lib/module/types";

--- a/src/components/ActivityIndicator.tsx
+++ b/src/components/ActivityIndicator.tsx
@@ -8,6 +8,7 @@ import {
   View,
   ViewStyle,
 } from 'react-native';
+import type { Theme } from '../types';
 import { withTheme } from '../core/theming';
 
 type Props = React.ComponentPropsWithRef<typeof View> & {
@@ -31,7 +32,7 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 const DURATION = 2400;

--- a/src/components/ActivityIndicator.tsx
+++ b/src/components/ActivityIndicator.tsx
@@ -132,7 +132,7 @@ const ActivityIndicator = ({
     }
   }, [animating, fade, hidesWhenStopped, startRotation, scale, timer]);
 
-  const color = indicatorColor || theme.colors.primary;
+  const color = indicatorColor || theme.colors?.primary;
   const size =
     typeof indicatorSize === 'string'
       ? indicatorSize === 'small'

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -87,8 +87,8 @@ const Appbar = ({ children, dark, style, theme, ...rest }: Props) => {
   const backgroundColor = customBackground
     ? customBackground
     : isDarkTheme && mode === 'adaptive'
-    ? overlay(elevation, colors.surface)
-    : colors.primary;
+    ? overlay(elevation, colors?.surface)
+    : colors?.primary;
   if (typeof dark === 'boolean') {
     isDark = dark;
   } else {

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -9,6 +9,7 @@ import Surface from '../Surface';
 import { withTheme } from '../../core/theming';
 import { black, white } from '../../styles/themes/v2/colors';
 import overlay from '../../styles/overlay';
+import type { Theme } from '../../types';
 
 type Props = Partial<React.ComponentPropsWithRef<typeof View>> & {
   /**
@@ -22,7 +23,7 @@ type Props = Partial<React.ComponentPropsWithRef<typeof View>> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   style?: StyleProp<ViewStyle>;
 };
 

--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -15,7 +15,7 @@ import Text from '../Typography/Text';
 import { withTheme } from '../../core/theming';
 import { white } from '../../styles/themes/v2/colors';
 
-import type { $RemoveChildren } from '../../types';
+import type { $RemoveChildren, Theme } from '../../types';
 
 type Props = $RemoveChildren<typeof View> & {
   /**
@@ -50,7 +50,7 @@ type Props = $RemoveChildren<typeof View> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 /**

--- a/src/components/Appbar/AppbarHeader.tsx
+++ b/src/components/Appbar/AppbarHeader.tsx
@@ -11,6 +11,7 @@ import { DEFAULT_APPBAR_HEIGHT, Appbar } from './Appbar';
 import shadow from '../../styles/shadow';
 import { withTheme } from '../../core/theming';
 import { APPROX_STATUSBAR_HEIGHT } from '../../constants';
+import type { Theme } from '../../types';
 
 type Props = React.ComponentProps<typeof Appbar> & {
   /**
@@ -31,7 +32,7 @@ type Props = React.ComponentProps<typeof Appbar> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   style?: StyleProp<ViewStyle>;
 };
 

--- a/src/components/Appbar/AppbarHeader.tsx
+++ b/src/components/Appbar/AppbarHeader.tsx
@@ -96,8 +96,8 @@ const AppbarHeader = (props: Props) => {
   const backgroundColor = customBackground
     ? customBackground
     : isDarkTheme && mode === 'adaptive'
-    ? overlay(elevation, colors.surface)
-    : colors.primary;
+    ? overlay(elevation, colors?.surface)
+    : colors?.primary;
   // Let the user override the behaviour
   const Wrapper =
     typeof props.statusBarHeight === 'number' ? View : SafeAreaView;

--- a/src/components/Avatar/AvatarIcon.tsx
+++ b/src/components/Avatar/AvatarIcon.tsx
@@ -4,6 +4,7 @@ import Icon, { IconSource } from '../Icon';
 import { withTheme } from '../../core/theming';
 import { white } from '../../styles/themes/v2/colors';
 import getContrastingColor from '../../utils/getContrastingColor';
+import type { Theme } from '../../types';
 
 const defaultSize = 64;
 
@@ -24,7 +25,7 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 /**

--- a/src/components/Avatar/AvatarIcon.tsx
+++ b/src/components/Avatar/AvatarIcon.tsx
@@ -48,11 +48,11 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
  * ```
  */
 const Avatar = ({ icon, size = defaultSize, style, theme, ...rest }: Props) => {
-  const { backgroundColor = theme.colors.primary, ...restStyle } =
+  const { backgroundColor = theme.colors?.primary, ...restStyle } =
     StyleSheet.flatten(style) || {};
   const textColor =
     rest.color ??
-    getContrastingColor(backgroundColor, white, 'rgba(0, 0, 0, .54)');
+    getContrastingColor(backgroundColor || white, white, 'rgba(0, 0, 0, .54)');
 
   return (
     <View

--- a/src/components/Avatar/AvatarImage.tsx
+++ b/src/components/Avatar/AvatarImage.tsx
@@ -94,7 +94,7 @@ const AvatarImage = ({
 }: Props) => {
   const { colors } = theme;
 
-  const { backgroundColor = colors.primary } = StyleSheet.flatten(style) || {};
+  const { backgroundColor = colors?.primary } = StyleSheet.flatten(style) || {};
 
   return (
     <View

--- a/src/components/Avatar/AvatarImage.tsx
+++ b/src/components/Avatar/AvatarImage.tsx
@@ -9,6 +9,7 @@ import {
   StyleProp,
 } from 'react-native';
 import { withTheme } from '../../core/theming';
+import type { Theme } from '../../types';
 
 const defaultSize = 64;
 
@@ -55,7 +56,7 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 /**

--- a/src/components/Avatar/AvatarText.tsx
+++ b/src/components/Avatar/AvatarText.tsx
@@ -10,6 +10,7 @@ import Text from '../Typography/Text';
 import { withTheme } from '../../core/theming';
 import { white } from '../../styles/themes/v2/colors';
 import getContrastingColor from '../../utils/getContrastingColor';
+import type { Theme } from '../../types';
 
 const defaultSize = 64;
 
@@ -37,7 +38,7 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 /**

--- a/src/components/Avatar/AvatarText.tsx
+++ b/src/components/Avatar/AvatarText.tsx
@@ -69,11 +69,11 @@ const AvatarText = ({
   color: customColor,
   ...rest
 }: Props) => {
-  const { backgroundColor = theme.colors.primary, ...restStyle } =
+  const { backgroundColor = theme.colors?.primary, ...restStyle } =
     StyleSheet.flatten(style) || {};
   const textColor =
     customColor ??
-    getContrastingColor(backgroundColor, white, 'rgba(0, 0, 0, .54)');
+    getContrastingColor(backgroundColor || white, white, 'rgba(0, 0, 0, .54)');
 
   return (
     <View

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -3,6 +3,7 @@ import { Animated, StyleSheet, StyleProp, TextStyle } from 'react-native';
 import { white, black } from '../styles/themes/v2/colors';
 import { withTheme } from '../core/theming';
 import getContrastingColor from '../utils/getContrastingColor';
+import type { Theme } from '../types';
 
 const defaultSize = 20;
 
@@ -24,7 +25,7 @@ type Props = React.ComponentProps<typeof Animated.Text> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 /**

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -86,10 +86,10 @@ const Badge = ({
     }).start();
   }, [visible, opacity, scale]);
 
-  const { backgroundColor = theme.colors.notification, ...restStyle } =
+  const { backgroundColor = theme.colors?.notification, ...restStyle } =
     (StyleSheet.flatten(style) || {}) as TextStyle;
 
-  const textColor = getContrastingColor(backgroundColor, white, black);
+  const textColor = getContrastingColor(backgroundColor || white, white, black);
 
   const borderRadius = size / 2;
 

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -212,7 +212,7 @@ const Banner = ({
               </View>
             ) : null}
             <Text
-              style={[styles.message, { color: theme.colors.text }]}
+              style={[styles.message, { color: theme.colors?.text }]}
               accessibilityLiveRegion={visible ? 'polite' : 'none'}
               accessibilityRole="alert"
             >
@@ -226,7 +226,7 @@ const Banner = ({
                 compact
                 mode="text"
                 style={styles.button}
-                color={theme.colors.primary}
+                color={theme.colors?.primary}
                 {...others}
               >
                 {label}

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -5,7 +5,7 @@ import Text from './Typography/Text';
 import Button from './Button';
 import Icon, { IconSource } from './Icon';
 import { withTheme } from '../core/theming';
-import type { $RemoveChildren } from '../types';
+import type { $RemoveChildren, Theme } from '../types';
 import shadow from '../styles/shadow';
 
 const ELEVATION = 1;
@@ -48,7 +48,7 @@ type Props = $RemoveChildren<typeof Surface> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   /**
    * @optional
    * Optional callback that will be called after the opening animation finished running normally

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -379,7 +379,7 @@ const BottomNavigation = ({
 
   /**
    * Index of the currently active tab. Used for setting the background color.
-   * We don't use the color as an animated value directly, because `setValue` seems to be buggy with colors.
+   * We don't use the color as an animated value directly, because `setValue` seems to be buggy with colors?.
    */
   const indexAnim = useAnimatedValue(navigationState.index);
 
@@ -545,8 +545,8 @@ const BottomNavigation = ({
   const approxBackgroundColor = customBackground
     ? customBackground
     : isDarkTheme && mode === 'adaptive'
-    ? overlay(elevation, colors.surface)
-    : colors.primary;
+    ? overlay(elevation, colors?.surface)
+    : colors?.primary;
 
   const backgroundColor = shifting
     ? indexAnim.interpolate({
@@ -593,7 +593,7 @@ const BottomNavigation = ({
 
   return (
     <View style={[styles.container, style]}>
-      <View style={[styles.content, { backgroundColor: colors.background }]}>
+      <View style={[styles.content, { backgroundColor: colors?.background }]}>
         {routes.map((route, index) => {
           if (!loaded.includes(route.key)) {
             // Don't render a screen if we've never navigated to it
@@ -744,7 +744,7 @@ const BottomNavigation = ({
                 : 7;
 
               // We render the active icon and label on top of inactive ones and cross-fade them on change.
-              // This trick gives the illusion that we are animating between active and inactive colors.
+              // This trick gives the illusion that we are animating between active and inactive colors?.
               // This is to ensure that we can use native driver, as colors cannot be animated with native driver.
               const activeOpacity = active;
               const inactiveOpacity = active.interpolate({

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -744,7 +744,7 @@ const BottomNavigation = ({
                 : 7;
 
               // We render the active icon and label on top of inactive ones and cross-fade them on change.
-              // This trick gives the illusion that we are animating between active and inactive colors?.
+              // This trick gives the illusion that we are animating between active and inactive colors.
               // This is to ensure that we can use native driver, as colors cannot be animated with native driver.
               const activeOpacity = active;
               const inactiveOpacity = active.interpolate({

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -24,6 +24,7 @@ import useAnimatedValueArray from '../../utils/useAnimatedValueArray';
 import useLayout from '../../utils/useLayout';
 import useIsKeyboardShown from '../../utils/useIsKeyboardShown';
 import BottomNavigationRouteScreen from './BottomNavigationRouteScreen';
+import type { Theme } from '../../types';
 
 type Route = {
   key: string;
@@ -230,7 +231,7 @@ type Props = {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 const MIN_RIPPLE_SCALE = 0.001; // Minimum scale is not 0 due to bug with animation

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -194,7 +194,7 @@ const Button = ({
     } else if (buttonColor) {
       backgroundColor = buttonColor;
     } else {
-      backgroundColor = colors.primary;
+      backgroundColor = colors?.primary || white;
     }
   } else {
     backgroundColor = 'transparent';
@@ -232,7 +232,7 @@ const Button = ({
   } else if (buttonColor) {
     textColor = buttonColor;
   } else {
-    textColor = colors.primary;
+    textColor = colors?.primary || black;
   }
 
   const rippleColor = color(textColor).alpha(0.32).rgb().string();

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -16,6 +16,7 @@ import Text from './Typography/Text';
 import TouchableRipple from './TouchableRipple/TouchableRipple';
 import { black, white } from '../styles/themes/v2/colors';
 import { withTheme } from '../core/theming';
+import type { Theme } from '../types';
 
 type Props = React.ComponentProps<typeof Surface> & {
   /**
@@ -86,7 +87,7 @@ type Props = React.ComponentProps<typeof Surface> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   /**
    * testID to be used on tests.
    */

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -17,6 +17,7 @@ import CardCover, { CardCover as _CardCover } from './CardCover';
 import CardTitle, { CardTitle as _CardTitle } from './CardTitle';
 import Surface from '../Surface';
 import { withTheme } from '../../core/theming';
+import type { Theme } from '../../types';
 
 type OutlinedCardProps = {
   mode: 'outlined';
@@ -57,7 +58,7 @@ type Props = React.ComponentProps<typeof Surface> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   /**
    * Pass down testID from card props to touchable
    */

--- a/src/components/Card/CardCover.tsx
+++ b/src/components/Card/CardCover.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { StyleSheet, View, ViewStyle, Image, StyleProp } from 'react-native';
 import { withTheme } from '../../core/theming';
 import { grey200 } from '../../styles/themes/v2/colors';
+import type { Theme } from '../../types';
 
 type Props = React.ComponentPropsWithRef<typeof Image> & {
   /**
@@ -16,7 +17,7 @@ type Props = React.ComponentPropsWithRef<typeof Image> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 /**

--- a/src/components/Card/CardTitle.tsx
+++ b/src/components/Card/CardTitle.tsx
@@ -10,6 +10,7 @@ import {
 import { withTheme } from '../../core/theming';
 import Caption from './../Typography/Caption';
 import Title from './../Typography/Title';
+import type { Theme } from '../../types';
 
 type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
@@ -64,7 +65,7 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 const LEFT_SIZE = 40;

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -3,6 +3,7 @@ import { Platform } from 'react-native';
 import CheckboxIOS from './CheckboxIOS';
 import CheckboxAndroid from './CheckboxAndroid';
 import { withTheme } from '../../core/theming';
+import type { Theme } from '../../types';
 
 type Props = {
   /**
@@ -28,7 +29,7 @@ type Props = {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   /**
    * testID to be used on tests.
    */

--- a/src/components/Checkbox/CheckboxAndroid.tsx
+++ b/src/components/Checkbox/CheckboxAndroid.tsx
@@ -4,7 +4,7 @@ import color from 'color';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { withTheme } from '../../core/theming';
-import type { $RemoveChildren } from '../../types';
+import type { $RemoveChildren, Theme } from '../../types';
 
 type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
@@ -30,7 +30,7 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   /**
    * testID to be used on tests.
    */

--- a/src/components/Checkbox/CheckboxAndroid.tsx
+++ b/src/components/Checkbox/CheckboxAndroid.tsx
@@ -5,6 +5,7 @@ import MaterialCommunityIcon from '../MaterialCommunityIcon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { withTheme } from '../../core/theming';
 import type { $RemoveChildren, Theme } from '../../types';
+import { white } from '../../styles/themes/v2/colors';
 
 type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
@@ -100,10 +101,10 @@ const CheckboxAndroid = ({
 
   const checked = status === 'checked';
   const indeterminate = status === 'indeterminate';
-  const checkedColor = rest.color || theme.colors.accent;
+  const checkedColor = rest.color || theme.colors?.accent;
   const uncheckedColor =
     rest.uncheckedColor ||
-    color(theme.colors.text)
+    color(theme.colors?.text)
       .alpha(theme.dark ? 0.7 : 0.54)
       .rgb()
       .string();
@@ -111,8 +112,8 @@ const CheckboxAndroid = ({
   let rippleColor, checkboxColor;
 
   if (disabled) {
-    rippleColor = color(theme.colors.text).alpha(0.16).rgb().string();
-    checkboxColor = theme.colors.disabled;
+    rippleColor = color(theme.colors?.text).alpha(0.16).rgb().string();
+    checkboxColor = theme.colors?.disabled;
   } else {
     rippleColor = color(checkedColor).fade(0.32).rgb().string();
     checkboxColor = checked ? checkedColor : uncheckedColor;
@@ -150,7 +151,7 @@ const CheckboxAndroid = ({
           allowFontScaling={false}
           name={icon}
           size={24}
-          color={checkboxColor}
+          color={checkboxColor || white}
           direction="ltr"
         />
         <View style={[StyleSheet.absoluteFill, styles.fillContainer]}>

--- a/src/components/Checkbox/CheckboxIOS.tsx
+++ b/src/components/Checkbox/CheckboxIOS.tsx
@@ -4,7 +4,7 @@ import color from 'color';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { withTheme } from '../../core/theming';
-import type { $RemoveChildren } from '../../types';
+import type { $RemoveChildren, Theme } from '../../types';
 
 type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
@@ -26,7 +26,7 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   /**
    * testID to be used on tests.
    */

--- a/src/components/Checkbox/CheckboxIOS.tsx
+++ b/src/components/Checkbox/CheckboxIOS.tsx
@@ -5,6 +5,7 @@ import MaterialCommunityIcon from '../MaterialCommunityIcon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { withTheme } from '../../core/theming';
 import type { $RemoveChildren, Theme } from '../../types';
+import { black } from '../../styles/themes/v2/colors';
 
 type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
@@ -61,13 +62,13 @@ const CheckboxIOS = ({
   const indeterminate = status === 'indeterminate';
 
   const checkedColor = disabled
-    ? theme.colors.disabled
-    : rest.color || theme.colors.accent;
+    ? theme.colors?.disabled
+    : rest.color || theme.colors?.accent;
 
   let rippleColor;
 
   if (disabled) {
-    rippleColor = color(theme.colors.text).alpha(0.16).rgb().string();
+    rippleColor = color(theme.colors?.text).alpha(0.16).rgb().string();
   } else {
     rippleColor = color(checkedColor).fade(0.32).rgb().string();
   }
@@ -95,7 +96,7 @@ const CheckboxIOS = ({
           allowFontScaling={false}
           name={icon}
           size={24}
-          color={checkedColor}
+          color={checkedColor || black}
           direction="ltr"
         />
       </View>

--- a/src/components/Checkbox/CheckboxItem.tsx
+++ b/src/components/Checkbox/CheckboxItem.tsx
@@ -14,6 +14,7 @@ import CheckboxIOS from './CheckboxIOS';
 import Text from '../Typography/Text';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { withTheme } from '../../core/theming';
+import type { Theme } from '../../types';
 
 type Props = {
   /**
@@ -51,7 +52,7 @@ type Props = {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   /**
    * testID to be used on tests.
    */

--- a/src/components/Checkbox/CheckboxItem.tsx
+++ b/src/components/Checkbox/CheckboxItem.tsx
@@ -131,7 +131,7 @@ const CheckboxItem = ({
           style={[
             styles.label,
             {
-              color: theme.colors.text,
+              color: theme.colors?.text,
               textAlign: isLeading ? 'right' : 'left',
             },
             labelStyle,

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -167,7 +167,7 @@ const Chip = ({
 
   const { dark, colors } = theme;
   const defaultBackgroundColor =
-    mode === 'outlined' ? colors.surface : dark ? '#383838' : '#ebebeb';
+    mode === 'outlined' ? colors?.surface : dark ? '#383838' : '#ebebeb';
 
   const { backgroundColor = defaultBackgroundColor, borderRadius = 16 } =
     (StyleSheet.flatten(style) || {}) as ViewStyle;
@@ -184,14 +184,14 @@ const Chip = ({
           .string()
       : backgroundColor;
   const textColor = disabled
-    ? colors.disabled
-    : color(selectedColor !== undefined ? selectedColor : colors.text)
+    ? colors?.disabled
+    : color(selectedColor !== undefined ? selectedColor : colors?.text)
         .alpha(0.87)
         .rgb()
         .string();
   const iconColor = disabled
-    ? colors.disabled
-    : color(selectedColor !== undefined ? selectedColor : colors.text)
+    ? colors?.disabled
+    : color(selectedColor !== undefined ? selectedColor : colors?.text)
         .alpha(0.54)
         .rgb()
         .string();

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -19,7 +19,7 @@ import Text from './Typography/Text';
 import TouchableRipple from './TouchableRipple/TouchableRipple';
 import { withTheme } from '../core/theming';
 import { black, white } from '../styles/themes/v2/colors';
-import type { EllipsizeProp } from '../types';
+import type { EllipsizeProp, Theme } from '../types';
 
 type Props = React.ComponentProps<typeof Surface> & {
   /**
@@ -85,7 +85,7 @@ type Props = React.ComponentProps<typeof Surface> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   /**
    * Pass down testID from chip props to touchable for Detox tests.
    */

--- a/src/components/CrossFadeIcon.tsx
+++ b/src/components/CrossFadeIcon.tsx
@@ -3,6 +3,7 @@ import { Animated, StyleSheet, View } from 'react-native';
 import Icon, { isValidIcon, IconSource, isEqualIcon } from './Icon';
 
 import { withTheme } from '../core/theming';
+import type { Theme } from '../types';
 
 type Props = {
   /**
@@ -20,7 +21,7 @@ type Props = {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 const CrossFadeIcon = ({ color, size, source, theme }: Props) => {

--- a/src/components/DataTable/DataTableHeader.tsx
+++ b/src/components/DataTable/DataTableHeader.tsx
@@ -3,6 +3,7 @@ import color from 'color';
 import { StyleSheet, StyleProp, View, ViewStyle } from 'react-native';
 import { black, white } from '../../styles/themes/v2/colors';
 import { withTheme } from '../../core/theming';
+import type { Theme } from '../../types';
 
 type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
@@ -13,7 +14,7 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 /**

--- a/src/components/DataTable/DataTablePagination.tsx
+++ b/src/components/DataTable/DataTablePagination.tsx
@@ -94,7 +94,7 @@ const PaginationControls = ({
               direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
             />
           )}
-          color={colors.text}
+          color={colors?.text}
           disabled={page === 0}
           onPress={() => onPageChange(0)}
           accessibilityLabel="page-first"
@@ -109,7 +109,7 @@ const PaginationControls = ({
             direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
           />
         )}
-        color={colors.text}
+        color={colors?.text}
         disabled={page === 0}
         onPress={() => onPageChange(page - 1)}
         accessibilityLabel="chevron-left"
@@ -123,7 +123,7 @@ const PaginationControls = ({
             direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
           />
         )}
-        color={colors.text}
+        color={colors?.text}
         disabled={numberOfPages === 0 || page === numberOfPages - 1}
         onPress={() => onPageChange(page + 1)}
         accessibilityLabel="chevron-right"
@@ -138,7 +138,7 @@ const PaginationControls = ({
               direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
             />
           )}
-          color={colors.text}
+          color={colors?.text}
           disabled={numberOfPages === 0 || page === numberOfPages - 1}
           onPress={() => onPageChange(numberOfPages - 1)}
           accessibilityLabel="page-last"
@@ -177,7 +177,7 @@ const PaginationDropdown = ({
           key={option}
           titleStyle={
             option === numberOfItemsPerPage && {
-              color: colors.primary,
+              color: colors?.primary,
             }
           }
           onPress={() => {
@@ -269,7 +269,7 @@ const DataTablePagination = ({
   selectPageDropdownAccessibilityLabel,
   ...rest
 }: Props) => {
-  const labelColor = color(theme.colors.text).alpha(0.6).rgb().string();
+  const labelColor = color(theme.colors?.text).alpha(0.6).rgb().string();
 
   return (
     <View

--- a/src/components/DataTable/DataTablePagination.tsx
+++ b/src/components/DataTable/DataTablePagination.tsx
@@ -13,6 +13,7 @@ import { withTheme, useTheme } from '../../core/theming';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
 import Menu from '../Menu/Menu';
 import Button from '../Button';
+import type { Theme } from '../../types';
 
 type Props = React.ComponentPropsWithRef<typeof View> &
   PaginationControlsProps &
@@ -37,7 +38,7 @@ type Props = React.ComponentPropsWithRef<typeof View> &
     /**
      * @optional
      */
-    theme: ReactNativePaper.Theme;
+    theme: Theme;
   };
 
 type PaginationDropdownProps = {

--- a/src/components/DataTable/DataTableRow.tsx
+++ b/src/components/DataTable/DataTableRow.tsx
@@ -10,7 +10,7 @@ import {
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { black, white } from '../../styles/themes/v2/colors';
 import { withTheme } from '../../core/theming';
-import type { $RemoveChildren } from '../../types';
+import type { $RemoveChildren, Theme } from '../../types';
 
 type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
@@ -25,7 +25,7 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   /**
    * `pointerEvents` passed to the `View` container, which is wrapping children within `TouchableRipple`.
    */

--- a/src/components/DataTable/DataTableTitle.tsx
+++ b/src/components/DataTable/DataTableTitle.tsx
@@ -12,6 +12,7 @@ import color from 'color';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
 import Text from '../Typography/Text';
 import { withTheme } from '../../core/theming';
+import type { Theme } from '../../types';
 
 type Props = React.ComponentPropsWithRef<typeof TouchableWithoutFeedback> & {
   /**
@@ -38,7 +39,7 @@ type Props = React.ComponentPropsWithRef<typeof TouchableWithoutFeedback> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 /**

--- a/src/components/DataTable/DataTableTitle.tsx
+++ b/src/components/DataTable/DataTableTitle.tsx
@@ -13,6 +13,7 @@ import MaterialCommunityIcon from '../MaterialCommunityIcon';
 import Text from '../Typography/Text';
 import { withTheme } from '../../core/theming';
 import type { Theme } from '../../types';
+import { black } from '../../styles/themes/v2/colors';
 
 type Props = React.ComponentPropsWithRef<typeof TouchableWithoutFeedback> & {
   /**
@@ -97,7 +98,7 @@ const DataTableTitle = ({
     }).start();
   }, [sortDirection, spinAnim]);
 
-  const textColor = color(theme.colors.text).alpha(0.6).rgb().string();
+  const textColor = color(theme.colors?.text).alpha(0.6).rgb().string();
 
   const spin = spinAnim.interpolate({
     inputRange: [0, 1],
@@ -109,7 +110,7 @@ const DataTableTitle = ({
       <MaterialCommunityIcon
         name="arrow-up"
         size={16}
-        color={theme.colors.text}
+        color={theme.colors?.text || black}
         direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
       />
     </Animated.View>

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -8,6 +8,7 @@ import DialogTitle, { DialogTitle as _DialogTitle } from './DialogTitle';
 import DialogScrollArea from './DialogScrollArea';
 import { withTheme } from '../../core/theming';
 import overlay from '../../styles/overlay';
+import type { Theme } from '../../types';
 
 type Props = {
   /**
@@ -30,7 +31,7 @@ type Props = {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 const DIALOG_ELEVATION: number = 24;

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -98,8 +98,8 @@ const Dialog = ({
         borderRadius: theme.roundness,
         backgroundColor:
           theme.dark && theme.mode === 'adaptive'
-            ? overlay(DIALOG_ELEVATION, theme.colors.surface)
-            : theme.colors.surface,
+            ? overlay(DIALOG_ELEVATION, theme.colors?.surface)
+            : theme.colors?.surface,
       },
       styles.container,
       style,

--- a/src/components/Dialog/DialogTitle.tsx
+++ b/src/components/Dialog/DialogTitle.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { StyleSheet, StyleProp, TextStyle } from 'react-native';
 import Title from '../Typography/Title';
 import { withTheme } from '../../core/theming';
+import type { Theme } from '../../types';
 
 type Props = React.ComponentPropsWithRef<typeof Title> & {
   /**
@@ -12,7 +13,7 @@ type Props = React.ComponentPropsWithRef<typeof Title> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 /**

--- a/src/components/Dialog/DialogTitle.tsx
+++ b/src/components/Dialog/DialogTitle.tsx
@@ -55,7 +55,7 @@ const DialogTitle = ({ children, theme, style, ...rest }: Props) => (
     // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
     accessibilityTraits="header"
     accessibilityRole="header"
-    style={[styles.text, { color: theme.colors.text }, style]}
+    style={[styles.text, { color: theme.colors?.text }, style]}
     {...rest}
   >
     {children}

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -3,7 +3,7 @@ import color from 'color';
 import { StyleSheet, View, ViewStyle, StyleProp } from 'react-native';
 import { withTheme } from '../core/theming';
 import { black, white } from '../styles/themes/v2/colors';
-import type { $RemoveChildren } from '../types';
+import type { $RemoveChildren, Theme } from '../types';
 
 type Props = $RemoveChildren<typeof View> & {
   /**
@@ -14,7 +14,7 @@ type Props = $RemoveChildren<typeof View> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 /**

--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -5,6 +5,7 @@ import Text from '../Typography/Text';
 import Icon, { IconSource } from '../Icon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { withTheme } from '../../core/theming';
+import type { Theme } from '../../types';
 
 type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
@@ -35,7 +36,7 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 /**

--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -6,6 +6,7 @@ import Icon, { IconSource } from '../Icon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { withTheme } from '../../core/theming';
 import type { Theme } from '../../types';
+import { black } from '../../styles/themes/v2/colors';
 
 type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
@@ -77,11 +78,11 @@ const DrawerItem = ({
 }: Props) => {
   const { colors, roundness } = theme;
   const backgroundColor = active
-    ? color(colors.primary).alpha(0.12).rgb().string()
+    ? color(colors?.primary).alpha(0.12).rgb().string()
     : 'transparent';
   const contentColor = active
-    ? colors.primary
-    : color(colors.text).alpha(0.68).rgb().string();
+    ? colors?.primary
+    : color(colors?.text).alpha(0.68).rgb().string();
   const font = theme.fonts.medium;
   const labelMargin = icon ? 32 : 0;
 
@@ -123,7 +124,8 @@ const DrawerItem = ({
               {label}
             </Text>
           </View>
-          {right?.({ color: contentColor })}
+
+          {right?.({ color: contentColor || black })}
         </View>
       </TouchableRipple>
     </View>

--- a/src/components/Drawer/DrawerSection.tsx
+++ b/src/components/Drawer/DrawerSection.tsx
@@ -4,6 +4,7 @@ import { View, ViewStyle, StyleSheet, StyleProp } from 'react-native';
 import Text from '../Typography/Text';
 import Divider from '../Divider';
 import { withTheme } from '../../core/theming';
+import type { Theme } from '../../types';
 
 type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
@@ -18,7 +19,7 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 /**

--- a/src/components/Drawer/DrawerSection.tsx
+++ b/src/components/Drawer/DrawerSection.tsx
@@ -61,7 +61,7 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
  */
 const DrawerSection = ({ children, title, theme, style, ...rest }: Props) => {
   const { colors, fonts } = theme;
-  const titleColor = color(colors.text).alpha(0.54).rgb().string();
+  const titleColor = color(colors?.text).alpha(0.54).rgb().string();
   const font = fonts.medium;
 
   return (

--- a/src/components/FAB/AnimatedFAB/AnimatedFAB.tsx
+++ b/src/components/FAB/AnimatedFAB/AnimatedFAB.tsx
@@ -15,7 +15,7 @@ import {
 import Surface from '../../Surface';
 import Icon from '../../Icon';
 import TouchableRipple from '../../TouchableRipple/TouchableRipple';
-import type { $RemoveChildren } from '../../../types';
+import type { $RemoveChildren, Theme } from '../../../types';
 import type { IconSource } from '../../Icon';
 import { withTheme } from '../../../core/theming';
 import type {
@@ -88,7 +88,7 @@ type Props = $RemoveChildren<typeof Surface> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   testID?: string;
 };
 

--- a/src/components/FAB/AnimatedFAB/AnimatedFAB.tsx
+++ b/src/components/FAB/AnimatedFAB/AnimatedFAB.tsx
@@ -151,7 +151,7 @@ const AnimatedFAB = ({
     .rgb()
     .string();
 
-  const { backgroundColor = disabled ? disabledColor : theme.colors.accent } =
+  const { backgroundColor = disabled ? disabledColor : theme.colors?.accent } =
     StyleSheet.flatten<ViewStyle>(style) || {};
 
   let foregroundColor: string;

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -17,9 +17,7 @@ import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { black, white } from '../../styles/themes/v2/colors';
 import { withTheme } from '../../core/theming';
 import getContrastingColor from '../../utils/getContrastingColor';
-import type { $RemoveChildren } from '../../types';
-
-getContrastingColor;
+import type { $RemoveChildren, Theme } from '../../types';
 
 type Props = $RemoveChildren<typeof Surface> & {
   /**
@@ -79,7 +77,7 @@ type Props = $RemoveChildren<typeof Surface> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   testID?: string;
 };
 

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -163,7 +163,7 @@ const FAB = ({
     .rgb()
     .string();
 
-  const { backgroundColor = disabled ? disabledColor : theme.colors.accent } =
+  const { backgroundColor = disabled ? disabledColor : theme.colors?.accent } =
     (StyleSheet.flatten(style) || {}) as ViewStyle;
 
   let foregroundColor;
@@ -177,7 +177,7 @@ const FAB = ({
       .string();
   } else {
     foregroundColor = getContrastingColor(
-      backgroundColor,
+      backgroundColor || white,
       white,
       'rgba(0, 0, 0, .54)'
     );

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -233,8 +233,8 @@ const FABGroup = ({
   const { colors } = theme;
 
   const labelColor = theme.dark
-    ? colors.text
-    : color(colors.text).fade(0.54).rgb().string();
+    ? colors?.text
+    : color(colors?.text).fade(0.54).rgb().string();
   const backdropOpacity = open
     ? backdrop.interpolate({
         inputRange: [0, 0.5, 1],
@@ -268,7 +268,7 @@ const FABGroup = ({
             styles.backdrop,
             {
               opacity: backdropOpacity,
-              backgroundColor: colors.backdrop,
+              backgroundColor: colors?.backdrop,
             },
           ]}
         />
@@ -329,7 +329,7 @@ const FABGroup = ({
                     {
                       transform: [{ scale: scales[i] }],
                       opacity: opacities[i],
-                      backgroundColor: theme.colors.surface,
+                      backgroundColor: theme.colors?.surface,
                     },
                     it.style,
                   ] as StyleProp<ViewStyle>

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -14,6 +14,7 @@ import Text from '../Typography/Text';
 import Card from '../Card/Card';
 import { withTheme } from '../../core/theming';
 import type { IconSource } from '../Icon';
+import type { Theme } from '../../types';
 
 type Props = {
   /**
@@ -83,7 +84,7 @@ type Props = {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   /**
    * Pass down testID from Group props to FAB.
    */

--- a/src/components/HelperText.tsx
+++ b/src/components/HelperText.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-native';
 import AnimatedText from './Typography/AnimatedText';
 import { withTheme } from '../core/theming';
-import type { $Omit } from '../types';
+import type { $Omit, Theme } from '../types';
 
 type Props = $Omit<
   $Omit<React.ComponentPropsWithRef<typeof AnimatedText>, 'padding'>,
@@ -35,7 +35,7 @@ type Props = $Omit<
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   /**
    * TestID used for testing purposes
    */

--- a/src/components/HelperText.tsx
+++ b/src/components/HelperText.tsx
@@ -121,8 +121,8 @@ const HelperText = ({
 
   const textColor =
     type === 'error'
-      ? colors.error
-      : color(colors.text)
+      ? colors?.error
+      : color(colors?.text)
           .alpha(dark ? 0.7 : 0.54)
           .rgb()
           .string();

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -8,6 +8,7 @@ import {
 import { Consumer as SettingsConsumer } from '../core/settings';
 import { accessibilityProps } from './MaterialCommunityIcon';
 import { withTheme } from '../core/theming';
+import type { Theme } from '../types';
 
 type IconSourceBase = string | ImageSourcePropType;
 
@@ -27,7 +28,7 @@ type Props = IconProps & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 const isImageSource = (source: any) =>

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -79,7 +79,7 @@ const Icon = ({ source, color, size, theme, ...rest }: Props) => {
     typeof source === 'object' && source.direction && source.source
       ? source.source
       : source;
-  const iconColor = color || theme.colors.text;
+  const iconColor = color || theme.colors?.text;
 
   if (isImageSource(s)) {
     return (

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -13,9 +13,8 @@ import TouchableRipple from './TouchableRipple/TouchableRipple';
 import Icon, { IconSource } from './Icon';
 import CrossFadeIcon from './CrossFadeIcon';
 import { withTheme } from '../core/theming';
-import type { Theme } from '../types';
-
-import type { $RemoveChildren } from '../types';
+import type { $RemoveChildren, Theme } from '../types';
+import { black } from '../styles/themes/v2/colors';
 
 type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
@@ -101,7 +100,7 @@ const IconButton = ({
   ...rest
 }: Props) => {
   const iconColor =
-    typeof customColor !== 'undefined' ? customColor : theme.colors.text;
+    typeof customColor !== 'undefined' ? customColor : theme.colors?.text;
   const rippleColor = color(iconColor).alpha(0.32).rgb().string();
   const IconComponent = animated ? CrossFadeIcon : Icon;
   const buttonSize = size * 1.5;
@@ -132,7 +131,7 @@ const IconButton = ({
       {...rest}
     >
       <View>
-        <IconComponent color={iconColor} source={icon} size={size} />
+        <IconComponent color={iconColor || black} source={icon} size={size} />
       </View>
     </TouchableRipple>
   );

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -13,6 +13,7 @@ import TouchableRipple from './TouchableRipple/TouchableRipple';
 import Icon, { IconSource } from './Icon';
 import CrossFadeIcon from './CrossFadeIcon';
 import { withTheme } from '../core/theming';
+import type { Theme } from '../types';
 
 import type { $RemoveChildren } from '../types';
 
@@ -50,7 +51,7 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 /**

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -13,6 +13,7 @@ import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
 import Text from '../Typography/Text';
 import { withTheme } from '../../core/theming';
+import type { Theme } from '../../types';
 
 import { ListAccordionGroupContext } from './ListAccordionGroup';
 
@@ -54,7 +55,7 @@ type Props = {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   /**
    * Style that is passed to the wrapping TouchableRipple element.
    */

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -16,6 +16,7 @@ import { withTheme } from '../../core/theming';
 import type { Theme } from '../../types';
 
 import { ListAccordionGroupContext } from './ListAccordionGroup';
+import { black } from '../../styles/themes/v2/colors';
 
 type Props = {
   /**
@@ -168,8 +169,8 @@ const ListAccordion = ({
     }
   };
 
-  const titleColor = color(theme.colors.text).alpha(0.87).rgb().string();
-  const descriptionColor = color(theme.colors.text).alpha(0.54).rgb().string();
+  const titleColor = color(theme.colors?.text).alpha(0.87).rgb().string();
+  const descriptionColor = color(theme.colors?.text).alpha(0.54).rgb().string();
 
   const expandedInternal = expandedProp !== undefined ? expandedProp : expanded;
 
@@ -188,7 +189,7 @@ const ListAccordion = ({
       : handlePressAction;
   return (
     <View>
-      <View style={{ backgroundColor: theme.colors.background }}>
+      <View style={{ backgroundColor: theme.colors?.background }}>
         <TouchableRipple
           style={[styles.container, style]}
           onPress={handlePress}
@@ -206,7 +207,9 @@ const ListAccordion = ({
           <View style={styles.row} pointerEvents="none">
             {left
               ? left({
-                  color: isExpanded ? theme.colors.primary : descriptionColor,
+                  color: isExpanded
+                    ? theme.colors?.primary || black
+                    : descriptionColor || black,
                 })
               : null}
             <View style={[styles.item, styles.content]}>
@@ -216,7 +219,7 @@ const ListAccordion = ({
                 style={[
                   styles.title,
                   {
-                    color: isExpanded ? theme.colors.primary : titleColor,
+                    color: isExpanded ? theme.colors?.primary : titleColor,
                   },
                   titleStyle,
                 ]}

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -12,6 +12,7 @@ import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import Text from '../Typography/Text';
 import { withTheme } from '../../core/theming';
 import type { $RemoveChildren, EllipsizeProp } from '../../types';
+import type { Theme } from '../../types';
 
 type Title =
   | React.ReactNode
@@ -68,7 +69,7 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   /**
    * Style that is passed to the wrapping TouchableRipple element.
    */

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -177,7 +177,7 @@ const ListItem = ({
   };
 
   const renderTitle = () => {
-    const titleColor = color(theme.colors.text).alpha(0.87).rgb().string();
+    const titleColor = color(theme.colors?.text).alpha(0.87).rgb().string();
 
     return typeof title === 'function' ? (
       title({
@@ -198,7 +198,7 @@ const ListItem = ({
     );
   };
 
-  const descriptionColor = color(theme.colors.text).alpha(0.54).rgb().string();
+  const descriptionColor = color(theme.colors?.text).alpha(0.54).rgb().string();
 
   return (
     <TouchableRipple

--- a/src/components/List/ListSection.tsx
+++ b/src/components/List/ListSection.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-native';
 import ListSubheader from './ListSubheader';
 import { withTheme } from '../../core/theming';
+import type { Theme } from '../../types';
 
 type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
@@ -21,7 +22,7 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   /**
    * Style that is passed to Title element.
    */

--- a/src/components/List/ListSubheader.tsx
+++ b/src/components/List/ListSubheader.tsx
@@ -3,12 +3,13 @@ import { StyleSheet, StyleProp, TextStyle } from 'react-native';
 import color from 'color';
 import Text from '../Typography/Text';
 import { withTheme } from '../../core/theming';
+import type { Theme } from '../../types';
 
 type Props = React.ComponentProps<typeof Text> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   /**
    * Style that is passed to Text element.
    */

--- a/src/components/List/ListSubheader.tsx
+++ b/src/components/List/ListSubheader.tsx
@@ -32,7 +32,7 @@ type Props = React.ComponentProps<typeof Text> & {
 const ListSubheader = ({ style, theme, ...rest }: Props) => {
   const { colors, fonts } = theme;
   const font = fonts.medium;
-  const textColor = color(colors.text).alpha(0.54).rgb().string();
+  const textColor = color(colors?.text).alpha(0.54).rgb().string();
 
   return (
     <Text

--- a/src/components/MaterialCommunityIcon.tsx
+++ b/src/components/MaterialCommunityIcon.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { StyleSheet, Text, Platform, TextProps, ViewProps } from 'react-native';
+import { black } from '../styles/themes/v2/colors';
 
 export type IconProps = {
   name: string;
-  color: string;
+  color?: string;
   size: number;
   direction: 'rtl' | 'ltr';
   allowFontScaling?: boolean;
@@ -73,7 +74,7 @@ export const accessibilityProps =
 
 const defaultIcon = ({
   name,
-  color,
+  color = black,
   size,
   direction,
   allowFontScaling,

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -24,6 +24,7 @@ import Surface from '../Surface';
 import MenuItem from './MenuItem';
 import { APPROX_STATUSBAR_HEIGHT } from '../../constants';
 import { addEventListener } from '../../utils/addEventListener';
+import type { Theme } from '../../types';
 
 type Props = {
   /**
@@ -61,7 +62,7 @@ type Props = {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 type Layout = $Omit<$Omit<LayoutRectangle, 'x'>, 'y'>;

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -12,6 +12,7 @@ import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import Text from '../Typography/Text';
 import { black, white } from '../../styles/themes/v2/colors';
 import { withTheme } from '../../core/theming';
+import type { Theme } from '../../types';
 
 type Props = {
   /**
@@ -39,7 +40,7 @@ type Props = {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   /**
    * TestID used for testing purposes
    */

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -98,11 +98,11 @@ const MenuItem = ({
 
   const titleColor = disabled
     ? disabledColor
-    : color(theme.colors.text).alpha(0.87).rgb().string();
+    : color(theme.colors?.text).alpha(0.87).rgb().string();
 
   const iconColor = disabled
     ? disabledColor
-    : color(theme.colors.text).alpha(0.54).rgb().string();
+    : color(theme.colors?.text).alpha(0.54).rgb().string();
 
   return (
     <TouchableRipple

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -219,7 +219,7 @@ export default function Modal({
         <Animated.View
           style={[
             styles.backdrop,
-            { backgroundColor: colors.backdrop, opacity },
+            { backgroundColor: colors?.backdrop, opacity },
           ]}
         />
       </TouchableWithoutFeedback>

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -6,6 +6,7 @@ import {
   Consumer as SettingsConsumer,
 } from '../../core/settings';
 import { ThemeProvider, withTheme } from '../../core/theming';
+import type { Theme } from '../../types';
 
 type Props = {
   /**
@@ -15,7 +16,7 @@ type Props = {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 /**

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import setColor from 'color';
 import { withTheme } from '../core/theming';
+import type { Theme } from '../types';
 
 type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
@@ -33,7 +34,7 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 const INDETERMINATE_DURATION = 2000;

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -147,7 +147,7 @@ const ProgressBar = ({
     setWidth(event.nativeEvent.layout.width);
   };
 
-  const tintColor = color || theme.colors.primary;
+  const tintColor = color || theme.colors?.primary;
   const trackTintColor = setColor(tintColor).alpha(0.38).rgb().string();
 
   return (

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -3,6 +3,7 @@ import { Platform } from 'react-native';
 import RadioButtonAndroid from './RadioButtonAndroid';
 import RadioButtonIOS from './RadioButtonIOS';
 import { withTheme } from '../../core/theming';
+import type { Theme } from '../../types';
 
 export type Props = {
   /**
@@ -32,7 +33,7 @@ export type Props = {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   /**
    * testID to be used on tests.
    */

--- a/src/components/RadioButton/RadioButtonAndroid.tsx
+++ b/src/components/RadioButton/RadioButtonAndroid.tsx
@@ -6,6 +6,7 @@ import { handlePress, isChecked } from './utils';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { withTheme } from '../../core/theming';
 import type { $RemoveChildren, Theme } from '../../types';
+import { black } from '../../styles/themes/v2/colors';
 
 type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
@@ -107,10 +108,10 @@ const RadioButtonAndroid = ({
     }
   }, [status, borderAnim, radioAnim, scale]);
 
-  const checkedColor = rest.color || theme.colors.accent;
+  const checkedColor = rest.color || theme.colors?.accent;
   const uncheckedColor =
     rest.uncheckedColor ||
-    color(theme.colors.text)
+    color(theme.colors?.text)
       .alpha(theme.dark ? 0.7 : 0.54)
       .rgb()
       .string();
@@ -128,11 +129,13 @@ const RadioButtonAndroid = ({
           }) === 'checked';
 
         if (disabled) {
-          rippleColor = color(theme.colors.text).alpha(0.16).rgb().string();
-          radioColor = theme.colors.disabled;
+          rippleColor = color(theme.colors?.text).alpha(0.16).rgb().string();
+          radioColor = theme.colors?.disabled || black;
         } else {
           rippleColor = color(checkedColor).fade(0.32).rgb().string();
-          radioColor = checked ? checkedColor : uncheckedColor;
+          radioColor = checked
+            ? checkedColor || black
+            : uncheckedColor || black;
         }
 
         return (

--- a/src/components/RadioButton/RadioButtonAndroid.tsx
+++ b/src/components/RadioButton/RadioButtonAndroid.tsx
@@ -5,7 +5,7 @@ import { RadioButtonContext, RadioButtonContextType } from './RadioButtonGroup';
 import { handlePress, isChecked } from './utils';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { withTheme } from '../../core/theming';
-import type { $RemoveChildren } from '../../types';
+import type { $RemoveChildren, Theme } from '../../types';
 
 type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
@@ -35,7 +35,7 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   /**
    * testID to be used on tests.
    */

--- a/src/components/RadioButton/RadioButtonIOS.tsx
+++ b/src/components/RadioButton/RadioButtonIOS.tsx
@@ -6,7 +6,7 @@ import { handlePress, isChecked } from './utils';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import { withTheme } from '../../core/theming';
-import type { $RemoveChildren } from '../../types';
+import type { $RemoveChildren, Theme } from '../../types';
 
 type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
@@ -32,7 +32,7 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   /**
    * testID to be used on tests.
    */

--- a/src/components/RadioButton/RadioButtonIOS.tsx
+++ b/src/components/RadioButton/RadioButtonIOS.tsx
@@ -65,13 +65,13 @@ const RadioButtonIOS = ({
   ...rest
 }: Props) => {
   const checkedColor = disabled
-    ? theme.colors.disabled
-    : rest.color || theme.colors.accent;
+    ? theme.colors?.disabled
+    : rest.color || theme.colors?.accent;
 
   let rippleColor: string;
 
   if (disabled) {
-    rippleColor = color(theme.colors.text).alpha(0.16).rgb().string();
+    rippleColor = color(theme.colors?.text).alpha(0.16).rgb().string();
   } else {
     rippleColor = color(checkedColor).fade(0.32).rgb().string();
   }

--- a/src/components/RadioButton/RadioButtonItem.tsx
+++ b/src/components/RadioButton/RadioButtonItem.tsx
@@ -157,7 +157,7 @@ const RadioButtonItem = ({
                 style={[
                   styles.label,
                   {
-                    color: colors.text,
+                    color: colors?.text,
                     textAlign: isLeading ? 'right' : 'left',
                   },
                   labelStyle,

--- a/src/components/RadioButton/RadioButtonItem.tsx
+++ b/src/components/RadioButton/RadioButtonItem.tsx
@@ -14,6 +14,7 @@ import RadioButton from './RadioButton';
 import Text from '../Typography/Text';
 import RadioButtonAndroid from './RadioButtonAndroid';
 import RadioButtonIOS from './RadioButtonIOS';
+import type { Theme } from '../../types';
 
 export type Props = {
   /**
@@ -59,7 +60,7 @@ export type Props = {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   /**
    * testID to be used on tests.
    */

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -15,6 +15,7 @@ import IconButton from './IconButton';
 import Surface from './Surface';
 import { withTheme } from '../core/theming';
 import type { IconSource } from './Icon';
+import type { Theme } from '../types';
 import MaterialCommunityIcon from './MaterialCommunityIcon';
 
 type Props = React.ComponentPropsWithRef<typeof TextInput> & {
@@ -55,7 +56,7 @@ type Props = React.ComponentPropsWithRef<typeof TextInput> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
   /**
    * Custom color for icon, default will be derived from theme
    */

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -154,7 +154,7 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
     };
 
     const { colors, roundness, dark, fonts } = theme;
-    const textColor = colors.text;
+    const textColor = colors?.text;
     const font = fonts.regular;
     const iconColor =
       customIconColor ||
@@ -202,8 +202,8 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
             inputStyle,
           ]}
           placeholder={placeholder || ''}
-          placeholderTextColor={colors.placeholder}
-          selectionColor={colors.primary}
+          placeholderTextColor={colors?.placeholder}
+          selectionColor={colors?.primary}
           underlineColorAndroid="transparent"
           returnKeyType="search"
           keyboardAppearance={dark ? 'dark' : 'light'}

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -202,7 +202,7 @@ const Snackbar = ({
                 },
               ],
             },
-            { backgroundColor: colors.onSurface },
+            { backgroundColor: colors?.onSurface },
             style,
           ] as StyleProp<ViewStyle>
         }
@@ -211,7 +211,7 @@ const Snackbar = ({
         <Text
           style={[
             styles.content,
-            { marginRight: action ? 0 : 16, color: colors.surface },
+            { marginRight: action ? 0 : 16, color: colors?.surface },
           ]}
         >
           {children}
@@ -223,7 +223,7 @@ const Snackbar = ({
               onDismiss();
             }}
             style={[styles.button, actionStyle]}
-            color={colors.accent}
+            color={colors?.accent}
             compact
             mode="text"
             {...actionProps}

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -12,6 +12,7 @@ import Button from './Button';
 import Surface from './Surface';
 import Text from './Typography/Text';
 import { withTheme } from '../core/theming';
+import type { Theme } from '../types';
 
 export type SnackbarProps = React.ComponentProps<typeof Surface> & {
   /**
@@ -47,7 +48,7 @@ export type SnackbarProps = React.ComponentProps<typeof Surface> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 const DURATION_SHORT = 4000;

--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -70,8 +70,8 @@ const Surface = ({ style, theme, ...rest }: Props) => {
         {
           backgroundColor:
             isDarkTheme && mode === 'adaptive'
-              ? overlay(elevation, colors.surface)
-              : colors.surface,
+              ? overlay(elevation, colors?.surface)
+              : colors?.surface,
         },
         elevation ? shadow(elevation) : null,
         style,

--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -3,6 +3,7 @@ import { Animated, StyleSheet, View, StyleProp, ViewStyle } from 'react-native';
 import shadow from '../styles/shadow';
 import { withTheme } from '../core/theming';
 import overlay from '../styles/overlay';
+import type { Theme } from '../types';
 
 type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
@@ -13,7 +14,7 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 /**

--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -91,7 +91,7 @@ const Switch = ({
   theme,
   ...rest
 }: Props) => {
-  const checkedColor = color || theme.colors.accent;
+  const checkedColor = color || theme.colors?.accent;
 
   const onTintColor =
     Platform.OS === 'ios'

--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -15,6 +15,7 @@ import {
 } from 'react-native';
 import setColor from 'color';
 import { withTheme } from '../core/theming';
+import type { Theme } from '../types';
 
 const version = NativeModules.PlatformConstants
   ? NativeModules.PlatformConstants.reactNativeVersion
@@ -41,7 +42,7 @@ type Props = React.ComponentPropsWithRef<typeof NativeSwitch> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 /**

--- a/src/components/TextInput/Adornment/TextInputAffix.tsx
+++ b/src/components/TextInput/Adornment/TextInputAffix.tsx
@@ -12,6 +12,7 @@ import {
 
 import { withTheme } from '../../../core/theming';
 import { AdornmentSide } from './enums';
+import type { Theme } from '../../../types';
 
 const AFFIX_OFFSET = 12;
 
@@ -28,7 +29,7 @@ export type Props = {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 type ContextState = {
@@ -110,7 +111,7 @@ const AffixAdornment: React.FunctionComponent<
 const TextInputAffix = ({ text, textStyle: labelStyle, theme }: Props) => {
   const { textStyle, onLayout, topPosition, side, visible, paddingHorizontal } =
     React.useContext(AffixContext);
-  const textColor = color(theme.colors.text)
+  const textColor = color(theme?.colors?.text)
     .alpha(theme.dark ? 0.7 : 0.54)
     .rgb()
     .string();

--- a/src/components/TextInput/Adornment/TextInputIcon.tsx
+++ b/src/components/TextInput/Adornment/TextInputIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, StyleSheet, StyleProp, ViewStyle } from 'react-native';
 
 import IconButton from '../../IconButton';
-import type { $Omit } from '../../../../src/types';
+import type { $Omit, Theme } from '../../../types';
 import type { IconSource } from '../../Icon';
 
 export type Props = $Omit<
@@ -29,7 +29,7 @@ export type Props = $Omit<
   /**
    * @optional
    */
-  theme?: ReactNativePaper.Theme;
+  theme?: Theme;
 };
 
 export const ICON_SIZE = 24;

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -132,7 +132,7 @@ export type TextInputProps = React.ComponentPropsWithRef<
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 interface CompoundedComponent

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -16,6 +16,7 @@ import TextInputAffix, {
 } from './Adornment/TextInputAffix';
 import { withTheme } from '../../core/theming';
 import type { RenderProps, TextInputLabelProp } from './types';
+import type { Theme } from '../../types';
 
 const BLUR_ANIMATION_DURATION = 180;
 const FOCUS_ANIMATION_DURATION = 150;
@@ -28,7 +29,7 @@ export type TextInputProps = React.ComponentPropsWithRef<
    * - `flat` - flat input with an underline.
    * - `outlined` - input with an outline.
    *
-   * In `outlined` mode, the background color of the label is derived from `colors.background` in theme or the `backgroundColor` style.
+   * In `outlined` mode, the background color of the label is derived from `colors?.background` in theme or the `backgroundColor` style.
    * This component render TextInputOutlined or TextInputFlat based on that props
    */
   mode?: 'flat' | 'outlined';

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -38,6 +38,7 @@ import {
   getAdornmentStyleAdjustmentForNativeInput,
 } from './Adornment/TextInputAdornment';
 import { AdornmentSide, AdornmentType, InputMode } from './Adornment/enums';
+import { black } from '../../styles/themes/v2/colors';
 
 const MINIMIZED_LABEL_Y_OFFSET = -18;
 
@@ -133,24 +134,26 @@ const TextInputFlat = ({
     errorColor;
 
   if (disabled) {
-    inputTextColor = activeColor = color(colors.text)
+    inputTextColor = activeColor = color(colors?.text || black)
       .alpha(0.54)
       .rgb()
       .string();
-    placeholderColor = colors.disabled;
+    placeholderColor = colors?.disabled || black;
     underlineColorCustom = 'transparent';
   } else {
-    inputTextColor = colors.text;
-    activeColor = error ? colors.error : activeUnderlineColor || colors.primary;
-    placeholderColor = colors.placeholder;
-    errorColor = colors.error;
-    underlineColorCustom = underlineColor || colors.disabled;
+    inputTextColor = colors?.text || black;
+    activeColor = error
+      ? colors?.error || black
+      : activeUnderlineColor || colors?.primary || black;
+    placeholderColor = colors?.placeholder || black;
+    errorColor = colors?.error || black;
+    underlineColorCustom = underlineColor || colors?.disabled || black;
   }
 
   const containerStyle = {
     backgroundColor: theme.dark
-      ? color(colors.background).lighten(0.24).rgb().string()
-      : color(colors.background).darken(0.06).rgb().string(),
+      ? color(colors?.background).lighten(0.24).rgb().string()
+      : color(colors?.background).darken(0.06).rgb().string(),
     borderTopLeftRadius: theme.roundness,
     borderTopRightRadius: theme.roundness,
   };
@@ -379,8 +382,8 @@ type UnderlineProps = {
     focused: boolean;
   };
   error?: boolean;
-  colors: {
-    error: string;
+  colors?: {
+    error?: string;
   };
   activeColor: string;
   underlineColorCustom?: string;
@@ -396,7 +399,9 @@ const Underline = ({
   let backgroundColor = parentState.focused
     ? activeColor
     : underlineColorCustom;
-  if (error) backgroundColor = colors.error;
+
+  if (error) backgroundColor = colors?.error || black;
+
   return (
     <Animated.View
       style={[

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -37,6 +37,8 @@ import {
   calculateOutlinedIconAndAffixTopPosition,
 } from './helpers';
 import { AdornmentType, AdornmentSide } from './Adornment/enums';
+import type { Theme } from '../../types';
+import { black } from '../../styles/themes/v2/colors';
 
 const OUTLINE_MINIMIZED_LABEL_Y_OFFSET = -6;
 const LABEL_PADDING_TOP = 8;
@@ -83,7 +85,7 @@ const TextInputOutlined = ({
     fontWeight,
     lineHeight,
     height,
-    backgroundColor = colors.background,
+    backgroundColor = colors?.background || black,
     textAlign,
     ...viewStyle
   } = (StyleSheet.flatten(style) || {}) as TextStyle;
@@ -93,18 +95,22 @@ const TextInputOutlined = ({
 
   if (disabled) {
     const isTransparent = color(customOutlineColor).alpha() === 0;
-    inputTextColor = activeColor = color(colors.text)
+    inputTextColor = activeColor = color(colors?.text)
       .alpha(0.54)
       .rgb()
       .string();
-    placeholderColor = colors.disabled;
-    outlineColor = isTransparent ? customOutlineColor : colors.disabled;
+    placeholderColor = colors?.disabled || black;
+    outlineColor = isTransparent
+      ? customOutlineColor
+      : colors?.disabled || black;
   } else {
-    inputTextColor = colors.text;
-    activeColor = error ? colors.error : activeOutlineColor || colors.primary;
-    placeholderColor = colors.placeholder;
-    outlineColor = customOutlineColor || colors.placeholder;
-    errorColor = colors.error;
+    inputTextColor = colors?.text || black;
+    activeColor = error
+      ? colors?.error || black
+      : activeOutlineColor || colors?.primary || black;
+    placeholderColor = colors?.placeholder || black;
+    outlineColor = customOutlineColor || colors?.placeholder || black;
+    errorColor = colors?.error || black;
   }
 
   const labelScale = MINIMIZED_LABEL_FONT_SIZE / fontSize;

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -349,7 +349,7 @@ type OutlineProps = {
   focused?: boolean;
   outlineColor?: string;
   backgroundColor: ColorValue;
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 const Outline = ({

--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -11,6 +11,7 @@ import IconButton from '../IconButton';
 import { ToggleButtonGroupContext } from './ToggleButtonGroup';
 import { black, white } from '../../styles/themes/v2/colors';
 import type { IconSource } from '../Icon';
+import type { Theme } from '../../types';
 
 type Props = {
   /**
@@ -49,7 +50,7 @@ type Props = {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 /**

--- a/src/components/TouchableRipple/TouchableRipple.native.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.native.tsx
@@ -44,7 +44,7 @@ const TouchableRipple = ({
   const disabled = disabledProp || !rest.onPress;
   const calculatedRippleColor =
     rippleColor ||
-    color(colors.text)
+    color(colors?.text)
       .alpha(dark ? 0.32 : 0.2)
       .rgb()
       .string();

--- a/src/components/TouchableRipple/TouchableRipple.native.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.native.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-native';
 import color from 'color';
 import { withTheme } from '../../core/theming';
+import type { Theme } from '../../types';
 
 const ANDROID_VERSION_LOLLIPOP = 21;
 const ANDROID_VERSION_PIE = 28;
@@ -25,7 +26,7 @@ type Props = React.ComponentProps<typeof TouchableWithoutFeedback> & {
   underlayColor?: string;
   children: React.ReactNode;
   style?: StyleProp<ViewStyle>;
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 const TouchableRipple = ({

--- a/src/components/TouchableRipple/TouchableRipple.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.tsx
@@ -107,7 +107,7 @@ const TouchableRipple = ({
     const { dark, colors } = theme;
     const calculatedRippleColor =
       rippleColor ||
-      color(colors.text)
+      color(colors?.text)
         .alpha(dark ? 0.32 : 0.2)
         .rgb()
         .string();

--- a/src/components/TouchableRipple/TouchableRipple.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import color from 'color';
 import { withTheme } from '../../core/theming';
+import type { Theme } from '../../types';
 
 type Props = React.ComponentPropsWithRef<typeof TouchableWithoutFeedback> & {
   /**
@@ -53,7 +54,7 @@ type Props = React.ComponentPropsWithRef<typeof TouchableWithoutFeedback> & {
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 /**

--- a/src/components/Typography/AnimatedText.tsx
+++ b/src/components/Typography/AnimatedText.tsx
@@ -32,7 +32,7 @@ function AnimatedText({ style, theme, ...rest }: Props) {
         styles.text,
         {
           ...theme.fonts.regular,
-          color: theme.colors.text,
+          color: theme.colors?.text,
           writingDirection,
         },
         style,

--- a/src/components/Typography/AnimatedText.tsx
+++ b/src/components/Typography/AnimatedText.tsx
@@ -7,13 +7,14 @@ import {
   StyleSheet,
 } from 'react-native';
 import { withTheme } from '../../core/theming';
+import type { Theme } from '../../types';
 
 type Props = React.ComponentPropsWithRef<typeof Animated.Text> & {
   style?: StyleProp<TextStyle>;
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 /**

--- a/src/components/Typography/StyledText.tsx
+++ b/src/components/Typography/StyledText.tsx
@@ -4,16 +4,17 @@ import { I18nManager, StyleProp, TextStyle, StyleSheet } from 'react-native';
 
 import Text from './Text';
 import { withTheme } from '../../core/theming';
+import type { Theme } from '../../types';
 
 type Props = React.ComponentProps<typeof Text> & {
   alpha: number;
   family: 'regular' | 'medium' | 'light' | 'thin';
   style?: StyleProp<TextStyle>;
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 const StyledText = ({ theme, alpha, family, style, ...rest }: Props) => {
-  const textColor = color(theme.colors.text).alpha(alpha).rgb().string();
+  const textColor = color(theme?.colors?.text).alpha(alpha).rgb().string();
   const font = theme.fonts[family];
   const writingDirection = I18nManager.isRTL ? 'rtl' : 'ltr';
 

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -6,13 +6,14 @@ import {
   StyleSheet,
 } from 'react-native';
 import { withTheme } from '../../core/theming';
+import type { Theme } from '../../types';
 
 type Props = React.ComponentProps<typeof NativeText> & {
   style?: StyleProp<TextStyle>;
   /**
    * @optional
    */
-  theme: ReactNativePaper.Theme;
+  theme: Theme;
 };
 
 // @component-group Typography

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -40,7 +40,7 @@ const Text: React.RefForwardingComponent<{}, Props> = (
       style={[
         {
           ...theme.fonts.regular,
-          color: theme.colors.text,
+          color: theme.colors?.text,
         },
         styles.text,
         style,

--- a/src/core/Provider.tsx
+++ b/src/core/Provider.tsx
@@ -13,7 +13,7 @@ import LightTheme from '../styles/themes/v2/LightTheme';
 import DarkTheme from '../styles/themes/v2/DarkTheme';
 import { addEventListener } from '../utils/addEventListener';
 import { get } from 'lodash';
-import type { MD3Token, Theme } from '../types';
+import type { MD2Theme, MD3ThemeExtended, MD3Token, Theme } from '../types';
 
 type Props = {
   children: React.ReactNode;
@@ -81,6 +81,19 @@ const Provider = ({ ...props }: Props) => {
 
     const isV3 = theme?.version === 3;
 
+    const extendedTheme = {
+      ...theme,
+      isV3,
+      animation: {
+        ...theme.animation,
+        scale: reduceMotionEnabled ? 0 : 1,
+      },
+    };
+
+    if (!isV3) {
+      return extendedTheme as MD2Theme;
+    }
+
     /**
      * Function that allows to access theme values using Material 3 tokens
      * @param {string} tokenKey - Material 3 token
@@ -90,17 +103,7 @@ const Provider = ({ ...props }: Props) => {
      */
     const md = (tokenKey: MD3Token) => get(theme.tokens, tokenKey);
 
-    return {
-      ...theme,
-      isV3,
-      animation: {
-        ...theme.animation,
-        scale: reduceMotionEnabled ? 0 : 1,
-      },
-      ...(isV3 && {
-        md,
-      }),
-    };
+    return { ...extendedTheme, md } as MD3ThemeExtended;
   };
 
   const { children, settings } = props;

--- a/src/core/theming.tsx
+++ b/src/core/theming.tsx
@@ -1,5 +1,7 @@
 import { createTheming } from '@callstack/react-theme-provider';
+import type { Theme } from '../types';
 import LightTheme from '../styles/themes/v2/LightTheme';
 
-export const { ThemeProvider, withTheme, useTheme } =
-  createTheming<ReactNativePaper.Theme>(LightTheme as ReactNativePaper.Theme);
+export const { ThemeProvider, withTheme, useTheme } = createTheming<Theme>(
+  LightTheme as Theme
+);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -55,4 +55,4 @@ export { default as Subheading } from './components/Typography/Subheading';
 export { default as Title } from './components/Typography/Title';
 export { default as Text } from './components/Typography/Text';
 
-export { Theme } from './types';
+export type { Theme } from './types';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -54,3 +54,5 @@ export { default as Paragraph } from './components/Typography/Paragraph';
 export { default as Subheading } from './components/Typography/Subheading';
 export { default as Title } from './components/Typography/Title';
 export { default as Text } from './components/Typography/Text';
+
+export { Theme } from './types';

--- a/src/styles/overlay.tsx
+++ b/src/styles/overlay.tsx
@@ -8,7 +8,7 @@ const isAnimatedValue = (
 
 export default function overlay<T extends Animated.Value | number>(
   elevation: T,
-  surfaceColor: string = DarkTheme.colors.surface
+  surfaceColor: string = DarkTheme.colors?.surface
 ): T extends number ? string : Animated.AnimatedInterpolation {
   if (isAnimatedValue(elevation)) {
     const inputRange = [0, 1, 2, 3, 8, 24];

--- a/src/styles/themes/v2/LightTheme.tsx
+++ b/src/styles/themes/v2/LightTheme.tsx
@@ -7,6 +7,7 @@ const LightTheme: MD2Theme = {
   dark: false,
   roundness: 4,
   version: 2,
+  isV3: false,
   colors: {
     primary: '#6200ee',
     accent: '#03dac4',

--- a/src/styles/themes/v2/LightTheme.tsx
+++ b/src/styles/themes/v2/LightTheme.tsx
@@ -7,7 +7,6 @@ const LightTheme: MD2Theme = {
   dark: false,
   roundness: 4,
   version: 2,
-  isV3: false,
   colors: {
     primary: '#6200ee',
     accent: '#03dac4',

--- a/src/styles/themes/v3/DarkTheme.tsx
+++ b/src/styles/themes/v3/DarkTheme.tsx
@@ -1,10 +1,10 @@
 import LightTheme from './LightTheme';
-import type { MD3Theme } from '../../../types';
+import type { MD3ThemeBase } from '../../../types';
 import { tokens } from './tokens';
 
 const { palette } = tokens.md.ref;
 
-const DarkTheme: MD3Theme = {
+const DarkTheme: MD3ThemeBase = {
   ...LightTheme,
   dark: true,
   mode: 'adaptive',

--- a/src/styles/themes/v3/LightTheme.tsx
+++ b/src/styles/themes/v3/LightTheme.tsx
@@ -1,10 +1,10 @@
 import configureFonts from '../../fonts';
-import type { MD3Theme } from '../../../types';
+import type { MD3ThemeBase } from '../../../types';
 import { tokens } from './tokens';
 
 const { palette } = tokens.md.ref;
 
-const LightTheme: MD3Theme = {
+const LightTheme: MD3ThemeBase = {
   dark: false,
   roundness: 4,
   version: 3,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -78,19 +78,18 @@ type SharedTheme = {
   version?: 2 | 3;
   isV3?: boolean;
   fonts: Fonts;
-  userDefinedThemeProperty: string;
   animation: {
     scale: number;
   };
 };
 
-export type Theme = AllXOR<[MD2Theme, MD3Theme]>;
+export type Theme = AllXOR<[MD2Theme, MD3ThemeBase]>;
 
 export type MD2Theme = SharedTheme & {
   colors: Material2Colors;
 };
 
-export type MD3Theme = SharedTheme & {
+export type MD3ThemeBase = SharedTheme & {
   tokens: {
     md: {
       sys: {
@@ -109,7 +108,10 @@ export type MD3Theme = SharedTheme & {
       };
     };
   };
-  md?(tokenKey: MD3Token): string | number | object;
+};
+
+export type MD3ThemeExtended = MD3ThemeBase & {
+  md(tokenKey: MD3Token): string | number | object;
 };
 
 type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
@@ -134,7 +136,7 @@ type PathImpl<T, K extends keyof T> = K extends string
 
 type Path<T> = PathImpl<T, keyof T> | keyof T;
 
-export type MD3Token = Path<MD3Theme['tokens']>;
+export type MD3Token = Path<MD3ThemeBase['tokens']>;
 
 export type $Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 export type $RemoveChildren<T extends React.ComponentType<any>> = $Omit<


### PR DESCRIPTION
### Summary

These changes fix other parts of application when theme V3 would be used instead of V2. Changes:
- [x] each ReactNativePaper.Theme got replaced with exported Theme type
- [x] each way of accessing theme colors, like `colors.background`, were replaced with optional chaining or dirty defaults (to be resolved later on, during the works on individual components)
