### PR TITLE
fix: supporting empty labels

### DIFF
--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -308,7 +308,7 @@ const TextInputFlat = ({
           },
         ]}
       >
-        {!isAndroid && multiline && Boolean(label) && (
+        {!isAndroid && multiline && !!label && (
           // Workaround for: https://github.com/callstack/react-native-paper/issues/2799
           // Patch for a multiline TextInput with fixed height, which allow to avoid covering input label with its value.
           <View

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -308,7 +308,7 @@ const TextInputFlat = ({
           },
         ]}
       >
-        {!isAndroid && multiline && label && (
+        {!isAndroid && multiline && Boolean(label) && (
           // Workaround for: https://github.com/callstack/react-native-paper/issues/2799
           // Patch for a multiline TextInput with fixed height, which allow to avoid covering input label with its value.
           <View


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->


When using the current `TextInputFlat.js`, I get the error:

> Text strings must be rendered within a <Text> component.

which __breaks my components tree__.

This is how I am using the `TextInput` component:

```javascript
<TextInput
  ref={textInputRef}
  label="" <---- Try with an empty label
  placeholder="Enter a description..."
  ...
/>
```


The problem is in the __line 311__ of the `TextInputFlat.js` module. If you just do the following:

`{!isAndroid && multiline && Boolean(label) && (`

the error disappears.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

Just pass an empty label to the `TextInput` component. Something which, in my opinion, should be accepted.

You can also check this little [snack](https://snack.expo.dev/-QUJzBClx), where the current bug is reproduced.
