### PR TITLE
fix: refactor fonts in components, themes and types

### DIFF
--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -15,7 +15,7 @@ import Text from '../Typography/Text';
 import { withTheme } from '../../core/theming';
 import { white } from '../../styles/themes/v2/colors';
 
-import type { $RemoveChildren, Theme } from '../../types';
+import type { $RemoveChildren, MD3TypescaleKey, Theme } from '../../types';
 import { modeTextVariant } from './utils';
 
 type Props = $RemoveChildren<typeof View> & {
@@ -94,7 +94,7 @@ const AppbarContent = ({
   mode = 'small',
   ...rest
 }: Props) => {
-  const { fonts, isV3, colors } = theme;
+  const { isV3, colors } = theme;
 
   const titleTextColor = titleColor
     ? titleColor
@@ -111,6 +111,8 @@ const AppbarContent = ({
     'center-aligned': styles.v3DefaultContainer,
   };
 
+  const variant = modeTextVariant[mode] as MD3TypescaleKey;
+
   return (
     <TouchableWithoutFeedback onPress={onPress} disabled={!onPress}>
       <View
@@ -119,13 +121,16 @@ const AppbarContent = ({
         {...rest}
       >
         <Text
-          {...(isV3 && { variant: modeTextVariant[mode] })}
+          {...(isV3 && { variant })}
           ref={titleRef}
           style={[
             {
               color: titleTextColor,
-              ...(!isV3 &&
-                (Platform.OS === 'ios' ? fonts.regular : fonts.medium)),
+              ...(isV3
+                ? theme.typescale[variant]
+                : Platform.OS === 'ios'
+                ? theme.fonts.regular
+                : theme.fonts.medium),
             },
             !isV3 && styles.title,
             titleStyle,

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -110,7 +110,7 @@ const Badge = ({
           backgroundColor,
           color: textColor,
           fontSize: size * 0.5,
-          ...theme.fonts.regular,
+          ...(!theme.isV3 && theme.fonts.regular),
           lineHeight: size,
           height: size,
           minWidth: size,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -178,7 +178,7 @@ const Button = ({
     },
     [mode]
   );
-  const { roundness, isV3, animation, fonts } = theme;
+  const { roundness, isV3, animation } = theme;
 
   const isElevationEntitled =
     !disabled && (isV3 ? isMode('elevated') : isMode('contained'));
@@ -246,7 +246,10 @@ const Button = ({
   const { color: customLabelColor, fontSize: customLabelSize } =
     StyleSheet.flatten(labelStyle) || {};
 
-  const textStyle = { color: textColor, ...(!isV3 && fonts.medium) };
+  const textStyle = {
+    color: textColor,
+    ...(isV3 ? theme.typescale.labelLarge : theme.fonts.medium),
+  };
   const iconStyle =
     StyleSheet.flatten(contentStyle)?.flexDirection === 'row-reverse'
       ? [

--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -75,7 +75,7 @@ const DrawerItem = ({
   right,
   ...rest
 }: Props) => {
-  const { roundness, fonts, isV3 } = theme;
+  const { roundness, isV3 } = theme;
 
   const backgroundColor = active
     ? isV3
@@ -130,9 +130,7 @@ const DrawerItem = ({
                 {
                   color: contentColor,
                   marginLeft: labelMargin,
-                },
-                !isV3 && {
-                  ...fonts.medium,
+                  ...(isV3 ? theme.typescale.labelLarge : theme.fonts.medium),
                 },
               ]}
             >

--- a/src/components/Drawer/DrawerSection.tsx
+++ b/src/components/Drawer/DrawerSection.tsx
@@ -60,7 +60,7 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
  * ```
  */
 const DrawerSection = ({ children, title, theme, style, ...rest }: Props) => {
-  const { fonts, isV3 } = theme;
+  const { isV3 } = theme;
   const titleColor = isV3
     ? theme.colors.onSurfaceVariant
     : color(theme.colors.text).alpha(0.54).rgb().string();
@@ -74,8 +74,11 @@ const DrawerSection = ({ children, title, theme, style, ...rest }: Props) => {
               variant="titleSmall"
               numberOfLines={1}
               style={[
-                { color: titleColor, marginLeft: titleMargin },
-                !isV3 && { ...fonts.medium },
+                {
+                  color: titleColor,
+                  marginLeft: titleMargin,
+                  ...(isV3 ? theme.typescale.titleSmall : theme.fonts.medium),
+                },
               ]}
             >
               {title}

--- a/src/components/FAB/AnimatedFAB.tsx
+++ b/src/components/FAB/AnimatedFAB.tsx
@@ -210,7 +210,7 @@ const AnimatedFAB = ({
   const { current: animFAB } = React.useRef<Animated.Value>(
     new Animated.Value(0)
   );
-  const { isV3, animation, fonts } = theme;
+  const { isV3, animation } = theme;
   const { scale } = animation;
 
   const [textWidth, setTextWidth] = React.useState<number>(0);
@@ -293,7 +293,7 @@ const AnimatedFAB = ({
 
   const textStyle = {
     color: foregroundColor,
-    ...(!isV3 && fonts.medium),
+    ...(isV3 ? theme.typescale.labelLarge : theme.fonts.medium),
   };
 
   const md2Elevation = disabled || !isIOS ? 0 : 6;

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -167,7 +167,7 @@ const FAB = ({
   const { current: visibility } = React.useRef<Animated.Value>(
     new Animated.Value(visible ? 1 : 0)
   );
-  const { isV3, animation, fonts } = theme;
+  const { isV3, animation } = theme;
   const { scale } = animation;
 
   React.useEffect(() => {
@@ -206,7 +206,7 @@ const FAB = ({
   const shapeStyle = { borderRadius: fabStyle.borderRadius };
   const textStyle = {
     color: foregroundColor,
-    ...(!isV3 && fonts.medium),
+    ...(isV3 ? theme.typescale.labelLarge : theme.fonts.medium),
   };
 
   const containerStyles = [

--- a/src/components/List/ListSubheader.tsx
+++ b/src/components/List/ListSubheader.tsx
@@ -30,17 +30,23 @@ type Props = React.ComponentProps<typeof Text> & {
  * ```
  */
 const ListSubheader = ({ style, theme, ...rest }: Props) => {
-  const { fonts } = theme;
-  const font = fonts.medium;
   const textColor = theme.isV3
     ? theme.colors.onSurfaceVariant
     : color(theme.colors.text).alpha(0.54).rgb().string();
 
   return (
     <Text
+      variant="bodyMedium"
       numberOfLines={1}
       {...rest}
-      style={[styles.container, { color: textColor, ...font }, style]}
+      style={[
+        styles.container,
+        {
+          color: textColor,
+          ...(theme.isV3 ? theme.typescale.bodyMedium : theme.fonts.medium),
+        },
+        style,
+      ]}
     />
   );
 };

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -159,9 +159,8 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
       rest.onChangeText?.('');
     };
 
-    const { colors, roundness, dark, fonts, isV3 } = theme;
+    const { colors, roundness, dark, isV3 } = theme;
     const textColor = isV3 ? theme.colors.onSurface : theme.colors.text;
-    const font = fonts.regular;
     const iconColor =
       customIconColor ||
       (dark ? textColor : color(textColor).alpha(0.54).rgb().string());
@@ -201,7 +200,7 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
             styles.input,
             {
               color: textColor,
-              ...font,
+              ...(!isV3 && theme.fonts.regular),
               ...Platform.select({ web: { outline: 'none' } }),
             },
             inputStyle,

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -72,8 +72,8 @@ const TextInputFlat = ({
   ...rest
 }: ChildTextInputProps) => {
   const isAndroid = Platform.OS === 'android';
-  const { colors, fonts, isV3, roundness } = theme;
-  const font = fonts.regular;
+  const { colors, isV3, roundness } = theme;
+  const font = !isV3 ? theme.fonts.regular : {};
   const hasActiveOutline = parentState.focused || error;
 
   const { LABEL_PADDING_TOP, FLAT_INPUT_OFFSET, MIN_HEIGHT } =

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -71,8 +71,8 @@ const TextInputOutlined = ({
 }: ChildTextInputProps) => {
   const adornmentConfig = getAdornmentConfig({ left, right });
 
-  const { colors, fonts, isV3, roundness } = theme;
-  const font = fonts.regular;
+  const { colors, isV3, roundness } = theme;
+  const font = !isV3 ? theme.fonts.regular : {};
   const hasActiveOutline = parentState.focused || error;
 
   const { INPUT_PADDING_HORIZONTAL, MIN_HEIGHT, ADORNMENT_OFFSET } =

--- a/src/components/Typography/AnimatedText.tsx
+++ b/src/components/Typography/AnimatedText.tsx
@@ -44,17 +44,17 @@ function AnimatedText({ style, theme, variant, ...rest }: Props) {
   if (theme.isV3 && variant) {
     const stylesByVariant = Object.keys(MD3TypescaleKey).reduce(
       (acc, key) => {
-        const { size, weight, lineHeight, tracking, font } =
+        const { fontSize, fontWeight, lineHeight, letterSpacing, fontFamily } =
           theme.typescale[key as keyof typeof MD3TypescaleKey];
 
         return {
           ...acc,
           [key]: {
-            ...(Platform.OS === 'android' && { fontFamily: font }),
-            fontSize: size,
-            fontWeight: weight,
+            ...(Platform.OS === 'android' && { fontFamily }),
+            fontSize,
+            fontWeight,
             lineHeight: lineHeight,
-            letterSpacing: tracking,
+            letterSpacing,
             color: theme.colors.onSurface,
           },
         };
@@ -84,7 +84,7 @@ function AnimatedText({ style, theme, variant, ...rest }: Props) {
         style={[
           styles.text,
           {
-            ...theme.fonts.regular,
+            ...(!theme.isV3 && theme.fonts.regular),
             color: theme.isV3 ? theme.colors.onSurface : theme.colors.text,
             writingDirection,
           },

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -93,17 +93,17 @@ const Text: React.ForwardRefRenderFunction<{}, Props> = (
   if (theme.isV3 && variant) {
     const stylesByVariant = Object.keys(MD3TypescaleKey).reduce(
       (acc, key) => {
-        const { size, weight, lineHeight, tracking, font } =
+        const { fontSize, fontWeight, lineHeight, letterSpacing, fontFamily } =
           theme.typescale[key as keyof typeof MD3TypescaleKey];
 
         return {
           ...acc,
           [key]: {
-            ...(Platform.OS === 'android' && { fontFamily: font }),
-            fontSize: size,
-            fontWeight: weight,
-            lineHeight: lineHeight,
-            letterSpacing: tracking,
+            ...(Platform.OS === 'android' && { fontFamily }),
+            fontSize,
+            fontWeight,
+            lineHeight,
+            letterSpacing,
             color: theme.colors.onSurface,
           },
         };
@@ -134,7 +134,7 @@ const Text: React.ForwardRefRenderFunction<{}, Props> = (
         ref={root}
         style={[
           {
-            ...theme.fonts?.regular,
+            ...(!theme.isV3 && theme.fonts?.regular),
             color: theme.isV3 ? theme.colors?.onSurface : theme.colors.text,
           },
           styles.text,

--- a/src/components/Typography/v2/StyledText.tsx
+++ b/src/components/Typography/v2/StyledText.tsx
@@ -20,7 +20,6 @@ const StyledText = ({ alpha = 1, family, style, ...rest }: Props) => {
     .alpha(alpha)
     .rgb()
     .string();
-  const font = theme.fonts?.[family];
   const writingDirection = I18nManager.isRTL ? 'rtl' : 'ltr';
 
   return (
@@ -28,7 +27,11 @@ const StyledText = ({ alpha = 1, family, style, ...rest }: Props) => {
       {...rest}
       style={[
         styles.text,
-        { color: textColor, ...font, writingDirection },
+        {
+          color: textColor,
+          ...(!theme.isV3 && theme.fonts?.[family]),
+          writingDirection,
+        },
         style,
       ]}
     />

--- a/src/components/Typography/v2/Text.tsx
+++ b/src/components/Typography/v2/Text.tsx
@@ -40,7 +40,7 @@ const Text: React.ForwardRefRenderFunction<{}, Props> = (
       ref={root}
       style={[
         {
-          ...theme.fonts?.regular,
+          ...(!theme.isV3 && theme.fonts?.regular),
           color: theme.isV3 ? theme.colors?.onSurface : theme.colors.text,
         },
         styles.text,

--- a/src/components/__tests__/__snapshots__/DrawerItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DrawerItem.test.js.snap
@@ -97,11 +97,9 @@ exports[`renders DrawerItem with icon 1`] = `
                 },
                 Object {
                   "color": "rgba(0, 0, 0, 0.68)",
-                  "marginLeft": 32,
-                },
-                Object {
                   "fontFamily": "System",
                   "fontWeight": "500",
+                  "marginLeft": 32,
                 },
               ],
             ]
@@ -212,11 +210,9 @@ exports[`renders active DrawerItem 1`] = `
                 },
                 Object {
                   "color": "#6200ee",
-                  "marginLeft": 32,
-                },
-                Object {
                   "fontFamily": "System",
                   "fontWeight": "500",
+                  "marginLeft": 32,
                 },
               ],
             ]
@@ -308,11 +304,9 @@ exports[`renders basic DrawerItem 1`] = `
                 },
                 Object {
                   "color": "rgba(0, 0, 0, 0.68)",
-                  "marginLeft": 0,
-                },
-                Object {
                   "fontFamily": "System",
                   "fontWeight": "500",
+                  "marginLeft": 0,
                 },
               ],
             ]

--- a/src/styles/themes/v2/DarkTheme.tsx
+++ b/src/styles/themes/v2/DarkTheme.tsx
@@ -1,6 +1,7 @@
 import color from 'color';
 import LightTheme from './LightTheme';
 import { black, white, pinkA100 } from './colors';
+import configureFonts from '../../fonts';
 import type { ThemeBase } from '../../../types';
 
 const DarkTheme: ThemeBase = {
@@ -23,6 +24,7 @@ const DarkTheme: ThemeBase = {
     backdrop: color(black).alpha(0.5).rgb().string(),
     notification: pinkA100,
   },
+  fonts: configureFonts(),
 };
 
 export default DarkTheme;

--- a/src/styles/themes/v3/DarkTheme.tsx
+++ b/src/styles/themes/v3/DarkTheme.tsx
@@ -1,6 +1,6 @@
 import LightTheme from './LightTheme';
 import type { ThemeBase } from '../../../types';
-import { tokens } from './tokens';
+import { tokens, typescale } from './tokens';
 import color from 'color';
 
 const { palette, opacity } = tokens.md.ref;
@@ -59,6 +59,7 @@ const DarkTheme: ThemeBase = {
       level5: 'rgb(52, 49, 63)', // palette.primary80, alpha 0.14
     },
   },
+  typescale,
 };
 
 export default DarkTheme;

--- a/src/styles/themes/v3/LightTheme.tsx
+++ b/src/styles/themes/v3/LightTheme.tsx
@@ -1,6 +1,5 @@
-import configureFonts from '../../fonts';
 import type { ThemeBase } from '../../../types';
-import { tokens } from './tokens';
+import { tokens, typescale } from './tokens';
 import color from 'color';
 
 const { palette, opacity } = tokens.md.ref;
@@ -58,7 +57,7 @@ const LightTheme: ThemeBase = {
       level5: 'rgb(233, 227, 241)', // palette.primary40, alpha 0.14
     },
   },
-  fonts: configureFonts(),
+  typescale,
   animation: {
     scale: 1.0,
   },

--- a/src/styles/themes/v3/tokens.tsx
+++ b/src/styles/themes/v3/tokens.tsx
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native';
 import type { Font } from '../../../types';
 
 const ref = {
@@ -83,10 +84,16 @@ const ref = {
   },
 
   typeface: {
-    brandRegular: 'sans-serif',
+    brandRegular: Platform.select({
+      ios: 'System',
+      default: 'sans-serif',
+    }),
     weightRegular: '400' as Font['fontWeight'],
 
-    plainMedium: 'sans-serif-medium',
+    plainMedium: Platform.select({
+      ios: 'System',
+      default: 'sans-serif-medium',
+    }),
     weightMedium: '500' as Font['fontWeight'],
   },
 
@@ -99,108 +106,108 @@ const ref = {
 };
 
 const regularType = {
-  font: ref.typeface.brandRegular,
-  tracking: 0,
-  weight: ref.typeface.weightRegular,
+  fontFamily: ref.typeface.brandRegular,
+  letterSpacing: 0,
+  fontWeight: ref.typeface.weightRegular,
 };
 
 const mediumType = {
-  font: ref.typeface.plainMedium,
-  tracking: 0.15,
-  weight: ref.typeface.weightMedium,
+  fontFamily: ref.typeface.plainMedium,
+  letterSpacing: 0.15,
+  fontWeight: ref.typeface.weightMedium,
 };
 
 export const typescale = {
   displayLarge: {
     ...regularType,
     lineHeight: 64,
-    size: 57,
+    fontSize: 57,
   },
   displayMedium: {
     ...regularType,
     lineHeight: 52,
-    size: 45,
+    fontSize: 45,
   },
   displaySmall: {
     ...regularType,
     lineHeight: 44,
-    size: 36,
+    fontSize: 36,
   },
 
   headlineLarge: {
     ...regularType,
     lineHeight: 40,
-    size: 32,
+    fontSize: 32,
   },
   headlineMedium: {
     ...regularType,
     lineHeight: 36,
-    size: 28,
+    fontSize: 28,
   },
   headlineSmall: {
     ...regularType,
     lineHeight: 32,
-    size: 24,
+    fontSize: 24,
   },
 
   titleLarge: {
     ...regularType,
     lineHeight: 28,
-    size: 22,
+    fontSize: 22,
   },
   titleMedium: {
     ...mediumType,
     lineHeight: 24,
-    size: 16,
+    fontSize: 16,
   },
   titleSmall: {
     ...mediumType,
-    tracking: 0.1,
+    letterSpacing: 0.1,
     lineHeight: 20,
-    size: 14,
+    fontSize: 14,
   },
 
   labelLarge: {
     ...mediumType,
-    tracking: 0.1,
+    letterSpacing: 0.1,
     lineHeight: 20,
-    size: 14,
+    fontSize: 14,
   },
   labelMedium: {
     ...mediumType,
-    tracking: 0.5,
+    letterSpacing: 0.5,
     lineHeight: 16,
-    size: 12,
+    fontSize: 12,
   },
   labelSmall: {
     ...mediumType,
-    tracking: 0.5,
+    letterSpacing: 0.5,
     lineHeight: 16,
-    size: 11,
+    fontSize: 11,
   },
 
   bodyLarge: {
     ...mediumType,
-    weight: '400',
-    font: ref.typeface.brandRegular,
+    fontWeight: ref.typeface.weightRegular,
+    fontFamily: ref.typeface.brandRegular,
     lineHeight: 24,
-    size: 16,
+    fontSize: 16,
   },
   bodyMedium: {
     ...mediumType,
-    weight: '400',
-    font: ref.typeface.brandRegular,
-    tracking: 0.25,
+    fontWeight: ref.typeface.weightRegular,
+    fontFamily: ref.typeface.brandRegular,
+    letterSpacing: 0.25,
     lineHeight: 20,
-    size: 14,
+    fontSize: 14,
   },
   bodySmall: {
     ...mediumType,
-    weight: '400',
-    font: ref.typeface.brandRegular,
-    tracking: 0.4,
+    fontWeight: ref.typeface.weightRegular,
+    fontFamily: ref.typeface.brandRegular,
+    letterSpacing: 0.4,
     lineHeight: 16,
-    size: 12,
+    fontSize: 12,
   },
 };
 

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -81,22 +81,20 @@ export type ThemeBase = {
   dark: boolean;
   mode?: Mode;
   roundness: number;
-  fonts: Fonts;
   animation: {
     scale: number;
   };
 } & (
-  | { version: 2; colors: MD2Colors; isV3: false }
+  | { version: 2; colors: MD2Colors; isV3: false; fonts: Fonts }
   | {
       version: 3;
       colors: MD3Colors;
       isV3: true;
+      typescale: MD3Typescale;
     }
 );
 
-export type Theme = ThemeBase & {
-  typescale: MD3Typescale;
-};
+export type Theme = ThemeBase;
 
 // MD3 types
 export enum MD3TypescaleKey {
@@ -122,11 +120,11 @@ export enum MD3TypescaleKey {
 }
 
 export type MD3Type = {
-  font: string;
-  tracking: number;
-  weight: Font['fontWeight'];
+  fontFamily: string;
+  letterSpacing: number;
+  fontWeight: Font['fontWeight'];
   lineHeight: number;
-  size: number;
+  fontSize: number;
 };
 
 export type MD3Typescale = {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

PR corrects theme where for MD2 there are `fonts` and `typescale` for MD3. 
Moreover, it introduces the ability to overwrite the theme typescale in several components. 
Typescale properties were refined to be consistent with text styles.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
