### PR TITLE
feat: adjust Appbar components into Material You

### DIFF
--- a/example/src/ExampleList.tsx
+++ b/example/src/ExampleList.tsx
@@ -102,15 +102,13 @@ export default function ExampleList({ navigation }: Props) {
 
   const keyExtractor = (item: { id: string }) => item.id;
 
-  const { colors, isV3, md } = useTheme();
+  const { colors } = useTheme();
   const safeArea = useSafeArea();
 
   return (
     <FlatList
       contentContainerStyle={{
-        backgroundColor: isV3
-          ? (md('md.sys.color.background') as string)
-          : colors?.background,
+        backgroundColor: colors.background,
         paddingBottom: safeArea.bottom,
         paddingLeft: safeArea.left,
         paddingRight: safeArea.right,

--- a/example/src/ExampleList.tsx
+++ b/example/src/ExampleList.tsx
@@ -102,13 +102,15 @@ export default function ExampleList({ navigation }: Props) {
 
   const keyExtractor = (item: { id: string }) => item.id;
 
-  const { colors } = useTheme();
+  const { colors, isV3, md } = useTheme();
   const safeArea = useSafeArea();
 
   return (
     <FlatList
       contentContainerStyle={{
-        backgroundColor: colors?.background,
+        backgroundColor: isV3
+          ? (md('md.sys.color.background') as string)
+          : colors?.background,
         paddingBottom: safeArea.bottom,
         paddingLeft: safeArea.left,
         paddingRight: safeArea.right,

--- a/example/src/Examples/AppbarExample.tsx
+++ b/example/src/Examples/AppbarExample.tsx
@@ -1,13 +1,23 @@
 import * as React from 'react';
 import { View, Platform, StyleSheet } from 'react-native';
 import type { StackNavigationProp } from '@react-navigation/stack';
-import { Appbar, FAB, Switch, Paragraph } from 'react-native-paper';
+import {
+  Appbar,
+  FAB,
+  Switch,
+  Paragraph,
+  Text,
+  useTheme,
+  RadioButton,
+} from 'react-native-paper';
 import ScreenWrapper from '../ScreenWrapper';
 import { yellowA200 } from '../../../src/styles/themes/v2/colors';
 
 type Props = {
   navigation: StackNavigationProp<{}>;
 };
+
+type AppbarModes = 'small' | 'medium' | 'large' | 'center-aligned';
 
 const MORE_ICON = Platform.OS === 'ios' ? 'dots-horizontal' : 'dots-vertical';
 
@@ -18,6 +28,10 @@ const AppbarExample = ({ navigation }: Props) => {
   const [showMoreIcon, setShowMoreIcon] = React.useState(true);
   const [showCustomColor, setShowCustomColor] = React.useState(false);
   const [showExactTheme, setShowExactTheme] = React.useState(false);
+  const [appbarMode, setAppbarMode] = React.useState<AppbarModes>('small');
+  const [showCalendarIcon, setShowCalendarIcon] = React.useState(false);
+
+  const { isV3 } = useTheme();
 
   React.useLayoutEffect(() => {
     navigation.setOptions({
@@ -27,6 +41,7 @@ const AppbarExample = ({ navigation }: Props) => {
           theme={{
             mode: showExactTheme ? 'exact' : 'adaptive',
           }}
+          mode={appbarMode}
         >
           {showLeftIcon && (
             <Appbar.BackAction onPress={() => navigation.goBack()} />
@@ -35,6 +50,9 @@ const AppbarExample = ({ navigation }: Props) => {
             title="Title"
             subtitle={showSubtitle ? 'Subtitle' : null}
           />
+          {showCalendarIcon && (
+            <Appbar.Action icon="calendar" onPress={() => {}} />
+          )}
           {showSearchIcon && (
             <Appbar.Action icon="magnify" onPress={() => {}} />
           )}
@@ -52,7 +70,11 @@ const AppbarExample = ({ navigation }: Props) => {
     showMoreIcon,
     showCustomColor,
     showExactTheme,
+    appbarMode,
+    showCalendarIcon,
   ]);
+
+  const TextComponent = isV3 ? Text : Paragraph;
 
   return (
     <>
@@ -61,29 +83,71 @@ const AppbarExample = ({ navigation }: Props) => {
         contentContainerStyle={styles.contentContainer}
       >
         <View style={styles.row}>
-          <Paragraph>Left icon</Paragraph>
+          <TextComponent variant="label-large">Left icon</TextComponent>
           <Switch value={showLeftIcon} onValueChange={setShowLeftIcon} />
         </View>
+        {!isV3 && (
+          <View style={styles.row}>
+            <TextComponent variant="label-large">Subtitle</TextComponent>
+            <Switch value={showSubtitle} onValueChange={setShowSubtitle} />
+          </View>
+        )}
         <View style={styles.row}>
-          <Paragraph>Subtitle</Paragraph>
-          <Switch value={showSubtitle} onValueChange={setShowSubtitle} />
-        </View>
-        <View style={styles.row}>
-          <Paragraph>Search icon</Paragraph>
+          <TextComponent variant="label-large">Search icon</TextComponent>
           <Switch value={showSearchIcon} onValueChange={setShowSearchIcon} />
         </View>
         <View style={styles.row}>
-          <Paragraph>More icon</Paragraph>
+          <TextComponent variant="label-large">More icon</TextComponent>
           <Switch value={showMoreIcon} onValueChange={setShowMoreIcon} />
         </View>
+        {isV3 && (
+          <View style={styles.row}>
+            <TextComponent variant="label-large">Calendar icon</TextComponent>
+            <Switch
+              value={showCalendarIcon}
+              disabled={appbarMode === 'center-aligned'}
+              onValueChange={setShowCalendarIcon}
+            />
+          </View>
+        )}
         <View style={styles.row}>
-          <Paragraph>Custom Color</Paragraph>
+          <TextComponent variant="label-large">Custom Color</TextComponent>
           <Switch value={showCustomColor} onValueChange={setShowCustomColor} />
         </View>
         <View style={styles.row}>
-          <Paragraph>Exact Dark Theme</Paragraph>
+          <TextComponent variant="label-large">Exact Dark Theme</TextComponent>
           <Switch value={showExactTheme} onValueChange={setShowExactTheme} />
         </View>
+        {isV3 && (
+          <RadioButton.Group
+            value={appbarMode}
+            onValueChange={(value: string) =>
+              setAppbarMode(value as AppbarModes)
+            }
+          >
+            <TextComponent style={styles.appbarMode}>Appbar Mode</TextComponent>
+            <View style={styles.row}>
+              <TextComponent variant="label-large">
+                Small (default)
+              </TextComponent>
+              <RadioButton value="small" />
+            </View>
+            <View style={styles.row}>
+              <TextComponent variant="label-large">Medium</TextComponent>
+              <RadioButton value="medium" />
+            </View>
+            <View style={styles.row}>
+              <TextComponent variant="label-large">Large</TextComponent>
+              <RadioButton value="large" />
+            </View>
+            <View style={styles.row}>
+              <TextComponent variant="label-large">
+                Center-aligned
+              </TextComponent>
+              <RadioButton value="center-aligned" />
+            </View>
+          </RadioButton.Group>
+        )}
       </ScreenWrapper>
       <Appbar
         style={styles.bottom}
@@ -130,5 +194,8 @@ const styles = StyleSheet.create({
   },
   customColor: {
     backgroundColor: yellowA200,
+  },
+  appbarMode: {
+    textAlign: 'center',
   },
 });

--- a/example/src/Examples/AppbarExample.tsx
+++ b/example/src/Examples/AppbarExample.tsx
@@ -33,6 +33,8 @@ const AppbarExample = ({ navigation }: Props) => {
 
   const { isV3 } = useTheme();
 
+  const isCenterAlignedMode = appbarMode === 'center-aligned';
+
   React.useLayoutEffect(() => {
     navigation.setOptions({
       header: () => (
@@ -50,9 +52,11 @@ const AppbarExample = ({ navigation }: Props) => {
             title="Title"
             subtitle={showSubtitle ? 'Subtitle' : null}
           />
-          {showCalendarIcon && (
-            <Appbar.Action icon="calendar" onPress={() => {}} />
-          )}
+          {isCenterAlignedMode
+            ? false
+            : showCalendarIcon && (
+                <Appbar.Action icon="calendar" onPress={() => {}} />
+              )}
           {showSearchIcon && (
             <Appbar.Action icon="magnify" onPress={() => {}} />
           )}
@@ -72,6 +76,7 @@ const AppbarExample = ({ navigation }: Props) => {
     showExactTheme,
     appbarMode,
     showCalendarIcon,
+    isCenterAlignedMode,
   ]);
 
   const TextComponent = isV3 ? Text : Paragraph;
@@ -104,8 +109,8 @@ const AppbarExample = ({ navigation }: Props) => {
           <View style={styles.row}>
             <TextComponent variant="label-large">Calendar icon</TextComponent>
             <Switch
-              value={showCalendarIcon}
-              disabled={appbarMode === 'center-aligned'}
+              value={isCenterAlignedMode ? false : showCalendarIcon}
+              disabled={isCenterAlignedMode}
               onValueChange={setShowCalendarIcon}
             />
           </View>
@@ -125,7 +130,9 @@ const AppbarExample = ({ navigation }: Props) => {
               setAppbarMode(value as AppbarModes)
             }
           >
-            <TextComponent style={styles.appbarMode}>Appbar Mode</TextComponent>
+            <TextComponent variant="label-large" style={styles.appbarMode}>
+              Appbar Mode
+            </TextComponent>
             <View style={styles.row}>
               <TextComponent variant="label-large">
                 Small (default)

--- a/example/src/Examples/AppbarExample.tsx
+++ b/example/src/Examples/AppbarExample.tsx
@@ -9,6 +9,7 @@ import {
   Text,
   useTheme,
   RadioButton,
+  List,
 } from 'react-native-paper';
 import ScreenWrapper from '../ScreenWrapper';
 import { yellowA200 } from '../../../src/styles/themes/v2/colors';
@@ -30,6 +31,7 @@ const AppbarExample = ({ navigation }: Props) => {
   const [showExactTheme, setShowExactTheme] = React.useState(false);
   const [appbarMode, setAppbarMode] = React.useState<AppbarModes>('small');
   const [showCalendarIcon, setShowCalendarIcon] = React.useState(false);
+  const [showElevated, setShowElevated] = React.useState(false);
 
   const { isV3 } = useTheme();
 
@@ -39,11 +41,12 @@ const AppbarExample = ({ navigation }: Props) => {
     navigation.setOptions({
       header: () => (
         <Appbar.Header
-          style={showCustomColor ? styles.customColor : null}
+          style={[showCustomColor ? styles.customColor : null]}
           theme={{
             mode: showExactTheme ? 'exact' : 'adaptive',
           }}
           mode={appbarMode}
+          elevated={showElevated}
         >
           {showLeftIcon && (
             <Appbar.BackAction onPress={() => navigation.goBack()} />
@@ -77,9 +80,57 @@ const AppbarExample = ({ navigation }: Props) => {
     appbarMode,
     showCalendarIcon,
     isCenterAlignedMode,
+    showElevated,
   ]);
 
   const TextComponent = isV3 ? Text : Paragraph;
+
+  const renderDefaultOptions = () => (
+    <>
+      <View style={styles.row}>
+        <TextComponent variant="labelLarge">Left icon</TextComponent>
+        <Switch value={showLeftIcon} onValueChange={setShowLeftIcon} />
+      </View>
+      {!isV3 && (
+        <View style={styles.row}>
+          <TextComponent variant="labelLarge">Subtitle</TextComponent>
+          <Switch value={showSubtitle} onValueChange={setShowSubtitle} />
+        </View>
+      )}
+      <View style={styles.row}>
+        <TextComponent variant="labelLarge">Search icon</TextComponent>
+        <Switch value={showSearchIcon} onValueChange={setShowSearchIcon} />
+      </View>
+      <View style={styles.row}>
+        <TextComponent variant="labelLarge">More icon</TextComponent>
+        <Switch value={showMoreIcon} onValueChange={setShowMoreIcon} />
+      </View>
+      {isV3 && (
+        <View style={styles.row}>
+          <TextComponent variant="labelLarge">Calendar icon</TextComponent>
+          <Switch
+            value={isCenterAlignedMode ? false : showCalendarIcon}
+            disabled={isCenterAlignedMode}
+            onValueChange={setShowCalendarIcon}
+          />
+        </View>
+      )}
+      <View style={styles.row}>
+        <TextComponent variant="labelLarge">Custom Color</TextComponent>
+        <Switch value={showCustomColor} onValueChange={setShowCustomColor} />
+      </View>
+      <View style={styles.row}>
+        <TextComponent variant="labelLarge">Exact Dark Theme</TextComponent>
+        <Switch value={showExactTheme} onValueChange={setShowExactTheme} />
+      </View>
+      {isV3 && (
+        <View style={styles.row}>
+          <TextComponent variant="labelLarge">Elevated</TextComponent>
+          <Switch value={showElevated} onValueChange={setShowElevated} />
+        </View>
+      )}
+    </>
+  );
 
   return (
     <>
@@ -87,71 +138,43 @@ const AppbarExample = ({ navigation }: Props) => {
         style={styles.container}
         contentContainerStyle={styles.contentContainer}
       >
-        <View style={styles.row}>
-          <TextComponent variant="labelLarge">Left icon</TextComponent>
-          <Switch value={showLeftIcon} onValueChange={setShowLeftIcon} />
-        </View>
-        {!isV3 && (
-          <View style={styles.row}>
-            <TextComponent variant="labelLarge">Subtitle</TextComponent>
-            <Switch value={showSubtitle} onValueChange={setShowSubtitle} />
-          </View>
+        {isV3 ? (
+          <List.Section title="Default options">
+            {renderDefaultOptions()}
+          </List.Section>
+        ) : (
+          renderDefaultOptions()
         )}
-        <View style={styles.row}>
-          <TextComponent variant="labelLarge">Search icon</TextComponent>
-          <Switch value={showSearchIcon} onValueChange={setShowSearchIcon} />
-        </View>
-        <View style={styles.row}>
-          <TextComponent variant="labelLarge">More icon</TextComponent>
-          <Switch value={showMoreIcon} onValueChange={setShowMoreIcon} />
-        </View>
         {isV3 && (
-          <View style={styles.row}>
-            <TextComponent variant="labelLarge">Calendar icon</TextComponent>
-            <Switch
-              value={isCenterAlignedMode ? false : showCalendarIcon}
-              disabled={isCenterAlignedMode}
-              onValueChange={setShowCalendarIcon}
-            />
-          </View>
-        )}
-        <View style={styles.row}>
-          <TextComponent variant="labelLarge">Custom Color</TextComponent>
-          <Switch value={showCustomColor} onValueChange={setShowCustomColor} />
-        </View>
-        <View style={styles.row}>
-          <TextComponent variant="labelLarge">Exact Dark Theme</TextComponent>
-          <Switch value={showExactTheme} onValueChange={setShowExactTheme} />
-        </View>
-        {isV3 && (
-          <RadioButton.Group
-            value={appbarMode}
-            onValueChange={(value: string) =>
-              setAppbarMode(value as AppbarModes)
-            }
-          >
-            <TextComponent variant="labelLarge" style={styles.appbarMode}>
-              Appbar Mode
-            </TextComponent>
-            <View style={styles.row}>
-              <TextComponent variant="labelLarge">
-                Small (default)
-              </TextComponent>
-              <RadioButton value="small" />
-            </View>
-            <View style={styles.row}>
-              <TextComponent variant="labelLarge">Medium</TextComponent>
-              <RadioButton value="medium" />
-            </View>
-            <View style={styles.row}>
-              <TextComponent variant="labelLarge">Large</TextComponent>
-              <RadioButton value="large" />
-            </View>
-            <View style={styles.row}>
-              <TextComponent variant="labelLarge">Center-aligned</TextComponent>
-              <RadioButton value="center-aligned" />
-            </View>
-          </RadioButton.Group>
+          <List.Section title="Appbar Modes">
+            <RadioButton.Group
+              value={appbarMode}
+              onValueChange={(value: string) =>
+                setAppbarMode(value as AppbarModes)
+              }
+            >
+              <View style={styles.row}>
+                <TextComponent variant="labelLarge">
+                  Small (default)
+                </TextComponent>
+                <RadioButton value="small" />
+              </View>
+              <View style={styles.row}>
+                <TextComponent variant="labelLarge">Medium</TextComponent>
+                <RadioButton value="medium" />
+              </View>
+              <View style={styles.row}>
+                <TextComponent variant="labelLarge">Large</TextComponent>
+                <RadioButton value="large" />
+              </View>
+              <View style={styles.row}>
+                <TextComponent variant="labelLarge">
+                  Center-aligned
+                </TextComponent>
+                <RadioButton value="center-aligned" />
+              </View>
+            </RadioButton.Group>
+          </List.Section>
         )}
       </ScreenWrapper>
       <Appbar
@@ -199,8 +222,5 @@ const styles = StyleSheet.create({
   },
   customColor: {
     backgroundColor: yellowA200,
-  },
-  appbarMode: {
-    textAlign: 'center',
   },
 });

--- a/example/src/Examples/AppbarExample.tsx
+++ b/example/src/Examples/AppbarExample.tsx
@@ -88,26 +88,26 @@ const AppbarExample = ({ navigation }: Props) => {
         contentContainerStyle={styles.contentContainer}
       >
         <View style={styles.row}>
-          <TextComponent variant="label-large">Left icon</TextComponent>
+          <TextComponent variant="labelLarge">Left icon</TextComponent>
           <Switch value={showLeftIcon} onValueChange={setShowLeftIcon} />
         </View>
         {!isV3 && (
           <View style={styles.row}>
-            <TextComponent variant="label-large">Subtitle</TextComponent>
+            <TextComponent variant="labelLarge">Subtitle</TextComponent>
             <Switch value={showSubtitle} onValueChange={setShowSubtitle} />
           </View>
         )}
         <View style={styles.row}>
-          <TextComponent variant="label-large">Search icon</TextComponent>
+          <TextComponent variant="labelLarge">Search icon</TextComponent>
           <Switch value={showSearchIcon} onValueChange={setShowSearchIcon} />
         </View>
         <View style={styles.row}>
-          <TextComponent variant="label-large">More icon</TextComponent>
+          <TextComponent variant="labelLarge">More icon</TextComponent>
           <Switch value={showMoreIcon} onValueChange={setShowMoreIcon} />
         </View>
         {isV3 && (
           <View style={styles.row}>
-            <TextComponent variant="label-large">Calendar icon</TextComponent>
+            <TextComponent variant="labelLarge">Calendar icon</TextComponent>
             <Switch
               value={isCenterAlignedMode ? false : showCalendarIcon}
               disabled={isCenterAlignedMode}
@@ -116,11 +116,11 @@ const AppbarExample = ({ navigation }: Props) => {
           </View>
         )}
         <View style={styles.row}>
-          <TextComponent variant="label-large">Custom Color</TextComponent>
+          <TextComponent variant="labelLarge">Custom Color</TextComponent>
           <Switch value={showCustomColor} onValueChange={setShowCustomColor} />
         </View>
         <View style={styles.row}>
-          <TextComponent variant="label-large">Exact Dark Theme</TextComponent>
+          <TextComponent variant="labelLarge">Exact Dark Theme</TextComponent>
           <Switch value={showExactTheme} onValueChange={setShowExactTheme} />
         </View>
         {isV3 && (
@@ -130,27 +130,25 @@ const AppbarExample = ({ navigation }: Props) => {
               setAppbarMode(value as AppbarModes)
             }
           >
-            <TextComponent variant="label-large" style={styles.appbarMode}>
+            <TextComponent variant="labelLarge" style={styles.appbarMode}>
               Appbar Mode
             </TextComponent>
             <View style={styles.row}>
-              <TextComponent variant="label-large">
+              <TextComponent variant="labelLarge">
                 Small (default)
               </TextComponent>
               <RadioButton value="small" />
             </View>
             <View style={styles.row}>
-              <TextComponent variant="label-large">Medium</TextComponent>
+              <TextComponent variant="labelLarge">Medium</TextComponent>
               <RadioButton value="medium" />
             </View>
             <View style={styles.row}>
-              <TextComponent variant="label-large">Large</TextComponent>
+              <TextComponent variant="labelLarge">Large</TextComponent>
               <RadioButton value="large" />
             </View>
             <View style={styles.row}>
-              <TextComponent variant="label-large">
-                Center-aligned
-              </TextComponent>
+              <TextComponent variant="labelLarge">Center-aligned</TextComponent>
               <RadioButton value="center-aligned" />
             </View>
           </RadioButton.Group>

--- a/example/src/RootNavigator.tsx
+++ b/example/src/RootNavigator.tsx
@@ -12,12 +12,13 @@ export default function Root() {
       headerMode="screen"
       screenOptions={{
         header: ({ navigation, scene, previous }) => (
-          <Appbar.Header>
+          <Appbar.Header elevated>
             {previous ? (
               <Appbar.BackAction onPress={() => navigation.goBack()} />
             ) : (navigation as any).openDrawer ? (
               <Appbar.Action
                 icon="menu"
+                isLeading
                 onPress={() =>
                   (navigation as any as DrawerNavigationProp<{}>).openDrawer()
                 }

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -177,7 +177,7 @@ export default function PaperExample() {
                   <Drawer.Screen name="Home" component={App} />
                 </Drawer.Navigator>
               )}
-              <StatusBar style="light" />
+              <StatusBar style={!theme.dark ? 'dark' : 'light'} />
             </NavigationContainer>
           </React.Fragment>
         </PreferencesContext.Provider>

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -14,9 +14,14 @@ import AppbarAction from './AppbarAction';
 import AppbarBackAction from './AppbarBackAction';
 import Surface from '../Surface';
 import { withTheme } from '../../core/theming';
-import { black, white } from '../../styles/themes/v2/colors';
-import overlay from '../../styles/overlay';
 import type { MD3Elevation, Theme } from '../../types';
+import {
+  getAppbarColor,
+  renderAppbarContent,
+  DEFAULT_APPBAR_HEIGHT,
+  modeAppbarHeight,
+  AppbarModes,
+} from './utils';
 
 type Props = Partial<React.ComponentPropsWithRef<typeof View>> & {
   /**
@@ -28,14 +33,27 @@ type Props = Partial<React.ComponentPropsWithRef<typeof View>> & {
    */
   children: React.ReactNode;
   /**
+   * @supported Available in v3.x with theme version 3
+   *
+   * Mode of the Appbar.
+   * - `small` - Appbar with default height (56).
+   * - `medium` - Appbar with medium height (112).
+   * - `large` - Appbar with large height (152).
+   * - `center-aligned` - Appbar with default height and center-aligned title.
+   */
+  mode?: 'small' | 'medium' | 'large' | 'center-aligned';
+  /**
+   * @supported Available in v3.x with theme version 3
+   * Whether Appbar background should have the elevation along with primary color pigment.
+   */
+  elevated?: boolean;
+  /**
    * @optional
    */
   theme: Theme;
   style?: StyleProp<ViewStyle>;
   elevation?: 0 | 1 | 2 | 3 | 4 | 5 | Animated.Value;
 };
-
-export const DEFAULT_APPBAR_HEIGHT = 56;
 
 /**
  * A component to display action items in a bar. It can be placed at the top or bottom.
@@ -44,10 +62,6 @@ export const DEFAULT_APPBAR_HEIGHT = 56;
  *
  * By default Appbar uses primary color as a background, in dark theme with `adaptive` mode it will use surface colour instead.
  * See [Dark Theme](https://callstack.github.io/react-native-paper/theming.html#dark-theme) for more informations
- *
- * <div class="screenshots">
- *   <img class="medium" src="screenshots/appbar.png" />
- * </div>
  *
  * ## Usage
  * ```js
@@ -82,21 +96,31 @@ export const DEFAULT_APPBAR_HEIGHT = 56;
  * });
  * ```
  */
-const Appbar = ({ children, dark, style, theme, ...rest }: Props) => {
-  const { colors, dark: isDarkTheme, mode } = theme;
+const Appbar = ({
+  children,
+  dark,
+  style,
+  theme,
+  mode = 'small',
+  elevated,
+  ...rest
+}: Props) => {
+  const { isV3 } = theme;
   const {
     backgroundColor: customBackground,
-    elevation = rest.elevation || theme.isV3 ? 0 : 4,
+    elevation = rest.elevation || isV3 ? (elevated ? 2 : 0) : 4,
     ...restStyle
   }: ViewStyle = StyleSheet.flatten(style) || {};
 
   let isDark: boolean;
 
-  const backgroundColor = customBackground
-    ? customBackground
-    : isDarkTheme && mode === 'adaptive'
-    ? overlay(elevation, colors?.surface)
-    : colors?.primary;
+  const backgroundColor = getAppbarColor(
+    theme,
+    elevation,
+    customBackground,
+    elevated
+  );
+
   if (typeof dark === 'boolean') {
     isDark = dark;
   } else {
@@ -129,15 +153,33 @@ const Appbar = ({ children, dark, style, theme, ...rest }: Props) => {
     });
 
     shouldCenterContent =
-      hasAppbarContent && leftItemsCount < 2 && rightItemsCount < 2;
-    shouldAddLeftSpacing = shouldCenterContent && leftItemsCount === 0;
-    shouldAddRightSpacing = shouldCenterContent && rightItemsCount === 0;
+      !isV3 && hasAppbarContent && leftItemsCount < 2 && rightItemsCount < 2;
+    shouldAddLeftSpacing = !isV3 && shouldCenterContent && leftItemsCount === 0;
+    shouldAddRightSpacing =
+      !isV3 && shouldCenterContent && rightItemsCount === 0;
   }
+
+  const isMode = (modeToCompare: AppbarModes) => {
+    return isV3 && mode === modeToCompare;
+  };
+
+  const filterAppbarActions = React.useCallback(
+    (isLeading = false) =>
+      React.Children.toArray(children).filter((child) =>
+        // @ts-expect-error: TypeScript complains about the type of type but it doesn't matter
+        isLeading ? child.props.isLeading : !child.props.isLeading
+      ),
+    [children]
+  );
+
   return (
     <Surface
       style={[
         { backgroundColor },
         styles.appbar,
+        {
+          height: isV3 ? modeAppbarHeight[mode] : DEFAULT_APPBAR_HEIGHT,
+        },
         restStyle,
         !theme.isV3 && { elevation },
       ]}
@@ -145,38 +187,59 @@ const Appbar = ({ children, dark, style, theme, ...rest }: Props) => {
       {...rest}
     >
       {shouldAddLeftSpacing ? <View style={styles.spacing} /> : null}
-      {React.Children.toArray(children)
-        .filter((child) => child != null && typeof child !== 'boolean')
-        .map((child, i) => {
-          if (
-            !React.isValidElement(child) ||
-            ![AppbarContent, AppbarAction, AppbarBackAction].includes(
-              // @ts-expect-error: TypeScript complains about the type of type but it doesn't matter
-              child.type
-            )
-          ) {
-            return child;
-          }
-
-          const props: { color?: string; style?: StyleProp<ViewStyle> } = {
-            color:
-              typeof child.props.color !== 'undefined'
-                ? child.props.color
-                : isDark
-                ? white
-                : black,
-          };
-
-          if (child.type === AppbarContent) {
-            props.style = [
-              // Since content is not first item, add extra left margin
-              i !== 0 && { marginLeft: 8 },
-              shouldCenterContent && { alignItems: 'center' },
-              child.props.style,
-            ];
-          }
-          return React.cloneElement(child, props);
+      {(!isV3 || isMode('small')) &&
+        renderAppbarContent({
+          children,
+          isDark,
+          isV3,
+          shouldCenterContent,
         })}
+      {(isMode('medium') || isMode('large') || isMode('center-aligned')) && (
+        <View
+          style={[
+            styles.columnContainer,
+            isMode('center-aligned') && styles.centerAlignedContainer,
+          ]}
+        >
+          {/* Appbar top row with controls */}
+          <View style={styles.controlsRow}>
+            {/* Left side of row container, can contain AppbarBackAction or AppbarAction if it's leading icon  */}
+            {renderAppbarContent({
+              children,
+              isDark,
+              isV3,
+              renderOnly: [AppbarBackAction],
+              mode,
+            })}
+            {renderAppbarContent({
+              children: filterAppbarActions(true),
+              isDark,
+              isV3,
+              renderOnly: [AppbarAction],
+              mode,
+            })}
+            {/* Right side of row container, can contain other AppbarAction if they are not leading icons */}
+            <View style={styles.rightActionControls}>
+              {renderAppbarContent({
+                children: filterAppbarActions(false),
+                isDark,
+                isV3,
+                renderOnly: [AppbarAction],
+                mode,
+              })}
+            </View>
+          </View>
+          {/* Middle of the row, can contain only AppbarContent */}
+          {renderAppbarContent({
+            children,
+            isDark,
+            isV3,
+            shouldCenterContent: isMode('center-aligned'),
+            renderOnly: [AppbarContent],
+            mode,
+          })}
+        </View>
+      )}
       {shouldAddRightSpacing ? <View style={styles.spacing} /> : null}
     </Surface>
   );
@@ -184,13 +247,31 @@ const Appbar = ({ children, dark, style, theme, ...rest }: Props) => {
 
 const styles = StyleSheet.create({
   appbar: {
-    height: DEFAULT_APPBAR_HEIGHT,
     flexDirection: 'row',
     alignItems: 'center',
     paddingHorizontal: 4,
   },
   spacing: {
     width: 48,
+  },
+  controlsRow: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  rightActionControls: {
+    flexDirection: 'row',
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  columnContainer: {
+    flexDirection: 'column',
+    flex: 1,
+    paddingTop: 8,
+  },
+  centerAlignedContainer: {
+    paddingTop: 0,
   },
 });
 

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -15,6 +15,7 @@ import {
   modeAppbarHeight,
   AppbarModes,
 } from './utils';
+import AppbarHeader from './AppbarHeader';
 
 type Props = Partial<React.ComponentPropsWithRef<typeof View>> & {
   /**
@@ -220,7 +221,12 @@ const Appbar = ({
                 children: filterAppbarActions(false),
                 isDark,
                 isV3,
-                renderOnly: [AppbarAction],
+                renderExcept: [
+                  Appbar,
+                  AppbarBackAction,
+                  AppbarContent,
+                  AppbarHeader,
+                ],
                 mode,
               })}
             </View>

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -1,12 +1,5 @@
 import * as React from 'react';
-import {
-  View,
-  ViewStyle,
-  Platform,
-  StyleSheet,
-  StyleProp,
-  Animated,
-} from 'react-native';
+import { View, ViewStyle, Platform, StyleSheet, StyleProp } from 'react-native';
 import color from 'color';
 
 import AppbarContent from './AppbarContent';
@@ -52,7 +45,6 @@ type Props = Partial<React.ComponentPropsWithRef<typeof View>> & {
    */
   theme: Theme;
   style?: StyleProp<ViewStyle>;
-  elevation?: 0 | 1 | 2 | 3 | 4 | 5 | Animated.Value;
 };
 
 /**
@@ -62,6 +54,10 @@ type Props = Partial<React.ComponentPropsWithRef<typeof View>> & {
  *
  * By default Appbar uses primary color as a background, in dark theme with `adaptive` mode it will use surface colour instead.
  * See [Dark Theme](https://callstack.github.io/react-native-paper/theming.html#dark-theme) for more informations
+ *
+ * <div class="screenshots">
+ *   <img class="medium" src="screenshots/appbar.png" />
+ * </div>
  *
  * ## Usage
  * ```js
@@ -108,7 +104,7 @@ const Appbar = ({
   const { isV3 } = theme;
   const {
     backgroundColor: customBackground,
-    elevation = rest.elevation || isV3 ? (elevated ? 2 : 0) : 4,
+    elevation = isV3 ? (elevated ? 2 : 0) : 4,
     ...restStyle
   }: ViewStyle = StyleSheet.flatten(style) || {};
 

--- a/src/components/Appbar/AppbarAction.tsx
+++ b/src/components/Appbar/AppbarAction.tsx
@@ -36,7 +36,7 @@ type Props = React.ComponentPropsWithoutRef<typeof IconButton> & {
    */
   onPress?: () => void;
   /**
-   * `Available in v3.x`
+   * @supported Available in v3.x with theme version 3
    *
    * Whether it's the leading button.
    */
@@ -47,19 +47,6 @@ type Props = React.ComponentPropsWithoutRef<typeof IconButton> & {
 
 /**
  * A component used to display an action item in the appbar.
- * <div class="screenshots">
- *   <figure>
- *     <img class="medium" src="screenshots/appbar-action-android.png" />
- *       <figcaption>Android</figcaption>
- *   </figure>
- * </div>
- *
- * <div class="screenshots">
- *   <figure>
- *     <img class="medium" src="screenshots/appbar-action-ios.png" />
- *       <figcaption>iOS</figcaption>
- *   </figure>
- * </div>
  *
  * ## Usage
  * ```js

--- a/src/components/Appbar/AppbarAction.tsx
+++ b/src/components/Appbar/AppbarAction.tsx
@@ -41,7 +41,10 @@ type Props = React.ComponentPropsWithoutRef<typeof IconButton> &
   };
 
 type MD3Props = {
-  isLeadingIcon?: boolean;
+  /**
+   * Whether it's the leading button.
+   */
+  isLeading?: boolean;
 };
 
 /**
@@ -86,7 +89,7 @@ const AppbarAction = ({
   disabled,
   onPress,
   accessibilityLabel,
-  isLeadingIcon,
+  isLeading,
   ...rest
 }: Props) => {
   const { isV3, md } = useTheme();
@@ -94,7 +97,7 @@ const AppbarAction = ({
   const actionIconColor = iconColor
     ? iconColor
     : isV3
-    ? isLeadingIcon
+    ? isLeading
       ? (md('md.sys.color.on-surface') as string)
       : (md('md.sys.color.on-surface-variant') as string)
     : color(black).alpha(0.54).rgb().string();

--- a/src/components/Appbar/AppbarAction.tsx
+++ b/src/components/Appbar/AppbarAction.tsx
@@ -8,34 +8,40 @@ import type {
 import { black } from '../../styles/themes/v2/colors';
 import IconButton from '../IconButton';
 import type { IconSource } from '../Icon';
+import { useTheme } from '../../core/theming';
 
-type Props = React.ComponentPropsWithoutRef<typeof IconButton> & {
-  /**
-   *  Custom color for action icon.
-   */
-  color?: string;
-  /**
-   * Name of the icon to show.
-   */
-  icon: IconSource;
-  /**
-   * Optional icon size.
-   */
-  size?: number;
-  /**
-   * Whether the button is disabled. A disabled button is greyed out and `onPress` is not called on touch.
-   */
-  disabled?: boolean;
-  /**
-   * Accessibility label for the button. This is read by the screen reader when the user taps the button.
-   */
-  accessibilityLabel?: string;
-  /**
-   * Function to execute on press.
-   */
-  onPress?: () => void;
-  style?: StyleProp<ViewStyle>;
-  ref?: React.RefObject<TouchableWithoutFeedback>;
+type Props = React.ComponentPropsWithoutRef<typeof IconButton> &
+  MD3Props & {
+    /**
+     *  Custom color for action icon.
+     */
+    color?: string;
+    /**
+     * Name of the icon to show.
+     */
+    icon: IconSource;
+    /**
+     * Optional icon size.
+     */
+    size?: number;
+    /**
+     * Whether the button is disabled. A disabled button is greyed out and `onPress` is not called on touch.
+     */
+    disabled?: boolean;
+    /**
+     * Accessibility label for the button. This is read by the screen reader when the user taps the button.
+     */
+    accessibilityLabel?: string;
+    /**
+     * Function to execute on press.
+     */
+    onPress?: () => void;
+    style?: StyleProp<ViewStyle>;
+    ref?: React.RefObject<TouchableWithoutFeedback>;
+  };
+
+type MD3Props = {
+  isLeadingIcon?: boolean;
 };
 
 /**
@@ -75,24 +81,37 @@ type Props = React.ComponentPropsWithoutRef<typeof IconButton> & {
  */
 const AppbarAction = ({
   size = 24,
-  color: iconColor = color(black).alpha(0.54).rgb().string(),
+  color: iconColor,
   icon,
   disabled,
   onPress,
   accessibilityLabel,
+  isLeadingIcon,
   ...rest
-}: Props) => (
-  <IconButton
-    size={size}
-    onPress={onPress}
-    color={iconColor}
-    icon={icon}
-    disabled={disabled}
-    accessibilityLabel={accessibilityLabel}
-    animated
-    {...rest}
-  />
-);
+}: Props) => {
+  const { isV3, md } = useTheme();
+
+  const actionIconColor = iconColor
+    ? iconColor
+    : isV3
+    ? isLeadingIcon
+      ? (md('md.sys.color.on-surface') as string)
+      : (md('md.sys.color.on-surface-variant') as string)
+    : color(black).alpha(0.54).rgb().string();
+
+  return (
+    <IconButton
+      size={size}
+      onPress={onPress}
+      color={actionIconColor}
+      icon={icon}
+      disabled={disabled}
+      accessibilityLabel={accessibilityLabel}
+      animated
+      {...rest}
+    />
+  );
+};
 
 AppbarAction.displayName = 'Appbar.Action';
 

--- a/src/components/Appbar/AppbarAction.tsx
+++ b/src/components/Appbar/AppbarAction.tsx
@@ -90,14 +90,14 @@ const AppbarAction = ({
   isLeading,
   ...rest
 }: Props) => {
-  const { isV3, md } = useTheme();
+  const theme = useTheme();
 
   const actionIconColor = iconColor
     ? iconColor
-    : isV3
+    : theme.isV3
     ? isLeading
-      ? (md('md.sys.color.on-surface') as string)
-      : (md('md.sys.color.on-surface-variant') as string)
+      ? theme.colors.onSurface
+      : theme.colors.onSurfaceVariant
     : color(black).alpha(0.54).rgb().string();
 
   return (

--- a/src/components/Appbar/AppbarAction.tsx
+++ b/src/components/Appbar/AppbarAction.tsx
@@ -10,41 +10,39 @@ import IconButton from '../IconButton';
 import type { IconSource } from '../Icon';
 import { useTheme } from '../../core/theming';
 
-type Props = React.ComponentPropsWithoutRef<typeof IconButton> &
-  MD3Props & {
-    /**
-     *  Custom color for action icon.
-     */
-    color?: string;
-    /**
-     * Name of the icon to show.
-     */
-    icon: IconSource;
-    /**
-     * Optional icon size.
-     */
-    size?: number;
-    /**
-     * Whether the button is disabled. A disabled button is greyed out and `onPress` is not called on touch.
-     */
-    disabled?: boolean;
-    /**
-     * Accessibility label for the button. This is read by the screen reader when the user taps the button.
-     */
-    accessibilityLabel?: string;
-    /**
-     * Function to execute on press.
-     */
-    onPress?: () => void;
-    style?: StyleProp<ViewStyle>;
-    ref?: React.RefObject<TouchableWithoutFeedback>;
-  };
-
-type MD3Props = {
+type Props = React.ComponentPropsWithoutRef<typeof IconButton> & {
   /**
+   *  Custom color for action icon.
+   */
+  color?: string;
+  /**
+   * Name of the icon to show.
+   */
+  icon: IconSource;
+  /**
+   * Optional icon size.
+   */
+  size?: number;
+  /**
+   * Whether the button is disabled. A disabled button is greyed out and `onPress` is not called on touch.
+   */
+  disabled?: boolean;
+  /**
+   * Accessibility label for the button. This is read by the screen reader when the user taps the button.
+   */
+  accessibilityLabel?: string;
+  /**
+   * Function to execute on press.
+   */
+  onPress?: () => void;
+  /**
+   * `Available in v3.x`
+   *
    * Whether it's the leading button.
    */
   isLeading?: boolean;
+  style?: StyleProp<ViewStyle>;
+  ref?: React.RefObject<TouchableWithoutFeedback>;
 };
 
 /**

--- a/src/components/Appbar/AppbarAction.tsx
+++ b/src/components/Appbar/AppbarAction.tsx
@@ -47,6 +47,19 @@ type Props = React.ComponentPropsWithoutRef<typeof IconButton> & {
 
 /**
  * A component used to display an action item in the appbar.
+ * <div class="screenshots">
+ *   <figure>
+ *     <img class="medium" src="screenshots/appbar-action-android.png" />
+ *       <figcaption>Android</figcaption>
+ *   </figure>
+ * </div>
+ *
+ * <div class="screenshots">
+ *   <figure>
+ *     <img class="medium" src="screenshots/appbar-action-ios.png" />
+ *       <figcaption>iOS</figcaption>
+ *   </figure>
+ * </div>
  *
  * ## Usage
  * ```js

--- a/src/components/Appbar/AppbarBackAction.tsx
+++ b/src/components/Appbar/AppbarBackAction.tsx
@@ -68,6 +68,7 @@ const AppbarBackAction = ({ accessibilityLabel = 'Back', ...rest }: Props) => (
     accessibilityLabel={accessibilityLabel}
     {...rest}
     icon={AppbarBackIcon}
+    isLeadingIcon
   />
 );
 

--- a/src/components/Appbar/AppbarBackAction.tsx
+++ b/src/components/Appbar/AppbarBackAction.tsx
@@ -68,7 +68,7 @@ const AppbarBackAction = ({ accessibilityLabel = 'Back', ...rest }: Props) => (
     accessibilityLabel={accessibilityLabel}
     {...rest}
     icon={AppbarBackIcon}
-    isLeadingIcon
+    isLeading
   />
 );
 

--- a/src/components/Appbar/AppbarBackAction.tsx
+++ b/src/components/Appbar/AppbarBackAction.tsx
@@ -34,20 +34,6 @@ type Props = $Omit<
 /**
  * A component used to display a back button in the appbar.
  *
- * <div class="screenshots">
- *   <figure>
- *     <img class="medium" src="screenshots/appbar-backaction-android.png" />
- *     <figcaption>Android</figcaption>
- *   </figure>
- * </div>
- *
- * <div class="screenshots">
- *   <figure>
- *     <img class="medium" src="screenshots/appbar-backaction-ios.png" />
- *     <figcaption>iOS</figcaption>
- *   </figure>
- * </div>
- *
  * ## Usage
  * ```js
  * import * as React from 'react';

--- a/src/components/Appbar/AppbarBackAction.tsx
+++ b/src/components/Appbar/AppbarBackAction.tsx
@@ -34,6 +34,20 @@ type Props = $Omit<
 /**
  * A component used to display a back button in the appbar.
  *
+ * <div class="screenshots">
+ *   <figure>
+ *     <img class="medium" src="screenshots/appbar-backaction-android.png" />
+ *     <figcaption>Android</figcaption>
+ *   </figure>
+ * </div>
+ *
+ * <div class="screenshots">
+ *   <figure>
+ *     <img class="medium" src="screenshots/appbar-backaction-ios.png" />
+ *     <figcaption>iOS</figcaption>
+ *   </figure>
+ * </div>
+ *
  * ## Usage
  * ```js
  * import * as React from 'react';

--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -18,47 +18,40 @@ import { white } from '../../styles/themes/v2/colors';
 import type { $RemoveChildren, Theme } from '../../types';
 import { AppbarModes, modeTextVariant } from './utils';
 
-type Props = $RemoveChildren<typeof View> &
-  MD3Props & {
-    /**
-     * Custom color for the text.
-     */
-    color?: string;
-    /**
-     * Text for the title.
-     */
-    title: React.ReactNode;
-    /**
-     * Style for the title.
-     */
-    titleStyle?: StyleProp<TextStyle>;
-    /**
-     * Reference for the title.
-     */
-    titleRef?: React.RefObject<Text>;
-    /**
-     * @deprecated
-     * Text for the subtitle.
-     */
-    subtitle?: React.ReactNode;
-    /**
-     * @deprecated
-     * Style for the subtitle.
-     */
-    subtitleStyle?: StyleProp<TextStyle>;
-    /**
-     * Function to execute on press.
-     */
-    onPress?: () => void;
-    style?: StyleProp<ViewStyle>;
-    /**
-     * @optional
-     */
-    theme: Theme;
-  };
-
-type MD3Props = {
+type Props = $RemoveChildren<typeof View> & {
   /**
+   * Custom color for the text.
+   */
+  color?: string;
+  /**
+   * Text for the title.
+   */
+  title: React.ReactNode;
+  /**
+   * Style for the title.
+   */
+  titleStyle?: StyleProp<TextStyle>;
+  /**
+   * Reference for the title.
+   */
+  titleRef?: React.RefObject<Text>;
+  /**
+   * @deprecated
+   * Text for the subtitle.
+   */
+  subtitle?: React.ReactNode;
+  /**
+   * @deprecated
+   * Style for the subtitle.
+   */
+  subtitleStyle?: StyleProp<TextStyle>;
+  /**
+   * Function to execute on press.
+   */
+  onPress?: () => void;
+  /**
+   * `Available in v3.x`
+   *
    * Mode of the Appbar.
    * - `small` - Appbar with default height (56).
    * - `medium` - Appbar with medium height (112).
@@ -66,6 +59,11 @@ type MD3Props = {
    * - `center-aligned` - Appbar with default height and center-aligned title.
    */
   mode?: AppbarModes;
+  style?: StyleProp<ViewStyle>;
+  /**
+   * @optional
+   */
+  theme: Theme;
 };
 
 /**

--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -50,13 +50,7 @@ type Props = $RemoveChildren<typeof View> & {
    */
   onPress?: () => void;
   /**
-   * @supported Available in v3.x with theme version 3
-   *
-   * Mode of the Appbar.
-   * - `small` - Appbar with default height (56).
-   * - `medium` - Appbar with medium height (112).
-   * - `large` - Appbar with large height (152).
-   * - `center-aligned` - Appbar with default height and center-aligned title.
+   * @internal
    */
   mode?: 'small' | 'medium' | 'large' | 'center-aligned';
   style?: StyleProp<ViewStyle>;

--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -16,7 +16,7 @@ import { withTheme } from '../../core/theming';
 import { white } from '../../styles/themes/v2/colors';
 
 import type { $RemoveChildren, Theme } from '../../types';
-import { AppbarModes, modeTextVariant } from './utils';
+import { modeTextVariant } from './utils';
 
 type Props = $RemoveChildren<typeof View> & {
   /**
@@ -36,12 +36,12 @@ type Props = $RemoveChildren<typeof View> & {
    */
   titleRef?: React.RefObject<Text>;
   /**
-   * @deprecated
+   * @deprecated Deprecated in v3.x
    * Text for the subtitle.
    */
   subtitle?: React.ReactNode;
   /**
-   * @deprecated
+   * @deprecated Deprecated in v3.x
    * Style for the subtitle.
    */
   subtitleStyle?: StyleProp<TextStyle>;
@@ -50,7 +50,7 @@ type Props = $RemoveChildren<typeof View> & {
    */
   onPress?: () => void;
   /**
-   * `Available in v3.x`
+   * @supported Available in v3.x with theme version 3
    *
    * Mode of the Appbar.
    * - `small` - Appbar with default height (56).
@@ -58,7 +58,7 @@ type Props = $RemoveChildren<typeof View> & {
    * - `large` - Appbar with large height (152).
    * - `center-aligned` - Appbar with default height and center-aligned title.
    */
-  mode?: AppbarModes;
+  mode?: 'small' | 'medium' | 'large' | 'center-aligned';
   style?: StyleProp<ViewStyle>;
   /**
    * @optional
@@ -68,12 +68,6 @@ type Props = $RemoveChildren<typeof View> & {
 
 /**
  * A component used to display a title and optional subtitle in an appbar.
- *
- * <div class="screenshots">
- *   <figure>
- *     <img class="medium" src="screenshots/appbar-content.png" />
- *   </figure>
- * </div>
  *
  * ## Usage
  * ```js
@@ -122,6 +116,7 @@ const AppbarContent = ({
   return (
     <TouchableWithoutFeedback onPress={onPress} disabled={!onPress}>
       <View
+        pointerEvents="box-none"
         style={[styles.container, isV3 && modeContainerStyles[mode], style]}
         {...rest}
       >

--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -16,7 +16,7 @@ import { withTheme } from '../../core/theming';
 import { white } from '../../styles/themes/v2/colors';
 
 import type { $RemoveChildren, Theme } from '../../types';
-import type { AppbarModes } from './utils';
+import { AppbarModes, modeTextVariant } from './utils';
 
 type Props = $RemoveChildren<typeof View> &
   MD3Props & {
@@ -58,6 +58,13 @@ type Props = $RemoveChildren<typeof View> &
   };
 
 type MD3Props = {
+  /**
+   * Mode of the Appbar.
+   * - `small` - Appbar with default height (56).
+   * - `medium` - Appbar with medium height (112).
+   * - `large` - Appbar with large height (152).
+   * - `center-aligned` - Appbar with default height and center-aligned title.
+   */
   mode?: AppbarModes;
 };
 
@@ -77,7 +84,7 @@ type MD3Props = {
  *
  * const MyComponent = () => (
  *     <Appbar.Header>
- *        <Appbar.Content title="Title" subtitle={'Subtitle'} />
+ *        <Appbar.Content title="Title" />
  *     </Appbar.Header>
  * );
  *
@@ -107,37 +114,21 @@ const AppbarContent = ({
     ? (md('md.sys.color.on-surface') as string)
     : white;
 
-  const getTextVariant = () => {
-    if (isV3) {
-      switch (mode) {
-        case 'small':
-          return 'title-large';
-        case 'medium':
-          return 'headline-small';
-        case 'large':
-          return 'headline-medium';
-        case 'center-aligned':
-          return 'title-large';
-      }
-    }
-    return undefined;
+  const modeContainerStyles = {
+    small: styles.v3DefaultContainer,
+    medium: styles.v3MediumContainer,
+    large: styles.v3LargeContainer,
+    'center-aligned': styles.v3DefaultContainer,
   };
-
-  const isHigherAppbar = mode === 'large' || mode === 'medium';
 
   return (
     <TouchableWithoutFeedback onPress={onPress} disabled={!onPress}>
       <View
-        style={[
-          styles.container,
-          isV3 &&
-            (isHigherAppbar ? styles.v3Container : styles.v3SmallContainer),
-          style,
-        ]}
+        style={[styles.container, isV3 && modeContainerStyles[mode], style]}
         {...rest}
       >
         <Text
-          variant={getTextVariant()}
+          {...(isV3 && { variant: modeTextVariant[mode] })}
           ref={titleRef}
           style={[
             {
@@ -176,13 +167,19 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingHorizontal: 12,
   },
-  v3SmallContainer: {
+  v3DefaultContainer: {
     paddingHorizontal: 0,
   },
-  v3Container: {
+  v3MediumContainer: {
     paddingHorizontal: 0,
     justifyContent: 'flex-end',
     paddingBottom: 24,
+  },
+  v3LargeContainer: {
+    paddingHorizontal: 0,
+    paddingTop: 36,
+    justifyContent: 'flex-end',
+    paddingBottom: 28,
   },
   title: {
     fontSize: Platform.OS === 'ios' ? 17 : 20,

--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -102,14 +102,14 @@ const AppbarContent = ({
   mode = 'small',
   ...rest
 }: Props) => {
-  const { fonts, isV3, md } = theme;
+  const { fonts, isV3, colors } = theme;
 
   const subtitleColor = color(titleColor).alpha(0.7).rgb().string();
 
   const titleTextColor = titleColor
     ? titleColor
     : isV3
-    ? (md('md.sys.color.on-surface') as string)
+    ? colors.onSurface
     : white;
 
   const modeContainerStyles = {

--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -63,6 +63,12 @@ type Props = $RemoveChildren<typeof View> & {
 /**
  * A component used to display a title and optional subtitle in an appbar.
  *
+ * <div class="screenshots">
+ *   <figure>
+ *     <img class="medium" src="screenshots/appbar-content.png" />
+ *   </figure>
+ * </div>
+ *
  * ## Usage
  * ```js
  * import * as React from 'react';

--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -130,7 +130,8 @@ const AppbarContent = ({
       <View
         style={[
           styles.container,
-          isV3 && isHigherAppbar ? styles.v3Container : styles.v3SmallContainer,
+          isV3 &&
+            (isHigherAppbar ? styles.v3Container : styles.v3SmallContainer),
           style,
         ]}
         {...rest}

--- a/src/components/Appbar/AppbarHeader.tsx
+++ b/src/components/Appbar/AppbarHeader.tsx
@@ -6,12 +6,17 @@ import {
   SafeAreaView,
   ViewStyle,
 } from 'react-native';
-import { DEFAULT_APPBAR_HEIGHT, Appbar } from './Appbar';
+import { Appbar } from './Appbar';
 import shadow from '../../styles/shadow';
 import { withTheme } from '../../core/theming';
 import { APPROX_STATUSBAR_HEIGHT } from '../../constants';
 import type { Theme } from '../../types';
-import { AppbarModes, getAppbarColor } from './utils';
+import {
+  AppbarModes,
+  DEFAULT_APPBAR_HEIGHT,
+  getAppbarColor,
+  modeAppbarHeight,
+} from './utils';
 
 type Props = React.ComponentProps<typeof Appbar> &
   MD3Props & {
@@ -38,6 +43,13 @@ type Props = React.ComponentProps<typeof Appbar> &
   };
 
 type MD3Props = {
+  /**
+   * Mode of the Appbar.
+   * - `small` - Appbar with default height (56).
+   * - `medium` - Appbar with medium height (112).
+   * - `large` - Appbar with large height (152).
+   * - `center-aligned` - Appbar with default height and center-aligned title.
+   */
   mode?: AppbarModes;
 };
 
@@ -71,7 +83,7 @@ type MD3Props = {
  *   return (
  *     <Appbar.Header>
  *       <Appbar.BackAction onPress={_goBack} />
- *       <Appbar.Content title="Title" subtitle="Subtitle" />
+ *       <Appbar.Content title="Title" />
  *       <Appbar.Action icon="magnify" onPress={_handleSearch} />
  *       <Appbar.Action icon="dots-vertical" onPress={_handleMore} />
  *     </Appbar.Header>
@@ -93,15 +105,8 @@ const AppbarHeader = (props: Props) => {
 
   const { isV3 } = rest.theme;
 
-  const appbarHeight = {
-    small: DEFAULT_APPBAR_HEIGHT,
-    medium: 112,
-    large: 152,
-    'center-aligned': DEFAULT_APPBAR_HEIGHT,
-  };
-
   const {
-    height = isV3 ? appbarHeight[mode] : DEFAULT_APPBAR_HEIGHT,
+    height = isV3 ? modeAppbarHeight[mode] : DEFAULT_APPBAR_HEIGHT,
     elevation = isV3 ? 0 : 4,
     backgroundColor: customBackground,
     zIndex = 0,

--- a/src/components/Appbar/AppbarHeader.tsx
+++ b/src/components/Appbar/AppbarHeader.tsx
@@ -18,32 +18,25 @@ import {
   modeAppbarHeight,
 } from './utils';
 
-type Props = React.ComponentProps<typeof Appbar> &
-  MD3Props & {
-    /**
-     * Whether the background color is a dark color. A dark header will render light text and vice-versa.
-     */
-    dark?: boolean;
-    /**
-     * Extra padding to add at the top of header to account for translucent status bar.
-     * This is automatically handled on iOS >= 11 including iPhone X using `SafeAreaView`.
-     * If you are using Expo, we assume translucent status bar and set a height for status bar automatically.
-     * Pass `0` or a custom value to disable the default behaviour, and customize the height.
-     */
-    statusBarHeight?: number;
-    /**
-     * Content of the header.
-     */
-    children: React.ReactNode;
-    /**
-     * @optional
-     */
-    theme: Theme;
-    style?: StyleProp<ViewStyle>;
-  };
-
-type MD3Props = {
+type Props = React.ComponentProps<typeof Appbar> & {
   /**
+   * Whether the background color is a dark color. A dark header will render light text and vice-versa.
+   */
+  dark?: boolean;
+  /**
+   * Extra padding to add at the top of header to account for translucent status bar.
+   * This is automatically handled on iOS >= 11 including iPhone X using `SafeAreaView`.
+   * If you are using Expo, we assume translucent status bar and set a height for status bar automatically.
+   * Pass `0` or a custom value to disable the default behaviour, and customize the height.
+   */
+  statusBarHeight?: number;
+  /**
+   * Content of the header.
+   */
+  children: React.ReactNode;
+  /**
+   * `Available in v3.x`
+   *
    * Mode of the Appbar.
    * - `small` - Appbar with default height (56).
    * - `medium` - Appbar with medium height (112).
@@ -51,6 +44,11 @@ type MD3Props = {
    * - `center-aligned` - Appbar with default height and center-aligned title.
    */
   mode?: AppbarModes;
+  /**
+   * @optional
+   */
+  theme: Theme;
+  style?: StyleProp<ViewStyle>;
 };
 
 /**

--- a/src/components/Appbar/AppbarHeader.tsx
+++ b/src/components/Appbar/AppbarHeader.tsx
@@ -5,6 +5,7 @@ import {
   View,
   SafeAreaView,
   ViewStyle,
+  Platform,
 } from 'react-native';
 import { Appbar } from './Appbar';
 import shadow from '../../styles/shadow';
@@ -12,7 +13,6 @@ import { withTheme } from '../../core/theming';
 import { APPROX_STATUSBAR_HEIGHT } from '../../constants';
 import type { Theme } from '../../types';
 import {
-  AppbarModes,
   DEFAULT_APPBAR_HEIGHT,
   getAppbarColor,
   modeAppbarHeight,
@@ -35,7 +35,7 @@ type Props = React.ComponentProps<typeof Appbar> & {
    */
   children: React.ReactNode;
   /**
-   * `Available in v3.x`
+   * @supported Available in v3.x with theme version 3
    *
    * Mode of the Appbar.
    * - `small` - Appbar with default height (56).
@@ -43,7 +43,12 @@ type Props = React.ComponentProps<typeof Appbar> & {
    * - `large` - Appbar with large height (152).
    * - `center-aligned` - Appbar with default height and center-aligned title.
    */
-  mode?: AppbarModes;
+  mode?: 'small' | 'medium' | 'large' | 'center-aligned';
+  /**
+   * @supported Available in v3.x with theme version 3
+   * Whether Appbar background should have the elevation along with primary color pigment.
+   */
+  elevated?: boolean;
   /**
    * @optional
    */
@@ -91,21 +96,20 @@ type Props = React.ComponentProps<typeof Appbar> & {
  * export default MyComponent;
  * ```
  */
-const AppbarHeader = (props: Props) => {
-  const {
-    // Don't use default props since we check it to know whether we should use SafeAreaView
-    statusBarHeight = APPROX_STATUSBAR_HEIGHT,
-    style,
-    dark,
-    mode = 'small',
-    ...rest
-  } = props;
-
+const AppbarHeader = ({
+  // Don't use default props since we check it to know whether we should use SafeAreaView
+  statusBarHeight,
+  style,
+  dark,
+  mode = Platform.OS === 'ios' ? 'center-aligned' : 'small',
+  elevated = false,
+  ...rest
+}: Props) => {
   const { isV3 } = rest.theme;
 
   const {
     height = isV3 ? modeAppbarHeight[mode] : DEFAULT_APPBAR_HEIGHT,
-    elevation = isV3 ? 0 : 4,
+    elevation = isV3 ? (elevated ? 2 : 0) : 4,
     backgroundColor: customBackground,
     zIndex = 0,
     ...restStyle
@@ -114,17 +118,22 @@ const AppbarHeader = (props: Props) => {
   const backgroundColor = getAppbarColor(
     rest.theme,
     elevation,
-    customBackground
+    customBackground,
+    elevated
   );
 
   // Let the user override the behaviour
-  const Wrapper =
-    typeof props.statusBarHeight === 'number' ? View : SafeAreaView;
+  const Wrapper = typeof statusBarHeight === 'number' ? View : SafeAreaView;
   return (
     <Wrapper
       style={
         [
-          { backgroundColor, zIndex, elevation, paddingTop: statusBarHeight },
+          {
+            backgroundColor,
+            zIndex,
+            elevation,
+            paddingTop: statusBarHeight || APPROX_STATUSBAR_HEIGHT,
+          },
           shadow(elevation),
         ] as StyleProp<ViewStyle>
       }

--- a/src/components/Appbar/utils.ts
+++ b/src/components/Appbar/utils.ts
@@ -15,17 +15,17 @@ export const getAppbarColor = (
   elevation: number,
   customBackground?: ColorValue
 ) => {
-  const { isV3, md, dark: isDarkTheme, mode, colors } = theme;
+  const { isV3, dark: isDarkTheme, mode, colors } = theme;
   const isAdaptiveMode = mode === 'adaptive';
   let backgroundColor;
   if (customBackground) {
     backgroundColor = customBackground;
   } else if (isV3) {
-    backgroundColor = md('md.sys.color.surface') as string;
+    backgroundColor = colors.surface;
   } else if (!isV3) {
     if (isDarkTheme && isAdaptiveMode) {
       backgroundColor = overlay(elevation, colors?.surface);
-    } else backgroundColor = colors?.primary;
+    } else backgroundColor = colors.primary;
   }
 
   return backgroundColor;
@@ -50,10 +50,10 @@ export const modeAppbarHeight = {
 };
 
 export const modeTextVariant = {
-  small: 'title-large',
-  medium: 'headline-small',
-  large: 'headline-medium',
-  'center-aligned': 'title-large',
+  small: 'titleLarge',
+  medium: 'headlineSmall',
+  large: 'headlineMedium',
+  'center-aligned': 'titleLarge',
 };
 
 export const renderAppbarContent = ({

--- a/src/components/Appbar/utils.ts
+++ b/src/components/Appbar/utils.ts
@@ -22,9 +22,11 @@ export const getAppbarColor = (
     backgroundColor = customBackground;
   } else if (isV3) {
     backgroundColor = md('md.sys.color.surface') as string;
-  } else if (isDarkTheme && isAdaptiveMode) {
-    backgroundColor = overlay(elevation, colors?.surface);
-  } else backgroundColor = colors?.primary;
+  } else if (!isV3) {
+    if (isDarkTheme && isAdaptiveMode) {
+      backgroundColor = overlay(elevation, colors?.surface);
+    } else backgroundColor = colors?.primary;
+  }
 
   return backgroundColor;
 };
@@ -33,12 +35,8 @@ type RenderAppbarContentProps = {
   children: React.ReactNode;
   isDark: boolean;
   shouldCenterContent?: boolean;
-  theme: Theme;
-  renderOnly?: (
-    | typeof AppbarContent
-    | typeof AppbarAction
-    | typeof AppbarBackAction
-  )[];
+  isV3: boolean;
+  renderOnly?: React.ReactNode[];
   mode?: AppbarModes;
 };
 
@@ -62,16 +60,15 @@ export const renderAppbarContent = ({
   children,
   isDark,
   shouldCenterContent = false,
-  theme,
-  renderOnly = [AppbarContent, AppbarAction, AppbarBackAction],
+  isV3,
+  renderOnly,
   mode = 'small',
 }: RenderAppbarContentProps) => {
-  const { isV3 } = theme;
   return (
     React.Children.toArray(children)
       .filter((child) => child != null && typeof child !== 'boolean')
       // @ts-expect-error: TypeScript complains about the type of type but it doesn't matter
-      .filter((child) => renderOnly.includes(child.type))
+      .filter((child) => (renderOnly ? renderOnly.includes(child.type) : child))
       .map((child, i) => {
         if (
           !React.isValidElement(child) ||
@@ -100,8 +97,10 @@ export const renderAppbarContent = ({
           props.mode = mode;
           props.style = [
             isV3 ? i === 0 && styles.v3Spacing : i !== 0 && styles.v2Spacing,
-            shouldCenterContent && isV3 && styles.v3CenterAlignedContent,
-            shouldCenterContent && !isV3 && styles.v2CenterAlignedContent,
+            shouldCenterContent &&
+              (isV3
+                ? styles.v3CenterAlignedContent
+                : styles.v2CenterAlignedContent),
             child.props.style,
           ];
         }

--- a/src/components/Appbar/utils.ts
+++ b/src/components/Appbar/utils.ts
@@ -19,25 +19,26 @@ export const getAppbarColor = (
 ) => {
   const { isV3, dark: isDarkTheme, mode, colors } = theme;
   const isAdaptiveMode = mode === 'adaptive';
-  let backgroundColor;
   if (customBackground) {
-    backgroundColor = customBackground;
-  } else if (isV3) {
-    if (elevated) {
-      backgroundColor = color(colors.surface)
-        .mix(color(colors.primary), 0.08)
-        .rgb()
-        .string();
-    } else {
-      backgroundColor = colors.surface;
-    }
-  } else if (!isV3) {
-    if (isDarkTheme && isAdaptiveMode) {
-      backgroundColor = overlay(elevation, colors?.surface);
-    } else backgroundColor = colors.primary;
+    return customBackground;
   }
 
-  return backgroundColor;
+  if (!isV3) {
+    if (isDarkTheme && isAdaptiveMode) {
+      return overlay(elevation, colors?.surface);
+    }
+
+    return colors.primary;
+  }
+
+  if (elevated) {
+    return color(colors.surface)
+      .mix(color(colors.primary), 0.08)
+      .rgb()
+      .string();
+  }
+
+  return colors.surface;
 };
 
 type RenderAppbarContentProps = {

--- a/src/components/Appbar/utils.ts
+++ b/src/components/Appbar/utils.ts
@@ -1,0 +1,112 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import type { ColorValue, StyleProp, ViewStyle } from 'react-native';
+import AppbarContent from './AppbarContent';
+import AppbarAction from './AppbarAction';
+import AppbarBackAction from './AppbarBackAction';
+import overlay from '../../styles/overlay';
+import type { Theme } from '../../types';
+import { black, white } from '../../styles/themes/v2/colors';
+
+export type AppbarModes = 'small' | 'medium' | 'large' | 'center-aligned';
+
+export const getAppbarColor = (
+  theme: Theme,
+  elevation: number,
+  customBackground?: ColorValue
+) => {
+  const { isV3, md, dark: isDarkTheme, mode, colors } = theme;
+  const isAdaptiveMode = mode === 'adaptive';
+  let backgroundColor;
+  if (customBackground) {
+    backgroundColor = customBackground;
+  } else if (isV3) {
+    backgroundColor = md('md.sys.color.surface') as string;
+  } else if (isDarkTheme && isAdaptiveMode) {
+    backgroundColor = overlay(elevation, colors?.surface);
+  } else backgroundColor = colors?.primary;
+
+  return backgroundColor;
+};
+
+type RenderAppbarContentProps = {
+  children: React.ReactNode;
+  isDark: boolean;
+  shouldCenterContent?: boolean;
+  theme: Theme;
+  renderOnly?: (
+    | typeof AppbarContent
+    | typeof AppbarAction
+    | typeof AppbarBackAction
+  )[];
+  mode?: AppbarModes;
+};
+
+export const renderAppbarContent = ({
+  children,
+  isDark,
+  shouldCenterContent = false,
+  theme,
+  renderOnly = [AppbarContent, AppbarAction, AppbarBackAction],
+  mode = 'small',
+}: RenderAppbarContentProps) => {
+  const { isV3 } = theme;
+  return (
+    React.Children.toArray(children)
+      .filter((child) => child != null && typeof child !== 'boolean')
+      // @ts-expect-error: TypeScript complains about the type of type but it doesn't matter
+      .filter((child) => renderOnly.includes(child.type))
+      .map((child, i) => {
+        if (
+          !React.isValidElement(child) ||
+          ![AppbarContent, AppbarAction, AppbarBackAction].includes(
+            // @ts-expect-error: TypeScript complains about the type of type but it doesn't matter
+            child.type
+          )
+        ) {
+          return child;
+        }
+
+        const props: {
+          color?: string;
+          style?: StyleProp<ViewStyle>;
+          mode?: AppbarModes;
+        } = {
+          color:
+            typeof child.props.color !== 'undefined'
+              ? child.props.color
+              : isDark
+              ? white
+              : black,
+        };
+
+        if (child.type === AppbarContent) {
+          props.mode = mode;
+          props.style = [
+            isV3 ? i === 0 && styles.v3Spacing : i !== 0 && styles.v2Spacing,
+            shouldCenterContent && isV3 && styles.v3CenterAlignedContent,
+            shouldCenterContent && !isV3 && styles.v2CenterAlignedContent,
+            child.props.style,
+          ];
+        }
+        return React.cloneElement(child, props);
+      })
+  );
+};
+
+const styles = StyleSheet.create({
+  v2Spacing: {
+    marginLeft: 8,
+  },
+  v2CenterAlignedContent: {
+    alignItems: 'center',
+  },
+  v3Spacing: {
+    marginLeft: 12,
+  },
+  v3CenterAlignedContent: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/src/components/Appbar/utils.ts
+++ b/src/components/Appbar/utils.ts
@@ -42,6 +42,22 @@ type RenderAppbarContentProps = {
   mode?: AppbarModes;
 };
 
+export const DEFAULT_APPBAR_HEIGHT = 56;
+
+export const modeAppbarHeight = {
+  small: DEFAULT_APPBAR_HEIGHT,
+  medium: 112,
+  large: 152,
+  'center-aligned': DEFAULT_APPBAR_HEIGHT,
+};
+
+export const modeTextVariant = {
+  small: 'title-large',
+  medium: 'headline-small',
+  large: 'headline-medium',
+  'center-aligned': 'title-large',
+};
+
 export const renderAppbarContent = ({
   children,
   isDark,

--- a/src/components/Appbar/utils.ts
+++ b/src/components/Appbar/utils.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import color from 'color';
 import { StyleSheet } from 'react-native';
 import type { ColorValue, StyleProp, ViewStyle } from 'react-native';
 import AppbarContent from './AppbarContent';
@@ -13,7 +14,8 @@ export type AppbarModes = 'small' | 'medium' | 'large' | 'center-aligned';
 export const getAppbarColor = (
   theme: Theme,
   elevation: number,
-  customBackground?: ColorValue
+  customBackground?: ColorValue,
+  elevated?: boolean
 ) => {
   const { isV3, dark: isDarkTheme, mode, colors } = theme;
   const isAdaptiveMode = mode === 'adaptive';
@@ -21,7 +23,14 @@ export const getAppbarColor = (
   if (customBackground) {
     backgroundColor = customBackground;
   } else if (isV3) {
-    backgroundColor = colors.surface;
+    if (elevated) {
+      backgroundColor = color(colors.surface)
+        .mix(color(colors.primary), 0.08)
+        .rgb()
+        .string();
+    } else {
+      backgroundColor = colors.surface;
+    }
   } else if (!isV3) {
     if (isDarkTheme && isAdaptiveMode) {
       backgroundColor = overlay(elevation, colors?.surface);

--- a/src/components/Appbar/utils.ts
+++ b/src/components/Appbar/utils.ts
@@ -46,6 +46,7 @@ type RenderAppbarContentProps = {
   shouldCenterContent?: boolean;
   isV3: boolean;
   renderOnly?: React.ReactNode[];
+  renderExcept?: React.ReactNode[];
   mode?: AppbarModes;
 };
 
@@ -71,11 +72,16 @@ export const renderAppbarContent = ({
   shouldCenterContent = false,
   isV3,
   renderOnly,
+  renderExcept,
   mode = 'small',
 }: RenderAppbarContentProps) => {
   return (
     React.Children.toArray(children)
       .filter((child) => child != null && typeof child !== 'boolean')
+      .filter((child) =>
+        // @ts-expect-error: TypeScript complains about the type of type but it doesn't matter
+        renderExcept ? !renderExcept.includes(child.type) : child
+      )
       // @ts-expect-error: TypeScript complains about the type of type but it doesn't matter
       .filter((child) => (renderOnly ? renderOnly.includes(child.type) : child))
       .map((child, i) => {

--- a/src/components/__tests__/Appbar/Appbar.test.js
+++ b/src/components/__tests__/Appbar/Appbar.test.js
@@ -2,10 +2,12 @@ import React from 'react';
 import { StyleSheet } from 'react-native';
 import renderer from 'react-test-renderer';
 import { get } from 'lodash';
+import Menu from '../../Menu/Menu';
 import Appbar from '../../Appbar';
 import AppbarAction from '../../Appbar/AppbarAction';
 import AppbarContent from '../../Appbar/AppbarContent';
 import AppbarBackAction from '../../Appbar/AppbarBackAction';
+import AppbarHeader from '../../Appbar/AppbarHeader';
 import { getAppbarColor, renderAppbarContent } from '../../Appbar/utils';
 import Searchbar from '../../Searchbar';
 import { tokens } from '../../../styles/themes/v3/tokens';
@@ -58,6 +60,22 @@ describe('renderAppbarContent', () => {
     });
 
     expect(result).toHaveLength(4);
+  });
+
+  it('should render all children types except specified in renderExcept', () => {
+    const result = renderAppbarContent({
+      children: [
+        ...children,
+        <Menu
+          key={4}
+          anchor={<Appbar.Action icon="menu" onPress={() => {}} />}
+        />,
+      ],
+      isDark: false,
+      renderExcept: [Appbar, AppbarHeader, AppbarBackAction, AppbarContent],
+    });
+
+    expect(result).toHaveLength(3);
   });
 
   it('should render only children types specifed in renderOnly', () => {

--- a/src/components/__tests__/Appbar/Appbar.test.js
+++ b/src/components/__tests__/Appbar/Appbar.test.js
@@ -1,7 +1,19 @@
 import React from 'react';
+import { StyleSheet } from 'react-native';
 import renderer from 'react-test-renderer';
+import { get } from 'lodash';
 import Appbar from '../../Appbar';
+import AppbarAction from '../../Appbar/AppbarAction';
+import AppbarContent from '../../Appbar/AppbarContent';
+import AppbarBackAction from '../../Appbar/AppbarBackAction';
+import { getAppbarColor, renderAppbarContent } from '../../Appbar/utils';
 import Searchbar from '../../Searchbar';
+import { tokens } from '../../../styles/themes/v3/tokens';
+import MD3LightTheme from '../../../styles/themes/v3/LightTheme';
+import MD2LightTheme from '../../../styles/themes/v2/LightTheme';
+import MD3DarkTheme from '../../../styles/themes/v3/DarkTheme';
+import MD2DarkTheme from '../../../styles/themes/v2/DarkTheme';
+import overlay from '../../../styles/overlay';
 
 describe('Appbar', () => {
   it('does not pass any additional props to Searchbar', () => {
@@ -28,5 +40,148 @@ describe('Appbar', () => {
       .toJSON();
 
     expect(tree).toMatchSnapshot();
+  });
+});
+
+describe('renderAppbarContent', () => {
+  const children = [
+    <Appbar.BackAction onPress={() => {}} key={0} />,
+    <Appbar.Content title="Examples" key={1} />,
+    <Appbar.Action icon="magnify" onPress={() => {}} key={2} />,
+    <Appbar.Action icon="menu" onPress={() => {}} key={3} />,
+  ];
+
+  it('should render all children types if renderOnly is not specified', () => {
+    const result = renderAppbarContent({
+      children,
+      isDark: false,
+    });
+
+    expect(result).toHaveLength(4);
+  });
+
+  it('should render only children types specifed in renderOnly', () => {
+    const result = renderAppbarContent({
+      children,
+      isDark: false,
+      renderOnly: [AppbarAction],
+    });
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('should render AppbarContent with correct mode', () => {
+    const result = renderAppbarContent({
+      children,
+      isDark: false,
+      renderOnly: [AppbarContent],
+      mode: 'large',
+    });
+
+    expect(result[0].props.mode).toBe('large');
+  });
+
+  it('should render centered AppbarContent', () => {
+    const renderResult = (isV3 = true) =>
+      renderAppbarContent({
+        children,
+        isDark: false,
+        isV3,
+        renderOnly: [AppbarContent],
+        mode: 'center-aligned',
+        shouldCenterContent: true,
+      });
+
+    const v3CenterAlignedStyle = {
+      ...StyleSheet.absoluteFillObject,
+      alignItems: 'center',
+      justifyContent: 'center',
+    };
+
+    const v2CenterAlignedContent = {
+      alignItems: 'center',
+    };
+
+    expect(renderResult()[0].props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining(v3CenterAlignedStyle)])
+    );
+
+    expect(renderResult(false)[0].props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining(v2CenterAlignedContent)])
+    );
+  });
+
+  it('should render AppbarContent with correct spacings', () => {
+    const renderResult = (isV3 = true, withAppbarBackAction = false) =>
+      renderAppbarContent({
+        children,
+        isDark: false,
+        isV3,
+        renderOnly: [AppbarContent, withAppbarBackAction && AppbarBackAction],
+      });
+
+    const v2Spacing = {
+      marginLeft: 8,
+    };
+
+    const v3Spacing = {
+      marginLeft: 12,
+    };
+
+    expect(renderResult()[0].props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining(v3Spacing)])
+    );
+
+    expect(renderResult(false, true)[1].props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining(v2Spacing)])
+    );
+  });
+});
+
+describe('getAppbarColors', () => {
+  const getTheme = (isDark = false, isV3 = true) => {
+    const theme = isDark
+      ? isV3
+        ? MD3DarkTheme
+        : MD2DarkTheme
+      : isV3
+      ? MD3LightTheme
+      : MD2LightTheme;
+    return {
+      ...theme,
+      isV3,
+      md: (tokenKey) => get(theme.tokens, tokenKey),
+    };
+  };
+
+  const elevation = 4;
+  const customBackground = 'aquamarine';
+
+  it('should return custom color no matter what is the theme version', () => {
+    expect(getAppbarColor(getTheme(), elevation, customBackground)).toBe(
+      customBackground
+    );
+  });
+
+  it('should return v3 light color if theme version is 3', () => {
+    expect(getAppbarColor(getTheme(), elevation)).toBe(
+      tokens.md.ref.palette.neutral99
+    );
+  });
+
+  it('should return v3 dark color if theme version is 3', () => {
+    expect(getAppbarColor(getTheme(true), elevation)).toBe(
+      tokens.md.ref.palette.neutral10
+    );
+  });
+
+  it('should return v2 light color if theme version is 2', () => {
+    expect(getAppbarColor(getTheme(false, false), elevation)).toBe('#6200ee');
+  });
+
+  it('should return v2 dark color if theme version is 2', () => {
+    expect(getAppbarColor(getTheme(true, false), elevation)).toBe(
+      overlay(elevation, '#121212')
+    );
   });
 });

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
@@ -19,7 +19,199 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
       "shadowRadius": 4,
     }
   }
-/>
+>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#ffffff",
+        "borderRadius": 4,
+        "elevation": 4,
+        "flexDirection": "row",
+        "shadowColor": "#000000",
+        "shadowOffset": Object {
+          "height": 3,
+          "width": 0,
+        },
+        "shadowOpacity": 0.24,
+        "shadowRadius": 4,
+      }
+    }
+  >
+    <View
+      accessibilityLabel="search"
+      accessibilityRole="button"
+      accessibilityState={
+        Object {
+          "disabled": undefined,
+        }
+      }
+      accessible={true}
+      focusable={false}
+      hitSlop={
+        Object {
+          "bottom": 6,
+          "left": 6,
+          "right": 6,
+          "top": 6,
+        }
+      }
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+              "margin": 6,
+              "overflow": "hidden",
+            },
+            Object {
+              "borderRadius": 18,
+              "height": 36,
+              "width": 36,
+            },
+            undefined,
+            undefined,
+          ],
+        ]
+      }
+    >
+      <View>
+        <Text
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "backgroundColor": "transparent",
+              },
+              Object {
+                "color": "rgba(0, 0, 0, 0.54)",
+                "fontSize": 24,
+              },
+            ]
+          }
+        >
+          □
+        </Text>
+      </View>
+    </View>
+    <TextInput
+      accessibilityRole="search"
+      accessibilityTraits="search"
+      allowFontScaling={true}
+      keyboardAppearance="light"
+      placeholder="Search"
+      placeholderTextColor="rgba(0, 0, 0, 0.54)"
+      rejectResponderTermination={true}
+      returnKeyType="search"
+      selectionColor="#6200ee"
+      style={
+        Array [
+          Object {
+            "alignSelf": "stretch",
+            "flex": 1,
+            "fontSize": 18,
+            "minWidth": 0,
+            "paddingLeft": 8,
+            "textAlign": "left",
+          },
+          Object {
+            "color": "#000000",
+            "fontFamily": "System",
+            "fontWeight": "400",
+          },
+          undefined,
+        ]
+      }
+      underlineColorAndroid="transparent"
+    />
+    <View
+      accessibilityLabel="clear"
+      accessibilityRole="button"
+      accessibilityState={
+        Object {
+          "disabled": true,
+        }
+      }
+      accessible={true}
+      focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 6,
+          "left": 6,
+          "right": 6,
+          "top": 6,
+        }
+      }
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+              "margin": 6,
+              "overflow": "hidden",
+            },
+            Object {
+              "borderRadius": 18,
+              "height": 36,
+              "width": 36,
+            },
+            Object {
+              "opacity": 0.32,
+            },
+            undefined,
+          ],
+        ]
+      }
+    >
+      <View>
+        <Text
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "backgroundColor": "transparent",
+              },
+              Object {
+                "color": "rgba(255, 255, 255, 0)",
+                "fontSize": 24,
+              },
+            ]
+          }
+        >
+          □
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
 `;
 
 exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and AppbarAction 1`] = `
@@ -186,7 +378,6 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
           Object {
             "marginLeft": 8,
           },
-          undefined,
           Object {
             "alignItems": "center",
           },

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
@@ -367,6 +367,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
     onResponderTerminate={[Function]}
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
+    pointerEvents="box-none"
     style={
       Array [
         Object {

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
@@ -181,9 +181,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
           "flex": 1,
           "paddingHorizontal": 12,
         },
-        Object {
-          "paddingHorizontal": 0,
-        },
+        undefined,
         Array [
           Object {
             "marginLeft": 8,

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
@@ -19,199 +19,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
       "shadowRadius": 4,
     }
   }
->
-  <View
-    style={
-      Object {
-        "alignItems": "center",
-        "backgroundColor": "#ffffff",
-        "borderRadius": 4,
-        "elevation": 4,
-        "flexDirection": "row",
-        "shadowColor": "#000000",
-        "shadowOffset": Object {
-          "height": 3,
-          "width": 0,
-        },
-        "shadowOpacity": 0.24,
-        "shadowRadius": 4,
-      }
-    }
-  >
-    <View
-      accessibilityLabel="search"
-      accessibilityRole="button"
-      accessibilityState={
-        Object {
-          "disabled": undefined,
-        }
-      }
-      accessible={true}
-      focusable={false}
-      hitSlop={
-        Object {
-          "bottom": 6,
-          "left": 6,
-          "right": 6,
-          "top": 6,
-        }
-      }
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        Array [
-          Object {
-            "overflow": "hidden",
-          },
-          Array [
-            Object {
-              "alignItems": "center",
-              "justifyContent": "center",
-              "margin": 6,
-              "overflow": "hidden",
-            },
-            Object {
-              "borderRadius": 18,
-              "height": 36,
-              "width": 36,
-            },
-            undefined,
-            undefined,
-          ],
-        ]
-      }
-    >
-      <View>
-        <Text
-          accessibilityElementsHidden={true}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "backgroundColor": "transparent",
-              },
-              Object {
-                "color": "rgba(0, 0, 0, 0.54)",
-                "fontSize": 24,
-              },
-            ]
-          }
-        >
-          □
-        </Text>
-      </View>
-    </View>
-    <TextInput
-      accessibilityRole="search"
-      accessibilityTraits="search"
-      allowFontScaling={true}
-      keyboardAppearance="light"
-      placeholder="Search"
-      placeholderTextColor="rgba(0, 0, 0, 0.54)"
-      rejectResponderTermination={true}
-      returnKeyType="search"
-      selectionColor="#6200ee"
-      style={
-        Array [
-          Object {
-            "alignSelf": "stretch",
-            "flex": 1,
-            "fontSize": 18,
-            "minWidth": 0,
-            "paddingLeft": 8,
-            "textAlign": "left",
-          },
-          Object {
-            "color": "#000000",
-            "fontFamily": "System",
-            "fontWeight": "400",
-          },
-          undefined,
-        ]
-      }
-      underlineColorAndroid="transparent"
-    />
-    <View
-      accessibilityLabel="clear"
-      accessibilityRole="button"
-      accessibilityState={
-        Object {
-          "disabled": true,
-        }
-      }
-      accessible={true}
-      focusable={true}
-      hitSlop={
-        Object {
-          "bottom": 6,
-          "left": 6,
-          "right": 6,
-          "top": 6,
-        }
-      }
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        Array [
-          Object {
-            "overflow": "hidden",
-          },
-          Array [
-            Object {
-              "alignItems": "center",
-              "justifyContent": "center",
-              "margin": 6,
-              "overflow": "hidden",
-            },
-            Object {
-              "borderRadius": 18,
-              "height": 36,
-              "width": 36,
-            },
-            Object {
-              "opacity": 0.32,
-            },
-            undefined,
-          ],
-        ]
-      }
-    >
-      <View>
-        <Text
-          accessibilityElementsHidden={true}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "backgroundColor": "transparent",
-              },
-              Object {
-                "color": "rgba(255, 255, 255, 0)",
-                "fontSize": 24,
-              },
-            ]
-          }
-        >
-          □
-        </Text>
-      </View>
-    </View>
-  </View>
-</View>
+/>
 `;
 
 exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and AppbarAction 1`] = `
@@ -373,10 +181,14 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
           "flex": 1,
           "paddingHorizontal": 12,
         },
+        Object {
+          "paddingHorizontal": 0,
+        },
         Array [
           Object {
             "marginLeft": 8,
           },
+          undefined,
           Object {
             "alignItems": "center",
           },

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
@@ -373,7 +373,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
           "flex": 1,
           "paddingHorizontal": 12,
         },
-        undefined,
+        false,
         Array [
           Object {
             "marginLeft": 8,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

PR:
* adjusts `Appbar` and its subcomponents to Material You. 
* introduces new props:
  * `mode: 'small' (default) | 'medium' | 'large' | 'center-aligned'`
  * `elevated` - adding shadow


## iOS 
<details>
<summary>light theme</summary>

small | medium | large | center-aligned
--- | --- | --- | ---
<img width="441" alt="Zrzut ekranu 2022-02-4 o 12 18 06" src="https://user-images.githubusercontent.com/22746080/152520778-16ea001b-2cb9-47b4-9e4b-474bf86b916b.png"> | <img width="441" alt="Zrzut ekranu 2022-02-4 o 12 18 11" src="https://user-images.githubusercontent.com/22746080/152520790-efcf5e21-a384-4df6-b4e1-b34540d1e7df.png"> | <img width="441" alt="Zrzut ekranu 2022-02-4 o 12 18 15" src="https://user-images.githubusercontent.com/22746080/152520793-1d58b2c7-49c6-40f7-a6e2-14db9956944e.png"> | <img width="441" alt="Zrzut ekranu 2022-02-4 o 12 18 19" src="https://user-images.githubusercontent.com/22746080/152520796-6f600d74-0604-45cb-a60a-74e40a530431.png"> 

</details>

<details>
<summary>dark theme</summary>

small | medium | large | center-aligned
--- | --- | --- | ---
<img width="441" alt="Zrzut ekranu 2022-02-4 o 12 19 45" src="https://user-images.githubusercontent.com/22746080/152521023-1f87d22a-f865-4dfd-b0b4-dc7c1c891bc0.png"> | <img width="441" alt="Zrzut ekranu 2022-02-4 o 12 19 48" src="https://user-images.githubusercontent.com/22746080/152521041-0030926c-a343-4b7d-b0fd-ae922d0b9361.png"> | <img width="441" alt="Zrzut ekranu 2022-02-4 o 12 19 51" src="https://user-images.githubusercontent.com/22746080/152521066-6f675b29-254f-4daa-b0b9-7f193e1a2f42.png"> | <img width="441" alt="Zrzut ekranu 2022-02-4 o 12 19 54" src="https://user-images.githubusercontent.com/22746080/152521086-78fc8d6e-366f-4070-9f2f-e26c7b39418d.png">
</details>

## Android

<details>
<summary>light theme</summary>

small | medium | large | center-aligned
--- | --- | --- | ---
<img width="452" alt="Zrzut ekranu 2022-02-4 o 12 44 45" src="https://user-images.githubusercontent.com/22746080/152523773-f7159cd8-f3ac-4ccf-944d-fd83e335eff7.png"> | <img width="452" alt="Zrzut ekranu 2022-02-4 o 12 44 50" src="https://user-images.githubusercontent.com/22746080/152523782-4777d8ac-e905-46dd-b818-5d5bd0ee463b.png"> | <img width="452" alt="Zrzut ekranu 2022-02-4 o 12 46 38" src="https://user-images.githubusercontent.com/22746080/152523946-d427c7b7-b1f9-41a8-a0fb-0b612a053079.png"> | <img width="452" alt="Zrzut ekranu 2022-02-4 o 12 46 43" src="https://user-images.githubusercontent.com/22746080/152523951-8b04d53c-56ea-4f4a-b6e0-914ba2897c38.png">
</details>

<details>
<summary>dark theme</summary>

small | medium | large | center-aligned
--- | --- | --- | ---
<img width="408" alt="Zrzut ekranu 2022-02-4 o 12 48 29" src="https://user-images.githubusercontent.com/22746080/152524202-e3d7ab56-3cb1-4e47-bae1-18236598426c.png"> | <img width="452" alt="Zrzut ekranu 2022-02-4 o 12 48 34" src="https://user-images.githubusercontent.com/22746080/152524213-09213263-db6c-44a7-a7cf-aaa233e959d2.png"> | <img width="452" alt="Zrzut ekranu 2022-02-4 o 12 48 39" src="https://user-images.githubusercontent.com/22746080/152524225-6d0d4ce8-e8ac-402b-8c39-c334b703c229.png"> | <img width="452" alt="Zrzut ekranu 2022-02-4 o 12 48 45" src="https://user-images.githubusercontent.com/22746080/152524240-acaa3dd7-41d3-4c50-a87a-e11337ee4454.png">
</details>


<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
