### PR TITLE
fix: correct v2 should center appbar

### DIFF
--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -118,6 +118,10 @@ const Appbar = ({
     elevated
   );
 
+  const isMode = (modeToCompare: AppbarModes) => {
+    return isV3 && mode === modeToCompare;
+  };
+
   if (typeof dark === 'boolean') {
     isDark = dark;
   } else {
@@ -129,10 +133,12 @@ const Appbar = ({
         : true;
   }
 
+  const isV3CenterAlignedMode = isV3 && isMode('center-aligned');
+
   let shouldCenterContent = false;
   let shouldAddLeftSpacing = false;
   let shouldAddRightSpacing = false;
-  if (isV3 || Platform.OS === 'ios') {
+  if ((!isV3 && Platform.OS === 'ios') || isV3CenterAlignedMode) {
     let hasAppbarContent = false;
     let leftItemsCount = 0;
     let rightItemsCount = 0;
@@ -156,10 +162,6 @@ const Appbar = ({
     shouldAddLeftSpacing = shouldCenterContent && leftItemsCount === 0;
     shouldAddRightSpacing = shouldCenterContent && rightItemsCount === 0;
   }
-
-  const isMode = (modeToCompare: AppbarModes) => {
-    return isV3 && mode === modeToCompare;
-  };
 
   const filterAppbarActions = React.useCallback(
     (isLeading = false) =>
@@ -192,8 +194,7 @@ const Appbar = ({
           children,
           isDark,
           isV3,
-          shouldCenterContent:
-            (isV3 && !isMode('small')) ?? shouldCenterContent,
+          shouldCenterContent: isV3CenterAlignedMode || shouldCenterContent,
         })}
       {(isMode('medium') || isMode('large')) && (
         <View

--- a/src/components/__tests__/Appbar/Appbar.test.js
+++ b/src/components/__tests__/Appbar/Appbar.test.js
@@ -11,6 +11,7 @@ import Searchbar from '../../Searchbar';
 import { tokens } from '../../../styles/themes/v3/tokens';
 import { getTheme } from '../../../core/theming';
 import overlay from '../../../styles/overlay';
+import { Platform } from 'react-native';
 
 describe('Appbar', () => {
   it('does not pass any additional props to Searchbar', () => {
@@ -112,6 +113,48 @@ describe('renderAppbarContent', () => {
     expect(renderResult()[0].props.style).toEqual(
       expect.arrayContaining([expect.objectContaining(centerAlignedContent)])
     );
+
+    expect(renderResult(false)[0].props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining(centerAlignedContent)])
+    );
+  });
+
+  it('should not render centered AppbarContent for Android, if not V3', () => {
+    Platform.OS = 'android';
+    const renderResult = (isV3 = true) =>
+      renderAppbarContent({
+        children,
+        isDark: false,
+        isV3,
+        renderOnly: [AppbarContent],
+        mode: 'center-aligned',
+        shouldCenterContent: !isV3 && Platform.OS === 'ios',
+      });
+
+    const centerAlignedContent = {
+      alignItems: 'center',
+    };
+
+    expect(renderResult(false)[0].props.style).not.toEqual(
+      expect.arrayContaining([expect.objectContaining(centerAlignedContent)])
+    );
+  });
+
+  it('should render centered AppbarContent always for iOS, if not V3', () => {
+    Platform.OS = 'ios';
+    const renderResult = (isV3 = true) =>
+      renderAppbarContent({
+        children,
+        isDark: false,
+        isV3,
+        renderOnly: [AppbarContent],
+        mode: 'center-aligned',
+        shouldCenterContent: !isV3 && Platform.OS === 'ios',
+      });
+
+    const centerAlignedContent = {
+      alignItems: 'center',
+    };
 
     expect(renderResult(false)[0].props.style).toEqual(
       expect.arrayContaining([expect.objectContaining(centerAlignedContent)])


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

PR correct `Appbar` on v2 to be centered properly on iOS.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Added test cases.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
