### PR TITLE
feat: introduce new prop labelMaxFontSizeMultiplier for BottomNavigation

### DIFF
--- a/example/src/Examples/BottomNavigationExample.tsx
+++ b/example/src/Examples/BottomNavigationExample.tsx
@@ -63,6 +63,7 @@ const BottomNavigationExample = () => {
       safeAreaInsets={{ bottom: insets.bottom }}
       navigationState={{ index, routes }}
       onIndexChange={setIndex}
+      labelMaxFontSizeMultiplier={2}
       renderScene={BottomNavigation.SceneMap({
         album: PhotoGallery,
         library: PhotoGallery,

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -226,6 +226,10 @@ type Props = {
    * ```
    */
   barStyle?: StyleProp<ViewStyle>;
+  /**
+   * Specifies the largest possible scale a label font can reach.
+   */
+  labelMaxFontSizeMultiplier?: number;
   style?: StyleProp<ViewStyle>;
   /**
    * @optional
@@ -344,6 +348,7 @@ const BottomNavigation = ({
   onIndexChange,
   shifting = navigationState.routes.length > 3,
   safeAreaInsets,
+  labelMaxFontSizeMultiplier,
 }: Props) => {
   const { scale } = theme.animation;
 
@@ -856,6 +861,7 @@ const BottomNavigation = ({
                             })
                           ) : (
                             <Text
+                              maxFontSizeMultiplier={labelMaxFontSizeMultiplier}
                               style={[styles.label, { color: activeTintColor }]}
                             >
                               {getLabelText({ route })}
@@ -877,6 +883,9 @@ const BottomNavigation = ({
                               })
                             ) : (
                               <Text
+                                maxFontSizeMultiplier={
+                                  labelMaxFontSizeMultiplier
+                                }
                                 selectable={false}
                                 style={[
                                   styles.label,
@@ -988,6 +997,7 @@ const styles = StyleSheet.create({
   // eslint-disable-next-line react-native/no-color-literals
   label: {
     fontSize: 12,
+    height: BAR_HEIGHT,
     textAlign: 'center',
     backgroundColor: 'transparent',
     ...(Platform.OS === 'web'

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -348,7 +348,7 @@ const BottomNavigation = ({
   onIndexChange,
   shifting = navigationState.routes.length > 3,
   safeAreaInsets,
-  labelMaxFontSizeMultiplier,
+  labelMaxFontSizeMultiplier = 1,
 }: Props) => {
   const { scale } = theme.animation;
 

--- a/src/components/__tests__/BottomNavigation.test.js
+++ b/src/components/__tests__/BottomNavigation.test.js
@@ -194,3 +194,21 @@ it('should have appropriate display style according to the visibility', () => {
     expect.arrayContaining([expect.objectContaining({ display: 'none' })])
   );
 });
+
+it('should have labelMaxFontSizeMultiplier passed to label', () => {
+  const labelMaxFontSizeMultiplier = 2;
+  const { getAllByText } = render(
+    <BottomNavigation
+      shifting={false}
+      labeled={true}
+      labelMaxFontSizeMultiplier={labelMaxFontSizeMultiplier}
+      navigationState={createState(0, 3)}
+      onIndexChange={jest.fn()}
+      renderScene={({ route }) => route.title}
+    />
+  );
+
+  const label = getAllByText('Route: 0')[0];
+
+  expect(label.props.maxFontSizeMultiplier).toBe(labelMaxFontSizeMultiplier);
+});

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
@@ -2966,6 +2966,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                 }
               >
                 <Text
+                  maxFontSizeMultiplier={1}
                   style={
                     Array [
                       Object {
@@ -3006,6 +3007,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                 }
               >
                 <Text
+                  maxFontSizeMultiplier={1}
                   selectable={false}
                   style={
                     Array [
@@ -3209,6 +3211,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                 }
               >
                 <Text
+                  maxFontSizeMultiplier={1}
                   style={
                     Array [
                       Object {
@@ -3249,6 +3252,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                 }
               >
                 <Text
+                  maxFontSizeMultiplier={1}
                   selectable={false}
                   style={
                     Array [
@@ -3452,6 +3456,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                 }
               >
                 <Text
+                  maxFontSizeMultiplier={1}
                   style={
                     Array [
                       Object {
@@ -3492,6 +3497,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                 }
               >
                 <Text
+                  maxFontSizeMultiplier={1}
                   selectable={false}
                   style={
                     Array [
@@ -3831,6 +3837,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                 }
               >
                 <Text
+                  maxFontSizeMultiplier={1}
                   style={
                     Array [
                       Object {
@@ -4033,6 +4040,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                 }
               >
                 <Text
+                  maxFontSizeMultiplier={1}
                   style={
                     Array [
                       Object {
@@ -4235,6 +4243,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                 }
               >
                 <Text
+                  maxFontSizeMultiplier={1}
                   style={
                     Array [
                       Object {
@@ -4552,6 +4561,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  maxFontSizeMultiplier={1}
                   style={
                     Array [
                       Object {
@@ -4592,6 +4602,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  maxFontSizeMultiplier={1}
                   selectable={false}
                   style={
                     Array [
@@ -4795,6 +4806,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  maxFontSizeMultiplier={1}
                   style={
                     Array [
                       Object {
@@ -4835,6 +4847,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  maxFontSizeMultiplier={1}
                   selectable={false}
                   style={
                     Array [
@@ -5038,6 +5051,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  maxFontSizeMultiplier={1}
                   style={
                     Array [
                       Object {
@@ -5078,6 +5092,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  maxFontSizeMultiplier={1}
                   selectable={false}
                   style={
                     Array [
@@ -5416,6 +5431,7 @@ exports[`renders shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  maxFontSizeMultiplier={1}
                   style={
                     Array [
                       Object {
@@ -5618,6 +5634,7 @@ exports[`renders shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  maxFontSizeMultiplier={1}
                   style={
                     Array [
                       Object {
@@ -5820,6 +5837,7 @@ exports[`renders shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  maxFontSizeMultiplier={1}
                   style={
                     Array [
                       Object {
@@ -6022,6 +6040,7 @@ exports[`renders shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  maxFontSizeMultiplier={1}
                   style={
                     Array [
                       Object {
@@ -6224,6 +6243,7 @@ exports[`renders shifting bottom navigation 1`] = `
                 }
               >
                 <Text
+                  maxFontSizeMultiplier={1}
                   style={
                     Array [
                       Object {

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
@@ -2980,6 +2980,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                         Object {
                           "backgroundColor": "transparent",
                           "fontSize": 12,
+                          "height": 56,
                           "textAlign": "center",
                         },
                         Object {
@@ -3020,6 +3021,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                         Object {
                           "backgroundColor": "transparent",
                           "fontSize": 12,
+                          "height": 56,
                           "textAlign": "center",
                         },
                         Object {
@@ -3221,6 +3223,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                         Object {
                           "backgroundColor": "transparent",
                           "fontSize": 12,
+                          "height": 56,
                           "textAlign": "center",
                         },
                         Object {
@@ -3261,6 +3264,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                         Object {
                           "backgroundColor": "transparent",
                           "fontSize": 12,
+                          "height": 56,
                           "textAlign": "center",
                         },
                         Object {
@@ -3462,6 +3466,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                         Object {
                           "backgroundColor": "transparent",
                           "fontSize": 12,
+                          "height": 56,
                           "textAlign": "center",
                         },
                         Object {
@@ -3502,6 +3507,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                         Object {
                           "backgroundColor": "transparent",
                           "fontSize": 12,
+                          "height": 56,
                           "textAlign": "center",
                         },
                         Object {
@@ -3839,6 +3845,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                         Object {
                           "backgroundColor": "transparent",
                           "fontSize": 12,
+                          "height": 56,
                           "textAlign": "center",
                         },
                         Object {
@@ -4040,6 +4047,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                         Object {
                           "backgroundColor": "transparent",
                           "fontSize": 12,
+                          "height": 56,
                           "textAlign": "center",
                         },
                         Object {
@@ -4241,6 +4249,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                         Object {
                           "backgroundColor": "transparent",
                           "fontSize": 12,
+                          "height": 56,
                           "textAlign": "center",
                         },
                         Object {
@@ -4557,6 +4566,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                         Object {
                           "backgroundColor": "transparent",
                           "fontSize": 12,
+                          "height": 56,
                           "textAlign": "center",
                         },
                         Object {
@@ -4597,6 +4607,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                         Object {
                           "backgroundColor": "transparent",
                           "fontSize": 12,
+                          "height": 56,
                           "textAlign": "center",
                         },
                         Object {
@@ -4798,6 +4809,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                         Object {
                           "backgroundColor": "transparent",
                           "fontSize": 12,
+                          "height": 56,
                           "textAlign": "center",
                         },
                         Object {
@@ -4838,6 +4850,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                         Object {
                           "backgroundColor": "transparent",
                           "fontSize": 12,
+                          "height": 56,
                           "textAlign": "center",
                         },
                         Object {
@@ -5039,6 +5052,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                         Object {
                           "backgroundColor": "transparent",
                           "fontSize": 12,
+                          "height": 56,
                           "textAlign": "center",
                         },
                         Object {
@@ -5079,6 +5093,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                         Object {
                           "backgroundColor": "transparent",
                           "fontSize": 12,
+                          "height": 56,
                           "textAlign": "center",
                         },
                         Object {
@@ -5415,6 +5430,7 @@ exports[`renders shifting bottom navigation 1`] = `
                         Object {
                           "backgroundColor": "transparent",
                           "fontSize": 12,
+                          "height": 56,
                           "textAlign": "center",
                         },
                         Object {
@@ -5616,6 +5632,7 @@ exports[`renders shifting bottom navigation 1`] = `
                         Object {
                           "backgroundColor": "transparent",
                           "fontSize": 12,
+                          "height": 56,
                           "textAlign": "center",
                         },
                         Object {
@@ -5817,6 +5834,7 @@ exports[`renders shifting bottom navigation 1`] = `
                         Object {
                           "backgroundColor": "transparent",
                           "fontSize": 12,
+                          "height": 56,
                           "textAlign": "center",
                         },
                         Object {
@@ -6018,6 +6036,7 @@ exports[`renders shifting bottom navigation 1`] = `
                         Object {
                           "backgroundColor": "transparent",
                           "fontSize": 12,
+                          "height": 56,
                           "textAlign": "center",
                         },
                         Object {
@@ -6219,6 +6238,7 @@ exports[`renders shifting bottom navigation 1`] = `
                         Object {
                           "backgroundColor": "transparent",
                           "fontSize": 12,
+                          "height": 56,
                           "textAlign": "center",
                         },
                         Object {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/3099

### Summary

PR introduces new prop for `BottomNavigation` called `labelMaxFontSizeMultiplier` which specifies the largest possible scale a label font can reach in the similar way as rn text prop [maxFontSizeMultipliers](https://reactnative.dev/docs/text#maxfontsizemultiplier)

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

before | after - `labelMaxFontSizeMultiplier={2}` | after - `labelMaxFontSizeMultiplier={1}`
--- | --- | ---
<img width="493" alt="Zrzut ekranu 2022-02-23 o 22 16 52" src="https://user-images.githubusercontent.com/22746080/155410738-dda962c3-0490-45d8-8314-6444cb18db3f.png"> | <img width="493" alt="Zrzut ekranu 2022-02-23 o 22 16 19" src="https://user-images.githubusercontent.com/22746080/155410770-c6fcbaa2-2e8e-4c65-800f-46bd3473f5bb.png"> | <img width="493" alt="Zrzut ekranu 2022-02-23 o 22 16 27" src="https://user-images.githubusercontent.com/22746080/155410826-22e04479-64a9-46bb-b499-7dc5f73a575a.png">

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
