### PR TITLE
fix: pass maxFontSizeMultiplier to input label and adornments

### DIFF
--- a/src/components/HelperText.tsx
+++ b/src/components/HelperText.tsx
@@ -94,6 +94,8 @@ const HelperText = ({
 
   const { scale } = theme.animation;
 
+  const { maxFontSizeMultiplier = 1.5 } = rest;
+
   React.useEffect(() => {
     if (visible) {
       // show text
@@ -150,6 +152,7 @@ const HelperText = ({
         },
         style,
       ]}
+      maxFontSizeMultiplier={maxFontSizeMultiplier}
       {...rest}
     >
       {rest.children}

--- a/src/components/TextInput/Adornment/TextInputAdornment.tsx
+++ b/src/components/TextInput/Adornment/TextInputAdornment.tsx
@@ -124,6 +124,7 @@ export interface TextInputAdornmentProps {
   visible?: Animated.Value;
   isTextInputFocused: boolean;
   paddingHorizontal?: number | string;
+  maxFontSizeMultiplier?: number | undefined | null;
 }
 
 const TextInputAdornment: React.FunctionComponent<TextInputAdornmentProps> = ({
@@ -137,6 +138,7 @@ const TextInputAdornment: React.FunctionComponent<TextInputAdornmentProps> = ({
   isTextInputFocused,
   forceFocus,
   paddingHorizontal,
+  maxFontSizeMultiplier,
 }) => {
   if (adornmentConfig.length) {
     return (
@@ -174,6 +176,7 @@ const TextInputAdornment: React.FunctionComponent<TextInputAdornmentProps> = ({
                 textStyle={textStyle}
                 onLayout={onAffixChange[side]}
                 visible={visible}
+                maxFontSizeMultiplier={maxFontSizeMultiplier}
               />
             );
           } else {

--- a/src/components/TextInput/Adornment/TextInputAffix.tsx
+++ b/src/components/TextInput/Adornment/TextInputAffix.tsx
@@ -38,6 +38,7 @@ type ContextState = {
   textStyle?: StyleProp<TextStyle>;
   side: AdornmentSide;
   paddingHorizontal?: number | string;
+  maxFontSizeMultiplier?: number | undefined | null;
 };
 
 const AffixContext = React.createContext<ContextState>({
@@ -59,6 +60,7 @@ const AffixAdornment: React.FunctionComponent<
   onLayout,
   visible,
   paddingHorizontal,
+  maxFontSizeMultiplier,
 }) => {
   return (
     <AffixContext.Provider
@@ -69,6 +71,7 @@ const AffixAdornment: React.FunctionComponent<
         onLayout,
         visible,
         paddingHorizontal,
+        maxFontSizeMultiplier,
       }}
     >
       {affix}
@@ -108,8 +111,15 @@ const AffixAdornment: React.FunctionComponent<
  */
 
 const TextInputAffix = ({ text, textStyle: labelStyle, theme }: Props) => {
-  const { textStyle, onLayout, topPosition, side, visible, paddingHorizontal } =
-    React.useContext(AffixContext);
+  const {
+    textStyle,
+    onLayout,
+    topPosition,
+    side,
+    visible,
+    paddingHorizontal,
+    maxFontSizeMultiplier,
+  } = React.useContext(AffixContext);
   const textColor = color(theme.colors.text)
     .alpha(theme.dark ? 0.7 : 0.54)
     .rgb()
@@ -138,7 +148,12 @@ const TextInputAffix = ({ text, textStyle: labelStyle, theme }: Props) => {
       ]}
       onLayout={onLayout}
     >
-      <Text style={[{ color: textColor }, textStyle, labelStyle]}>{text}</Text>
+      <Text
+        maxFontSizeMultiplier={maxFontSizeMultiplier}
+        style={[{ color: textColor }, textStyle, labelStyle]}
+      >
+        {text}
+      </Text>
     </Animated.View>
   );
 };

--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -27,6 +27,7 @@ const InputLabel = (props: InputLabelProps) => {
     placeholderColor,
     errorColor,
     labelTranslationXOffset,
+    maxFontSizeMultiplier,
   } = props.labelProps;
 
   const labelTranslationX = {
@@ -94,6 +95,7 @@ const InputLabel = (props: InputLabelProps) => {
         parentState,
         labelStyle,
         labelProps: props.labelProps,
+        maxFontSizeMultiplier: maxFontSizeMultiplier,
       })}
       <AnimatedText
         onLayout={onLayoutAnimatedText}
@@ -113,6 +115,7 @@ const InputLabel = (props: InputLabelProps) => {
           },
         ]}
         numberOfLines={1}
+        maxFontSizeMultiplier={maxFontSizeMultiplier}
       >
         {label}
       </AnimatedText>
@@ -130,6 +133,7 @@ const InputLabel = (props: InputLabelProps) => {
           },
         ]}
         numberOfLines={1}
+        maxFontSizeMultiplier={maxFontSizeMultiplier}
       >
         {label}
       </AnimatedText>

--- a/src/components/TextInput/Label/LabelBackground.tsx
+++ b/src/components/TextInput/Label/LabelBackground.tsx
@@ -17,6 +17,7 @@ const LabelBackground = ({
     roundness,
   },
   labelStyle,
+  maxFontSizeMultiplier,
 }: LabelBackgroundProps) => {
   const hasFocus = hasActiveOutline || parentState.value;
   const opacity = parentState.labeled.interpolate({
@@ -77,6 +78,7 @@ const LabelBackground = ({
             },
           ]}
           numberOfLines={1}
+          maxFontSizeMultiplier={maxFontSizeMultiplier}
         >
           {label}
         </AnimatedText>,

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -389,6 +389,8 @@ const TextInput = React.forwardRef<TextInputHandles, TextInputProps>(
     };
     const forceFocus = () => root.current?.focus();
 
+    const { maxFontSizeMultiplier = 1.5 } = rest;
+
     if (mode === 'outlined') {
       return (
         <TextInputOutlined
@@ -420,6 +422,7 @@ const TextInput = React.forwardRef<TextInputHandles, TextInputProps>(
           onLayoutAnimatedText={handleLayoutAnimatedText}
           onLeftAffixLayoutChange={onLeftAffixLayoutChange}
           onRightAffixLayoutChange={onRightAffixLayoutChange}
+          maxFontSizeMultiplier={maxFontSizeMultiplier}
         />
       );
     }
@@ -454,6 +457,7 @@ const TextInput = React.forwardRef<TextInputHandles, TextInputProps>(
         onLayoutAnimatedText={handleLayoutAnimatedText}
         onLeftAffixLayoutChange={onLeftAffixLayoutChange}
         onRightAffixLayoutChange={onRightAffixLayoutChange}
+        maxFontSizeMultiplier={maxFontSizeMultiplier}
       />
     );
   }

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -263,6 +263,7 @@ const TextInputFlat = ({
     placeholderColor,
     errorColor,
     roundness: theme.roundness,
+    maxFontSizeMultiplier: rest.maxFontSizeMultiplier,
   };
   const affixTopPosition = {
     [AdornmentSide.Left]: leftAffixTopPosition,
@@ -283,6 +284,7 @@ const TextInputFlat = ({
     },
     onAffixChange,
     isTextInputFocused: parentState.focused,
+    maxFontSizeMultiplier: rest.maxFontSizeMultiplier,
   };
   if (adornmentConfig.length) {
     adornmentProps = {
@@ -331,6 +333,7 @@ const TextInputFlat = ({
         )}
         <InputLabel parentState={parentState} labelProps={labelProps} />
         {render?.({
+          testID: 'text-input-flat',
           ...rest,
           ref: innerRef,
           onChangeText,

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -198,6 +198,7 @@ const TextInputOutlined = ({
     errorColor,
     labelTranslationXOffset,
     roundness: theme.roundness,
+    maxFontSizeMultiplier: rest.maxFontSizeMultiplier,
   };
 
   const minHeight = (height ||
@@ -255,6 +256,7 @@ const TextInputOutlined = ({
     },
     onAffixChange,
     isTextInputFocused: parentState.focused,
+    maxFontSizeMultiplier: rest.maxFontSizeMultiplier,
   };
   if (adornmentConfig.length) {
     adornmentProps = {
@@ -295,6 +297,7 @@ const TextInputOutlined = ({
             parentState={parentState}
             labelProps={labelProps}
             labelBackground={LabelBackground}
+            maxFontSizeMultiplier={rest.maxFontSizeMultiplier}
           />
           {render?.({
             testID: 'text-input-outlined',

--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -71,14 +71,18 @@ export type LabelProps = {
   error?: boolean | null;
   onLayoutAnimatedText: (args: any) => void;
   roundness: number;
+  maxFontSizeMultiplier?: number | undefined | null;
 };
 export type InputLabelProps = {
   parentState: State;
   labelProps: LabelProps;
   labelBackground?: any;
+  maxFontSizeMultiplier?: number | undefined | null;
 };
+
 export type LabelBackgroundProps = {
   labelProps: LabelProps;
   labelStyle: any;
   parentState: State;
+  maxFontSizeMultiplier?: number | undefined | null;
 };

--- a/src/components/__tests__/TextInput.test.js
+++ b/src/components/__tests__/TextInput.test.js
@@ -174,3 +174,57 @@ it('correctly applies a component as the text label', () => {
 
   expect(toJSON()).toMatchSnapshot();
 });
+
+describe('maxFontSizeMultiplier', () => {
+  const createInput = (type, maxFontSizeMultiplier) => {
+    return (
+      <TextInput mode={type} maxFontSizeMultiplier={maxFontSizeMultiplier} />
+    );
+  };
+
+  it('should have default value in flat input', () => {
+    const { getByTestId } = render(createInput('flat'));
+
+    expect(getByTestId('text-input-flat').props.maxFontSizeMultiplier).toBe(
+      1.5
+    );
+  });
+
+  it('should have default value in outlined input', () => {
+    const { getByTestId } = render(createInput('outlined'));
+
+    expect(getByTestId('text-input-outlined').props.maxFontSizeMultiplier).toBe(
+      1.5
+    );
+  });
+
+  it('should have correct passed value in flat input', () => {
+    const { getByTestId } = render(createInput('flat', 2));
+
+    expect(getByTestId('text-input-flat').props.maxFontSizeMultiplier).toBe(2);
+  });
+
+  it('should have correct passed value in outlined input', () => {
+    const { getByTestId } = render(createInput('outlined', 2));
+
+    expect(getByTestId('text-input-outlined').props.maxFontSizeMultiplier).toBe(
+      2
+    );
+  });
+
+  it('should have passed null value in flat input', () => {
+    const { getByTestId } = render(createInput('flat', null));
+
+    expect(getByTestId('text-input-flat').props.maxFontSizeMultiplier).toBe(
+      null
+    );
+  });
+
+  it('should have passed null value in outlined input', () => {
+    const { getByTestId } = render(createInput('outlined', null));
+
+    expect(getByTestId('text-input-outlined').props.maxFontSizeMultiplier).toBe(
+      null
+    );
+  });
+});

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -64,6 +64,7 @@ exports[`correctly applies a component as the text label 1`] = `
       }
     >
       <Text
+        maxFontSizeMultiplier={1.5}
         numberOfLines={1}
         onLayout={[Function]}
         style={
@@ -105,6 +106,7 @@ exports[`correctly applies a component as the text label 1`] = `
         </Text>
       </Text>
       <Text
+        maxFontSizeMultiplier={1.5}
         numberOfLines={1}
         style={
           Object {
@@ -148,6 +150,7 @@ exports[`correctly applies a component as the text label 1`] = `
     <TextInput
       allowFontScaling={true}
       editable={true}
+      maxFontSizeMultiplier={1.5}
       multiline={false}
       onBlur={[Function]}
       onChangeText={[Function]}
@@ -187,6 +190,7 @@ exports[`correctly applies a component as the text label 1`] = `
           ],
         ]
       }
+      testID="text-input-flat"
       underlineColorAndroid="transparent"
       value="Some test value"
     />
@@ -258,6 +262,7 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
       }
     >
       <Text
+        maxFontSizeMultiplier={1.5}
         numberOfLines={1}
         onLayout={[Function]}
         style={
@@ -291,6 +296,7 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
         Flat input
       </Text>
       <Text
+        maxFontSizeMultiplier={1.5}
         numberOfLines={1}
         style={
           Object {
@@ -326,6 +332,7 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
     <TextInput
       allowFontScaling={true}
       editable={true}
+      maxFontSizeMultiplier={1.5}
       multiline={false}
       onBlur={[Function]}
       onChangeText={[Function]}
@@ -365,6 +372,7 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
           ],
         ]
       }
+      testID="text-input-flat"
       underlineColorAndroid="transparent"
       value="Some test value"
     />
@@ -452,6 +460,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
           }
         />
         <Text
+          maxFontSizeMultiplier={1.5}
           numberOfLines={1}
           style={
             Object {
@@ -488,6 +497,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
           Outline Input
         </Text>
         <Text
+          maxFontSizeMultiplier={1.5}
           numberOfLines={1}
           onLayout={[Function]}
           style={
@@ -520,6 +530,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
           Outline Input
         </Text>
         <Text
+          maxFontSizeMultiplier={1.5}
           numberOfLines={1}
           style={
             Object {
@@ -554,6 +565,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
       <TextInput
         allowFontScaling={true}
         editable={true}
+        maxFontSizeMultiplier={1.5}
         multiline={true}
         onBlur={[Function]}
         onChangeText={[Function]}
@@ -664,6 +676,7 @@ exports[`correctly applies textAlign center 1`] = `
       }
     >
       <Text
+        maxFontSizeMultiplier={1.5}
         numberOfLines={1}
         onLayout={[Function]}
         style={
@@ -697,6 +710,7 @@ exports[`correctly applies textAlign center 1`] = `
         Flat input
       </Text>
       <Text
+        maxFontSizeMultiplier={1.5}
         numberOfLines={1}
         style={
           Object {
@@ -732,6 +746,7 @@ exports[`correctly applies textAlign center 1`] = `
     <TextInput
       allowFontScaling={true}
       editable={true}
+      maxFontSizeMultiplier={1.5}
       multiline={false}
       onBlur={[Function]}
       onChangeText={[Function]}
@@ -771,6 +786,7 @@ exports[`correctly applies textAlign center 1`] = `
           ],
         ]
       }
+      testID="text-input-flat"
       underlineColorAndroid="transparent"
       value="Some test value"
     />
@@ -842,6 +858,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
       }
     >
       <Text
+        maxFontSizeMultiplier={1.5}
         numberOfLines={1}
         onLayout={[Function]}
         style={
@@ -875,6 +892,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
         Flat input
       </Text>
       <Text
+        maxFontSizeMultiplier={1.5}
         numberOfLines={1}
         style={
           Object {
@@ -910,6 +928,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
     <TextInput
       allowFontScaling={true}
       editable={true}
+      maxFontSizeMultiplier={1.5}
       multiline={false}
       onBlur={[Function]}
       onChangeText={[Function]}
@@ -952,6 +971,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
           },
         ]
       }
+      testID="text-input-flat"
       underlineColorAndroid="transparent"
       value="Some test value"
     />
@@ -970,6 +990,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
     }
   >
     <Text
+      maxFontSizeMultiplier={1.5}
       style={
         Array [
           Object {
@@ -1145,6 +1166,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
       }
     >
       <Text
+        maxFontSizeMultiplier={1.5}
         numberOfLines={1}
         onLayout={[Function]}
         style={
@@ -1178,6 +1200,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
         Flat input
       </Text>
       <Text
+        maxFontSizeMultiplier={1.5}
         numberOfLines={1}
         style={
           Object {
@@ -1213,6 +1236,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
     <TextInput
       allowFontScaling={true}
       editable={true}
+      maxFontSizeMultiplier={1.5}
       multiline={false}
       onBlur={[Function]}
       onChangeText={[Function]}
@@ -1255,6 +1279,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
           },
         ]
       }
+      testID="text-input-flat"
       underlineColorAndroid="transparent"
       value="Some test value"
     />
@@ -1362,6 +1387,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
     }
   >
     <Text
+      maxFontSizeMultiplier={1.5}
       style={
         Array [
           Object {


### PR DESCRIPTION
Following the [PR](https://github.com/callstack/react-native-paper/pull/2940), but changing the approach previously introduced in `BottomNavigation` based on using `maxFontSizeMultiplier` rather the disabling font scale.

### Summary

Passing `maxFontSizeMutliplier` from input to its adornments and labels.

ios | android
--- | ---
<img width="488" alt="Zrzut ekranu 2022-03-29 o 08 57 25" src="https://user-images.githubusercontent.com/22746080/160557128-af4749eb-711f-43f9-a5bd-42f859f27e50.png"> | <img width="502" alt="Zrzut ekranu 2022-03-29 o 09 22 09" src="https://user-images.githubusercontent.com/22746080/160556951-338718d4-6d64-4f9a-be06-d7fcb465a31b.png">



<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

* manual testing
* unit tests covering `maxFontSizeMultiplier` use

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
