### PR TITLE
docs: noting that Provider includes Portal.Host

### DIFF
--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -20,9 +20,10 @@ type Props = {
 };
 
 /**
- * Portal allows to render a component at a different place in the parent tree.
+ * Portal allows rendering a component at a different place in the parent tree.
  * You can use it to render content which should appear above other elements, similar to `Modal`.
  * It requires a [`Portal.Host`](portal-host.html) component to be rendered somewhere in the parent tree.
+ * Note that if you're using the `Provider` component, this already includes a `Portal.Host`.
  *
  * ## Usage
  * ```js


### PR DESCRIPTION
### Summary

The existing Portal documentation doesn't note that `Provider` supplies a `Portal.Host`; you have to click through to the documentation for `Portal.Host` to find this out. This is key information for using this component, and should be available on this page. 

I also corrected a grammatical error in the same paragraph.
### Test plan

Load the documentation; the extra sentence should be added.
