### PR TITLE
feat: add ability to provide version in provider

### DIFF
--- a/src/core/Provider.tsx
+++ b/src/core/Provider.tsx
@@ -9,19 +9,27 @@ import { ThemeProvider } from './theming';
 import { Provider as SettingsProvider, Settings } from './settings';
 import MaterialCommunityIcon from '../components/MaterialCommunityIcon';
 import PortalHost from '../components/Portal/PortalHost';
-import LightTheme from '../styles/themes/v3/LightTheme';
-import DarkTheme from '../styles/themes/v3/DarkTheme';
+import MD2LightTheme from '../styles/themes/v2/LightTheme';
+import MD2DarkTheme from '../styles/themes/v2/DarkTheme';
+import MD3LightTheme from '../styles/themes/v3/LightTheme';
+import MD3DarkTheme from '../styles/themes/v3/DarkTheme';
 import { addEventListener } from '../utils/addEventListener';
 import type { Theme, ThemeBase } from '../types';
 import { typescale } from '../styles/themes/v3/tokens';
 
+type ThemeProp =
+  | ThemeBase
+  | {
+      version: 2 | 3;
+    };
+
 type Props = {
   children: React.ReactNode;
-  theme?: ThemeBase;
+  theme?: ThemeProp;
   settings?: Settings;
 };
 
-const Provider = ({ ...props }: Props) => {
+const Provider = (props: Props) => {
   const colorSchemeName =
     (!props.theme && Appearance?.getColorScheme()) || 'light';
 
@@ -73,25 +81,35 @@ const Provider = ({ ...props }: Props) => {
   }, [props.theme]);
 
   const getTheme = () => {
-    const { theme: providedTheme } = props;
+    const defaultThemesByVersion = {
+      2: {
+        light: MD2LightTheme,
+        dark: MD2DarkTheme,
+      },
+      3: {
+        light: MD3LightTheme,
+        dark: MD3DarkTheme,
+      },
+    };
 
-    const theme = providedTheme
-      ? (providedTheme as ThemeBase)
-      : ((colorScheme === 'dark' ? DarkTheme : LightTheme) as ThemeBase);
-
-    const isV3 = theme.version === 3;
+    const themeVersion = props.theme?.version || 3;
+    const scheme = colorScheme || 'light';
+    const defaultThemeBase = defaultThemesByVersion[themeVersion][scheme];
 
     const extendedThemeBase = {
-      ...theme,
-      version: theme.version || 3,
+      ...defaultThemeBase,
+      ...(props.theme as ThemeBase),
+      version: props.theme?.version || 3,
       animation: {
         scale: reduceMotionEnabled ? 0 : 1,
       },
-      isV3,
       typescale,
     };
 
-    return extendedThemeBase as Theme;
+    return {
+      ...extendedThemeBase,
+      isV3: extendedThemeBase.version === 3,
+    } as Theme;
   };
 
   const { children, settings } = props;

--- a/src/core/Provider.tsx
+++ b/src/core/Provider.tsx
@@ -5,14 +5,10 @@ import {
   ColorSchemeName,
   NativeEventSubscription,
 } from 'react-native';
-import { ThemeProvider } from './theming';
+import { defaultThemesByVersion, ThemeProvider } from './theming';
 import { Provider as SettingsProvider, Settings } from './settings';
 import MaterialCommunityIcon from '../components/MaterialCommunityIcon';
 import PortalHost from '../components/Portal/PortalHost';
-import MD2LightTheme from '../styles/themes/v2/LightTheme';
-import MD2DarkTheme from '../styles/themes/v2/DarkTheme';
-import MD3LightTheme from '../styles/themes/v3/LightTheme';
-import MD3DarkTheme from '../styles/themes/v3/DarkTheme';
 import { addEventListener } from '../utils/addEventListener';
 import type { Theme, ThemeBase } from '../types';
 
@@ -84,17 +80,6 @@ const Provider = (props: Props) => {
   }, [props.theme]);
 
   const getTheme = () => {
-    const defaultThemesByVersion = {
-      2: {
-        light: MD2LightTheme,
-        dark: MD2DarkTheme,
-      },
-      3: {
-        light: MD3LightTheme,
-        dark: MD3DarkTheme,
-      },
-    };
-
     const themeVersion = props.theme?.version || 3;
     const scheme = colorScheme || 'light';
     const defaultThemeBase = defaultThemesByVersion[themeVersion][scheme];

--- a/src/core/Provider.tsx
+++ b/src/core/Provider.tsx
@@ -15,7 +15,6 @@ import MD3LightTheme from '../styles/themes/v3/LightTheme';
 import MD3DarkTheme from '../styles/themes/v3/DarkTheme';
 import { addEventListener } from '../utils/addEventListener';
 import type { Theme, ThemeBase } from '../types';
-import { typescale } from '../styles/themes/v3/tokens';
 
 type ThemeProp =
   | ThemeBase
@@ -30,8 +29,12 @@ type Props = {
 };
 
 const Provider = (props: Props) => {
+  const isOnlyVersionInTheme =
+    props.theme && Object.keys(props.theme).length === 1 && props.theme.version;
+
   const colorSchemeName =
-    (!props.theme && Appearance?.getColorScheme()) || 'light';
+    ((!props.theme || isOnlyVersionInTheme) && Appearance?.getColorScheme()) ||
+    'light';
 
   const [reduceMotionEnabled, setReduceMotionEnabled] =
     React.useState<boolean>(false);
@@ -64,13 +67,13 @@ const Provider = (props: Props) => {
 
   React.useEffect(() => {
     let appearanceSubscription: NativeEventSubscription | undefined;
-    if (!props.theme) {
+    if (!props.theme || isOnlyVersionInTheme) {
       appearanceSubscription = Appearance?.addChangeListener(
         handleAppearanceChange
       ) as NativeEventSubscription | undefined;
     }
     return () => {
-      if (!props.theme) {
+      if (!props.theme || isOnlyVersionInTheme) {
         if (appearanceSubscription) {
           appearanceSubscription.remove();
         } else {
@@ -99,11 +102,10 @@ const Provider = (props: Props) => {
     const extendedThemeBase = {
       ...defaultThemeBase,
       ...(props.theme as ThemeBase),
-      version: props.theme?.version || 3,
+      version: themeVersion,
       animation: {
         scale: reduceMotionEnabled ? 0 : 1,
       },
-      typescale,
     };
 
     return {

--- a/src/core/__tests__/Provider.test.js
+++ b/src/core/__tests__/Provider.test.js
@@ -3,8 +3,10 @@ import { Appearance, AccessibilityInfo, View } from 'react-native';
 import { render, act } from 'react-native-testing-library';
 import Provider from '../Provider';
 import { useTheme } from '../theming';
-import DarkTheme from '../../styles/themes/v3/DarkTheme';
-import LightTheme from '../../styles/themes/v3/LightTheme';
+import MD2LightTheme from '../../styles/themes/v2/LightTheme';
+import MD2DarkTheme from '../../styles/themes/v2/DarkTheme';
+import MD3LightTheme from '../../styles/themes/v3/LightTheme';
+import MD3DarkTheme from '../../styles/themes/v3/DarkTheme';
 import { typescale } from '../../styles/themes/v3/tokens';
 
 const mockAppearance = () => {
@@ -65,8 +67,8 @@ const createProvider = (theme) => {
   );
 };
 
-const ExtendedLightTheme = { ...LightTheme, typescale, isV3: true };
-const ExtendedDarkTheme = { ...DarkTheme, typescale, isV3: true };
+const ExtendedLightTheme = { ...MD3LightTheme, typescale, isV3: true };
+const ExtendedDarkTheme = { ...MD3DarkTheme, typescale, isV3: true };
 
 describe('Provider', () => {
   beforeEach(() => {
@@ -181,4 +183,23 @@ describe('Provider', () => {
       customTheme
     );
   });
+
+  it.each`
+    version | colorScheme | expectedTheme
+    ${2}    | ${'light'}  | ${MD2LightTheme}
+    ${2}    | ${'dark'}   | ${MD2DarkTheme}
+    ${3}    | ${'light'}  | ${MD3LightTheme}
+    ${3}    | ${'dark'}   | ${MD3DarkTheme}
+  `(
+    'uses correct theme, $colorScheme mode, version $version',
+    async ({ version, colorScheme, expectedTheme }) => {
+      mockAppearance();
+      Appearance.getColorScheme.mockReturnValue(colorScheme);
+      const { getByTestId } = render(createProvider({ version }));
+
+      expect(getByTestId('provider-child-view').props.theme).toStrictEqual(
+        expectedTheme
+      );
+    }
+  );
 });


### PR DESCRIPTION
### Summary

This change allows specifying `version` in `<Provider>` and does not require to pass the entire theme object anymore

**Tasks**:
- [x] Implementation
- [x] Tests

### Test plan

1. Go to `example/src/index.tsx`
2. Change `<Provider theme={theme}` into `<Provider theme={{version: 2}}`
3. Provider should automatically pick up Material Design 2 theme
4. Same goes for `version: 3`
