### PR TITLE
Add reference to icons list to Avatar.icon

### DIFF
--- a/src/components/Avatar/AvatarIcon.tsx
+++ b/src/components/Avatar/AvatarIcon.tsx
@@ -29,13 +29,15 @@ type Props = React.ComponentPropsWithRef<typeof View> & {
 };
 
 /**
- * Avatars can be used to represent people in a graphical way.
+ * Avatars can be used to graphically represent users or actions.
  *
  * <div class="screenshots">
  *   <figure>
  *     <img class="medium" src="screenshots/avatar-icon.png" />
  *   </figure>
  * </div>
+ *
+ * You can see a list of available icons in the [Icons](icons.html) section.
  *
  * ## Usage
  * ```js


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Users going straight to the `Avatar.icon` section of the navigation may not realize there's a section dedicated to Icons above; I didn't. If they don't, it's unclear where to find what icons you can use with this prop.

This adds an explicit reference to the Icons section.

I also edited the grammar in another sentence on the page.

### Test plan

This changes the text on [avatar-icon.html](https://callstack.github.io/react-native-paper/avatar-icon.html); visual inspection is an appropriate test.
