### PR TITLE
refactor: adjust TouchableRipple

### DIFF
--- a/src/components/FAB/AnimatedFAB.tsx
+++ b/src/components/FAB/AnimatedFAB.tsx
@@ -239,7 +239,7 @@ const AnimatedFAB = ({
     style
   );
 
-  const rippleColor = color(foregroundColor).alpha(0.32).rgb().string();
+  const rippleColor = color(foregroundColor).alpha(0.12).rgb().string();
 
   const extendedWidth = textWidth + SIZE + borderRadius;
 

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -192,7 +192,7 @@ const FAB = ({
     style
   );
 
-  const rippleColor = color(foregroundColor).alpha(0.32).rgb().string();
+  const rippleColor = color(foregroundColor).alpha(0.12).rgb().string();
 
   const isLargeSize = size === 'large';
   const isFlatMode = mode === 'flat';

--- a/src/components/TouchableRipple/TouchableRipple.native.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.native.tsx
@@ -10,9 +10,9 @@ import {
   ViewStyle,
   StyleSheet,
 } from 'react-native';
-import color from 'color';
 import { withTheme } from '../../core/theming';
 import type { Theme } from '../../types';
+import { getTouchableRippleColors } from './utils';
 
 const ANDROID_VERSION_LOLLIPOP = 21;
 const ANDROID_VERSION_PIE = 28;
@@ -40,14 +40,13 @@ const TouchableRipple = ({
   theme,
   ...rest
 }: Props) => {
-  const { dark } = theme;
   const disabled = disabledProp || !rest.onPress;
-  const calculatedRippleColor =
-    rippleColor ||
-    color(theme.isV3 ? theme.colors.onSurface : theme.colors.text)
-      .alpha(dark ? 0.32 : 0.2)
-      .rgb()
-      .string();
+  const { calculatedRippleColor, calculatedUnderlayColor } =
+    getTouchableRippleColors({
+      theme,
+      rippleColor,
+      underlayColor,
+    });
 
   // A workaround for ripple on Android P is to use useForeground + overflow: 'hidden'
   // https://github.com/facebook/react-native/issues/6480
@@ -80,11 +79,7 @@ const TouchableRipple = ({
       {...rest}
       disabled={disabled}
       style={[borderless && styles.overflowHidden, style]}
-      underlayColor={
-        underlayColor != null
-          ? underlayColor
-          : color(calculatedRippleColor).fade(0.5).rgb().string()
-      }
+      underlayColor={calculatedUnderlayColor}
     >
       {React.Children.only(children)}
     </TouchableHighlight>

--- a/src/components/TouchableRipple/TouchableRipple.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.tsx
@@ -8,9 +8,9 @@ import {
   GestureResponderEvent,
   Platform,
 } from 'react-native';
-import color from 'color';
 import { withTheme } from '../../core/theming';
 import type { Theme } from '../../types';
+import { getTouchableRippleColors } from './utils';
 
 type Props = React.ComponentPropsWithRef<typeof TouchableWithoutFeedback> & {
   /**
@@ -104,13 +104,10 @@ const TouchableRipple = ({
 
     onPressIn?.(e);
 
-    const { dark } = theme;
-    const calculatedRippleColor =
-      rippleColor ||
-      color(theme.isV3 ? theme.colors.onSurface : theme.colors.text)
-        .alpha(dark ? 0.32 : 0.2)
-        .rgb()
-        .string();
+    const { calculatedRippleColor } = getTouchableRippleColors({
+      theme,
+      rippleColor,
+    });
 
     const button = e.currentTarget;
     const style = window.getComputedStyle(button);

--- a/src/components/TouchableRipple/utils.ts
+++ b/src/components/TouchableRipple/utils.ts
@@ -1,0 +1,63 @@
+import color from 'color';
+import type { Theme } from '../../types';
+
+const getUnderlayColor = ({
+  theme,
+  calculatedRippleColor,
+  underlayColor,
+}: {
+  theme: Theme;
+  calculatedRippleColor: string;
+  underlayColor?: string;
+}) => {
+  if (underlayColor != null) {
+    return underlayColor;
+  }
+
+  if (theme.isV3) {
+    return color(calculatedRippleColor).rgb().string();
+  }
+
+  return color(calculatedRippleColor).fade(0.5).rgb().string();
+};
+
+const getRippleColor = ({
+  theme,
+  rippleColor,
+}: {
+  theme: Theme;
+  rippleColor?: string;
+}) => {
+  if (rippleColor) {
+    return rippleColor;
+  }
+
+  if (theme.isV3) {
+    return color(theme.colors.onSurface).alpha(0.12).rgb().string();
+  }
+
+  if (theme.dark) {
+    return color(theme.colors.text).alpha(0.32).rgb().string();
+  }
+  return color(theme.colors.text).alpha(0.2).rgb().string();
+};
+
+export const getTouchableRippleColors = ({
+  theme,
+  rippleColor,
+  underlayColor,
+}: {
+  theme: Theme;
+  rippleColor?: string;
+  underlayColor?: string;
+}) => {
+  const calculatedRippleColor = getRippleColor({ theme, rippleColor });
+  return {
+    calculatedRippleColor,
+    calculatedUnderlayColor: getUnderlayColor({
+      theme,
+      calculatedRippleColor,
+      underlayColor,
+    }),
+  };
+};


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

PR adjusts `TouchableRipple` to Material You requirements. By default, ripple color is based on `theme.colors.onSurface` with 12% opacity.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
