### PR TITLE
fix: correct BottomNavigation background color

### DIFF
--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -255,6 +255,10 @@ type Props = {
    * @optional
    */
   theme: Theme;
+  /**
+   * TestID used for testing purposes
+   */
+  testID?: string;
 };
 
 const MIN_RIPPLE_SCALE = 0.001; // Minimum scale is not 0 due to bug with animation
@@ -374,6 +378,7 @@ const BottomNavigation = ({
   safeAreaInsets,
   labelMaxFontSizeMultiplier = 1,
   compact = !theme.isV3,
+  testID = 'bottom-navigation',
 }: Props) => {
   const { scale } = theme.animation;
 
@@ -599,17 +604,25 @@ const BottomNavigation = ({
     ? overlay(elevation, colors?.surface)
     : colors?.primary;
 
+  const v2BackgroundColorInterpolation = indexAnim.interpolate({
+    inputRange: routes.map((_, i) => i),
+    // FIXME: does outputRange support ColorValue or just strings?
+    // @ts-expect-error
+    outputRange: routes.map(
+      (route) => getColor({ route }) || approxBackgroundColor
+    ),
+  });
+
+  const v3BackgroundColor =
+    customBackground ||
+    //@ts-ignore TS indicates that MD2Colors does not contain 'elevation' property,
+    // which is true, however 'v3BackgroundColor' is used only for theme version 3.
+    theme.colors.elevation.level2;
+
   const backgroundColor = isV3
-    ? theme.colors.surface
+    ? v3BackgroundColor
     : shifting
-    ? indexAnim.interpolate({
-        inputRange: routes.map((_, i) => i),
-        // FIXME: does outputRange support ColorValue or just strings?
-        // @ts-expect-error
-        outputRange: routes.map(
-          (route) => getColor({ route }) || approxBackgroundColor
-        ),
-      })
+    ? v2BackgroundColorInterpolation
     : approxBackgroundColor;
 
   const isDark =
@@ -653,7 +666,7 @@ const BottomNavigation = ({
   };
 
   return (
-    <View style={[styles.container, style]}>
+    <View style={[styles.container, style]} testID={testID}>
       <View style={[styles.content, { backgroundColor: colors?.background }]}>
         {routes.map((route, index) => {
           if (!loaded.includes(route.key)) {
@@ -758,7 +771,10 @@ const BottomNavigation = ({
         }
         onLayout={onLayout}
       >
-        <Animated.View style={[styles.barContent, { backgroundColor }]}>
+        <Animated.View
+          style={[styles.barContent, { backgroundColor }]}
+          testID={`${testID}-bar-content`}
+        >
           <View
             style={[
               styles.items,

--- a/src/components/__tests__/BottomNavigation.test.js
+++ b/src/components/__tests__/BottomNavigation.test.js
@@ -7,8 +7,11 @@ import BottomNavigationRouteScreen from '../BottomNavigation/BottomNavigationRou
 import { red300 } from '../../styles/themes/v2/colors';
 
 const styles = StyleSheet.create({
-  bgColor: {
+  labelColor: {
     color: red300,
+  },
+  backgroundColor: {
+    backgroundColor: red300,
   },
 });
 
@@ -222,7 +225,7 @@ it('renders custom icon and label with custom colors in shifting bottom navigati
         renderScene={({ route }) => route.title}
         activeColor="#FBF7DB"
         inactiveColor="#853D4B"
-        barStyle={styles.bgColor}
+        barStyle={styles.labelColor}
       />
     )
     .toJSON();
@@ -240,7 +243,7 @@ it('renders custom icon and label with custom colors in non-shifting bottom navi
         renderScene={({ route }) => route.title}
         activeColor="#FBF7DB"
         inactiveColor="#853D4B"
-        barStyle={styles.bgColor}
+        barStyle={styles.labelColor}
       />
     )
     .toJSON();
@@ -314,4 +317,25 @@ it('should have labelMaxFontSizeMultiplier passed to label', () => {
   const label = getAllByText('Route: 0')[0];
 
   expect(label.props.maxFontSizeMultiplier).toBe(labelMaxFontSizeMultiplier);
+});
+
+it('renders custom background color passed to barStyle property', () => {
+  const { getByTestId } = render(
+    <BottomNavigation
+      shifting={false}
+      labeled={true}
+      navigationState={createState(0, 3)}
+      onIndexChange={jest.fn()}
+      renderScene={({ route }) => route.title}
+      barStyle={styles.backgroundColor}
+      testID={'bottom-navigation'}
+    />
+  );
+
+  const wrapper = getByTestId('bottom-navigation-bar-content');
+  expect(wrapper.props.style).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ backgroundColor: red300 }),
+    ])
+  );
 });

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
@@ -11,6 +11,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
       undefined,
     ]
   }
+  testID="bottom-navigation"
 >
   <View
     style={
@@ -122,10 +123,11 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
           style={
             Object {
               "alignItems": "center",
-              "backgroundColor": "rgba(255, 251, 254, 1)",
+              "backgroundColor": "rgb(243, 237, 246)",
               "overflow": "hidden",
             }
           }
+          testID="bottom-navigation-bar-content"
         >
           <View
             accessibilityRole="tablist"
@@ -689,6 +691,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
       undefined,
     ]
   }
+  testID="bottom-navigation"
 >
   <View
     style={
@@ -800,10 +803,11 @@ exports[`hides labels in shifting bottom navigation 1`] = `
           style={
             Object {
               "alignItems": "center",
-              "backgroundColor": "rgba(255, 251, 254, 1)",
+              "backgroundColor": "rgb(243, 237, 246)",
               "overflow": "hidden",
             }
           }
+          testID="bottom-navigation-bar-content"
         >
           <View
             accessibilityRole="tablist"
@@ -1388,6 +1392,7 @@ exports[`renders bottom navigation with scene animation 1`] = `
       undefined,
     ]
   }
+  testID="bottom-navigation"
 >
   <View
     style={
@@ -1499,10 +1504,11 @@ exports[`renders bottom navigation with scene animation 1`] = `
           style={
             Object {
               "alignItems": "center",
-              "backgroundColor": "rgba(255, 251, 254, 1)",
+              "backgroundColor": "rgb(243, 237, 246)",
               "overflow": "hidden",
             }
           }
+          testID="bottom-navigation-bar-content"
         >
           <View
             accessibilityRole="tablist"
@@ -2744,6 +2750,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
       undefined,
     ]
   }
+  testID="bottom-navigation"
 >
   <View
     style={
@@ -2855,10 +2862,11 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
           style={
             Object {
               "alignItems": "center",
-              "backgroundColor": "rgba(255, 251, 254, 1)",
+              "backgroundColor": "rgb(243, 237, 246)",
               "overflow": "hidden",
             }
           }
+          testID="bottom-navigation-bar-content"
         >
           <View
             accessibilityRole="tablist"
@@ -3452,6 +3460,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
       undefined,
     ]
   }
+  testID="bottom-navigation"
 >
   <View
     style={
@@ -3563,10 +3572,11 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
           style={
             Object {
               "alignItems": "center",
-              "backgroundColor": "rgba(255, 251, 254, 1)",
+              "backgroundColor": "rgb(243, 237, 246)",
               "overflow": "hidden",
             }
           }
+          testID="bottom-navigation-bar-content"
         >
           <View
             accessibilityRole="tablist"
@@ -4498,6 +4508,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
       undefined,
     ]
   }
+  testID="bottom-navigation"
 >
   <View
     style={
@@ -4610,10 +4621,11 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
           style={
             Object {
               "alignItems": "center",
-              "backgroundColor": "rgba(255, 251, 254, 1)",
+              "backgroundColor": "rgb(243, 237, 246)",
               "overflow": "hidden",
             }
           }
+          testID="bottom-navigation-bar-content"
         >
           <View
             accessibilityRole="tablist"
@@ -5486,6 +5498,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
       undefined,
     ]
   }
+  testID="bottom-navigation"
 >
   <View
     style={
@@ -5598,10 +5611,11 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
           style={
             Object {
               "alignItems": "center",
-              "backgroundColor": "rgba(255, 251, 254, 1)",
+              "backgroundColor": "rgb(243, 237, 246)",
               "overflow": "hidden",
             }
           }
+          testID="bottom-navigation-bar-content"
         >
           <View
             accessibilityRole="tablist"
@@ -6369,6 +6383,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
       undefined,
     ]
   }
+  testID="bottom-navigation"
 >
   <View
     style={
@@ -6480,10 +6495,11 @@ exports[`renders non-shifting bottom navigation 1`] = `
           style={
             Object {
               "alignItems": "center",
-              "backgroundColor": "rgba(255, 251, 254, 1)",
+              "backgroundColor": "rgb(243, 237, 246)",
               "overflow": "hidden",
             }
           }
+          testID="bottom-navigation-bar-content"
         >
           <View
             accessibilityRole="tablist"
@@ -7356,6 +7372,7 @@ exports[`renders shifting bottom navigation 1`] = `
       undefined,
     ]
   }
+  testID="bottom-navigation"
 >
   <View
     style={
@@ -7467,10 +7484,11 @@ exports[`renders shifting bottom navigation 1`] = `
           style={
             Object {
               "alignItems": "center",
-              "backgroundColor": "rgba(255, 251, 254, 1)",
+              "backgroundColor": "rgb(243, 237, 246)",
               "overflow": "hidden",
             }
           }
+          testID="bottom-navigation-bar-content"
         >
           <View
             accessibilityRole="tablist"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/3290

### Summary

PR fixes background color, which is now set accordingly to the docs and the value is `theme.colors.elevation.level2`.
Also it unblocks a possibility to override background color by `barStyle` prop.

* default theme colors

ios | android
--- | ---
<img width="525" alt="Zrzut ekranu 2022-08-8 o 10 34 58" src="https://user-images.githubusercontent.com/22746080/183376693-7573c169-3a39-4131-aa4b-aa4eb583a4bc.png"> | <img width="490" alt="Zrzut ekranu 2022-08-8 o 10 35 20" src="https://user-images.githubusercontent.com/22746080/183376710-4a56726d-d678-467e-800e-6c919ca175df.png">

* custom colors 

ios | android
--- | ---
<img width="525" alt="Zrzut ekranu 2022-08-8 o 10 35 55" src="https://user-images.githubusercontent.com/22746080/183376775-e9ed4be2-c3bb-4b47-8203-ee2dabe1b06b.png"> | <img width="468" alt="Zrzut ekranu 2022-08-8 o 10 35 57" src="https://user-images.githubusercontent.com/22746080/183376840-4c3caa96-ba47-4182-b2e0-17b7dc5c983d.png">

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Added tests.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
