### PR TITLE
fix: correct Card colors

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -16,7 +16,7 @@ import CardTitle, { CardTitle as _CardTitle } from './CardTitle';
 import Surface from '../Surface';
 import { withTheme } from '../../core/theming';
 import type { Theme } from '../../types';
-import { getCardColors } from './helpers';
+import { getCardColors } from './utils';
 
 type OutlinedCardProps = {
   mode: 'outlined';
@@ -190,7 +190,7 @@ const Card = ({
       Animated.timing(elevation, {
         toValue: isPressTypeIn ? (isV3 ? 2 : 8) : cardElevation,
         duration: animationDuration,
-        useNativeDriver: false,
+        useNativeDriver: true,
       }).start();
     }
   };
@@ -215,8 +215,6 @@ const Card = ({
   const { backgroundColor, borderColor } = getCardColors({
     theme,
     mode: cardMode,
-    isAdaptiveMode,
-    elevation,
   });
 
   return (
@@ -224,8 +222,8 @@ const Card = ({
       style={[
         {
           borderRadius: roundness,
-          backgroundColor: backgroundColor as unknown as string,
         },
+        isV3 && { backgroundColor },
         !isV3 && isMode('outlined')
           ? styles.resetElevation
           : {

--- a/src/components/Card/CardCover.tsx
+++ b/src/components/Card/CardCover.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, View, ViewStyle, Image, StyleProp } from 'react-native';
 import { withTheme } from '../../core/theming';
 import { grey200 } from '../../styles/themes/v2/colors';
 import type { Theme } from '../../types';
-import { getCardCoverStyle } from './helpers';
+import { getCardCoverStyle } from './utils';
 
 type Props = React.ComponentPropsWithRef<typeof Image> & {
   /**

--- a/src/components/Card/utils.tsx
+++ b/src/components/Card/utils.tsx
@@ -1,11 +1,8 @@
-import type { Animated } from 'react-native';
 import color from 'color';
 import { black, white } from '../../styles/themes/v2/colors';
 import type { Theme } from '../../types';
-import overlay from '../../styles/overlay';
 
 type CardMode = 'elevated' | 'outlined' | 'contained';
-type Elevation = 0 | 1 | 2 | 3 | 4 | 5 | Animated.Value;
 
 export const getCardCoverStyle = ({
   theme,
@@ -60,34 +57,25 @@ const getBorderColor = ({ theme }: { theme: Theme }) => {
 const getBackgroundColor = ({
   theme,
   isMode,
-  isAdaptiveMode,
-  elevation,
 }: {
   theme: Theme;
   isMode: (mode: CardMode) => boolean;
-  isAdaptiveMode?: boolean;
-  elevation: Elevation;
 }) => {
-  if (theme.isV3 && isMode('contained')) {
-    return theme.colors.surfaceVariant;
+  if (theme.isV3) {
+    if (isMode('contained')) {
+      return theme.colors.surfaceVariant;
+    }
+    return theme.colors.surface;
   }
-
-  if (theme.dark && isAdaptiveMode) {
-    return overlay(elevation, theme.colors.surface);
-  }
-  return theme.colors.surface;
+  return undefined;
 };
 
 export const getCardColors = ({
   theme,
   mode,
-  isAdaptiveMode,
-  elevation,
 }: {
   theme: Theme;
   mode: CardMode;
-  isAdaptiveMode?: boolean;
-  elevation: Elevation;
 }) => {
   const isMode = (modeToCompare: CardMode) => {
     return mode === modeToCompare;
@@ -97,8 +85,6 @@ export const getCardColors = ({
     backgroundColor: getBackgroundColor({
       theme,
       isMode,
-      isAdaptiveMode,
-      elevation,
     }),
     borderColor: getBorderColor({ theme }),
   };

--- a/src/components/__tests__/Card/Card.test.js
+++ b/src/components/__tests__/Card/Card.test.js
@@ -1,7 +1,11 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { render } from 'react-native-testing-library';
+import color from 'color';
 import Card from '../../Card/Card';
+import { black, white } from '../../../styles/themes/v2/colors';
+import { getCardColors } from '../../Card/utils';
+import { getTheme } from '../../../core/theming';
 
 describe('Card', () => {
   it('renders an outlined card', () => {
@@ -22,5 +26,65 @@ describe('Card', () => {
     expect(getByA11yLabel('card').props.style.backgroundColor).toEqual(
       '#0000FF'
     );
+  });
+});
+
+describe('getCardColors - background color', () => {
+  it('should return correct theme color, for theme version 3, contained mode', () => {
+    expect(
+      getCardColors({
+        theme: getTheme(),
+        mode: 'contained',
+      })
+    ).toMatchObject({ backgroundColor: getTheme().colors.surfaceVariant });
+  });
+
+  ['elevated', 'outlined'].forEach((mode) =>
+    it(`should return correct theme color, for theme version 3, ${mode} mode`, () => {
+      expect(
+        getCardColors({
+          theme: getTheme(),
+          mode,
+        })
+      ).toMatchObject({ backgroundColor: getTheme().colors.surface });
+    })
+  );
+
+  it('should return undefined, for theme version 2', () => {
+    expect(
+      getCardColors({
+        theme: getTheme(false, false),
+      })
+    ).toMatchObject({ backgroundColor: undefined });
+  });
+});
+
+describe('getCardColors - border color', () => {
+  it('should return correct theme color, for theme version 3', () => {
+    expect(
+      getCardColors({
+        theme: getTheme(),
+      })
+    ).toMatchObject({ borderColor: getTheme().colors.outline });
+  });
+
+  it('should return correct color, for theme version 2, dark mode', () => {
+    expect(
+      getCardColors({
+        theme: getTheme(true, false),
+      })
+    ).toMatchObject({
+      borderColor: color(white).alpha(0.12).rgb().string(),
+    });
+  });
+
+  it('should return correct color, for theme version 2, light mode', () => {
+    expect(
+      getCardColors({
+        theme: getTheme(false, false),
+      })
+    ).toMatchObject({
+      borderColor: color(black).alpha(0.12).rgb().string(),
+    });
   });
 });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

PR corrects `Card` background color for both themes:
* 3 - used proper color from the theme
* 2 - didn't pass the background colors into `Surface`, which was breaking the previous version

 
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Added test for utils.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
