### PR TITLE
fix: pass absolute styles to outer shadow layer for ios

### DIFF
--- a/src/components/Appbar/AppbarHeader.tsx
+++ b/src/components/Appbar/AppbarHeader.tsx
@@ -119,7 +119,7 @@ const AppbarHeader = ({
     height = isV3 ? modeAppbarHeight[mode] : DEFAULT_APPBAR_HEIGHT,
     elevation = isV3 ? (elevated ? 2 : 0) : 4,
     backgroundColor: customBackground,
-    zIndex = 0,
+    zIndex = isV3 && elevated ? 1 : 0,
     ...restStyle
   }: ViewStyle = StyleSheet.flatten(style) || {};
 

--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -133,8 +133,6 @@ const Surface = ({
     return colors.elevation?.[`level${elevation}`];
   })();
 
-  const sharedStyle = [{ backgroundColor }, style];
-
   if (Platform.OS === 'web') {
     return (
       <Animated.View
@@ -169,6 +167,7 @@ const Surface = ({
     ) as ViewStyle;
 
     const outerLayerStyles = { margin, padding, transform, borderRadius };
+    const sharedStyle = [{ backgroundColor }, style];
 
     return (
       <Animated.View
@@ -204,6 +203,12 @@ const Surface = ({
 
   const shadowColor = '#000';
 
+  const { position, top, left, right, bottom, ...restStyle } =
+    (StyleSheet.flatten(style) || {}) as ViewStyle;
+
+  const absoluteStyles = { position, top, right, bottom, left };
+  const sharedStyle = [{ backgroundColor }, restStyle];
+
   if (isAnimatedValue(elevation)) {
     const inputRange = [0, 1, 2, 3, 4, 5];
 
@@ -230,7 +235,9 @@ const Surface = ({
     };
 
     return (
-      <Animated.View style={getStyleForAnimatedShadowLayer(0)}>
+      <Animated.View
+        style={[getStyleForAnimatedShadowLayer(0), absoluteStyles]}
+      >
         <Animated.View style={getStyleForAnimatedShadowLayer(1)}>
           <Animated.View {...props} style={sharedStyle}>
             {children}
@@ -253,8 +260,8 @@ const Surface = ({
   };
 
   return (
-    <Animated.View style={getStyleForShadowLayer(0)}>
-      <Animated.View style={getStyleForShadowLayer(1)}>
+    <Animated.View style={[getStyleForShadowLayer(0), absoluteStyles]}>
+      <Animated.View style={[getStyleForShadowLayer(1)]}>
         <Animated.View {...props} style={sharedStyle}>
           {children}
         </Animated.View>

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
@@ -5,6 +5,10 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -12,6 +16,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -45,6 +50,10 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
         collapsable={false}
         style={
           Object {
+            "bottom": undefined,
+            "left": undefined,
+            "position": undefined,
+            "right": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 1,
@@ -52,6 +61,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
             },
             "shadowOpacity": 0.15,
             "shadowRadius": 3,
+            "top": undefined,
           }
         }
       >
@@ -84,6 +94,10 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
               collapsable={false}
               style={
                 Object {
+                  "bottom": undefined,
+                  "left": undefined,
+                  "position": undefined,
+                  "right": undefined,
                   "shadowColor": "#000",
                   "shadowOffset": Object {
                     "height": 0,
@@ -91,6 +105,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                   },
                   "shadowOpacity": 0,
                   "shadowRadius": 0,
+                  "top": undefined,
                 }
               }
             >
@@ -214,6 +229,10 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
               collapsable={false}
               style={
                 Object {
+                  "bottom": undefined,
+                  "left": undefined,
+                  "position": undefined,
+                  "right": undefined,
                   "shadowColor": "#000",
                   "shadowOffset": Object {
                     "height": 0,
@@ -221,6 +240,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                   },
                   "shadowOpacity": 0,
                   "shadowRadius": 0,
+                  "top": undefined,
                 }
               }
             >
@@ -328,6 +348,10 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -335,6 +359,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -368,6 +393,10 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
         collapsable={false}
         style={
           Object {
+            "bottom": undefined,
+            "left": undefined,
+            "position": undefined,
+            "right": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -375,6 +404,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "top": undefined,
           }
         }
       >
@@ -597,6 +627,10 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
         collapsable={false}
         style={
           Object {
+            "bottom": undefined,
+            "left": undefined,
+            "position": undefined,
+            "right": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -604,6 +638,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "top": undefined,
           }
         }
       >

--- a/src/components/__tests__/Card/__snapshots__/Card.test.js.snap
+++ b/src/components/__tests__/Card/__snapshots__/Card.test.js.snap
@@ -5,6 +5,10 @@ exports[`Card renders an outlined card 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -12,6 +16,7 @@ exports[`Card renders an outlined card 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >

--- a/src/components/__tests__/__snapshots__/AnimatedFAB.test.js.snap
+++ b/src/components/__tests__/__snapshots__/AnimatedFAB.test.js.snap
@@ -5,6 +5,10 @@ exports[`renders animated fab 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": "absolute",
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -12,6 +16,7 @@ exports[`renders animated fab 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "top": undefined,
     }
   }
 >
@@ -36,7 +41,6 @@ exports[`renders animated fab 1`] = `
           "backgroundColor": "transparent",
           "borderRadius": 16,
           "opacity": 1,
-          "position": "absolute",
           "transform": Array [
             Object {
               "scale": 1,
@@ -265,6 +269,10 @@ exports[`renders animated fab with label on the left 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": "absolute",
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -272,6 +280,7 @@ exports[`renders animated fab with label on the left 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "top": undefined,
     }
   }
 >
@@ -296,7 +305,6 @@ exports[`renders animated fab with label on the left 1`] = `
           "backgroundColor": "transparent",
           "borderRadius": 16,
           "opacity": 1,
-          "position": "absolute",
           "transform": Array [
             Object {
               "scale": 1,
@@ -528,6 +536,10 @@ exports[`renders animated fab with label on the right by default 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": "absolute",
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -535,6 +547,7 @@ exports[`renders animated fab with label on the right by default 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "top": undefined,
     }
   }
 >
@@ -559,7 +572,6 @@ exports[`renders animated fab with label on the right by default 1`] = `
           "backgroundColor": "transparent",
           "borderRadius": 16,
           "opacity": 1,
-          "position": "absolute",
           "transform": Array [
             Object {
               "scale": 1,

--- a/src/components/__tests__/__snapshots__/Banner.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.js.snap
@@ -5,6 +5,10 @@ exports[`render visible banner, with custom theme 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 1,
@@ -12,6 +16,7 @@ exports[`render visible banner, with custom theme 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
+      "top": undefined,
     }
   }
 >
@@ -113,6 +118,10 @@ exports[`render visible banner, with custom theme 1`] = `
               collapsable={false}
               style={
                 Object {
+                  "bottom": undefined,
+                  "left": undefined,
+                  "position": undefined,
+                  "right": undefined,
                   "shadowColor": "#000",
                   "shadowOffset": Object {
                     "height": 0,
@@ -120,6 +129,7 @@ exports[`render visible banner, with custom theme 1`] = `
                   },
                   "shadowOpacity": 0,
                   "shadowRadius": 0,
+                  "top": undefined,
                 }
               }
             >
@@ -255,6 +265,10 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 1,
@@ -262,6 +276,7 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
+      "top": undefined,
     }
   }
 >
@@ -383,6 +398,10 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 1,
@@ -390,6 +409,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
+      "top": undefined,
     }
   }
 >
@@ -492,6 +512,10 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
               collapsable={false}
               style={
                 Object {
+                  "bottom": undefined,
+                  "left": undefined,
+                  "position": undefined,
+                  "right": undefined,
                   "shadowColor": "#000",
                   "shadowOffset": Object {
                     "height": 0,
@@ -499,6 +523,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                   },
                   "shadowOpacity": 0,
                   "shadowRadius": 0,
+                  "top": undefined,
                 }
               }
             >
@@ -634,6 +659,10 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 1,
@@ -641,6 +670,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
+      "top": undefined,
     }
   }
 >
@@ -742,6 +772,10 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
               collapsable={false}
               style={
                 Object {
+                  "bottom": undefined,
+                  "left": undefined,
+                  "position": undefined,
+                  "right": undefined,
                   "shadowColor": "#000",
                   "shadowOffset": Object {
                     "height": 0,
@@ -749,6 +783,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   },
                   "shadowOpacity": 0,
                   "shadowRadius": 0,
+                  "top": undefined,
                 }
               }
             >
@@ -875,6 +910,10 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
               collapsable={false}
               style={
                 Object {
+                  "bottom": undefined,
+                  "left": undefined,
+                  "position": undefined,
+                  "right": undefined,
                   "shadowColor": "#000",
                   "shadowOffset": Object {
                     "height": 0,
@@ -882,6 +921,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   },
                   "shadowOpacity": 0,
                   "shadowRadius": 0,
+                  "top": undefined,
                 }
               }
             >
@@ -1017,6 +1057,10 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 1,
@@ -1024,6 +1068,7 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
+      "top": undefined,
     }
   }
 >
@@ -1134,6 +1179,10 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 1,
@@ -1141,6 +1190,7 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
+      "top": undefined,
     }
   }
 >

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
@@ -64,6 +64,10 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
     collapsable={false}
     style={
       Object {
+        "bottom": 0,
+        "left": 0,
+        "position": null,
+        "right": 0,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -71,6 +75,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "top": undefined,
       }
     }
   >
@@ -95,10 +100,6 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
         style={
           Object {
             "backgroundColor": "transparent",
-            "bottom": 0,
-            "left": 0,
-            "position": null,
-            "right": 0,
             "transform": Array [
               Object {
                 "translateY": 0,
@@ -732,6 +733,10 @@ exports[`hides labels in shifting bottom navigation 1`] = `
     collapsable={false}
     style={
       Object {
+        "bottom": 0,
+        "left": 0,
+        "position": null,
+        "right": 0,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -739,6 +744,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "top": undefined,
       }
     }
   >
@@ -763,10 +769,6 @@ exports[`hides labels in shifting bottom navigation 1`] = `
         style={
           Object {
             "backgroundColor": "transparent",
-            "bottom": 0,
-            "left": 0,
-            "position": null,
-            "right": 0,
             "transform": Array [
               Object {
                 "translateY": 0,
@@ -1421,6 +1423,10 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
     collapsable={false}
     style={
       Object {
+        "bottom": 0,
+        "left": 0,
+        "position": null,
+        "right": 0,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -1428,6 +1434,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "top": undefined,
       }
     }
   >
@@ -1452,10 +1459,6 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
         style={
           Object {
             "backgroundColor": "transparent",
-            "bottom": 0,
-            "left": 0,
-            "position": null,
-            "right": 0,
             "transform": Array [
               Object {
                 "translateY": 0,
@@ -2119,6 +2122,10 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
     collapsable={false}
     style={
       Object {
+        "bottom": 0,
+        "left": 0,
+        "position": null,
+        "right": 0,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -2126,6 +2133,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "top": undefined,
       }
     }
   >
@@ -2150,10 +2158,6 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
         style={
           Object {
             "backgroundColor": "transparent",
-            "bottom": 0,
-            "left": 0,
-            "position": null,
-            "right": 0,
             "transform": Array [
               Object {
                 "translateY": 0,
@@ -3155,6 +3159,10 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
     collapsable={false}
     style={
       Object {
+        "bottom": 0,
+        "left": 0,
+        "position": null,
+        "right": 0,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -3162,6 +3170,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "top": undefined,
       }
     }
   >
@@ -3186,11 +3195,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
         style={
           Object {
             "backgroundColor": "transparent",
-            "bottom": 0,
             "color": "#e57373",
-            "left": 0,
-            "position": null,
-            "right": 0,
             "transform": Array [
               Object {
                 "translateY": 0,
@@ -4133,6 +4138,10 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
     collapsable={false}
     style={
       Object {
+        "bottom": 0,
+        "left": 0,
+        "position": null,
+        "right": 0,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -4140,6 +4149,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "top": undefined,
       }
     }
   >
@@ -4164,11 +4174,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
         style={
           Object {
             "backgroundColor": "transparent",
-            "bottom": 0,
             "color": "#e57373",
-            "left": 0,
-            "position": null,
-            "right": 0,
             "transform": Array [
               Object {
                 "translateY": 0,
@@ -5006,6 +5012,10 @@ exports[`renders non-shifting bottom navigation 1`] = `
     collapsable={false}
     style={
       Object {
+        "bottom": 0,
+        "left": 0,
+        "position": null,
+        "right": 0,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -5013,6 +5023,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "top": undefined,
       }
     }
   >
@@ -5037,10 +5048,6 @@ exports[`renders non-shifting bottom navigation 1`] = `
         style={
           Object {
             "backgroundColor": "transparent",
-            "bottom": 0,
-            "left": 0,
-            "position": null,
-            "right": 0,
             "transform": Array [
               Object {
                 "translateY": 0,
@@ -5983,6 +5990,10 @@ exports[`renders shifting bottom navigation 1`] = `
     collapsable={false}
     style={
       Object {
+        "bottom": 0,
+        "left": 0,
+        "position": null,
+        "right": 0,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -5990,6 +6001,7 @@ exports[`renders shifting bottom navigation 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "top": undefined,
       }
     }
   >
@@ -6014,10 +6026,6 @@ exports[`renders shifting bottom navigation 1`] = `
         style={
           Object {
             "backgroundColor": "transparent",
-            "bottom": 0,
-            "left": 0,
-            "position": null,
-            "right": 0,
             "transform": Array [
               Object {
                 "translateY": 0,

--- a/src/components/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.js.snap
@@ -5,6 +5,10 @@ exports[`renders button with an accessibility hint 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -12,6 +16,7 @@ exports[`renders button with an accessibility hint 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -139,6 +144,10 @@ exports[`renders button with an accessibility label 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -146,6 +155,7 @@ exports[`renders button with an accessibility label 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -273,6 +283,10 @@ exports[`renders button with button color 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -280,6 +294,7 @@ exports[`renders button with button color 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -406,6 +421,10 @@ exports[`renders button with color 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -413,6 +432,7 @@ exports[`renders button with color 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -539,6 +559,10 @@ exports[`renders button with custom testID 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -546,6 +570,7 @@ exports[`renders button with custom testID 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -673,6 +698,10 @@ exports[`renders button with icon 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -680,6 +709,7 @@ exports[`renders button with icon 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -844,6 +874,10 @@ exports[`renders button with icon in reverse order 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -851,6 +885,7 @@ exports[`renders button with icon in reverse order 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -1017,6 +1052,10 @@ exports[`renders contained contained with mode 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -1024,6 +1063,7 @@ exports[`renders contained contained with mode 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -1151,6 +1191,10 @@ exports[`renders disabled button 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -1158,6 +1202,7 @@ exports[`renders disabled button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -1284,6 +1329,10 @@ exports[`renders loading button 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -1291,6 +1340,7 @@ exports[`renders loading button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -1625,6 +1675,10 @@ exports[`renders outlined button with mode 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -1632,6 +1686,7 @@ exports[`renders outlined button with mode 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -1759,6 +1814,10 @@ exports[`renders text button by default 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -1766,6 +1825,7 @@ exports[`renders text button by default 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -1892,6 +1952,10 @@ exports[`renders text button with mode 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -1899,6 +1963,7 @@ exports[`renders text button with mode 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >

--- a/src/components/__tests__/__snapshots__/Chip.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.js.snap
@@ -5,6 +5,10 @@ exports[`renders chip with close button 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -12,6 +16,7 @@ exports[`renders chip with close button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -240,6 +245,10 @@ exports[`renders chip with custom close button 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -247,6 +256,7 @@ exports[`renders chip with custom close button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -475,6 +485,10 @@ exports[`renders chip with icon 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -482,6 +496,7 @@ exports[`renders chip with icon 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -650,6 +665,10 @@ exports[`renders chip with onPress 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -657,6 +676,7 @@ exports[`renders chip with onPress 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -790,6 +810,10 @@ exports[`renders outlined disabled chip 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -797,6 +821,7 @@ exports[`renders outlined disabled chip 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -930,6 +955,10 @@ exports[`renders selected chip 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -937,6 +966,7 @@ exports[`renders selected chip 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >

--- a/src/components/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.js.snap
@@ -240,6 +240,10 @@ exports[`renders data table pagination 1`] = `
       collapsable={false}
       style={
         Object {
+          "bottom": undefined,
+          "left": undefined,
+          "position": undefined,
+          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -247,6 +251,7 @@ exports[`renders data table pagination 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "top": undefined,
         }
       }
     >
@@ -345,6 +350,10 @@ exports[`renders data table pagination 1`] = `
       collapsable={false}
       style={
         Object {
+          "bottom": undefined,
+          "left": undefined,
+          "position": undefined,
+          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -352,6 +361,7 @@ exports[`renders data table pagination 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "top": undefined,
         }
       }
     >
@@ -502,6 +512,10 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
       collapsable={false}
       style={
         Object {
+          "bottom": undefined,
+          "left": undefined,
+          "position": undefined,
+          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -509,6 +523,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "top": undefined,
         }
       }
     >
@@ -607,6 +622,10 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
       collapsable={false}
       style={
         Object {
+          "bottom": undefined,
+          "left": undefined,
+          "position": undefined,
+          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -614,6 +633,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "top": undefined,
         }
       }
     >
@@ -712,6 +732,10 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
       collapsable={false}
       style={
         Object {
+          "bottom": undefined,
+          "left": undefined,
+          "position": undefined,
+          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -719,6 +743,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "top": undefined,
         }
       }
     >
@@ -817,6 +842,10 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
       collapsable={false}
       style={
         Object {
+          "bottom": undefined,
+          "left": undefined,
+          "position": undefined,
+          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -824,6 +853,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "top": undefined,
         }
       }
     >
@@ -974,6 +1004,10 @@ exports[`renders data table pagination with label 1`] = `
       collapsable={false}
       style={
         Object {
+          "bottom": undefined,
+          "left": undefined,
+          "position": undefined,
+          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -981,6 +1015,7 @@ exports[`renders data table pagination with label 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "top": undefined,
         }
       }
     >
@@ -1079,6 +1114,10 @@ exports[`renders data table pagination with label 1`] = `
       collapsable={false}
       style={
         Object {
+          "bottom": undefined,
+          "left": undefined,
+          "position": undefined,
+          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -1086,6 +1125,7 @@ exports[`renders data table pagination with label 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "top": undefined,
         }
       }
     >
@@ -1242,6 +1282,10 @@ exports[`renders data table pagination with options select 1`] = `
         collapsable={false}
         style={
           Object {
+            "bottom": undefined,
+            "left": undefined,
+            "position": undefined,
+            "right": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1249,6 +1293,7 @@ exports[`renders data table pagination with options select 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "top": undefined,
           }
         }
       >
@@ -1446,6 +1491,10 @@ exports[`renders data table pagination with options select 1`] = `
       collapsable={false}
       style={
         Object {
+          "bottom": undefined,
+          "left": undefined,
+          "position": undefined,
+          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -1453,6 +1502,7 @@ exports[`renders data table pagination with options select 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "top": undefined,
         }
       }
     >
@@ -1551,6 +1601,10 @@ exports[`renders data table pagination with options select 1`] = `
       collapsable={false}
       style={
         Object {
+          "bottom": undefined,
+          "left": undefined,
+          "position": undefined,
+          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -1558,6 +1612,7 @@ exports[`renders data table pagination with options select 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "top": undefined,
         }
       }
     >
@@ -1656,6 +1711,10 @@ exports[`renders data table pagination with options select 1`] = `
       collapsable={false}
       style={
         Object {
+          "bottom": undefined,
+          "left": undefined,
+          "position": undefined,
+          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -1663,6 +1722,7 @@ exports[`renders data table pagination with options select 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "top": undefined,
         }
       }
     >
@@ -1761,6 +1821,10 @@ exports[`renders data table pagination with options select 1`] = `
       collapsable={false}
       style={
         Object {
+          "bottom": undefined,
+          "left": undefined,
+          "position": undefined,
+          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -1768,6 +1832,7 @@ exports[`renders data table pagination with options select 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "top": undefined,
         }
       }
     >

--- a/src/components/__tests__/__snapshots__/FAB.test.js.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.js.snap
@@ -5,6 +5,10 @@ exports[`renders FAB with custom size prop 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -12,6 +16,7 @@ exports[`renders FAB with custom size prop 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "top": undefined,
     }
   }
 >
@@ -154,6 +159,10 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -161,6 +170,7 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "top": undefined,
     }
   }
 >
@@ -303,6 +313,10 @@ exports[`renders disabled FAB 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -310,6 +324,7 @@ exports[`renders disabled FAB 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -452,6 +467,10 @@ exports[`renders extended FAB 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -459,6 +478,7 @@ exports[`renders extended FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "top": undefined,
     }
   }
 >
@@ -638,6 +658,10 @@ exports[`renders extended FAB with custom size prop 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -645,6 +669,7 @@ exports[`renders extended FAB with custom size prop 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "top": undefined,
     }
   }
 >
@@ -823,6 +848,10 @@ exports[`renders loading FAB 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -830,6 +859,7 @@ exports[`renders loading FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "top": undefined,
     }
   }
 >
@@ -1114,6 +1144,10 @@ exports[`renders loading FAB with custom size prop 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -1121,6 +1155,7 @@ exports[`renders loading FAB with custom size prop 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "top": undefined,
     }
   }
 >
@@ -1405,6 +1440,10 @@ exports[`renders normal FAB 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -1412,6 +1451,7 @@ exports[`renders normal FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "top": undefined,
     }
   }
 >
@@ -1554,6 +1594,10 @@ exports[`renders not visible FAB 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -1561,6 +1605,7 @@ exports[`renders not visible FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "top": undefined,
     }
   }
 >
@@ -1703,6 +1748,10 @@ exports[`renders small FAB 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -1710,6 +1759,7 @@ exports[`renders small FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "top": undefined,
     }
   }
 >
@@ -1852,6 +1902,10 @@ exports[`renders visible FAB 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -1859,6 +1913,7 @@ exports[`renders visible FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "top": undefined,
     }
   }
 >

--- a/src/components/__tests__/__snapshots__/IconButton.test.js.snap
+++ b/src/components/__tests__/__snapshots__/IconButton.test.js.snap
@@ -5,6 +5,10 @@ exports[`renders disabled icon button 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -12,6 +16,7 @@ exports[`renders disabled icon button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -112,6 +117,10 @@ exports[`renders icon button by default 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -119,6 +128,7 @@ exports[`renders icon button by default 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -219,6 +229,10 @@ exports[`renders icon button with color 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -226,6 +240,7 @@ exports[`renders icon button with color 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -326,6 +341,10 @@ exports[`renders icon button with size 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -333,6 +352,7 @@ exports[`renders icon button with size 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -433,6 +453,10 @@ exports[`renders icon change animated 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -440,6 +464,7 @@ exports[`renders icon change animated 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >

--- a/src/components/__tests__/__snapshots__/ListItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.js.snap
@@ -91,6 +91,10 @@ exports[`renders list item with custom description 1`] = `
             collapsable={false}
             style={
               Object {
+                "bottom": undefined,
+                "left": undefined,
+                "position": undefined,
+                "right": undefined,
                 "shadowColor": "#000",
                 "shadowOffset": Object {
                   "height": 0,
@@ -98,6 +102,7 @@ exports[`renders list item with custom description 1`] = `
                 },
                 "shadowOpacity": 0,
                 "shadowRadius": 0,
+                "top": undefined,
               }
             }
           >

--- a/src/components/__tests__/__snapshots__/Menu.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.js.snap
@@ -8,6 +8,10 @@ exports[`renders menu with content styles 1`] = `
     collapsable={false}
     style={
       Object {
+        "bottom": undefined,
+        "left": undefined,
+        "position": undefined,
+        "right": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -15,6 +19,7 @@ exports[`renders menu with content styles 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "top": undefined,
       }
     }
   >
@@ -146,6 +151,10 @@ exports[`renders not visible menu 1`] = `
     collapsable={false}
     style={
       Object {
+        "bottom": undefined,
+        "left": undefined,
+        "position": undefined,
+        "right": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -153,6 +162,7 @@ exports[`renders not visible menu 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "top": undefined,
       }
     }
   >
@@ -284,6 +294,10 @@ exports[`renders visible menu 1`] = `
     collapsable={false}
     style={
       Object {
+        "bottom": undefined,
+        "left": undefined,
+        "position": undefined,
+        "right": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -291,6 +305,7 @@ exports[`renders visible menu 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "top": undefined,
       }
     }
   >

--- a/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
@@ -5,6 +5,10 @@ exports[`renders with placeholder 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 1,
@@ -12,6 +16,7 @@ exports[`renders with placeholder 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
+      "top": undefined,
     }
   }
 >
@@ -44,6 +49,10 @@ exports[`renders with placeholder 1`] = `
         collapsable={false}
         style={
           Object {
+            "bottom": undefined,
+            "left": undefined,
+            "position": undefined,
+            "right": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -51,6 +60,7 @@ exports[`renders with placeholder 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "top": undefined,
           }
         }
       >
@@ -174,6 +184,10 @@ exports[`renders with placeholder 1`] = `
         collapsable={false}
         style={
           Object {
+            "bottom": undefined,
+            "left": undefined,
+            "position": undefined,
+            "right": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -181,6 +195,7 @@ exports[`renders with placeholder 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "top": undefined,
           }
         }
       >
@@ -285,6 +300,10 @@ exports[`renders with text 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 1,
@@ -292,6 +311,7 @@ exports[`renders with text 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
+      "top": undefined,
     }
   }
 >
@@ -324,6 +344,10 @@ exports[`renders with text 1`] = `
         collapsable={false}
         style={
           Object {
+            "bottom": undefined,
+            "left": undefined,
+            "position": undefined,
+            "right": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -331,6 +355,7 @@ exports[`renders with text 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "top": undefined,
           }
         }
       >
@@ -455,6 +480,10 @@ exports[`renders with text 1`] = `
         collapsable={false}
         style={
           Object {
+            "bottom": undefined,
+            "left": undefined,
+            "position": undefined,
+            "right": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -462,6 +491,7 @@ exports[`renders with text 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "top": undefined,
           }
         }
       >

--- a/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
@@ -21,6 +21,10 @@ exports[`renders snackbar with Text as a child 1`] = `
     collapsable={false}
     style={
       Object {
+        "bottom": undefined,
+        "left": undefined,
+        "position": undefined,
+        "right": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 2,
@@ -28,6 +32,7 @@ exports[`renders snackbar with Text as a child 1`] = `
         },
         "shadowOpacity": 0.15,
         "shadowRadius": 6,
+        "top": undefined,
       }
     }
   >
@@ -119,6 +124,10 @@ exports[`renders snackbar with action button 1`] = `
     collapsable={false}
     style={
       Object {
+        "bottom": undefined,
+        "left": undefined,
+        "position": undefined,
+        "right": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 2,
@@ -126,6 +135,7 @@ exports[`renders snackbar with action button 1`] = `
         },
         "shadowOpacity": 0.15,
         "shadowRadius": 6,
+        "top": undefined,
       }
     }
   >
@@ -194,6 +204,10 @@ exports[`renders snackbar with action button 1`] = `
           collapsable={false}
           style={
             Object {
+              "bottom": undefined,
+              "left": undefined,
+              "position": undefined,
+              "right": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -201,6 +215,7 @@ exports[`renders snackbar with action button 1`] = `
               },
               "shadowOpacity": 0,
               "shadowRadius": 0,
+              "top": undefined,
             }
           }
         >
@@ -349,6 +364,10 @@ exports[`renders snackbar with content 1`] = `
     collapsable={false}
     style={
       Object {
+        "bottom": undefined,
+        "left": undefined,
+        "position": undefined,
+        "right": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 2,
@@ -356,6 +375,7 @@ exports[`renders snackbar with content 1`] = `
         },
         "shadowOpacity": 0.15,
         "shadowRadius": 6,
+        "top": undefined,
       }
     }
   >

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -1043,6 +1043,10 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
       collapsable={false}
       style={
         Object {
+          "bottom": undefined,
+          "left": undefined,
+          "position": undefined,
+          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -1050,6 +1054,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "top": undefined,
         }
       }
     >
@@ -1353,6 +1358,10 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
       collapsable={false}
       style={
         Object {
+          "bottom": undefined,
+          "left": undefined,
+          "position": undefined,
+          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -1360,6 +1369,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "top": undefined,
         }
       }
     >

--- a/src/components/__tests__/__snapshots__/ToggleButton.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ToggleButton.test.js.snap
@@ -5,6 +5,10 @@ exports[`renders disabled toggle button 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -12,6 +16,7 @@ exports[`renders disabled toggle button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -111,6 +116,10 @@ exports[`renders toggle button 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -118,6 +127,7 @@ exports[`renders toggle button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >
@@ -217,6 +227,10 @@ exports[`renders unchecked toggle button 1`] = `
   collapsable={false}
   style={
     Object {
+      "bottom": undefined,
+      "left": undefined,
+      "position": undefined,
+      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -224,6 +238,7 @@ exports[`renders unchecked toggle button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "top": undefined,
     }
   }
 >


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Due to two shadow layers on `ios` there is a need to extract absolute style properties and apply them to the outer layers to achieve the correct behavior.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Snapshots are properly updated.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
