### PR TITLE
feat: extend Button props by adding onPressIn and onPressOut

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -86,6 +86,16 @@ type Props = React.ComponentProps<typeof Surface> & {
    */
   onPress?: () => void;
   /**
+   * @supported Available in v5.x
+   * Function to execute as soon as the touchable element is pressed and invoked even before onPress.
+   */
+  onPressIn?: () => void;
+  /**
+   * @supported Available in v5.x
+   * Function to execute as soon as the touch is released even before onPress.
+   */
+  onPressOut?: () => void;
+  /**
    * Function to execute on long press.
    */
   onLongPress?: () => void;
@@ -162,6 +172,8 @@ const Button = ({
   accessibilityLabel,
   accessibilityHint,
   onPress,
+  onPressIn,
+  onPressOut,
   onLongPress,
   style,
   theme,
@@ -194,7 +206,8 @@ const Button = ({
   }, [isElevationEntitled, elevation, initialElevation]);
 
   const handlePressIn = () => {
-    if (isMode('contained')) {
+    onPressIn?.();
+    if (isV3 ? isMode('elevated') : isMode('contained')) {
       const { scale } = animation;
       Animated.timing(elevation, {
         toValue: activeElevation,
@@ -205,7 +218,8 @@ const Button = ({
   };
 
   const handlePressOut = () => {
-    if (isMode('contained')) {
+    onPressOut?.();
+    if (isV3 ? isMode('elevated') : isMode('contained')) {
       const { scale } = animation;
       Animated.timing(elevation, {
         toValue: initialElevation,

--- a/src/components/__tests__/Button.test.js
+++ b/src/components/__tests__/Button.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { StyleSheet } from 'react-native';
 import renderer from 'react-test-renderer';
+import { fireEvent, render } from 'react-native-testing-library';
 import color from 'color';
 import Button from '../Button/Button.tsx';
 import { pink500, black, white } from '../../styles/themes/v2/colors';
@@ -123,6 +124,26 @@ it('renders button with an accessibility hint', () => {
     .toJSON();
 
   expect(tree).toMatchSnapshot();
+});
+
+it('should execute onPressIn', () => {
+  const onPressInMock = jest.fn();
+
+  const { getByTestId } = render(
+    <Button onPressIn={onPressInMock} testID="button" />
+  );
+  fireEvent(getByTestId('button'), 'onPressIn');
+  expect(onPressInMock).toHaveBeenCalled();
+});
+
+it('should execute onPressOut', () => {
+  const onPressOutMock = jest.fn();
+
+  const { getByTestId } = render(
+    <Button onPressOut={onPressOutMock} testID="button" />
+  );
+  fireEvent(getByTestId('button'), 'onPressOut');
+  expect(onPressOutMock).toHaveBeenCalled();
 });
 
 describe('getButtonColors - background color', () => {

--- a/src/components/__tests__/Button.test.js
+++ b/src/components/__tests__/Button.test.js
@@ -133,7 +133,7 @@ it('should execute onPressIn', () => {
     <Button onPressIn={onPressInMock} testID="button" />
   );
   fireEvent(getByTestId('button'), 'onPressIn');
-  expect(onPressInMock).toHaveBeenCalled();
+  expect(onPressInMock).toHaveBeenCalledTimes(1);
 });
 
 it('should execute onPressOut', () => {
@@ -143,7 +143,7 @@ it('should execute onPressOut', () => {
     <Button onPressOut={onPressOutMock} testID="button" />
   );
   fireEvent(getByTestId('button'), 'onPressOut');
-  expect(onPressOutMock).toHaveBeenCalled();
+  expect(onPressOutMock).toHaveBeenCalledTimes(1);
 });
 
 describe('getButtonColors - background color', () => {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Solves: https://github.com/callstack/react-native-paper/issues/3185

### Summary

PR extends `Button` component by adding  `onPressIn` and `onPressOut` props.
Refines button's elevation.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

New props are covered by tests.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
