### PR TITLE
feat: adjust Chip

### DIFF
--- a/example/src/Examples/ChipExample.tsx
+++ b/example/src/Examples/ChipExample.tsx
@@ -65,7 +65,7 @@ const ChipExample = () => {
               Avatar (disabled)
             </Chip>
             {isV3 && (
-              <Chip dense style={styles.chip}>
+              <Chip dense style={styles.chip} onPress={() => {}}>
                 Dense chip
               </Chip>
             )}
@@ -134,7 +134,12 @@ const ChipExample = () => {
               Avatar (disabled)
             </Chip>
             {isV3 && (
-              <Chip mode="outlined" dense style={styles.chip}>
+              <Chip
+                mode="outlined"
+                dense
+                onPress={() => {}}
+                style={styles.chip}
+              >
                 Dense chip
               </Chip>
             )}

--- a/example/src/Examples/ChipExample.tsx
+++ b/example/src/Examples/ChipExample.tsx
@@ -6,7 +6,8 @@ import ScreenWrapper from '../ScreenWrapper';
 
 const ChipExample = () => {
   const [visible, setVisible] = React.useState<boolean>(false);
-  const { colors, isV3 } = useTheme();
+  const theme = useTheme();
+  const customColor = theme.isV3 ? theme.colors.error : theme.colors.primary;
 
   return (
     <>
@@ -16,6 +17,21 @@ const ChipExample = () => {
             <Chip selected onPress={() => {}} style={styles.chip}>
               Simple
             </Chip>
+            {theme.isV3 && (
+              <Chip
+                selected
+                showSelectedOverlay
+                onPress={() => {}}
+                style={styles.chip}
+              >
+                With selected overlay
+              </Chip>
+            )}
+            {theme.isV3 && (
+              <Chip elevated onPress={() => {}} style={styles.chip}>
+                Elevated
+              </Chip>
+            )}
             <Chip
               onPress={() => {}}
               onClose={() => {}}
@@ -64,9 +80,9 @@ const ChipExample = () => {
             >
               Avatar (disabled)
             </Chip>
-            {isV3 && (
-              <Chip dense style={styles.chip} onPress={() => {}}>
-                Dense chip
+            {theme.isV3 && (
+              <Chip compact style={styles.chip} onPress={() => {}}>
+                Compact chip
               </Chip>
             )}
           </View>
@@ -76,6 +92,27 @@ const ChipExample = () => {
             <Chip mode="outlined" onPress={() => {}} style={styles.chip}>
               Simple
             </Chip>
+            {theme.isV3 && (
+              <Chip
+                mode="outlined"
+                selected
+                showSelectedOverlay
+                onPress={() => {}}
+                style={styles.chip}
+              >
+                With selected overlay
+              </Chip>
+            )}
+            {theme.isV3 && (
+              <Chip
+                mode="outlined"
+                elevated
+                onPress={() => {}}
+                style={styles.chip}
+              >
+                Elevated
+              </Chip>
+            )}
             <Chip
               mode="outlined"
               onPress={() => {}}
@@ -133,43 +170,43 @@ const ChipExample = () => {
             >
               Avatar (disabled)
             </Chip>
-            {isV3 && (
+            {theme.isV3 && (
               <Chip
                 mode="outlined"
-                dense
+                compact
                 onPress={() => {}}
                 style={styles.chip}
               >
-                Dense chip
+                Compact chip
               </Chip>
             )}
           </View>
         </List.Section>
         <List.Section title="Custom chip">
           <View style={styles.row}>
-            {isV3 && (
+            {theme.isV3 && (
               <>
                 <Chip
                   mode="outlined"
                   onPress={() => {}}
-                  dense
+                  compact
                   avatar={
                     <Image source={require('../../assets/images/avatar.png')} />
                   }
                   style={[styles.chip, styles.customBorderRadius]}
                 >
-                  Dense with custom border radius
+                  Compact with custom border radius
                 </Chip>
                 <Chip
                   mode="flat"
                   onPress={() => {}}
-                  dense
+                  compact
                   avatar={
                     <Image source={require('../../assets/images/avatar.png')} />
                   }
                   style={[styles.chip, styles.customBorderRadius]}
                 >
-                  Dense with custom border radius
+                  Compact with custom border radius
                 </Chip>
               </>
             )}
@@ -187,20 +224,17 @@ const ChipExample = () => {
               style={[
                 styles.chip,
                 {
-                  backgroundColor: color(colors?.primary)
-                    .alpha(0.2)
-                    .rgb()
-                    .string(),
+                  backgroundColor: color(customColor).alpha(0.2).rgb().string(),
                 },
               ]}
-              selectedColor={colors?.primary}
+              selectedColor={customColor}
             >
               Flat selected chip with custom color
             </Chip>
             <Chip
               onPress={() => {}}
               style={styles.chip}
-              selectedColor={colors?.primary}
+              selectedColor={customColor}
             >
               Flat unselected chip with custom color
             </Chip>
@@ -211,13 +245,10 @@ const ChipExample = () => {
               style={[
                 styles.chip,
                 {
-                  backgroundColor: color(colors?.primary)
-                    .alpha(0.2)
-                    .rgb()
-                    .string(),
+                  backgroundColor: color(customColor).alpha(0.2).rgb().string(),
                 },
               ]}
-              selectedColor={colors?.primary}
+              selectedColor={customColor}
             >
               Outlined selected chip with custom color
             </Chip>
@@ -225,7 +256,7 @@ const ChipExample = () => {
               mode="outlined"
               onPress={() => {}}
               style={styles.chip}
-              selectedColor={colors?.primary}
+              selectedColor={customColor}
             >
               Outlined unselected chip with custom color
             </Chip>

--- a/example/src/Examples/ChipExample.tsx
+++ b/example/src/Examples/ChipExample.tsx
@@ -6,7 +6,7 @@ import ScreenWrapper from '../ScreenWrapper';
 
 const ChipExample = () => {
   const [visible, setVisible] = React.useState<boolean>(false);
-  const { colors } = useTheme();
+  const { colors, isV3 } = useTheme();
 
   return (
     <>
@@ -64,6 +64,11 @@ const ChipExample = () => {
             >
               Avatar (disabled)
             </Chip>
+            {isV3 && (
+              <Chip dense style={styles.chip}>
+                Dense chip
+              </Chip>
+            )}
           </View>
         </List.Section>
         <List.Section title="Outlined chip">
@@ -128,10 +133,41 @@ const ChipExample = () => {
             >
               Avatar (disabled)
             </Chip>
+            {isV3 && (
+              <Chip mode="outlined" dense style={styles.chip}>
+                Dense chip
+              </Chip>
+            )}
           </View>
         </List.Section>
         <List.Section title="Custom chip">
           <View style={styles.row}>
+            {isV3 && (
+              <>
+                <Chip
+                  mode="outlined"
+                  onPress={() => {}}
+                  dense
+                  avatar={
+                    <Image source={require('../../assets/images/avatar.png')} />
+                  }
+                  style={[styles.chip, styles.customBorderRadius]}
+                >
+                  Dense with custom border radius
+                </Chip>
+                <Chip
+                  mode="flat"
+                  onPress={() => {}}
+                  dense
+                  avatar={
+                    <Image source={require('../../assets/images/avatar.png')} />
+                  }
+                  style={[styles.chip, styles.customBorderRadius]}
+                >
+                  Dense with custom border radius
+                </Chip>
+              </>
+            )}
             <Chip
               mode="outlined"
               onPress={() => {}}
@@ -259,6 +295,9 @@ const styles = StyleSheet.create({
   fullWidthChip: {
     marginVertical: 4,
     marginHorizontal: 12,
+  },
+  customBorderRadius: {
+    borderRadius: 16,
   },
 });
 

--- a/example/src/Examples/ChipExample.tsx
+++ b/example/src/Examples/ChipExample.tsx
@@ -1,13 +1,20 @@
 import * as React from 'react';
 import { View, StyleSheet, Image } from 'react-native';
-import { Chip, List, useTheme, Snackbar } from 'react-native-paper';
+import {
+  Chip,
+  List,
+  useTheme,
+  Snackbar,
+  MD3Colors,
+  MD2Colors,
+} from 'react-native-paper';
 import color from 'color';
 import ScreenWrapper from '../ScreenWrapper';
 
 const ChipExample = () => {
   const [visible, setVisible] = React.useState<boolean>(false);
-  const theme = useTheme();
-  const customColor = theme.isV3 ? theme.colors.error : theme.colors.primary;
+  const { isV3 } = useTheme();
+  const customColor = isV3 ? MD3Colors.secondary20 : MD2Colors.purple900;
 
   return (
     <>
@@ -17,20 +24,23 @@ const ChipExample = () => {
             <Chip selected onPress={() => {}} style={styles.chip}>
               Simple
             </Chip>
-            {theme.isV3 && (
-              <Chip
-                selected
-                showSelectedOverlay
-                onPress={() => {}}
-                style={styles.chip}
-              >
-                With selected overlay
-              </Chip>
-            )}
-            {theme.isV3 && (
-              <Chip elevated onPress={() => {}} style={styles.chip}>
-                Elevated
-              </Chip>
+            {isV3 && (
+              <>
+                <Chip
+                  selected
+                  showSelectedOverlay
+                  onPress={() => {}}
+                  style={styles.chip}
+                >
+                  With selected overlay
+                </Chip>
+                <Chip elevated onPress={() => {}} style={styles.chip}>
+                  Elevated
+                </Chip>
+                <Chip compact style={styles.chip} onPress={() => {}}>
+                  Compact chip
+                </Chip>
+              </>
             )}
             <Chip
               onPress={() => {}}
@@ -80,11 +90,6 @@ const ChipExample = () => {
             >
               Avatar (disabled)
             </Chip>
-            {theme.isV3 && (
-              <Chip compact style={styles.chip} onPress={() => {}}>
-                Compact chip
-              </Chip>
-            )}
           </View>
         </List.Section>
         <List.Section title="Outlined chip">
@@ -92,26 +97,34 @@ const ChipExample = () => {
             <Chip mode="outlined" onPress={() => {}} style={styles.chip}>
               Simple
             </Chip>
-            {theme.isV3 && (
-              <Chip
-                mode="outlined"
-                selected
-                showSelectedOverlay
-                onPress={() => {}}
-                style={styles.chip}
-              >
-                With selected overlay
-              </Chip>
-            )}
-            {theme.isV3 && (
-              <Chip
-                mode="outlined"
-                elevated
-                onPress={() => {}}
-                style={styles.chip}
-              >
-                Elevated
-              </Chip>
+            {isV3 && (
+              <>
+                <Chip
+                  mode="outlined"
+                  selected
+                  showSelectedOverlay
+                  onPress={() => {}}
+                  style={styles.chip}
+                >
+                  With selected overlay
+                </Chip>
+                <Chip
+                  mode="outlined"
+                  elevated
+                  onPress={() => {}}
+                  style={styles.chip}
+                >
+                  Elevated
+                </Chip>
+                <Chip
+                  mode="outlined"
+                  compact
+                  onPress={() => {}}
+                  style={styles.chip}
+                >
+                  Compact chip
+                </Chip>
+              </>
             )}
             <Chip
               mode="outlined"
@@ -170,21 +183,11 @@ const ChipExample = () => {
             >
               Avatar (disabled)
             </Chip>
-            {theme.isV3 && (
-              <Chip
-                mode="outlined"
-                compact
-                onPress={() => {}}
-                style={styles.chip}
-              >
-                Compact chip
-              </Chip>
-            )}
           </View>
         </List.Section>
         <List.Section title="Custom chip">
           <View style={styles.row}>
-            {theme.isV3 && (
+            {isV3 && (
               <>
                 <Chip
                   mode="outlined"

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -165,12 +165,14 @@ const Chip = ({
     }).start();
   };
 
-  const { dark, colors } = theme;
+  const { dark, colors, isV3 } = theme;
   const defaultBackgroundColor =
     mode === 'outlined' ? colors?.surface : dark ? '#383838' : '#ebebeb';
 
-  const { backgroundColor = defaultBackgroundColor, borderRadius = 16 } =
-    (StyleSheet.flatten(style) || {}) as ViewStyle;
+  const {
+    backgroundColor = defaultBackgroundColor,
+    borderRadius = isV3 ? 8 : 16,
+  } = (StyleSheet.flatten(style) || {}) as ViewStyle;
 
   const themeTextColor = theme.isV3
     ? theme.colors.onSurface
@@ -274,9 +276,27 @@ const Chip = ({
         accessibilityState={accessibilityState}
         testID={testID}
       >
-        <View style={[styles.content, { paddingRight: onClose ? 32 : 4 }]}>
+        <View
+          style={[
+            styles.content,
+            isV3 && styles.md3Content,
+            isV3
+              ? {
+                  paddingRight: onClose ? 34 : 0,
+                }
+              : {
+                  paddingRight: onClose ? 32 : 8,
+                },
+          ]}
+        >
           {avatar && !icon ? (
-            <View style={[styles.avatarWrapper, disabled && { opacity: 0.26 }]}>
+            <View
+              style={[
+                styles.avatarWrapper,
+                isV3 && styles.md3AvatarWrapper,
+                disabled && { opacity: 0.26 },
+              ]}
+            >
               {React.isValidElement(avatar)
                 ? React.cloneElement(avatar, {
                     style: [styles.avatar, avatar.props.style],
@@ -288,7 +308,14 @@ const Chip = ({
             <View
               style={[
                 styles.icon,
-                avatar ? [styles.avatar, styles.avatarSelected] : null,
+                isV3 && styles.md3Icon,
+                avatar
+                  ? [
+                      styles.avatar,
+                      styles.avatarSelected,
+                      isV3 && selected && styles.md3SelectedIcon,
+                    ]
+                  : null,
               ]}
             >
               {icon ? (
@@ -308,16 +335,22 @@ const Chip = ({
             </View>
           ) : null}
           <Text
+            variant="labelLarge"
             selectable={false}
             numberOfLines={1}
             style={[
               styles.text,
-              {
-                ...theme.fonts.regular,
-                color: textColor,
-                marginRight: onClose ? 0 : 8,
-                marginLeft: avatar || icon || selected ? 4 : 8,
-              },
+              isV3
+                ? {
+                    marginLeft: avatar || icon || selected ? 8 : 16,
+                    marginRight: onClose ? 0 : 16,
+                  }
+                : {
+                    ...theme.fonts.regular,
+                    color: textColor,
+                    marginRight: onClose ? 0 : 8,
+                    marginLeft: avatar || icon || selected ? 4 : 8,
+                  },
               textStyle,
             ]}
             ellipsizeMode={ellipsizeMode}
@@ -336,13 +369,23 @@ const Chip = ({
             accessibilityRole="button"
             accessibilityLabel={closeIconAccessibilityLabel}
           >
-            <View style={[styles.icon, styles.closeIcon]}>
+            <View
+              style={[
+                styles.icon,
+                styles.closeIcon,
+                isV3 && styles.md3CloseIcon,
+              ]}
+            >
               {closeIcon ? (
-                <Icon source={closeIcon} color={iconColor} size={16} />
+                <Icon
+                  source={closeIcon}
+                  color={iconColor}
+                  size={isV3 ? 18 : 16}
+                />
               ) : (
                 <MaterialCommunityIcon
-                  name="close-circle"
-                  size={16}
+                  name={isV3 ? 'close' : 'close-circle'}
+                  size={isV3 ? 18 : 16}
                   color={iconColor}
                   direction="ltr"
                 />
@@ -368,12 +411,23 @@ const styles = StyleSheet.create({
     position: 'relative',
     flexGrow: 1,
   },
+  md3Content: {
+    paddingLeft: 0,
+  },
   icon: {
     padding: 4,
     alignSelf: 'center',
   },
+  md3Icon: {
+    paddingLeft: 8,
+    paddingRight: 0,
+  },
   closeIcon: {
     marginRight: 4,
+  },
+  md3CloseIcon: {
+    marginRight: 8,
+    padding: 0,
   },
   text: {
     minHeight: 24,
@@ -388,6 +442,12 @@ const styles = StyleSheet.create({
   },
   avatarWrapper: {
     marginRight: 4,
+  },
+  md3AvatarWrapper: {
+    marginLeft: 4,
+  },
+  md3SelectedIcon: {
+    paddingLeft: 4,
   },
   avatarSelected: {
     position: 'absolute',

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -69,6 +69,11 @@ type Props = React.ComponentProps<typeof Surface> & {
    */
   onPress?: () => void;
   /**
+   * @supported Available in v3.x with theme version 3
+   * Sets smaller horizontal paddings `12dp` around label, when there is only label.
+   */
+  dense?: boolean;
+  /**
    * Function to execute on long press.
    */
   onLongPress?: () => void;
@@ -141,6 +146,7 @@ const Chip = ({
   testID,
   selectedColor,
   ellipsizeMode,
+  dense,
   ...rest
 }: Props) => {
   const { current: elevation } = React.useRef<Animated.Value>(
@@ -208,7 +214,7 @@ const Chip = ({
   }
 
   const elevationStyle = Platform.OS === 'android' ? elevation : 0;
-  const multiplier = isV3 ? 2 : 1;
+  const multiplier = isV3 ? (dense ? 1.5 : 2) : 1;
   const labelSpacings = {
     marginRight: onClose ? 0 : 8 * multiplier,
     marginLeft: avatar || icon || selected ? 4 * multiplier : 8 * multiplier,
@@ -421,6 +427,7 @@ const styles = StyleSheet.create({
   },
   md3AvatarWrapper: {
     marginLeft: 4,
+    marginRight: 0,
   },
   md3SelectedIcon: {
     paddingLeft: 4,

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -174,7 +174,7 @@ const Chip = ({
     Animated.timing(elevation, {
       toValue: isV3 ? (elevated ? 2 : 0) : 4,
       duration: 200 * scale,
-      useNativeDriver: false,
+      useNativeDriver: true,
     }).start();
   };
 
@@ -183,7 +183,7 @@ const Chip = ({
     Animated.timing(elevation, {
       toValue: isV3 && elevated ? 1 : 0,
       duration: 150 * scale,
-      useNativeDriver: false,
+      useNativeDriver: true,
     }).start();
   };
 

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -53,6 +53,11 @@ type Props = React.ComponentProps<typeof Surface> & {
    */
   selectedColor?: string;
   /**
+   * @supported Available in v3.x with theme version 3
+   * Whether to display overlay on selected chip
+   */
+  showSelectedOverlay?: boolean;
+  /**
    * Whether the chip is disabled. A disabled chip is greyed out and `onPress` is not called on touch.
    */
   disabled?: boolean;
@@ -72,7 +77,12 @@ type Props = React.ComponentProps<typeof Surface> & {
    * @supported Available in v3.x with theme version 3
    * Sets smaller horizontal paddings `12dp` around label, when there is only label.
    */
-  dense?: boolean;
+  compact?: boolean;
+  /**
+   * @supported Available in v3.x with theme version 3
+   * Whether chip should have the elevation.
+   */
+  elevated?: boolean;
   /**
    * Function to execute on long press.
    */
@@ -145,12 +155,16 @@ const Chip = ({
   theme,
   testID,
   selectedColor,
+  showSelectedOverlay = false,
   ellipsizeMode,
-  dense,
+  compact,
+  elevated = false,
   ...rest
 }: Props) => {
+  const { isV3 } = theme;
+
   const { current: elevation } = React.useRef<Animated.Value>(
-    new Animated.Value(0)
+    new Animated.Value(isV3 && elevated ? 1 : 0)
   );
 
   const isOutlined = mode === 'outlined';
@@ -158,7 +172,7 @@ const Chip = ({
   const handlePressIn = () => {
     const { scale } = theme.animation;
     Animated.timing(elevation, {
-      toValue: 4,
+      toValue: isV3 ? (elevated ? 2 : 0) : 4,
       duration: 200 * scale,
       useNativeDriver: false,
     }).start();
@@ -167,13 +181,11 @@ const Chip = ({
   const handlePressOut = () => {
     const { scale } = theme.animation;
     Animated.timing(elevation, {
-      toValue: 0,
+      toValue: isV3 && elevated ? 1 : 0,
       duration: 150 * scale,
       useNativeDriver: false,
     }).start();
   };
-
-  const { isV3 } = theme;
 
   const opacity = isV3 ? 0.38 : 0.26;
   const defaultBorderRadius = isV3 ? 8 : 16;
@@ -193,6 +205,7 @@ const Chip = ({
     backgroundColor,
   } = getChipColors({
     selectedColor,
+    showSelectedOverlay,
     customBackgroundColor,
     theme,
     isOutlined,
@@ -213,8 +226,8 @@ const Chip = ({
     accessibilityTraits.push('disabled');
   }
 
-  const elevationStyle = Platform.OS === 'android' ? elevation : 0;
-  const multiplier = isV3 ? (dense ? 1.5 : 2) : 1;
+  const elevationStyle = isV3 || Platform.OS === 'android' ? elevation : 0;
+  const multiplier = isV3 ? (compact ? 1.5 : 2) : 1;
   const labelSpacings = {
     marginRight: onClose ? 0 : 8 * multiplier,
     marginLeft: avatar || icon || selected ? 4 * multiplier : 8 * multiplier,

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -204,11 +204,11 @@ const Chip = ({
     selectedBackgroundColor,
     backgroundColor,
   } = getChipColors({
+    isOutlined,
+    theme,
     selectedColor,
     showSelectedOverlay,
     customBackgroundColor,
-    theme,
-    isOutlined,
     disabled,
   });
 

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -10,16 +10,16 @@ import {
   View,
   ViewStyle,
 } from 'react-native';
-import color from 'color';
-import type { IconSource } from './Icon';
-import Icon from './Icon';
-import MaterialCommunityIcon from './MaterialCommunityIcon';
-import Surface from './Surface';
-import Text from './Typography/Text';
-import TouchableRipple from './TouchableRipple/TouchableRipple';
-import { withTheme } from '../core/theming';
-import { black, white } from '../styles/themes/v2/colors';
-import type { EllipsizeProp, Theme } from '../types';
+import type { IconSource } from '../Icon';
+import Icon from '../Icon';
+import MaterialCommunityIcon from '../MaterialCommunityIcon';
+import Surface from '../Surface';
+import Text from '../Typography/Text';
+import TouchableRipple from '../TouchableRipple/TouchableRipple';
+import { withTheme } from '../../core/theming';
+import { white } from '../../styles/themes/v2/colors';
+import type { EllipsizeProp, Theme } from '../../types';
+import { getChipColors } from './helpers';
 
 type Props = React.ComponentProps<typeof Surface> & {
   /**
@@ -167,90 +167,31 @@ const Chip = ({
     }).start();
   };
 
-  const { dark, colors, isV3 } = theme;
-
-  let defaultBackgroundColor;
-
-  if (isV3) {
-    defaultBackgroundColor = isOutlined
-      ? theme.colors.surface
-      : theme.colors.secondaryContainer;
-  } else {
-    defaultBackgroundColor = isOutlined
-      ? colors?.surface
-      : dark
-      ? '#383838'
-      : '#ebebeb';
-  }
+  const { isV3 } = theme;
 
   const opacity = isV3 ? 0.38 : 0.26;
   const defaultBorderRadius = isV3 ? 8 : 16;
   const iconSize = isV3 ? 18 : 16;
 
   const {
-    backgroundColor: customBackgroundColor = defaultBackgroundColor,
+    backgroundColor: customBackgroundColor,
     borderRadius = defaultBorderRadius,
   } = (StyleSheet.flatten(style) || {}) as ViewStyle;
 
-  let borderColor;
-  let textColor;
-  let iconColor;
-  let backgroundColor;
-  let underlayColor;
-
-  backgroundColor =
-    typeof customBackgroundColor === 'string'
-      ? customBackgroundColor
-      : defaultBackgroundColor;
-
-  const selectedBackgroundColor = (
-    dark
-      ? color(backgroundColor).lighten(mode === 'outlined' ? 0.2 : 0.4)
-      : color(backgroundColor).darken(mode === 'outlined' ? 0.08 : 0.2)
-  )
-    .rgb()
-    .string();
-
-  if (isV3) {
-    if (disabled) {
-      const customDisabledColor = color(theme.colors.onSurfaceVariant)
-        .alpha(0.12)
-        .rgb()
-        .string();
-      borderColor = customDisabledColor;
-      textColor = iconColor = theme.colors.onSurfaceDisabled;
-      backgroundColor = isOutlined ? 'transparent' : customDisabledColor;
-    } else {
-      borderColor = theme.colors.outline;
-      textColor = iconColor = isOutlined
-        ? theme.colors.onSurfaceVariant
-        : theme.colors.onSecondaryContainer;
-      underlayColor = color(textColor).alpha(0.12).rgb().string();
-    }
-  } else {
-    borderColor = isOutlined
-      ? color(
-          selectedColor !== undefined
-            ? selectedColor
-            : color(dark ? white : black)
-        )
-          .alpha(0.29)
-          .rgb()
-          .string()
-      : backgroundColor;
-    if (disabled) {
-      textColor = theme.colors.disabled;
-      iconColor = theme.colors.disabled;
-    } else {
-      const customTextColor =
-        selectedColor !== undefined ? selectedColor : theme.colors.text;
-      textColor = color(customTextColor).alpha(0.87).rgb().string();
-      iconColor = color(customTextColor).alpha(0.54).rgb().string();
-      underlayColor = selectedColor
-        ? color(selectedColor).fade(0.5).rgb().string()
-        : selectedBackgroundColor;
-    }
-  }
+  const {
+    borderColor,
+    textColor,
+    iconColor,
+    underlayColor,
+    selectedBackgroundColor,
+    backgroundColor,
+  } = getChipColors({
+    selectedColor,
+    customBackgroundColor,
+    theme,
+    isOutlined,
+    disabled,
+  });
 
   const accessibilityTraits = ['button'];
   const accessibilityState: AccessibilityState = {
@@ -273,7 +214,7 @@ const Chip = ({
     marginLeft: avatar || icon || selected ? 4 * multiplier : 8 * multiplier,
   };
   const contentSpacings = {
-    paddingRight: isV3 ? (onClose ? 34 : 0) : onClose ? 32 : 8,
+    paddingRight: isV3 ? (onClose ? 34 : 0) : onClose ? 32 : 4,
   };
 
   return (
@@ -377,13 +318,13 @@ const Chip = ({
             numberOfLines={1}
             style={[
               styles.text,
-              labelSpacings,
               {
                 color: textColor,
-                ...(isV3 && {
+                ...(!isV3 && {
                   ...theme.fonts.regular,
                 }),
               },
+              labelSpacings,
               textStyle,
             ]}
             ellipsizeMode={ellipsizeMode}

--- a/src/components/Chip/helpers.tsx
+++ b/src/components/Chip/helpers.tsx
@@ -5,12 +5,14 @@ import type { ColorValue } from 'react-native';
 
 export const getChipColors = ({
   selectedColor,
+  showSelectedOverlay,
   customBackgroundColor,
   theme,
   isOutlined,
   disabled,
 }: {
   selectedColor?: string;
+  showSelectedOverlay?: boolean;
   customBackgroundColor?: ColorValue;
   theme: Theme;
   isOutlined: boolean;
@@ -76,7 +78,7 @@ export const getChipColors = ({
               ? theme.colors.onSurfaceVariant
               : theme.colors.onSecondaryContainer
           ),
-          0.12
+          showSelectedOverlay ? 0.12 : 0
         )
         .rgb()
         .string();

--- a/src/components/Chip/helpers.tsx
+++ b/src/components/Chip/helpers.tsx
@@ -4,18 +4,18 @@ import { black, white } from '../../styles/themes/v2/colors';
 import type { ColorValue } from 'react-native';
 
 export const getChipColors = ({
+  isOutlined,
+  theme,
   selectedColor,
   showSelectedOverlay,
   customBackgroundColor,
-  theme,
-  isOutlined,
   disabled,
 }: {
+  isOutlined: boolean;
+  theme: Theme;
   selectedColor?: string;
   showSelectedOverlay?: boolean;
   customBackgroundColor?: ColorValue;
-  theme: Theme;
-  isOutlined: boolean;
   disabled?: boolean;
 }) => {
   let borderColor;
@@ -27,6 +27,7 @@ export const getChipColors = ({
   let selectedBackgroundColor;
 
   const { isV3, dark } = theme;
+  const isSelectedColor = selectedColor !== undefined;
 
   if (isV3) {
     defaultBackgroundColor = isOutlined
@@ -55,19 +56,15 @@ export const getChipColors = ({
       textColor = iconColor = theme.colors.onSurfaceDisabled;
       backgroundColor = isOutlined ? 'transparent' : customDisabledColor;
     } else {
-      borderColor =
-        selectedColor !== undefined
-          ? color(selectedColor).alpha(0.29).rgb().string()
-          : theme.colors.outline;
-      textColor = iconColor =
-        selectedColor !== undefined
-          ? selectedColor
-          : isOutlined
-          ? theme.colors.onSurfaceVariant
-          : theme.colors.onSecondaryContainer;
-      underlayColor = color(
-        selectedColor !== undefined ? selectedColor : textColor
-      )
+      borderColor = isSelectedColor
+        ? color(selectedColor).alpha(0.29).rgb().string()
+        : theme.colors.outline;
+      textColor = iconColor = isSelectedColor
+        ? selectedColor
+        : isOutlined
+        ? theme.colors.onSurfaceVariant
+        : theme.colors.onSecondaryContainer;
+      underlayColor = color(isSelectedColor ? selectedColor : textColor)
         .alpha(0.12)
         .rgb()
         .string();
@@ -92,11 +89,7 @@ export const getChipColors = ({
       .rgb()
       .string();
     borderColor = isOutlined
-      ? color(
-          selectedColor !== undefined
-            ? selectedColor
-            : color(dark ? white : black)
-        )
+      ? color(isSelectedColor ? selectedColor : color(dark ? white : black))
           .alpha(0.29)
           .rgb()
           .string()
@@ -105,8 +98,9 @@ export const getChipColors = ({
       textColor = theme.colors.disabled;
       iconColor = theme.colors.disabled;
     } else {
-      const customTextColor =
-        selectedColor !== undefined ? selectedColor : theme.colors.text;
+      const customTextColor = isSelectedColor
+        ? selectedColor
+        : theme.colors.text;
       textColor = color(customTextColor).alpha(0.87).rgb().string();
       iconColor = color(customTextColor).alpha(0.54).rgb().string();
       underlayColor = selectedColor

--- a/src/components/Chip/helpers.tsx
+++ b/src/components/Chip/helpers.tsx
@@ -1,0 +1,102 @@
+import color from 'color';
+import type { Theme } from '../../types';
+import { black, white } from '../../styles/themes/v2/colors';
+import type { ColorValue } from 'react-native';
+
+export const getChipColors = ({
+  selectedColor,
+  customBackgroundColor,
+  theme,
+  isOutlined,
+  disabled,
+}: {
+  selectedColor?: string;
+  customBackgroundColor?: ColorValue;
+  theme: Theme;
+  isOutlined: boolean;
+  disabled?: boolean;
+}) => {
+  let borderColor;
+  let textColor;
+  let iconColor;
+  let underlayColor;
+  let backgroundColor;
+  let defaultBackgroundColor;
+
+  const { isV3, dark } = theme;
+
+  if (isV3) {
+    defaultBackgroundColor = isOutlined
+      ? theme.colors.surface
+      : theme.colors.secondaryContainer;
+  } else {
+    defaultBackgroundColor = isOutlined
+      ? theme.colors?.surface
+      : dark
+      ? '#383838'
+      : '#ebebeb';
+  }
+
+  backgroundColor =
+    typeof customBackgroundColor === 'string'
+      ? customBackgroundColor
+      : defaultBackgroundColor;
+
+  const selectedBackgroundColor = (
+    dark
+      ? color(backgroundColor).lighten(isOutlined ? 0.2 : 0.4)
+      : color(backgroundColor).darken(isOutlined ? 0.08 : 0.2)
+  )
+    .rgb()
+    .string();
+
+  if (isV3) {
+    if (disabled) {
+      const customDisabledColor = color(theme.colors.onSurfaceVariant)
+        .alpha(0.12)
+        .rgb()
+        .string();
+      borderColor = customDisabledColor;
+      textColor = iconColor = theme.colors.onSurfaceDisabled;
+      backgroundColor = isOutlined ? 'transparent' : customDisabledColor;
+    } else {
+      borderColor = theme.colors.outline;
+      textColor = iconColor = isOutlined
+        ? theme.colors.onSurfaceVariant
+        : theme.colors.onSecondaryContainer;
+      underlayColor = color(textColor).alpha(0.12).rgb().string();
+    }
+  } else {
+    borderColor = isOutlined
+      ? color(
+          selectedColor !== undefined
+            ? selectedColor
+            : color(dark ? white : black)
+        )
+          .alpha(0.29)
+          .rgb()
+          .string()
+      : backgroundColor;
+    if (disabled) {
+      textColor = theme.colors.disabled;
+      iconColor = theme.colors.disabled;
+    } else {
+      const customTextColor =
+        selectedColor !== undefined ? selectedColor : theme.colors.text;
+      textColor = color(customTextColor).alpha(0.87).rgb().string();
+      iconColor = color(customTextColor).alpha(0.54).rgb().string();
+      underlayColor = selectedColor
+        ? color(selectedColor).fade(0.5).rgb().string()
+        : selectedBackgroundColor;
+    }
+  }
+
+  return {
+    borderColor,
+    textColor,
+    iconColor,
+    underlayColor,
+    backgroundColor,
+    selectedBackgroundColor,
+  };
+};

--- a/src/components/Chip/helpers.tsx
+++ b/src/components/Chip/helpers.tsx
@@ -22,6 +22,7 @@ export const getChipColors = ({
   let underlayColor;
   let backgroundColor;
   let defaultBackgroundColor;
+  let selectedBackgroundColor;
 
   const { isV3, dark } = theme;
 
@@ -42,14 +43,6 @@ export const getChipColors = ({
       ? customBackgroundColor
       : defaultBackgroundColor;
 
-  const selectedBackgroundColor = (
-    dark
-      ? color(backgroundColor).lighten(isOutlined ? 0.2 : 0.4)
-      : color(backgroundColor).darken(isOutlined ? 0.08 : 0.2)
-  )
-    .rgb()
-    .string();
-
   if (isV3) {
     if (disabled) {
       const customDisabledColor = color(theme.colors.onSurfaceVariant)
@@ -60,13 +53,42 @@ export const getChipColors = ({
       textColor = iconColor = theme.colors.onSurfaceDisabled;
       backgroundColor = isOutlined ? 'transparent' : customDisabledColor;
     } else {
-      borderColor = theme.colors.outline;
-      textColor = iconColor = isOutlined
-        ? theme.colors.onSurfaceVariant
-        : theme.colors.onSecondaryContainer;
-      underlayColor = color(textColor).alpha(0.12).rgb().string();
+      borderColor =
+        selectedColor !== undefined
+          ? color(selectedColor).alpha(0.29).rgb().string()
+          : theme.colors.outline;
+      textColor = iconColor =
+        selectedColor !== undefined
+          ? selectedColor
+          : isOutlined
+          ? theme.colors.onSurfaceVariant
+          : theme.colors.onSecondaryContainer;
+      underlayColor = color(
+        selectedColor !== undefined ? selectedColor : textColor
+      )
+        .alpha(0.12)
+        .rgb()
+        .string();
+      selectedBackgroundColor = color(backgroundColor)
+        .mix(
+          color(
+            isOutlined
+              ? theme.colors.onSurfaceVariant
+              : theme.colors.onSecondaryContainer
+          ),
+          0.12
+        )
+        .rgb()
+        .string();
     }
   } else {
+    selectedBackgroundColor = (
+      dark
+        ? color(backgroundColor).lighten(isOutlined ? 0.2 : 0.4)
+        : color(backgroundColor).darken(isOutlined ? 0.08 : 0.2)
+    )
+      .rgb()
+      .string();
     borderColor = isOutlined
       ? color(
           selectedColor !== undefined

--- a/src/components/Chip/helpers.tsx
+++ b/src/components/Chip/helpers.tsx
@@ -3,6 +3,255 @@ import type { Theme } from '../../types';
 import { black, white } from '../../styles/themes/v2/colors';
 import type { ColorValue } from 'react-native';
 
+type BaseProps = {
+  theme: Theme;
+  isOutlined: boolean;
+  disabled?: boolean;
+};
+
+const getBorderColor = ({
+  theme,
+  isOutlined,
+  disabled,
+  selectedColor,
+  backgroundColor,
+}: BaseProps & { backgroundColor: string; selectedColor?: string }) => {
+  const isSelectedColor = selectedColor !== undefined;
+
+  if (theme.isV3) {
+    if (disabled) {
+      return color(theme.colors.onSurfaceVariant).alpha(0.12).rgb().string();
+    }
+
+    if (isSelectedColor) {
+      return color(selectedColor).alpha(0.29).rgb().string();
+    }
+
+    return theme.colors.outline;
+  }
+
+  if (isOutlined) {
+    if (isSelectedColor) {
+      return color(selectedColor).alpha(0.29).rgb().string();
+    }
+
+    if (theme.dark) {
+      return color(white).alpha(0.29).rgb().string();
+    }
+
+    return color(black).alpha(0.29).rgb().string();
+  }
+
+  return backgroundColor;
+};
+
+const getTextColor = ({
+  theme,
+  isOutlined,
+  disabled,
+  selectedColor,
+}: BaseProps & {
+  selectedColor?: string;
+}) => {
+  const isSelectedColor = selectedColor !== undefined;
+  if (theme.isV3) {
+    if (disabled) {
+      return theme.colors.onSurfaceDisabled;
+    }
+
+    if (isSelectedColor) {
+      return selectedColor;
+    }
+
+    if (isOutlined) {
+      return theme.colors.onSurfaceVariant;
+    }
+
+    return theme.colors.onSecondaryContainer;
+  }
+
+  if (disabled) {
+    return theme.colors.disabled;
+  }
+
+  if (isSelectedColor) {
+    return color(selectedColor).alpha(0.87).rgb().string();
+  }
+
+  return color(theme.colors.text).alpha(0.87).rgb().string();
+};
+
+const getDefaultBackgroundColor = ({
+  theme,
+  isOutlined,
+}: Omit<BaseProps, 'disabled' | 'selectedColor'>) => {
+  if (theme.isV3) {
+    if (isOutlined) {
+      return theme.colors.surface;
+    }
+
+    return theme.colors.secondaryContainer;
+  }
+
+  if (isOutlined) {
+    return theme.colors?.surface;
+  }
+
+  if (theme.dark) {
+    return '#383838';
+  }
+
+  return '#ebebeb';
+};
+
+const getBackgroundColor = ({
+  theme,
+  isOutlined,
+  disabled,
+  customBackgroundColor,
+}: BaseProps & {
+  customBackgroundColor?: ColorValue;
+}) => {
+  if (typeof customBackgroundColor === 'string') {
+    return customBackgroundColor;
+  }
+
+  if (theme.isV3) {
+    if (disabled) {
+      if (isOutlined) {
+        return 'transparent';
+      }
+      return color(theme.colors.onSurfaceVariant).alpha(0.12).rgb().string();
+    }
+  }
+
+  return getDefaultBackgroundColor({ theme, isOutlined });
+};
+
+const getSelectedBackgroundColor = ({
+  theme,
+  isOutlined,
+  disabled,
+  customBackgroundColor,
+  showSelectedOverlay,
+}: BaseProps & {
+  customBackgroundColor?: ColorValue;
+  showSelectedOverlay?: boolean;
+}) => {
+  const backgroundColor = getBackgroundColor({
+    theme,
+    disabled,
+    isOutlined,
+    customBackgroundColor,
+  });
+
+  if (theme.isV3) {
+    if (isOutlined) {
+      if (showSelectedOverlay) {
+        return color(backgroundColor)
+          .mix(color(theme.colors.onSurfaceVariant), 0.12)
+          .rgb()
+          .string();
+      }
+      return color(backgroundColor)
+        .mix(color(theme.colors.onSurfaceVariant), 0)
+        .rgb()
+        .string();
+    }
+
+    if (showSelectedOverlay) {
+      return color(backgroundColor)
+        .mix(color(theme.colors.onSecondaryContainer), 0.12)
+        .rgb()
+        .string();
+    }
+
+    return color(backgroundColor)
+      .mix(color(theme.colors.onSecondaryContainer), 0)
+      .rgb()
+      .string();
+  }
+
+  if (theme.dark) {
+    if (isOutlined) {
+      return color(backgroundColor).lighten(0.2).rgb().string();
+    }
+    return color(backgroundColor).lighten(0.4).rgb().string();
+  }
+
+  if (isOutlined) {
+    return color(backgroundColor).darken(0.08).rgb().string();
+  }
+
+  return color(backgroundColor).darken(0.2).rgb().string();
+};
+
+const getIconColor = ({
+  theme,
+  isOutlined,
+  disabled,
+  selectedColor,
+}: BaseProps & {
+  selectedColor?: string;
+}) => {
+  const isSelectedColor = selectedColor !== undefined;
+  if (theme.isV3) {
+    if (disabled) {
+      return theme.colors.onSurfaceDisabled;
+    }
+
+    if (isSelectedColor) {
+      return selectedColor;
+    }
+
+    if (isOutlined) {
+      return theme.colors.onSurfaceVariant;
+    }
+
+    return theme.colors.onSecondaryContainer;
+  }
+
+  if (disabled) {
+    return theme.colors.disabled;
+  }
+
+  if (isSelectedColor) {
+    return color(selectedColor).alpha(0.54).rgb().string();
+  }
+
+  return color(theme.colors.text).alpha(0.54).rgb().string();
+};
+
+const getUnderlayColor = ({
+  theme,
+  isOutlined,
+  disabled,
+  selectedColor,
+  selectedBackgroundColor,
+}: BaseProps & { selectedBackgroundColor: string; selectedColor?: string }) => {
+  const isSelectedColor = selectedColor !== undefined;
+  const textColor = getTextColor({
+    theme,
+    disabled,
+    selectedColor,
+    isOutlined,
+  });
+
+  if (theme.isV3) {
+    if (isSelectedColor) {
+      return color(selectedColor).alpha(0.12).rgb().string();
+    }
+
+    return color(textColor).alpha(0.12).rgb().string();
+  }
+
+  if (isSelectedColor) {
+    return color(selectedColor).fade(0.5).rgb().string();
+  }
+
+  return selectedBackgroundColor;
+};
+
 export const getChipColors = ({
   isOutlined,
   theme,
@@ -10,110 +259,44 @@ export const getChipColors = ({
   showSelectedOverlay,
   customBackgroundColor,
   disabled,
-}: {
-  isOutlined: boolean;
-  theme: Theme;
-  selectedColor?: string;
-  showSelectedOverlay?: boolean;
+}: BaseProps & {
   customBackgroundColor?: ColorValue;
   disabled?: boolean;
+  showSelectedOverlay?: boolean;
+  selectedColor?: string;
 }) => {
-  let borderColor;
-  let textColor;
-  let iconColor;
-  let underlayColor;
-  let backgroundColor;
-  let defaultBackgroundColor;
-  let selectedBackgroundColor;
+  const baseChipColorProps = { theme, isOutlined, disabled };
 
-  const { isV3, dark } = theme;
-  const isSelectedColor = selectedColor !== undefined;
+  const backgroundColor = getBackgroundColor({
+    ...baseChipColorProps,
+    customBackgroundColor,
+  });
 
-  if (isV3) {
-    defaultBackgroundColor = isOutlined
-      ? theme.colors.surface
-      : theme.colors.secondaryContainer;
-  } else {
-    defaultBackgroundColor = isOutlined
-      ? theme.colors?.surface
-      : dark
-      ? '#383838'
-      : '#ebebeb';
-  }
-
-  backgroundColor =
-    typeof customBackgroundColor === 'string'
-      ? customBackgroundColor
-      : defaultBackgroundColor;
-
-  if (isV3) {
-    if (disabled) {
-      const customDisabledColor = color(theme.colors.onSurfaceVariant)
-        .alpha(0.12)
-        .rgb()
-        .string();
-      borderColor = customDisabledColor;
-      textColor = iconColor = theme.colors.onSurfaceDisabled;
-      backgroundColor = isOutlined ? 'transparent' : customDisabledColor;
-    } else {
-      borderColor = isSelectedColor
-        ? color(selectedColor).alpha(0.29).rgb().string()
-        : theme.colors.outline;
-      textColor = iconColor = isSelectedColor
-        ? selectedColor
-        : isOutlined
-        ? theme.colors.onSurfaceVariant
-        : theme.colors.onSecondaryContainer;
-      underlayColor = color(isSelectedColor ? selectedColor : textColor)
-        .alpha(0.12)
-        .rgb()
-        .string();
-      selectedBackgroundColor = color(backgroundColor)
-        .mix(
-          color(
-            isOutlined
-              ? theme.colors.onSurfaceVariant
-              : theme.colors.onSecondaryContainer
-          ),
-          showSelectedOverlay ? 0.12 : 0
-        )
-        .rgb()
-        .string();
-    }
-  } else {
-    selectedBackgroundColor = (
-      dark
-        ? color(backgroundColor).lighten(isOutlined ? 0.2 : 0.4)
-        : color(backgroundColor).darken(isOutlined ? 0.08 : 0.2)
-    )
-      .rgb()
-      .string();
-    borderColor = isOutlined
-      ? color(isSelectedColor ? selectedColor : color(dark ? white : black))
-          .alpha(0.29)
-          .rgb()
-          .string()
-      : backgroundColor;
-    if (disabled) {
-      textColor = theme.colors.disabled;
-      iconColor = theme.colors.disabled;
-    } else {
-      const customTextColor = isSelectedColor
-        ? selectedColor
-        : theme.colors.text;
-      textColor = color(customTextColor).alpha(0.87).rgb().string();
-      iconColor = color(customTextColor).alpha(0.54).rgb().string();
-      underlayColor = selectedColor
-        ? color(selectedColor).fade(0.5).rgb().string()
-        : selectedBackgroundColor;
-    }
-  }
+  const selectedBackgroundColor = getSelectedBackgroundColor({
+    ...baseChipColorProps,
+    customBackgroundColor,
+    showSelectedOverlay,
+  });
 
   return {
-    borderColor,
-    textColor,
-    iconColor,
-    underlayColor,
+    borderColor: getBorderColor({
+      ...baseChipColorProps,
+      selectedColor,
+      backgroundColor,
+    }),
+    textColor: getTextColor({
+      ...baseChipColorProps,
+      selectedColor,
+    }),
+    iconColor: getIconColor({
+      ...baseChipColorProps,
+      selectedColor,
+    }),
+    underlayColor: getUnderlayColor({
+      ...baseChipColorProps,
+      selectedColor,
+      selectedBackgroundColor,
+    }),
     backgroundColor,
     selectedBackgroundColor,
   };

--- a/src/components/__tests__/Chip.test.js
+++ b/src/components/__tests__/Chip.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import renderer from 'react-test-renderer';
-import Chip from '../Chip.tsx';
+import Chip from '../Chip/Chip.tsx';
 
 it('renders chip with onPress', () => {
   const tree = renderer

--- a/src/components/__tests__/Chip.test.js
+++ b/src/components/__tests__/Chip.test.js
@@ -1,6 +1,28 @@
 import * as React from 'react';
 import renderer from 'react-test-renderer';
+import color from 'color';
 import Chip from '../Chip/Chip.tsx';
+import { getChipColors } from '../Chip/helpers';
+import { black, white } from '../../styles/themes/v2/colors';
+
+import MD3LightTheme from '../../styles/themes/v3/LightTheme';
+import MD2LightTheme from '../../styles/themes/v2/LightTheme';
+import MD3DarkTheme from '../../styles/themes/v3/DarkTheme';
+import MD2DarkTheme from '../../styles/themes/v2/DarkTheme';
+
+const getTheme = (isDark = false, isV3 = true) => {
+  const theme = isDark
+    ? isV3
+      ? MD3DarkTheme
+      : MD2DarkTheme
+    : isV3
+    ? MD3LightTheme
+    : MD2LightTheme;
+  return {
+    ...theme,
+    isV3,
+  };
+};
 
 it('renders chip with onPress', () => {
   const tree = renderer
@@ -58,4 +80,645 @@ it('renders selected chip', () => {
   const tree = renderer.create(<Chip selected>Example Chip</Chip>).toJSON();
 
   expect(tree).toMatchSnapshot();
+});
+
+describe('getChipColors - text color', () => {
+  it('should return correct disabled color, for theme version 3', () => {
+    expect(
+      getChipColors({
+        disabled: true,
+        theme: getTheme(),
+      })
+    ).toMatchObject({
+      textColor: getTheme().colors.onSurfaceDisabled,
+    });
+  });
+
+  it('should return correct disabled color, for theme version 2', () => {
+    expect(
+      getChipColors({
+        disabled: true,
+        theme: getTheme(false, false),
+      })
+    ).toMatchObject({
+      textColor: getTheme(false, false).colors.disabled,
+    });
+  });
+
+  it('should return correct theme color, for theme version 3, flat mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+      })
+    ).toMatchObject({
+      textColor: getTheme().colors.onSecondaryContainer,
+    });
+  });
+
+  it('should return correct theme color, for theme version 3, outlined mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+        isOutlined: true,
+      })
+    ).toMatchObject({
+      textColor: getTheme().colors.onSurfaceVariant,
+    });
+  });
+
+  it('should return correct theme color, for theme version 2', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(false, false),
+      })
+    ).toMatchObject({
+      textColor: color(getTheme(false, false).colors.text)
+        .alpha(0.87)
+        .rgb()
+        .string(),
+    });
+  });
+
+  it('should return custom color, for theme version 3', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+        selectedColor: 'purple',
+      })
+    ).toMatchObject({
+      textColor: 'purple',
+    });
+  });
+
+  it('should return custom color, for theme version 2', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(false, false),
+        selectedColor: 'purple',
+      })
+    ).toMatchObject({
+      textColor: color('purple').alpha(0.87).rgb().string(),
+    });
+  });
+});
+
+describe('getChipColors - icon color', () => {
+  it('should return correct disabled color, for theme version 3', () => {
+    expect(
+      getChipColors({
+        disabled: true,
+        theme: getTheme(),
+      })
+    ).toMatchObject({
+      iconColor: getTheme().colors.onSurfaceDisabled,
+    });
+  });
+
+  it('should return correct disabled color, for theme version 2', () => {
+    expect(
+      getChipColors({
+        disabled: true,
+        theme: getTheme(false, false),
+      })
+    ).toMatchObject({
+      iconColor: getTheme(false, false).colors.disabled,
+    });
+  });
+
+  it('should return correct theme color, for theme version 3, flat mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+      })
+    ).toMatchObject({
+      iconColor: getTheme().colors.onSecondaryContainer,
+    });
+  });
+
+  it('should return correct theme color, for theme version 3, outlined mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+        isOutlined: true,
+      })
+    ).toMatchObject({
+      iconColor: getTheme().colors.onSurfaceVariant,
+    });
+  });
+
+  it('should return correct theme color, for theme version 2', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(false, false),
+      })
+    ).toMatchObject({
+      iconColor: color(getTheme(false, false).colors.text)
+        .alpha(0.54)
+        .rgb()
+        .string(),
+    });
+  });
+
+  it('should return custom color, for theme version 3', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+        selectedColor: 'purple',
+      })
+    ).toMatchObject({
+      iconColor: 'purple',
+    });
+  });
+
+  it('should return custom color, for theme version 2', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(false, false),
+        selectedColor: 'purple',
+      })
+    ).toMatchObject({
+      iconColor: color('purple').alpha(0.54).rgb().string(),
+    });
+  });
+});
+
+describe('getChipColors - underlay color', () => {
+  it('should return theme color, for theme version 3, flat mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+      })
+    ).toMatchObject({
+      underlayColor: color(getTheme().colors.onSecondaryContainer)
+        .alpha(0.12)
+        .rgb()
+        .string(),
+    });
+  });
+
+  it('should return theme color, for theme version 3, outline mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+        isOutlined: true,
+      })
+    ).toMatchObject({
+      underlayColor: color(getTheme().colors.onSurfaceVariant)
+        .alpha(0.12)
+        .rgb()
+        .string(),
+    });
+  });
+
+  it('should return custom color, for theme version 3', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+        selectedColor: 'purple',
+      })
+    ).toMatchObject({
+      underlayColor: color('purple').alpha(0.12).rgb().string(),
+    });
+  });
+
+  it('should return custom color, for theme version 2', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(false, false),
+        selectedColor: 'purple',
+      })
+    ).toMatchObject({
+      underlayColor: color('purple').fade(0.5).rgb().string(),
+    });
+  });
+
+  it('should return custom color, for theme version 2, dark mode, outline mode, customBackgroundColor', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(true, false),
+        customBackgroundColor: 'purple',
+        isOutlined: true,
+      })
+    ).toMatchObject({
+      underlayColor: color('purple').lighten(0.2).rgb().string(),
+    });
+  });
+
+  it('should return custom color, for theme version 2, dark mode, flat mode, customBackgroundColor', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(true, false),
+        customBackgroundColor: 'purple',
+      })
+    ).toMatchObject({
+      underlayColor: color('purple').lighten(0.4).rgb().string(),
+    });
+  });
+
+  it('should return custom color, for theme version 2, light mode, outline mode, customBackgroundColor', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(false, false),
+        customBackgroundColor: 'purple',
+        isOutlined: true,
+      })
+    ).toMatchObject({
+      underlayColor: color('purple').darken(0.08).rgb().string(),
+    });
+  });
+
+  it('should return custom color, for theme version 2, light mode, flat mode, customBackgroundColor', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(false, false),
+        customBackgroundColor: 'purple',
+      })
+    ).toMatchObject({
+      underlayColor: color('purple').darken(0.2).rgb().string(),
+    });
+  });
+
+  it('should return theme color, for theme version 2, light mode, outline mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(false, false),
+        isOutlined: true,
+      })
+    ).toMatchObject({
+      underlayColor: color(getTheme(false, false).colors.surface)
+        .darken(0.08)
+        .rgb()
+        .string(),
+    });
+  });
+
+  it('should return theme color, for theme version 2, light mode, flat mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(false, false),
+      })
+    ).toMatchObject({
+      underlayColor: color('#ebebeb').darken(0.2).rgb().string(),
+    });
+  });
+
+  it('should return theme color, for theme version 2, dark mode, outline mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(true, false),
+        isOutlined: true,
+      })
+    ).toMatchObject({
+      underlayColor: color(getTheme(true, false).colors.surface)
+        .lighten(0.2)
+        .rgb()
+        .string(),
+    });
+  });
+
+  it('should return theme color, for theme version 2, dark mode, flat mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(true, false),
+      })
+    ).toMatchObject({
+      underlayColor: color('#383838').lighten(0.4).rgb().string(),
+    });
+  });
+});
+
+describe('getChipColor - selected background color', () => {
+  it('should return custom color, for theme version 3, outlined mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+        customBackgroundColor: 'purple',
+        isOutlined: true,
+      })
+    ).toMatchObject({
+      selectedBackgroundColor: color('purple')
+        .mix(color(getTheme().colors.onSurfaceVariant), 0)
+        .rgb()
+        .string(),
+    });
+  });
+
+  it('should return custom color, for theme version 3, flat mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+        customBackgroundColor: 'purple',
+      })
+    ).toMatchObject({
+      selectedBackgroundColor: color('purple')
+        .mix(color(getTheme().colors.onSecondaryContainer), 0)
+        .rgb()
+        .string(),
+    });
+  });
+
+  it('should return custom color, for theme version 3, outlined mode, show selected overlay', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+        customBackgroundColor: 'purple',
+        showSelectedOverlay: true,
+        isOutlined: true,
+      })
+    ).toMatchObject({
+      selectedBackgroundColor: color('purple')
+        .mix(color(getTheme().colors.onSurfaceVariant), 0.12)
+        .rgb()
+        .string(),
+    });
+  });
+
+  it('should return custom color, for theme version 3, flat mode, show selected overlay', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+        customBackgroundColor: 'purple',
+        showSelectedOverlay: true,
+      })
+    ).toMatchObject({
+      selectedBackgroundColor: color('purple')
+        .mix(color(getTheme().colors.onSecondaryContainer), 0.12)
+        .rgb()
+        .string(),
+    });
+  });
+
+  it('should return theme color, for theme version 3, outlined mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+        isOutlined: true,
+      })
+    ).toMatchObject({
+      selectedBackgroundColor: color(getTheme().colors.surface)
+        .mix(color(getTheme().colors.onSurfaceVariant), 0)
+        .rgb()
+        .string(),
+    });
+  });
+
+  it('should return theme color, for theme version 3, flat mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+      })
+    ).toMatchObject({
+      selectedBackgroundColor: color(getTheme().colors.secondaryContainer)
+        .mix(color(getTheme().colors.onSecondaryContainer), 0)
+        .rgb()
+        .string(),
+    });
+  });
+
+  it('should return custom color, for theme version 2, light mode, outlined mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(false, false),
+        customBackgroundColor: 'purple',
+        isOutlined: true,
+      })
+    ).toMatchObject({
+      selectedBackgroundColor: color('purple').darken(0.08).rgb().string(),
+    });
+  });
+
+  it('should return custom color, for theme version 2, light mode, flat mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(false, false),
+        customBackgroundColor: 'purple',
+      })
+    ).toMatchObject({
+      selectedBackgroundColor: color('purple').darken(0.2).rgb().string(),
+    });
+  });
+
+  it('should return custom color, for theme version 2, dark mode, outlined mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(true, false),
+        customBackgroundColor: 'purple',
+        isOutlined: true,
+      })
+    ).toMatchObject({
+      selectedBackgroundColor: color('purple').lighten(0.2).rgb().string(),
+    });
+  });
+
+  it('should return custom color, for theme version 2, dark mode, flat mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(true, false),
+        customBackgroundColor: 'purple',
+      })
+    ).toMatchObject({
+      selectedBackgroundColor: color('purple').lighten(0.4).rgb().string(),
+    });
+  });
+
+  it('should return theme color, for theme version 2, outlined mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(false, false),
+        isOutlined: true,
+      })
+    ).toMatchObject({
+      selectedBackgroundColor: color(getTheme(false, false).colors.surface)
+        .darken(0.08)
+        .rgb()
+        .string(),
+    });
+  });
+
+  it('should return theme color, for theme version 2, light mode, flat mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(false, false),
+      })
+    ).toMatchObject({
+      selectedBackgroundColor: color('#ebebeb').darken(0.2).rgb().string(),
+    });
+  });
+
+  it('should return theme color, for theme version 2, dark mode, flat mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(true, false),
+      })
+    ).toMatchObject({
+      selectedBackgroundColor: color('#383838').lighten(0.4).rgb().string(),
+    });
+  });
+});
+
+describe('getChipColor - background color', () => {
+  it('should return custom color', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+        customBackgroundColor: 'purple',
+      })
+    ).toMatchObject({
+      backgroundColor: 'purple',
+    });
+  });
+
+  it('should return theme color, for theme version 3, outlined mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+        isOutlined: true,
+      })
+    ).toMatchObject({
+      backgroundColor: getTheme().colors.surface,
+    });
+  });
+
+  it('should return theme color, for theme version 3, flat mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+      })
+    ).toMatchObject({
+      backgroundColor: getTheme().colors.secondaryContainer,
+    });
+  });
+
+  it('should return theme color, for theme version 2, outlined mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(false, false),
+        isOutlined: true,
+      })
+    ).toMatchObject({
+      backgroundColor: getTheme(false, false).colors.surface,
+    });
+  });
+
+  it('should return theme color, for theme version 2, light mode, flat mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(false, false),
+      })
+    ).toMatchObject({
+      backgroundColor: '#ebebeb',
+    });
+  });
+
+  it('should return theme color, for theme version 2, dark mode, flat mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(true, false),
+      })
+    ).toMatchObject({
+      backgroundColor: '#383838',
+    });
+  });
+});
+
+describe('getChipColor - border color', () => {
+  it('should return correct disabled color, for theme version 3', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+        disabled: true,
+      })
+    ).toMatchObject({
+      borderColor: color(getTheme().colors.onSurfaceVariant)
+        .alpha(0.12)
+        .rgb()
+        .string(),
+    });
+  });
+
+  it('should return custom color, for theme version 3', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+        selectedColor: 'purple',
+      })
+    ).toMatchObject({
+      borderColor: color('purple').alpha(0.29).rgb().string(),
+    });
+  });
+
+  it('should return theme color, for theme version 3', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+      })
+    ).toMatchObject({
+      borderColor: getTheme().colors.outline,
+    });
+  });
+
+  it('should return custom color, for theme version 2, outlined mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(false, false),
+        selectedColor: 'purple',
+        isOutlined: true,
+      })
+    ).toMatchObject({
+      borderColor: color('purple').alpha(0.29).rgb().string(),
+    });
+  });
+
+  it('should return custom color, for theme version 2, flat mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(true, false),
+        customBackgroundColor: 'purple',
+      })
+    ).toMatchObject({
+      borderColor: 'purple',
+    });
+  });
+
+  it('should return theme color, for theme version 2, light mode, outlined mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(false, false),
+        isOutlined: true,
+      })
+    ).toMatchObject({
+      borderColor: color(black).alpha(0.29).rgb().string(),
+    });
+  });
+
+  it('should return theme color, for theme version 2, dark mode, outlined mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(true, false),
+        isOutlined: true,
+      })
+    ).toMatchObject({
+      borderColor: color(white).alpha(0.29).rgb().string(),
+    });
+  });
+
+  it('should return theme background color, for theme version 2, light mode, flat mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(false, false),
+      })
+    ).toMatchObject({
+      borderColor: '#ebebeb',
+    });
+  });
+
+  it('should return theme background color, for theme version 2, dark mode, flat mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(true, false),
+      })
+    ).toMatchObject({
+      borderColor: '#383838',
+    });
+  });
 });

--- a/src/components/__tests__/ListItem.test.js
+++ b/src/components/__tests__/ListItem.test.js
@@ -4,7 +4,7 @@ import renderer from 'react-test-renderer';
 import { Text, View } from 'react-native';
 import ListItem from '../List/ListItem.tsx';
 import ListIcon from '../List/ListIcon.tsx';
-import Chip from '../Chip';
+import Chip from '../Chip/Chip';
 import { red500 } from '../../styles/themes/v2/colors';
 
 const styles = StyleSheet.create({

--- a/src/components/__tests__/__snapshots__/Chip.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.js.snap
@@ -57,6 +57,7 @@ exports[`renders chip with close button 1`] = `
             "paddingLeft": 4,
             "position": "relative",
           },
+          false,
           Object {
             "paddingRight": 32,
           },
@@ -70,6 +71,7 @@ exports[`renders chip with close button 1`] = `
               "alignSelf": "center",
               "padding": 4,
             },
+            false,
             null,
           ]
         }
@@ -118,6 +120,8 @@ exports[`renders chip with close button 1`] = `
                 "color": "rgba(0, 0, 0, 0.87)",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "marginLeft": 4,
                 "marginRight": 0,
               },
@@ -162,6 +166,7 @@ exports[`renders chip with close button 1`] = `
           Object {
             "marginRight": 4,
           },
+          false,
         ]
       }
     >
@@ -246,6 +251,7 @@ exports[`renders chip with custom close button 1`] = `
             "paddingLeft": 4,
             "position": "relative",
           },
+          false,
           Object {
             "paddingRight": 32,
           },
@@ -259,6 +265,7 @@ exports[`renders chip with custom close button 1`] = `
               "alignSelf": "center",
               "padding": 4,
             },
+            false,
             null,
           ]
         }
@@ -307,6 +314,8 @@ exports[`renders chip with custom close button 1`] = `
                 "color": "rgba(0, 0, 0, 0.87)",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "marginLeft": 4,
                 "marginRight": 0,
               },
@@ -351,6 +360,7 @@ exports[`renders chip with custom close button 1`] = `
           Object {
             "marginRight": 4,
           },
+          false,
         ]
       }
     >
@@ -435,6 +445,7 @@ exports[`renders chip with icon 1`] = `
             "paddingLeft": 4,
             "position": "relative",
           },
+          false,
           Object {
             "paddingRight": 4,
           },
@@ -448,6 +459,7 @@ exports[`renders chip with icon 1`] = `
               "alignSelf": "center",
               "padding": 4,
             },
+            false,
             null,
           ]
         }
@@ -496,6 +508,8 @@ exports[`renders chip with icon 1`] = `
                 "color": "rgba(0, 0, 0, 0.87)",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "marginLeft": 4,
                 "marginRight": 8,
               },
@@ -568,6 +582,7 @@ exports[`renders chip with onPress 1`] = `
             "paddingLeft": 4,
             "position": "relative",
           },
+          false,
           Object {
             "paddingRight": 4,
           },
@@ -598,6 +613,8 @@ exports[`renders chip with onPress 1`] = `
                 "color": "rgba(0, 0, 0, 0.87)",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "marginLeft": 8,
                 "marginRight": 8,
               },
@@ -670,6 +687,7 @@ exports[`renders outlined disabled chip 1`] = `
             "paddingLeft": 4,
             "position": "relative",
           },
+          false,
           Object {
             "paddingRight": 4,
           },
@@ -697,9 +715,11 @@ exports[`renders outlined disabled chip 1`] = `
                 "textAlignVertical": "center",
               },
               Object {
-                "color": "#000000",
+                "color": "rgba(0, 0, 0, 0.26)",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "marginLeft": 8,
                 "marginRight": 8,
               },
@@ -772,6 +792,7 @@ exports[`renders selected chip 1`] = `
             "paddingLeft": 4,
             "position": "relative",
           },
+          false,
           Object {
             "paddingRight": 4,
           },
@@ -785,6 +806,7 @@ exports[`renders selected chip 1`] = `
               "alignSelf": "center",
               "padding": 4,
             },
+            false,
             null,
           ]
         }
@@ -833,6 +855,8 @@ exports[`renders selected chip 1`] = `
                 "color": "rgba(0, 0, 0, 0.87)",
                 "fontFamily": "System",
                 "fontWeight": "400",
+              },
+              Object {
                 "marginLeft": 4,
                 "marginRight": 8,
               },

--- a/src/components/__tests__/__snapshots__/ListItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.js.snap
@@ -140,6 +140,7 @@ exports[`renders list item with custom description 1`] = `
                       "paddingLeft": 4,
                       "position": "relative",
                     },
+                    false,
                     Object {
                       "paddingRight": 4,
                     },
@@ -153,6 +154,7 @@ exports[`renders list item with custom description 1`] = `
                         "alignSelf": "center",
                         "padding": 4,
                       },
+                      false,
                       null,
                     ]
                   }
@@ -201,6 +203,8 @@ exports[`renders list item with custom description 1`] = `
                           "color": "rgba(0, 0, 0, 0.87)",
                           "fontFamily": "System",
                           "fontWeight": "400",
+                        },
+                        Object {
                           "marginLeft": 4,
                           "marginRight": 8,
                         },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,7 +30,7 @@ export { default as BottomNavigation } from './components/BottomNavigation/Botto
 export { default as Button } from './components/Button';
 export { default as Card } from './components/Card/Card';
 export { default as Checkbox } from './components/Checkbox';
-export { default as Chip } from './components/Chip';
+export { default as Chip } from './components/Chip/Chip';
 export { default as DataTable } from './components/DataTable/DataTable';
 export { default as Dialog } from './components/Dialog/Dialog';
 export { default as Divider } from './components/Divider';


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

 
### Summary

PR:

* adjusts `Chip` component into Material You.
* introduces new props called:
  * `compact` for smaller horizontal paddings when there is only a label
  * `elevated` whether chip should have elevation
  * `showSelectedOverlay` indicating displaying an overlay on the selected chip
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

* check application in both themes, if `Chip` works and have correct colors in both themes on both platforms
* snapshots indicate that `Chip` from theme version 2 wasn't changed.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
