### PR TITLE
feat: allow to specify button's mode in CardAction

### DIFF
--- a/src/components/Card/CardActions.tsx
+++ b/src/components/Card/CardActions.tsx
@@ -49,7 +49,9 @@ const CardActions = (props: Props) => {
         return React.isValidElement(child)
           ? React.cloneElement(child, {
               compact: !isV3 && child.props.compact !== false,
-              mode: isV3 && (i === 0 ? 'outlined' : 'contained'),
+              mode:
+                child.props.mode ||
+                (isV3 && (i === 0 ? 'outlined' : 'contained')),
               style: isV3 && styles.button,
             })
           : child;

--- a/src/components/__tests__/Card/Card.test.js
+++ b/src/components/__tests__/Card/Card.test.js
@@ -3,6 +3,7 @@ import renderer from 'react-test-renderer';
 import { render } from 'react-native-testing-library';
 import color from 'color';
 import Card from '../../Card/Card';
+import Button from '../../Button/Button';
 import { black, white } from '../../../styles/themes/v2/colors';
 import { getCardColors } from '../../Card/utils';
 import { getTheme } from '../../../core/theming';
@@ -26,6 +27,22 @@ describe('Card', () => {
     expect(getByA11yLabel('card').props.style.backgroundColor).toEqual(
       '#0000FF'
     );
+  });
+});
+
+describe('CardActions', () => {
+  it('renders button with passed mode', () => {
+    const { getByTestId } = render(
+      <Card>
+        <Card.Actions>
+          <Button mode="contained" testID="card-action-button">
+            Agree
+          </Button>
+        </Card.Actions>
+      </Card>
+    );
+
+    expect(getByTestId('card-action-button').props.mode).toBe('contained');
   });
 });
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Solves: https://github.com/callstack/react-native-paper/issues/3274

### Summary

PR extending button within card action by adding condition whether the button's mode in child props is provided.

ios | android
--- | ---
<img width="481" alt="Zrzut ekranu 2022-07-25 o 11 43 36" src="https://user-images.githubusercontent.com/22746080/180748547-a6bb3e12-b3ab-411c-940c-461e613f12e3.png"> | <img width="490" alt="Zrzut ekranu 2022-07-25 o 11 43 39" src="https://user-images.githubusercontent.com/22746080/180748611-df4b4d6d-3dcd-4195-9066-84369be4a2f5.png">

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Added test covering change.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
