### PR TITLE
feat: TextStyle Props Add in Table and Cell

### DIFF
--- a/src/components/DataTable/DataTableCell.tsx
+++ b/src/components/DataTable/DataTableCell.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleSheet, StyleProp, ViewStyle } from 'react-native';
+import { StyleSheet, StyleProp, ViewStyle, TextStyle } from 'react-native';
 import Text from '../Typography/Text';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import type { $RemoveChildren } from '../../types';
@@ -18,6 +18,7 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
    */
   onPress?: () => void;
   style?: StyleProp<ViewStyle>;
+  textStyle?: StyleProp<TextStyle>;
 };
 
 /**
@@ -51,12 +52,12 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
  * MD Guidelines (https://github.com/callstack/react-native-paper/issues/2381).
  */
 
-const DataTableCell = ({ children, style, numeric, ...rest }: Props) => (
+const DataTableCell = ({ children, textStyle, style, numeric, ...rest }: Props) => (
   <TouchableRipple
     {...rest}
     style={[styles.container, numeric && styles.right, style]}
   >
-    <Text numberOfLines={1}>{children}</Text>
+    <Text style={textStyle} numberOfLines={1}>{children}</Text>
   </TouchableRipple>
 );
 

--- a/src/components/DataTable/DataTableCell.tsx
+++ b/src/components/DataTable/DataTableCell.tsx
@@ -18,6 +18,9 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
    */
   onPress?: () => void;
   style?: StyleProp<ViewStyle>;
+  /**
+   * text Content style of the `DataTableCell`.
+   */
   textStyle?: StyleProp<TextStyle>;
 };
 

--- a/src/components/DataTable/DataTableCell.tsx
+++ b/src/components/DataTable/DataTableCell.tsx
@@ -19,7 +19,7 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
   onPress?: () => void;
   style?: StyleProp<ViewStyle>;
   /**
-   * text Content style of the `DataTableCell`.
+   * Text content style of the `DataTableCell`.
    */
   textStyle?: StyleProp<TextStyle>;
 };

--- a/src/components/DataTable/DataTableTitle.tsx
+++ b/src/components/DataTable/DataTableTitle.tsx
@@ -7,6 +7,7 @@ import {
   View,
   ViewStyle,
   I18nManager,
+  TextStyle,
 } from 'react-native';
 import color from 'color';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
@@ -35,6 +36,7 @@ type Props = React.ComponentPropsWithRef<typeof TouchableWithoutFeedback> & {
    */
   onPress?: () => void;
   style?: StyleProp<ViewStyle>;
+  colorText?: StyleProp<TextStyle>;
   /**
    * @optional
    */
@@ -64,7 +66,7 @@ type Props = React.ComponentPropsWithRef<typeof TouchableWithoutFeedback> & {
  *           >
  *             Dessert
  *           </DataTable.Title>
- *           <DataTable.Title numeric>Calories</DataTable.Title>
+ *           <DataTable.Title colorText="#FFF" numeric>Calories</DataTable.Title>
  *           <DataTable.Title numeric>Fat (g)</DataTable.Title>
  *         </DataTable.Header>
  *       </DataTable>
@@ -80,6 +82,7 @@ const DataTableTitle = ({
   onPress,
   sortDirection,
   theme,
+  colorText,
   style,
   numberOfLines = 1,
   ...rest
@@ -122,7 +125,7 @@ const DataTableTitle = ({
         <Text
           style={[
             styles.cell,
-            sortDirection ? styles.sorted : { color: textColor },
+            sortDirection ? styles.sorted : { color: colorText ? colorText : textColor },
           ]}
           numberOfLines={numberOfLines}
         >

--- a/src/components/DataTable/DataTableTitle.tsx
+++ b/src/components/DataTable/DataTableTitle.tsx
@@ -36,7 +36,7 @@ type Props = React.ComponentPropsWithRef<typeof TouchableWithoutFeedback> & {
    */
   onPress?: () => void;
   style?: StyleProp<ViewStyle>;
-  colorText?: StyleProp<TextStyle>;
+  textStyle?: StyleProp<TextStyle>;
   /**
    * @optional
    */
@@ -82,7 +82,7 @@ const DataTableTitle = ({
   onPress,
   sortDirection,
   theme,
-  colorText,
+  textStyle,
   style,
   numberOfLines = 1,
   ...rest
@@ -125,7 +125,8 @@ const DataTableTitle = ({
         <Text
           style={[
             styles.cell,
-            sortDirection ? styles.sorted : { color: colorText ? colorText : textColor },
+            sortDirection ? styles.sorted : { color: textColor },
+            textStyle,
           ]}
           numberOfLines={numberOfLines}
         >

--- a/src/components/DataTable/DataTableTitle.tsx
+++ b/src/components/DataTable/DataTableTitle.tsx
@@ -36,6 +36,9 @@ type Props = React.ComponentPropsWithRef<typeof TouchableWithoutFeedback> & {
    */
   onPress?: () => void;
   style?: StyleProp<ViewStyle>;
+  /**
+   * Text content style of the `DataTableTitle`.
+   */
   textStyle?: StyleProp<TextStyle>;
   /**
    * @optional
@@ -66,7 +69,7 @@ type Props = React.ComponentPropsWithRef<typeof TouchableWithoutFeedback> & {
  *           >
  *             Dessert
  *           </DataTable.Title>
- *           <DataTable.Title colorText="#FFF" numeric>Calories</DataTable.Title>
+ *           <DataTable.Title numeric>Calories</DataTable.Title>
  *           <DataTable.Title numeric>Fat (g)</DataTable.Title>
  *         </DataTable.Header>
  *       </DataTable>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

```
DataTable.Title add new props for text style (prop name: textStyle)
DataTable.Cell add new props for text style (prop name: textStyle)

Now users can add change color easily if they need.
```

<-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
```
I was facing a problem in Table and cell I don't find any color props for color change so that is why I added some changes and make a pr for this.
```
