### PR TITLE
feat: add HeaderBar component

### DIFF
--- a/example/app.json
+++ b/example/app.json
@@ -21,11 +21,11 @@
     "owner": "react-native-paper",
     "ios": {
       "bundleIdentifier": "com.callstack.reactnativepaperexample",
-      "buildNumber": "3.0.0"
+      "buildNumber": "3.1.0"
     },
     "android": {
       "package": "com.callstack.reactnativepaperexample",
-      "versionCode": 4,
+      "versionCode": 5,
       "permissions": [
         "READ_EXTERNAL_STORAGE",
         "WRITE_EXTERNAL_STORAGE"

--- a/example/app.json
+++ b/example/app.json
@@ -21,7 +21,7 @@
     "owner": "react-native-paper",
     "ios": {
       "bundleIdentifier": "com.callstack.reactnativepaperexample",
-      "buildNumber": "3.1.0"
+      "buildNumber": "3.0.0"
     },
     "android": {
       "package": "com.callstack.reactnativepaperexample",

--- a/example/app.json
+++ b/example/app.json
@@ -25,7 +25,7 @@
     },
     "android": {
       "package": "com.callstack.reactnativepaperexample",
-      "versionCode": 5,
+      "versionCode": 4,
       "permissions": [
         "READ_EXTERNAL_STORAGE",
         "WRITE_EXTERNAL_STORAGE"

--- a/example/src/ExampleList.tsx
+++ b/example/src/ExampleList.tsx
@@ -38,6 +38,7 @@ import TouchableRippleExample from './Examples/TouchableRippleExample';
 import ThemeExample from './Examples/ThemeExample';
 import RadioButtonItemExample from './Examples/RadioButtonItemExample';
 import AnimatedFABExample from './Examples/AnimatedFABExample';
+import HeaderBarExample from './Examples/HeaderBarExample';
 
 export const examples: Record<
   string,
@@ -59,6 +60,7 @@ export const examples: Record<
   dialog: DialogExample,
   divider: DividerExample,
   fab: FABExample,
+  headerbar: HeaderBarExample,
   iconButton: IconButtonExample,
   listAccordion: ListAccordionExample,
   listAccordionGroup: ListAccordionExampleGroup,

--- a/example/src/Examples/HeaderBarExample.tsx
+++ b/example/src/Examples/HeaderBarExample.tsx
@@ -7,10 +7,7 @@ const HeaderBarExample = () => {
   const { colors } = useTheme();
   return (
     <ScreenWrapper contentContainerStyle={styles.content}>
-      <HeaderBar
-        textColor="light-content"
-        backgroundColor={colors.notification}
-      />
+      <HeaderBar textColor="light-content" backgroundColor={colors.accent} />
       <View style={styles.container}>
         <Title style={styles.title}>Status bar</Title>
       </View>

--- a/example/src/Examples/HeaderBarExample.tsx
+++ b/example/src/Examples/HeaderBarExample.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { View, StyleSheet } from 'react-native';
+import ScreenWrapper from '../ScreenWrapper';
+import { HeaderBar, useTheme, Title } from 'react-native-paper';
+
+const HeaderBarExample = () => {
+  const { colors } = useTheme();
+  return (
+    <ScreenWrapper contentContainerStyle={styles.content}>
+      <HeaderBar
+        textColor="light-content"
+        backgroundColor={colors.notification}
+      />
+      <View style={styles.container}>
+        <Title style={styles.title}>Status bar</Title>
+      </View>
+    </ScreenWrapper>
+  );
+};
+
+HeaderBarExample.title = 'HeaderBar';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  title: {
+    fontWeight: 'bold',
+  },
+  content: {
+    padding: 4,
+  },
+});
+
+export default HeaderBarExample;

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { StatusBar, StatusBarStyle, Platform } from 'react-native';
+import { withTheme } from '../core/theming';
+
+type Props = React.ComponentPropsWithRef<typeof StatusBar> & {
+  /**
+   * Se the background color of status bar.
+   */
+  backgroundColor: string | ReactNativePaper.ThemeColors;
+  /**
+   * Set the color of the status bar text.
+   */
+  textColor: StatusBarStyle;
+  /**
+   * @optional
+   */
+  theme: ReactNativePaper.Theme;
+};
+/**
+ * Component to control the app's status bar. The status bar is the zone, typically at
+ * the top of the screen, that displays the current time, Wi-Fi and cellular network
+ * information, battery level and/or other status icons.
+ */
+const HeaderBar = ({ textColor, backgroundColor }: Props) => {
+  return (
+    <StatusBar
+      animated={true}
+      backgroundColor={Platform.OS === 'android' ? backgroundColor : undefined}
+      barStyle={textColor}
+      networkActivityIndicatorVisible={true}
+    />
+  );
+};
+
+export default withTheme(HeaderBar);

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -9,6 +9,7 @@ type Props = React.ComponentPropsWithRef<typeof StatusBar> & {
   backgroundColor: string | ReactNativePaper.ThemeColors;
   /**
    * Set the color of the status bar text.
+   * Available color: 'default' | 'light-content' | 'dark-content';
    */
   textColor: StatusBarStyle;
   /**

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -1,17 +1,18 @@
 import * as React from 'react';
-import { StatusBar, StatusBarStyle, Platform } from 'react-native';
+import { StatusBar, Platform, OpaqueColorValue } from 'react-native';
 import { withTheme } from '../core/theming';
 
-type Props = React.ComponentPropsWithRef<typeof StatusBar> & {
+type Props = {
   /**
-   * Se the background color of status bar.
+   * Set the background color of status bar.
+   *  React Native Paper Theme Color or your custom Theme Color;
    */
-  backgroundColor: string | ReactNativePaper.ThemeColors;
+  backgroundColor: string | OpaqueColorValue;
   /**
    * Set the color of the status bar text.
    * Available color: 'default' | 'light-content' | 'dark-content';
    */
-  textColor: StatusBarStyle;
+  textColor: 'default' | 'light-content' | 'dark-content';
   /**
    * @optional
    */
@@ -25,10 +26,8 @@ type Props = React.ComponentPropsWithRef<typeof StatusBar> & {
 const HeaderBar = ({ textColor, backgroundColor }: Props) => {
   return (
     <StatusBar
-      animated={true}
       backgroundColor={Platform.OS === 'android' ? backgroundColor : undefined}
       barStyle={textColor}
-      networkActivityIndicatorVisible={true}
     />
   );
 };

--- a/src/components/__tests__/HeaderBar.test.js
+++ b/src/components/__tests__/HeaderBar.test.js
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import renderer from 'react-test-renderer';
+import HeaderBar from '../HeaderBar';
+
+it('render header status bar with custom color', () => {
+  const tree = renderer
+    .create(
+      <HeaderBar
+        textColor="light-content"
+        backgroundColor="green"
+        networkActivity={true}
+      />
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/__tests__/HeaderBar.test.js
+++ b/src/components/__tests__/HeaderBar.test.js
@@ -2,15 +2,17 @@ import * as React from 'react';
 import renderer from 'react-test-renderer';
 import HeaderBar from '../HeaderBar';
 
-it('render header status bar with custom color', () => {
+it('status bar with white background and dark text', async () => {
   const tree = renderer
-    .create(
-      <HeaderBar
-        textColor="light-content"
-        backgroundColor="green"
-        networkActivity={true}
-      />
-    )
+    .create(<HeaderBar textColor="dark-content" backgroundColor="white" />)
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+it('status bar with orange background and light text', () => {
+  const tree = renderer
+    .create(<HeaderBar textColor="light-content" backgroundColor="orange" />)
     .toJSON();
 
   expect(tree).toMatchSnapshot();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,6 +43,7 @@ export { default as Searchbar } from './components/Searchbar';
 export { default as Snackbar } from './components/Snackbar';
 export { default as Surface } from './components/Surface';
 export { default as Switch } from './components/Switch';
+export { default as HeaderBar } from './components/HeaderBar';
 export { default as Appbar } from './components/Appbar';
 export { default as TouchableRipple } from './components/TouchableRipple/TouchableRipple';
 export { default as TextInput } from './components/TextInput/TextInput';


### PR DESCRIPTION
I've added a component called `HeaderBar` to avoid the confusion with StatusBar component name of `react-native` packages. It allow user to change status bar color for the both IOS and Android devices.
In this component, user can use any color they want to change status bar colors or `react-native-paper` theme color.

### Summary

### Test plan

snapshots are not available for now but it work fine.