### PR TITLE
Allow progamatically update focused TextInput state through ref.

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -260,6 +260,7 @@ const TextInput = React.forwardRef<TextInputHandles, TextInputProps>(
       isFocused: () => root.current?.isFocused() || false,
       blur: () => root.current?.blur(),
       forceFocus: () => root.current?.focus(),
+      setFocused: (focused: boolean) => root.current?.setFocused(focused)
     }));
 
     React.useLayoutEffect(() => {


### PR DESCRIPTION
Given a <TextInput ref={inputRef} />

We could later do when needed.
inputRef.current.setFocused(true);

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
