### PR TITLE
fix: fix regression in Appbar.Header statusBarHeight

### DIFF
--- a/src/components/Appbar/AppbarHeader.tsx
+++ b/src/components/Appbar/AppbarHeader.tsx
@@ -140,7 +140,7 @@ const AppbarHeader = ({
             backgroundColor,
             zIndex,
             elevation,
-            paddingTop: statusBarHeight || APPROX_STATUSBAR_HEIGHT,
+            paddingTop: statusBarHeight ?? APPROX_STATUSBAR_HEIGHT,
           },
           shadow(elevation),
         ] as StyleProp<ViewStyle>


### PR DESCRIPTION
Hello,

I recently tested `5.0.0-rc2` and noticed a regression on the `Appbar.Header`

### Summary

I use it this way: `<Appbar.Header statusBarHeight={0}>`.
However, it is not working like before and I have a huge space instead.

The regression seems to come from this change:

https://github.com/callstack/react-native-paper/commit/c0f50076dd71f5d00a67b50500d11681149b9c14#diff-6d75c85ccdc33452375c1e517435df14b568c580a394df5c3c7b3f05add5bfa5R135

```js
paddingTop: statusBarHeight || APPROX_STATUSBAR_HEIGHT,
```

If `0` then it will default on `APPROX_STATUSBAR_HEIGHT` instead of allowing it as valid value.

### Test plan

Before PR: `<Appbar.Header statusBarHeight={0}>` => `paddingTop = APPROX_STATUSBAR_HEIGHT`
After PR: `<Appbar.Header statusBarHeight={0}>` => `paddingTop = 0`
