### PR TITLE
fix: use default cursor for data table cells

### DIFF
--- a/src/components/DataTable/DataTableCell.tsx
+++ b/src/components/DataTable/DataTableCell.tsx
@@ -79,6 +79,7 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
+    cursor: 'default',
   },
 
   right: {


### PR DESCRIPTION

### Summary

Hi there! This PR is for consideration, it is related to a change where TouchableRipple in the general case was changed such that the cursor was `pointer` #2515

I like that change - but - I think for DataTable.Cell components, you almost never want a pointer, you want default.

For my use case at least, I'm using this patch and I like it, but I understand adults disagree, maybe it is not acceptable?


### Test plan

On Web, look at DataTable.Cell components and check the pointer, it should be an arrow now. It is a pointer without this, even if it is just text (like most data table cells are)

Thanks for react-native-paper!
