### PR TITLE
fix: correct elevation when switching modes

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -148,11 +148,11 @@ const Button = ({
   ...rest
 }: Props) => {
   const { current: elevation } = React.useRef<Animated.Value>(
-    new Animated.Value(mode === 'contained' ? 2 : 0)
+    new Animated.Value(disabled || mode !== 'contained' ? 0 : 2)
   );
   React.useEffect(() => {
-    elevation.setValue(mode === 'contained' ? 2 : 0);
-  }, [mode, elevation]);
+    elevation.setValue(disabled || mode !== 'contained' ? 0 : 2);
+  }, [mode, elevation, disabled]);
 
   const handlePressIn = () => {
     if (mode === 'contained') {
@@ -252,7 +252,6 @@ const Button = ({
     StyleSheet.flatten(labelStyle) || {};
 
   const textStyle = { color: textColor, ...font };
-  const elevationRes = disabled || mode !== 'contained' ? 0 : elevation;
   const iconStyle =
     StyleSheet.flatten(contentStyle)?.flexDirection === 'row-reverse'
       ? styles.iconReverse
@@ -264,7 +263,7 @@ const Button = ({
       style={[
         styles.button,
         compact && styles.compact,
-        { elevation: elevationRes } as ViewStyle,
+        { elevation },
         buttonStyle,
         style,
       ]}

--- a/src/components/__tests__/__snapshots__/Banner.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.js.snap
@@ -99,6 +99,13 @@ exports[`render visible banner, with custom theme 1`] = `
               "elevation": 0,
               "margin": 4,
               "minWidth": "auto",
+              "shadowColor": "#000000",
+              "shadowOffset": Object {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0,
+              "shadowRadius": 0,
             }
           }
         >
@@ -397,6 +404,13 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
               "elevation": 0,
               "margin": 4,
               "minWidth": "auto",
+              "shadowColor": "#000000",
+              "shadowOffset": Object {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0,
+              "shadowRadius": 0,
             }
           }
         >
@@ -589,6 +603,13 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
               "elevation": 0,
               "margin": 4,
               "minWidth": "auto",
+              "shadowColor": "#000000",
+              "shadowOffset": Object {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0,
+              "shadowRadius": 0,
             }
           }
         >
@@ -687,6 +708,13 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
               "elevation": 0,
               "margin": 4,
               "minWidth": "auto",
+              "shadowColor": "#000000",
+              "shadowOffset": Object {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0,
+              "shadowRadius": 0,
             }
           }
         >

--- a/src/components/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.js.snap
@@ -11,6 +11,13 @@ exports[`renders button with an accessibility hint 1`] = `
       "borderWidth": 0,
       "elevation": 0,
       "minWidth": 64,
+      "shadowColor": "#000000",
+      "shadowOffset": Object {
+        "height": 0,
+        "width": 0,
+      },
+      "shadowOpacity": 0,
+      "shadowRadius": 0,
     }
   }
 >
@@ -110,6 +117,13 @@ exports[`renders button with an accessibility label 1`] = `
       "borderWidth": 0,
       "elevation": 0,
       "minWidth": 64,
+      "shadowColor": "#000000",
+      "shadowOffset": Object {
+        "height": 0,
+        "width": 0,
+      },
+      "shadowOpacity": 0,
+      "shadowRadius": 0,
     }
   }
 >
@@ -209,6 +223,13 @@ exports[`renders button with color 1`] = `
       "borderWidth": 0,
       "elevation": 0,
       "minWidth": 64,
+      "shadowColor": "#000000",
+      "shadowOffset": Object {
+        "height": 0,
+        "width": 0,
+      },
+      "shadowOpacity": 0,
+      "shadowRadius": 0,
     }
   }
 >
@@ -307,6 +328,13 @@ exports[`renders button with custom testID 1`] = `
       "borderWidth": 0,
       "elevation": 0,
       "minWidth": 64,
+      "shadowColor": "#000000",
+      "shadowOffset": Object {
+        "height": 0,
+        "width": 0,
+      },
+      "shadowOpacity": 0,
+      "shadowRadius": 0,
     }
   }
 >
@@ -406,6 +434,13 @@ exports[`renders button with icon 1`] = `
       "borderWidth": 0,
       "elevation": 0,
       "minWidth": 64,
+      "shadowColor": "#000000",
+      "shadowOffset": Object {
+        "height": 0,
+        "width": 0,
+      },
+      "shadowOpacity": 0,
+      "shadowRadius": 0,
     }
   }
 >
@@ -532,6 +567,13 @@ exports[`renders button with icon in reverse order 1`] = `
       "borderWidth": 0,
       "elevation": 0,
       "minWidth": 64,
+      "shadowColor": "#000000",
+      "shadowOffset": Object {
+        "height": 0,
+        "width": 0,
+      },
+      "shadowOpacity": 0,
+      "shadowRadius": 0,
     }
   }
 >
@@ -765,6 +807,13 @@ exports[`renders disabled button 1`] = `
       "borderWidth": 0,
       "elevation": 0,
       "minWidth": 64,
+      "shadowColor": "#000000",
+      "shadowOffset": Object {
+        "height": 0,
+        "width": 0,
+      },
+      "shadowOpacity": 0,
+      "shadowRadius": 0,
     }
   }
 >
@@ -863,6 +912,13 @@ exports[`renders loading button 1`] = `
       "borderWidth": 0,
       "elevation": 0,
       "minWidth": 64,
+      "shadowColor": "#000000",
+      "shadowOffset": Object {
+        "height": 0,
+        "width": 0,
+      },
+      "shadowOpacity": 0,
+      "shadowRadius": 0,
     }
   }
 >
@@ -1151,6 +1207,13 @@ exports[`renders outlined button with mode 1`] = `
       "borderWidth": 0.5,
       "elevation": 0,
       "minWidth": 64,
+      "shadowColor": "#000000",
+      "shadowOffset": Object {
+        "height": 0,
+        "width": 0,
+      },
+      "shadowOpacity": 0,
+      "shadowRadius": 0,
     }
   }
 >
@@ -1249,6 +1312,13 @@ exports[`renders text button by default 1`] = `
       "borderWidth": 0,
       "elevation": 0,
       "minWidth": 64,
+      "shadowColor": "#000000",
+      "shadowOffset": Object {
+        "height": 0,
+        "width": 0,
+      },
+      "shadowOpacity": 0,
+      "shadowRadius": 0,
     }
   }
 >
@@ -1347,6 +1417,13 @@ exports[`renders text button with mode 1`] = `
       "borderWidth": 0,
       "elevation": 0,
       "minWidth": 64,
+      "shadowColor": "#000000",
+      "shadowOffset": Object {
+        "height": 0,
+        "width": 0,
+      },
+      "shadowOpacity": 0,
+      "shadowRadius": 0,
     }
   }
 >

--- a/src/components/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.js.snap
@@ -968,6 +968,13 @@ exports[`renders data table pagination with options select 1`] = `
             "elevation": 0,
             "marginRight": 16,
             "minWidth": 64,
+            "shadowColor": "#000000",
+            "shadowOffset": Object {
+              "height": 0,
+              "width": 0,
+            },
+            "shadowOpacity": 0,
+            "shadowRadius": 0,
             "textAlign": "center",
           }
         }

--- a/src/components/__tests__/__snapshots__/Menu.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.js.snap
@@ -14,6 +14,13 @@ exports[`renders menu with content styles 1`] = `
         "borderWidth": 0.5,
         "elevation": 0,
         "minWidth": 64,
+        "shadowColor": "#000000",
+        "shadowOffset": Object {
+          "height": 0,
+          "width": 0,
+        },
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
       }
     }
   >
@@ -116,6 +123,13 @@ exports[`renders not visible menu 1`] = `
         "borderWidth": 0.5,
         "elevation": 0,
         "minWidth": 64,
+        "shadowColor": "#000000",
+        "shadowOffset": Object {
+          "height": 0,
+          "width": 0,
+        },
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
       }
     }
   >
@@ -218,6 +232,13 @@ exports[`renders visible menu 1`] = `
         "borderWidth": 0.5,
         "elevation": 0,
         "minWidth": 64,
+        "shadowColor": "#000000",
+        "shadowOffset": Object {
+          "height": 0,
+          "width": 0,
+        },
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
       }
     }
   >

--- a/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
@@ -162,6 +162,13 @@ exports[`renders snackbar with action button 1`] = `
           "marginHorizontal": 8,
           "marginVertical": 6,
           "minWidth": "auto",
+          "shadowColor": "#000000",
+          "shadowOffset": Object {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
         }
       }
     >


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/3137

### Summary

Switching button mode from `contained` to `outlined` didn't remove the previously set `elevation`, since `elevation` was wrongly overwritten by `0` instead of `Animated.Value` according to the [shadow](https://github.com/callstack/react-native-paper/blob/main/src/styles/shadow.tsx#L31-L33) logic.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

1. Run the example app
2. Switch dynamically button mode from `contained` to `outlined` - you can use the [snack](https://snack.expo.dev/@fabrizio.cucci/ab4d4d) from the issue
3. Expect there are no issues with elevation on android

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
