### PR TITLE
feat: adjust BottomNavigation

### DIFF
--- a/example/src/Examples/BadgeExample.tsx
+++ b/example/src/Examples/BadgeExample.tsx
@@ -7,11 +7,14 @@ import {
   Paragraph,
   Switch,
   MD2Colors,
+  useTheme,
+  MD3Colors,
 } from 'react-native-paper';
 import ScreenWrapper from '../ScreenWrapper';
 
 const BadgeExample = () => {
   const [visible, setVisible] = React.useState<boolean>(true);
+  const { isV3 } = useTheme();
 
   return (
     <ScreenWrapper>
@@ -34,7 +37,14 @@ const BadgeExample = () => {
             <IconButton icon="inbox" size={36} style={styles.button} />
             <Badge
               visible={visible}
-              style={[styles.badge, { backgroundColor: MD2Colors.blue500 }]}
+              style={[
+                styles.badge,
+                {
+                  backgroundColor: isV3
+                    ? MD3Colors.primary80
+                    : MD2Colors.blue500,
+                },
+              ]}
             >
               999+
             </Badge>
@@ -45,11 +55,11 @@ const BadgeExample = () => {
         <View style={styles.row}>
           <View style={styles.item}>
             <IconButton icon="book-open" size={36} style={styles.button} />
-            <Badge visible={visible} style={styles.badge} size={8} />
+            <Badge visible={visible} style={styles.badge} size={isV3 ? 6 : 8} />
           </View>
           <View style={styles.item}>
             <IconButton icon="receipt" size={36} style={styles.button} />
-            <Badge visible={visible} style={styles.badge} size={8} />
+            <Badge visible={visible} style={styles.badge} size={isV3 ? 6 : 8} />
           </View>
         </View>
       </List.Section>

--- a/example/src/Examples/BottomNavigationExample.tsx
+++ b/example/src/Examples/BottomNavigationExample.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import { View, Image, Dimensions, StyleSheet, Platform } from 'react-native';
-import { BottomNavigation } from 'react-native-paper';
+import { BottomNavigation, useTheme } from 'react-native-paper';
 import ScreenWrapper from '../ScreenWrapper';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 type RoutesState = Array<{
   key: string;
   title: string;
-  icon: string;
+  focusedIcon: string;
+  unfocusedIcon?: string;
   color?: string;
   badge?: boolean;
   getAccessibilityLabel?: string;
@@ -33,28 +34,42 @@ const PhotoGallery = ({ route }: Route) => {
 };
 
 const BottomNavigationExample = () => {
+  const { isV3 } = useTheme();
   const insets = useSafeAreaInsets();
   const [index, setIndex] = React.useState(0);
   const [routes] = React.useState<RoutesState>([
-    { key: 'album', title: 'Album', icon: 'image-album', color: '#6200ee' },
+    {
+      key: 'album',
+      title: 'Album',
+      focusedIcon: 'image-album',
+      ...(!isV3 && { color: '#6200ee' }),
+    },
     {
       key: 'library',
       title: 'Library',
-      icon: 'inbox',
-      color: '#2962ff',
+      focusedIcon: 'inbox',
       badge: true,
+      ...(isV3
+        ? { unfocusedIcon: 'inbox-outline' }
+        : {
+            color: '#2962ff',
+          }),
     },
     {
       key: 'favorites',
       title: 'Favorites',
-      icon: 'heart',
-      color: '#00796b',
+      focusedIcon: 'heart',
+      ...(isV3
+        ? { unfocusedIcon: 'heart-outline' }
+        : {
+            color: '#00796b',
+          }),
     },
     {
       key: 'purchased',
       title: 'Purchased',
-      icon: 'shopping-music',
-      color: '#c51162',
+      focusedIcon: 'shopping-music',
+      ...(!isV3 && { color: '#c51162' }),
     },
   ]);
 

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -32,6 +32,17 @@ type Props = React.ComponentProps<typeof Animated.Text> & {
  * Badges are small status descriptors for UI elements.
  * A badge consists of a small circle, typically containing a number or other short set of characters, that appears in proximity to another object.
  *
+ * <div class="screenshots">
+ *   <figure>
+ *     <img class="small" src="screenshots/badge-1.png" />
+ *     <figcaption>Badge with content</figcaption>
+ *   </figure>
+ *   <figure>
+ *     <img class="small" src="screenshots/badge-2.png" />
+ *     <figcaption>Badge without content</figcaption>
+ *   </figure>
+ * </div>
+ *
  * ## Usage
  * ```js
  * import * as React from 'react';

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -32,17 +32,6 @@ type Props = React.ComponentProps<typeof Animated.Text> & {
  * Badges are small status descriptors for UI elements.
  * A badge consists of a small circle, typically containing a number or other short set of characters, that appears in proximity to another object.
  *
- * <div class="screenshots">
- *   <figure>
- *     <img class="small" src="screenshots/badge-1.png" />
- *     <figcaption>Badge with content</figcaption>
- *   </figure>
- *   <figure>
- *     <img class="small" src="screenshots/badge-2.png" />
- *     <figcaption>Badge without content</figcaption>
- *   </figure>
- * </div>
- *
  * ## Usage
  * ```js
  * import * as React from 'react';
@@ -93,9 +82,13 @@ const Badge = ({
     ...restStyle
   } = (StyleSheet.flatten(style) || {}) as TextStyle;
 
-  const textColor = getContrastingColor(backgroundColor || white, white, black);
+  const textColor = theme.isV3
+    ? theme.colors.onError
+    : getContrastingColor(backgroundColor, white, black);
 
   const borderRadius = size / 2;
+
+  const paddingHorizontal = theme.isV3 ? 3 : 4;
 
   return (
     <Animated.Text
@@ -111,6 +104,7 @@ const Badge = ({
           height: size,
           minWidth: size,
           borderRadius,
+          paddingHorizontal,
         },
         styles.container,
         restStyle,
@@ -129,7 +123,6 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-end',
     textAlign: 'center',
     textAlignVertical: 'center',
-    paddingHorizontal: 4,
     overflow: 'hidden',
   },
 });

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -72,7 +72,7 @@ type Props = {
    * @supported Available in v3.x
    * Whether tabs should be spread across the entire width.
    */
-  dense?: boolean;
+  compact?: boolean;
   /**
    * State for the bottom navigation. The state should contain the following properties:
    *
@@ -354,7 +354,7 @@ const BottomNavigation = ({
   onIndexChange,
   shifting = theme.isV3 ? false : navigationState.routes.length > 3,
   safeAreaInsets,
-  dense = !theme.isV3,
+  compact = !theme.isV3,
 }: Props) => {
   const { scale } = theme.animation;
 
@@ -705,7 +705,7 @@ const BottomNavigation = ({
                 marginBottom: insets.bottom,
                 marginHorizontal: Math.max(insets.left, insets.right),
               },
-              dense && {
+              compact && {
                 maxWidth: maxTabBarWidth,
               },
             ]}

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -283,10 +283,6 @@ const SceneComponent = React.memo(({ component, ...rest }: any) =>
  * By default Bottom navigation uses primary color as a background, in dark theme with `adaptive` mode it will use surface colour instead.
  * See [Dark Theme](https://callstack.github.io/react-native-paper/theming.html#dark-theme) for more information.
  *
- * <div class="screenshots">
- *   <img class="medium" src="screenshots/bottom-navigation.gif" />
- * </div>
- *
  * ## Usage
  * ```js
  * import * as React from 'react';
@@ -541,7 +537,7 @@ const BottomNavigation = ({
   );
 
   const { routes } = navigationState;
-  const { colors, dark: isDarkTheme, mode, md, isV3 } = theme;
+  const { colors, dark: isDarkTheme, mode, isV3 } = theme;
 
   const { backgroundColor: customBackground, elevation = 4 }: ViewStyle =
     StyleSheet.flatten(barStyle) || {};
@@ -553,7 +549,7 @@ const BottomNavigation = ({
     : colors?.primary;
 
   const backgroundColor = isV3
-    ? (md('md.sys.color.surface') as string)
+    ? theme.colors.surface
     : shifting
     ? indexAnim.interpolate({
         inputRange: routes.map((_, i) => i),
@@ -575,13 +571,13 @@ const BottomNavigation = ({
     typeof activeColor !== 'undefined'
       ? activeColor
       : isV3
-      ? (md('md.sys.color.on-secondary-container') as string)
+      ? theme.colors.onSecondaryContainer
       : textColor;
   const inactiveTintColor =
     typeof inactiveColor !== 'undefined'
       ? inactiveColor
       : isV3
-      ? (md('md.sys.color.on-surface-variant') as string)
+      ? theme.colors.onSurfaceVariant
       : color(textColor).alpha(0.5).rgb().string();
 
   const touchColor = color(activeColor || activeTintColor)
@@ -779,6 +775,20 @@ const BottomNavigation = ({
 
               const badge = getBadge({ route });
 
+              const labelColor = !isV3
+                ? activeTintColor
+                : focused
+                ? theme.colors.onSurface
+                : theme.colors.onSurfaceVariant;
+
+              const badgeStyle = {
+                top: !isV3 ? -2 : typeof badge === 'boolean' ? 4 : 2,
+                right:
+                  (badge != null && typeof badge !== 'boolean'
+                    ? String(badge).length * -2
+                    : 0) - (!isV3 ? 2 : 0),
+              };
+
               return renderTouchable({
                 key: route.key,
                 route,
@@ -823,9 +833,7 @@ const BottomNavigation = ({
                                   scaleX: outlineScale,
                                 },
                               ],
-                              backgroundColor: md(
-                                'md.sys.color.secondary-container'
-                              ) as string,
+                              backgroundColor: theme.colors.secondaryContainer,
                             },
                           ]}
                         />
@@ -878,17 +886,7 @@ const BottomNavigation = ({
                           />
                         )}
                       </Animated.View>
-                      <View
-                        style={[
-                          styles.badgeContainer,
-                          {
-                            right:
-                              (badge != null && typeof badge !== 'boolean'
-                                ? String(badge).length * -2
-                                : 0) - 2,
-                          },
-                        ]}
-                      >
+                      <View style={[styles.badgeContainer, badgeStyle]}>
                         {typeof badge === 'boolean' ? (
                           <Badge visible={badge} size={isV3 ? 6 : 8} />
                         ) : (
@@ -915,27 +913,15 @@ const BottomNavigation = ({
                             renderLabel({
                               route,
                               focused: true,
-                              color: !isV3
-                                ? activeTintColor
-                                : focused
-                                ? (md('md.sys.color.on-surface') as string)
-                                : (md(
-                                    'md.sys.color.on-surface-variant'
-                                  ) as string),
+                              color: labelColor,
                             })
                           ) : (
                             <Text
-                              variant="label-medium"
+                              variant="labelMedium"
                               style={[
                                 styles.label,
                                 {
-                                  color: !isV3
-                                    ? activeTintColor
-                                    : focused
-                                    ? (md('md.sys.color.on-surface') as string)
-                                    : (md(
-                                        'md.sys.color.on-surface-variant'
-                                      ) as string),
+                                  color: labelColor,
                                 },
                               ]}
                             >
@@ -954,30 +940,16 @@ const BottomNavigation = ({
                               renderLabel({
                                 route,
                                 focused: false,
-                                color: !isV3
-                                  ? activeTintColor
-                                  : focused
-                                  ? (md('md.sys.color.on-surface') as string)
-                                  : (md(
-                                      'md.sys.color.on-surface-variant'
-                                    ) as string),
+                                color: labelColor,
                               })
                             ) : (
                               <Text
-                                variant="label-medium"
+                                variant="labelMedium"
                                 selectable={false}
                                 style={[
                                   styles.label,
                                   {
-                                    color: !isV3
-                                      ? activeTintColor
-                                      : focused
-                                      ? (md(
-                                          'md.sys.color.on-surface'
-                                        ) as string)
-                                      : (md(
-                                          'md.sys.color.on-surface-variant'
-                                        ) as string),
+                                    color: labelColor,
                                   },
                                 ]}
                               >
@@ -1110,7 +1082,6 @@ const styles = StyleSheet.create({
   badgeContainer: {
     position: 'absolute',
     left: 0,
-    top: -2,
   },
   v3TouchableContainer: {
     paddingTop: 12,

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -69,6 +69,11 @@ type Props = {
    */
   labeled?: boolean;
   /**
+   * @supported Available in v3.x
+   * Whether tabs should be spread across the entire width.
+   */
+  dense?: boolean;
+  /**
    * State for the bottom navigation. The state should contain the following properties:
    *
    * - `index`: a number representing the index of the active route in the `routes` array
@@ -349,6 +354,7 @@ const BottomNavigation = ({
   onIndexChange,
   shifting = theme.isV3 ? false : navigationState.routes.length > 3,
   safeAreaInsets,
+  dense = !theme.isV3,
 }: Props) => {
   const { scale } = theme.animation;
 
@@ -658,7 +664,7 @@ const BottomNavigation = ({
         })}
       </View>
       <Surface
-        {...(theme.isV3 && { elevation: 2 })}
+        {...(theme.isV3 && { elevation: 0 })}
         style={
           [
             !theme.isV3 && { elevation: 4 },
@@ -698,6 +704,8 @@ const BottomNavigation = ({
               {
                 marginBottom: insets.bottom,
                 marginHorizontal: Math.max(insets.left, insets.right),
+              },
+              dense && {
                 maxWidth: maxTabBarWidth,
               },
             ]}

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -78,8 +78,8 @@ type Props = {
    *
    * - `key`: a unique key to identify the route (required)
    * - `title`: title of the route to use as the tab label
-   * - `focusedIcon`:  icon to use as the focused tab icon, can be a string, an image source or a react component
-   * - `unfocusedIcon`:  icon to use as the unfocused tab icon, can be a string, an image source or a react component
+   * - `focusedIcon`:  icon to use as the focused tab icon, can be a string, an image source or a react component @renamed Renamed from 'icon' to 'focusedIcon' in v3.x
+   * - `unfocusedIcon`:  icon to use as the unfocused tab icon, can be a string, an image source or a react component @supported Available in v3.x with theme version 3
    * - `color`: color to use as background color for shifting bottom navigation
    * - `badge`: badge to show on the tab icon, can be `true` to show a dot, `string` or `number` to show text.
    * - `accessibilityLabel`: accessibility label for the tab button
@@ -567,12 +567,14 @@ const BottomNavigation = ({
       : true;
 
   const textColor = isDark ? white : black;
+
   const activeTintColor =
     typeof activeColor !== 'undefined'
       ? activeColor
       : isV3
       ? theme.colors.onSecondaryContainer
       : textColor;
+
   const inactiveTintColor =
     typeof inactiveColor !== 'undefined'
       ? inactiveColor
@@ -775,8 +777,14 @@ const BottomNavigation = ({
 
               const badge = getBadge({ route });
 
-              const labelColor = !isV3
+              const activeLabelColor = !isV3
                 ? activeTintColor
+                : focused
+                ? theme.colors.onSurface
+                : theme.colors.onSurfaceVariant;
+
+              const inactiveLabelColor = !isV3
+                ? inactiveTintColor
                 : focused
                 ? theme.colors.onSurface
                 : theme.colors.onSurfaceVariant;
@@ -913,7 +921,7 @@ const BottomNavigation = ({
                             renderLabel({
                               route,
                               focused: true,
-                              color: labelColor,
+                              color: activeLabelColor,
                             })
                           ) : (
                             <Text
@@ -921,7 +929,7 @@ const BottomNavigation = ({
                               style={[
                                 styles.label,
                                 {
-                                  color: labelColor,
+                                  color: activeLabelColor,
                                 },
                               ]}
                             >
@@ -940,7 +948,7 @@ const BottomNavigation = ({
                               renderLabel({
                                 route,
                                 focused: false,
-                                color: labelColor,
+                                color: inactiveLabelColor,
                               })
                             ) : (
                               <Text
@@ -949,7 +957,7 @@ const BottomNavigation = ({
                                 style={[
                                   styles.label,
                                   {
-                                    color: labelColor,
+                                    color: inactiveLabelColor,
                                   },
                                 ]}
                               >

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -761,16 +761,13 @@ const BottomNavigation = ({
               // This trick gives the illusion that we are animating between active and inactive colors.
               // This is to ensure that we can use native driver, as colors cannot be animated with native driver.
               const activeOpacity = active;
-              const inactiveOpacityInterpolation = active.interpolate({
+              const inactiveOpacity = active.interpolate({
                 inputRange: [0, 1],
                 outputRange: [1, 0],
               });
 
-              const inactiveOpacity = !isV3
-                ? inactiveOpacityInterpolation
-                : focused
-                ? inactiveOpacityInterpolation
-                : 1;
+              const v3ActiveOpacity = focused ? 1 : 0;
+              const v3InactiveOpacity = focused ? 0 : 1;
 
               // Scale horizontally the outline pill
               const outlineScale = focused
@@ -787,7 +784,7 @@ const BottomNavigation = ({
                 route,
                 borderless: true,
                 centered: true,
-                rippleColor: touchColor,
+                rippleColor: isV3 ? 'transparent' : touchColor,
                 onPress: () => handleTabPress(index),
                 testID: getTestID({ route }),
                 accessibilityLabel: getAccessibilityLabel({ route }),
@@ -837,7 +834,7 @@ const BottomNavigation = ({
                         style={[
                           styles.iconWrapper,
                           isV3 && styles.v3IconWrapper,
-                          { opacity: activeOpacity },
+                          { opacity: isV3 ? v3ActiveOpacity : activeOpacity },
                         ]}
                       >
                         {renderIcon ? (
@@ -858,7 +855,9 @@ const BottomNavigation = ({
                         style={[
                           styles.iconWrapper,
                           isV3 && styles.v3IconWrapper,
-                          { opacity: inactiveOpacity },
+                          {
+                            opacity: isV3 ? v3InactiveOpacity : inactiveOpacity,
+                          },
                         ]}
                       >
                         {renderIcon ? (

--- a/src/components/__tests__/BottomNavigation.test.js
+++ b/src/components/__tests__/BottomNavigation.test.js
@@ -32,7 +32,7 @@ const createState = (index, length) => ({
   index,
   routes: Array.from({ length }, (_, i) => ({
     key: `key-${i}`,
-    icon: icons[i],
+    focusedIcon: icons[i],
     title: `Route: ${i}`,
   })),
 });

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
@@ -131,12 +131,13 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -226,10 +227,10 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -290,12 +291,13 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -385,10 +387,10 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -449,12 +451,13 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -544,10 +547,10 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -743,12 +746,13 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -838,10 +842,10 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -902,12 +906,13 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -997,10 +1002,10 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -1061,12 +1066,13 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -1156,10 +1162,10 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -1335,12 +1341,13 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -1398,10 +1405,10 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -1500,12 +1507,13 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -1563,10 +1571,10 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -1665,12 +1673,13 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -1728,10 +1737,10 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -1965,12 +1974,13 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -2028,10 +2038,10 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -2114,12 +2124,13 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -2177,10 +2188,10 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -2263,12 +2274,13 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -2326,10 +2338,10 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -2412,12 +2424,13 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -2475,10 +2488,10 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -2561,12 +2574,13 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -2624,10 +2638,10 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -2826,12 +2840,13 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -2921,10 +2936,10 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -3070,12 +3085,13 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -3165,10 +3181,10 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -3314,12 +3330,13 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -3409,10 +3426,10 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -3694,12 +3711,13 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -3789,10 +3807,10 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -3898,12 +3916,13 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -3993,10 +4012,10 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -4102,12 +4121,13 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -4197,10 +4217,10 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -4421,12 +4441,13 @@ exports[`renders non-shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -4516,10 +4537,10 @@ exports[`renders non-shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -4665,12 +4686,13 @@ exports[`renders non-shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -4760,10 +4782,10 @@ exports[`renders non-shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -4909,12 +4931,13 @@ exports[`renders non-shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -5004,10 +5027,10 @@ exports[`renders non-shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -5288,12 +5311,13 @@ exports[`renders shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -5383,10 +5407,10 @@ exports[`renders shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -5492,12 +5516,13 @@ exports[`renders shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -5587,10 +5612,10 @@ exports[`renders shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -5696,12 +5721,13 @@ exports[`renders shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -5791,10 +5817,10 @@ exports[`renders shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -5900,12 +5926,13 @@ exports[`renders shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -5995,10 +6022,10 @@ exports[`renders shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }
@@ -6104,12 +6131,13 @@ exports[`renders shifting bottom navigation 1`] = `
                 "flex": 1,
                 "paddingVertical": 6,
               },
-              undefined,
+              false,
             ]
           }
         >
           <View
             pointerEvents="none"
+            style={false}
           >
             <View
               style={
@@ -6199,10 +6227,10 @@ exports[`renders shifting bottom navigation 1`] = `
                     Object {
                       "left": 0,
                       "position": "absolute",
-                      "top": -2,
                     },
                     Object {
                       "right": -2,
+                      "top": -2,
                     },
                   ]
                 }

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
@@ -126,10 +126,13 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -282,10 +285,13 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -438,10 +444,13 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -729,10 +738,13 @@ exports[`hides labels in shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -885,10 +897,13 @@ exports[`hides labels in shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -1041,10 +1056,13 @@ exports[`hides labels in shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -1312,10 +1330,13 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -1352,9 +1373,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
               >
                 <icon
                   color="#ffffff"
-                >
-                  magnify
-                </icon>
+                />
               </View>
               <View
                 style={
@@ -1371,9 +1390,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
               >
                 <icon
                   color="rgba(255, 255, 255, 0.5)"
-                >
-                  magnify
-                </icon>
+                />
               </View>
               <View
                 style={
@@ -1455,7 +1472,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
                 }
               >
                 <text
-                  color="rgba(255, 255, 255, 0.5)"
+                  color="#ffffff"
                 />
               </View>
             </View>
@@ -1478,10 +1495,13 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -1518,9 +1538,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
               >
                 <icon
                   color="#ffffff"
-                >
-                  camera
-                </icon>
+                />
               </View>
               <View
                 style={
@@ -1537,9 +1555,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
               >
                 <icon
                   color="rgba(255, 255, 255, 0.5)"
-                >
-                  camera
-                </icon>
+                />
               </View>
               <View
                 style={
@@ -1621,7 +1637,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
                 }
               >
                 <text
-                  color="rgba(255, 255, 255, 0.5)"
+                  color="#ffffff"
                 />
               </View>
             </View>
@@ -1644,10 +1660,13 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -1684,9 +1703,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
               >
                 <icon
                   color="#ffffff"
-                >
-                  inbox
-                </icon>
+                />
               </View>
               <View
                 style={
@@ -1703,9 +1720,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
               >
                 <icon
                   color="rgba(255, 255, 255, 0.5)"
-                >
-                  inbox
-                </icon>
+                />
               </View>
               <View
                 style={
@@ -1787,7 +1802,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
                 }
               >
                 <text
-                  color="rgba(255, 255, 255, 0.5)"
+                  color="#ffffff"
                 />
               </View>
             </View>
@@ -1945,10 +1960,13 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -1985,9 +2003,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
               >
                 <icon
                   color="#ffffff"
-                >
-                  magnify
-                </icon>
+                />
               </View>
               <View
                 style={
@@ -2004,9 +2020,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
               >
                 <icon
                   color="rgba(255, 255, 255, 0.5)"
-                >
-                  magnify
-                </icon>
+                />
               </View>
               <View
                 style={
@@ -2095,10 +2109,13 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -2135,9 +2152,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
               >
                 <icon
                   color="#ffffff"
-                >
-                  camera
-                </icon>
+                />
               </View>
               <View
                 style={
@@ -2154,9 +2169,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
               >
                 <icon
                   color="rgba(255, 255, 255, 0.5)"
-                >
-                  camera
-                </icon>
+                />
               </View>
               <View
                 style={
@@ -2245,10 +2258,13 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -2285,9 +2301,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
               >
                 <icon
                   color="#ffffff"
-                >
-                  inbox
-                </icon>
+                />
               </View>
               <View
                 style={
@@ -2304,9 +2318,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
               >
                 <icon
                   color="rgba(255, 255, 255, 0.5)"
-                >
-                  inbox
-                </icon>
+                />
               </View>
               <View
                 style={
@@ -2395,10 +2407,13 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -2435,9 +2450,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
               >
                 <icon
                   color="#ffffff"
-                >
-                  heart
-                </icon>
+                />
               </View>
               <View
                 style={
@@ -2454,9 +2467,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
               >
                 <icon
                   color="rgba(255, 255, 255, 0.5)"
-                >
-                  heart
-                </icon>
+                />
               </View>
               <View
                 style={
@@ -2545,10 +2556,13 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -2585,9 +2599,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
               >
                 <icon
                   color="#ffffff"
-                >
-                  shopping-music
-                </icon>
+                />
               </View>
               <View
                 style={
@@ -2604,9 +2616,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
               >
                 <icon
                   color="rgba(255, 255, 255, 0.5)"
-                >
-                  shopping-music
-                </icon>
+                />
               </View>
               <View
                 style={
@@ -2811,10 +2821,13 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -3023,7 +3036,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                           "textAlign": "center",
                         },
                         Object {
-                          "color": "#853D4B",
+                          "color": "#FBF7DB",
                         },
                       ],
                     ]
@@ -3052,10 +3065,13 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -3264,7 +3280,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                           "textAlign": "center",
                         },
                         Object {
-                          "color": "#853D4B",
+                          "color": "#FBF7DB",
                         },
                       ],
                     ]
@@ -3293,10 +3309,13 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -3505,7 +3524,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                           "textAlign": "center",
                         },
                         Object {
-                          "color": "#853D4B",
+                          "color": "#FBF7DB",
                         },
                       ],
                     ]
@@ -3670,10 +3689,13 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -3871,10 +3893,13 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -4072,10 +4097,13 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -4388,10 +4416,13 @@ exports[`renders non-shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -4600,7 +4631,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                           "textAlign": "center",
                         },
                         Object {
-                          "color": "rgba(255, 255, 255, 0.5)",
+                          "color": "#ffffff",
                         },
                       ],
                     ]
@@ -4629,10 +4660,13 @@ exports[`renders non-shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -4841,7 +4875,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                           "textAlign": "center",
                         },
                         Object {
-                          "color": "rgba(255, 255, 255, 0.5)",
+                          "color": "#ffffff",
                         },
                       ],
                     ]
@@ -4870,10 +4904,13 @@ exports[`renders non-shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -5082,7 +5119,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                           "textAlign": "center",
                         },
                         Object {
-                          "color": "rgba(255, 255, 255, 0.5)",
+                          "color": "#ffffff",
                         },
                       ],
                     ]
@@ -5246,10 +5283,13 @@ exports[`renders shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -5447,10 +5487,13 @@ exports[`renders shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -5648,10 +5691,13 @@ exports[`renders shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -5849,10 +5895,13 @@ exports[`renders shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View
@@ -6050,10 +6099,13 @@ exports[`renders shifting bottom navigation 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "flex": 1,
-              "paddingVertical": 6,
-            }
+            Array [
+              Object {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              undefined,
+            ]
           }
         >
           <View

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
@@ -1479,7 +1479,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
                 }
               >
                 <text
-                  color="#ffffff"
+                  color="rgba(255, 255, 255, 0.5)"
                 />
               </View>
             </View>
@@ -1645,7 +1645,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
                 }
               >
                 <text
-                  color="#ffffff"
+                  color="rgba(255, 255, 255, 0.5)"
                 />
               </View>
             </View>
@@ -1811,7 +1811,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
                 }
               >
                 <text
-                  color="#ffffff"
+                  color="rgba(255, 255, 255, 0.5)"
                 />
               </View>
             </View>
@@ -3051,7 +3051,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                           "textAlign": "center",
                         },
                         Object {
-                          "color": "#FBF7DB",
+                          "color": "#853D4B",
                         },
                       ],
                     ]
@@ -3296,7 +3296,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                           "textAlign": "center",
                         },
                         Object {
-                          "color": "#FBF7DB",
+                          "color": "#853D4B",
                         },
                       ],
                     ]
@@ -3541,7 +3541,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                           "textAlign": "center",
                         },
                         Object {
-                          "color": "#FBF7DB",
+                          "color": "#853D4B",
                         },
                       ],
                     ]
@@ -4652,7 +4652,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                           "textAlign": "center",
                         },
                         Object {
-                          "color": "#ffffff",
+                          "color": "rgba(255, 255, 255, 0.5)",
                         },
                       ],
                     ]
@@ -4897,7 +4897,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                           "textAlign": "center",
                         },
                         Object {
-                          "color": "#ffffff",
+                          "color": "rgba(255, 255, 255, 0.5)",
                         },
                       ],
                     ]
@@ -5142,7 +5142,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                           "textAlign": "center",
                         },
                         Object {
-                          "color": "#ffffff",
+                          "color": "rgba(255, 255, 255, 0.5)",
                         },
                       ],
                     ]

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
@@ -104,6 +104,8 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
             Object {
               "marginBottom": 0,
               "marginHorizontal": 0,
+            },
+            Object {
               "maxWidth": 504,
             },
           ]
@@ -699,6 +701,8 @@ exports[`hides labels in shifting bottom navigation 1`] = `
             Object {
               "marginBottom": 0,
               "marginHorizontal": 0,
+            },
+            Object {
               "maxWidth": 504,
             },
           ]
@@ -1314,6 +1318,8 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
             Object {
               "marginBottom": 0,
               "marginHorizontal": 0,
+            },
+            Object {
               "maxWidth": 504,
             },
           ]
@@ -1927,6 +1933,8 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
             Object {
               "marginBottom": 0,
               "marginHorizontal": 0,
+            },
+            Object {
               "maxWidth": 480,
             },
           ]
@@ -2813,6 +2821,8 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
             Object {
               "marginBottom": 0,
               "marginHorizontal": 0,
+            },
+            Object {
               "maxWidth": 504,
             },
           ]
@@ -3664,6 +3674,8 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
             Object {
               "marginBottom": 0,
               "marginHorizontal": 0,
+            },
+            Object {
               "maxWidth": 504,
             },
           ]
@@ -4414,6 +4426,8 @@ exports[`renders non-shifting bottom navigation 1`] = `
             Object {
               "marginBottom": 0,
               "marginHorizontal": 0,
+            },
+            Object {
               "maxWidth": 504,
             },
           ]
@@ -5264,6 +5278,8 @@ exports[`renders shifting bottom navigation 1`] = `
             Object {
               "marginBottom": 0,
               "marginHorizontal": 0,
+            },
+            Object {
               "maxWidth": 480,
             },
           ]


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

PR:
* adjusts `BottomNavigation` into Material You.
* introduced prop `compact` indicating whether tabs should be spread across the entire width.
* couple changes in `navigationState.routes`:
  * renamed from `icon` to `focusedIcon`
  * introduced `unfocusedIcon`
  * deprecated `color`

### Test plan

* check application in both themes, if `BottomNavigation` works and have correct colors in both themes on both platforms
* rotate the phone to confirm whether `BottomNavigation` works properly in horizontal mode
* snapshots indicate that `BottomNavigation` from theme version 2 wasn't changed.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
