### PR TITLE
fix: correct font weights

### DIFF
--- a/src/styles/themes/v3/tokens.tsx
+++ b/src/styles/themes/v3/tokens.tsx
@@ -161,7 +161,7 @@ export const typescale = {
   },
 
   labelLarge: {
-    ...regularType,
+    ...mediumType,
     tracking: 0.1,
     lineHeight: 20,
     size: 14,
@@ -181,17 +181,20 @@ export const typescale = {
 
   bodyLarge: {
     ...mediumType,
+    weight: '400',
     lineHeight: 24,
     size: 16,
   },
   bodyMedium: {
     ...mediumType,
+    weight: '400',
     tracking: 0.25,
     lineHeight: 20,
     size: 14,
   },
   bodySmall: {
     ...mediumType,
+    weight: '400',
     tracking: 0.4,
     lineHeight: 16,
     size: 12,


### PR DESCRIPTION
### Summary

Correct the following variants font properties:

* `labelLarge`:

**code:**

```
  labelLarge: {
    ...mediumType,
    tracking: 0.1,
    lineHeight: 20,
    size: 14,
 }
```  

**documentation:**
<img width="1050" alt="image" src="https://user-images.githubusercontent.com/22746080/164519700-f86fead8-21e5-49cf-bd4d-9707056e9419.png">

* `bodyLarge`, `bodyMedium` and `bodySmall`:

**code:**

```
  bodyLarge: {
    ...mediumType,
    weight: '400',
    lineHeight: 24,
    size: 16,
  },
  bodyMedium: {
    ...mediumType,
    weight: '400',
    tracking: 0.25,
    lineHeight: 20,
    size: 14,
  },
  bodySmall: {
    ...mediumType,
    weight: '400',
    tracking: 0.4,
    lineHeight: 16,
    size: 12,
  },
```

**documentation:**

<img width="835" alt="image" src="https://user-images.githubusercontent.com/22746080/164520351-8eb7cb1f-c9f5-4a88-952e-70a7b1ee97f5.png">

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
