### PR TITLE
fix: adjust Badge line height to the font scale

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { Animated, StyleSheet, StyleProp, TextStyle } from 'react-native';
+import {
+  Animated,
+  StyleSheet,
+  StyleProp,
+  TextStyle,
+  useWindowDimensions,
+} from 'react-native';
 import { white, black } from '../styles/themes/v2/colors';
 import { withTheme } from '../core/theming';
 import getContrastingColor from '../utils/getContrastingColor';
@@ -66,6 +72,8 @@ const Badge = ({
   const { current: opacity } = React.useRef<Animated.Value>(
     new Animated.Value(visible ? 1 : 0)
   );
+  const { fontScale } = useWindowDimensions();
+
   const isFirstRendering = React.useRef<boolean>(true);
 
   const {
@@ -111,7 +119,7 @@ const Badge = ({
           color: textColor,
           fontSize: size * 0.5,
           ...(!theme.isV3 && theme.fonts.regular),
-          lineHeight: size,
+          lineHeight: size / fontScale,
           height: size,
           minWidth: size,
           borderRadius,

--- a/src/components/__tests__/Badge.test.js
+++ b/src/components/__tests__/Badge.test.js
@@ -3,6 +3,16 @@ import renderer from 'react-test-renderer';
 import Badge from '../Badge.tsx';
 import { red500 } from '../../styles/themes/v2/colors';
 
+jest.mock('react-native', () => {
+  const RN = jest.requireActual('react-native');
+
+  RN.Dimensions.get = () => ({
+    fontScale: 1,
+  });
+
+  return RN;
+});
+
 it('renders badge', () => {
   const tree = renderer.create(<Badge />).toJSON();
 

--- a/src/components/__tests__/BottomNavigation.test.js
+++ b/src/components/__tests__/BottomNavigation.test.js
@@ -36,6 +36,10 @@ jest.mock('react-native', () => {
 
   RN.Animated.parallel = mock;
 
+  RN.Dimensions.get = () => ({
+    fontScale: 1,
+  });
+
   return RN;
 });
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/3251

### Summary

Adjust `Badge`'s line height to the font scale which increases along with setting a higher system font size.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Updated tests.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
