### PR TITLE
feat: add support for safe area insets in Appbar

### DIFF
--- a/docs/pages/10.migration-guide-to-5.0.md
+++ b/docs/pages/10.migration-guide-to-5.0.md
@@ -164,6 +164,14 @@ Take a look at the suggested replacement diff:
   /* ... */
 </Appbar>
 ```
+
+To make it easier for users to build the `BottomBar`, formed on the `Appbar` components, we have added a property `safeAreaInsets`:
+
+```js
+<Appbar safeAreaInsets={{ bottom: 47 }}>
+  /* ... */
+</Appbar>
+```
  
 It's worth noting that by default the theme version 3 `Appbar` and `Appbar.Header` don't have a shadow. However, it can be added by passing prop `elevated` into the component:
 

--- a/example/src/Examples/AppbarExample.tsx
+++ b/example/src/Examples/AppbarExample.tsx
@@ -194,27 +194,25 @@ const AppbarExample = ({ navigation }: Props) => {
           </List.Section>
         )}
       </ScreenWrapper>
-      {
-        <Appbar
-          style={[
-            styles.bottom,
-            {
-              height: height + bottom,
-              backgroundColor: theme.isV3
-                ? theme.colors.elevation.level2
-                : theme.colors.primary,
-            },
-          ]}
-          safeAreaInsets={{ bottom, left, right }}
-          theme={{ mode: showExactTheme ? 'exact' : 'adaptive' }}
-        >
-          <Appbar.Action icon="archive" onPress={() => {}} />
-          <Appbar.Action icon="email" onPress={() => {}} />
-          <Appbar.Action icon="label" onPress={() => {}} />
-          <Appbar.Action icon="delete" onPress={() => {}} />
-          {renderFAB()}
-        </Appbar>
-      }
+      <Appbar
+        style={[
+          styles.bottom,
+          {
+            height: height + bottom,
+            backgroundColor: theme.isV3
+              ? theme.colors.elevation.level2
+              : theme.colors.primary,
+          },
+        ]}
+        safeAreaInsets={{ bottom, left, right }}
+        theme={{ mode: showExactTheme ? 'exact' : 'adaptive' }}
+      >
+        <Appbar.Action icon="archive" onPress={() => {}} />
+        <Appbar.Action icon="email" onPress={() => {}} />
+        <Appbar.Action icon="label" onPress={() => {}} />
+        <Appbar.Action icon="delete" onPress={() => {}} />
+        {theme.isV3 && renderFAB()}
+      </Appbar>
       {!theme.isV3 && renderFAB()}
     </>
   );

--- a/example/src/Examples/AppbarExample.tsx
+++ b/example/src/Examples/AppbarExample.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react-native-paper';
 import ScreenWrapper from '../ScreenWrapper';
 import { yellowA200 } from '../../../src/styles/themes/v2/colors';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 type Props = {
   navigation: StackNavigationProp<{}>;
@@ -21,6 +22,7 @@ type Props = {
 type AppbarModes = 'small' | 'medium' | 'large' | 'center-aligned';
 
 const MORE_ICON = Platform.OS === 'ios' ? 'dots-horizontal' : 'dots-vertical';
+const MEDIUM_FAB_HEIGHT = 56;
 
 const AppbarExample = ({ navigation }: Props) => {
   const [showLeftIcon, setShowLeftIcon] = React.useState(true);
@@ -33,7 +35,9 @@ const AppbarExample = ({ navigation }: Props) => {
   const [showCalendarIcon, setShowCalendarIcon] = React.useState(false);
   const [showElevated, setShowElevated] = React.useState(false);
 
-  const { isV3 } = useTheme();
+  const theme = useTheme();
+  const { bottom, left, right } = useSafeAreaInsets();
+  const height = theme.isV3 ? 80 : 56;
 
   const isCenterAlignedMode = appbarMode === 'center-aligned';
 
@@ -83,7 +87,24 @@ const AppbarExample = ({ navigation }: Props) => {
     showElevated,
   ]);
 
-  const TextComponent = isV3 ? Text : Paragraph;
+  const TextComponent = theme.isV3 ? Text : Paragraph;
+
+  const renderFAB = () => {
+    return (
+      <FAB
+        mode={theme.isV3 ? 'flat' : 'elevated'}
+        size="medium"
+        icon="plus"
+        onPress={() => {}}
+        style={[
+          styles.fab,
+          theme.isV3
+            ? { top: (height - MEDIUM_FAB_HEIGHT) / 2 }
+            : { bottom: height / 2 + bottom },
+        ]}
+      />
+    );
+  };
 
   const renderDefaultOptions = () => (
     <>
@@ -91,7 +112,7 @@ const AppbarExample = ({ navigation }: Props) => {
         <TextComponent>Left icon</TextComponent>
         <Switch value={showLeftIcon} onValueChange={setShowLeftIcon} />
       </View>
-      {!isV3 && (
+      {!theme.isV3 && (
         <View style={styles.row}>
           <TextComponent>Subtitle</TextComponent>
           <Switch value={showSubtitle} onValueChange={setShowSubtitle} />
@@ -105,7 +126,7 @@ const AppbarExample = ({ navigation }: Props) => {
         <TextComponent>More icon</TextComponent>
         <Switch value={showMoreIcon} onValueChange={setShowMoreIcon} />
       </View>
-      {isV3 && (
+      {theme.isV3 && (
         <View style={styles.row}>
           <TextComponent>Calendar icon</TextComponent>
           <Switch
@@ -123,7 +144,7 @@ const AppbarExample = ({ navigation }: Props) => {
         <TextComponent>Exact Dark Theme</TextComponent>
         <Switch value={showExactTheme} onValueChange={setShowExactTheme} />
       </View>
-      {isV3 && (
+      {theme.isV3 && (
         <View style={styles.row}>
           <TextComponent>Elevated</TextComponent>
           <Switch value={showElevated} onValueChange={setShowElevated} />
@@ -138,14 +159,14 @@ const AppbarExample = ({ navigation }: Props) => {
         style={styles.container}
         contentContainerStyle={styles.contentContainer}
       >
-        {isV3 ? (
+        {theme.isV3 ? (
           <List.Section title="Default options">
             {renderDefaultOptions()}
           </List.Section>
         ) : (
           renderDefaultOptions()
         )}
-        {isV3 && (
+        {theme.isV3 && (
           <List.Section title="Appbar Modes">
             <RadioButton.Group
               value={appbarMode}
@@ -173,16 +194,28 @@ const AppbarExample = ({ navigation }: Props) => {
           </List.Section>
         )}
       </ScreenWrapper>
-      <Appbar
-        style={styles.bottom}
-        theme={{ mode: showExactTheme ? 'exact' : 'adaptive' }}
-      >
-        <Appbar.Action icon="archive" onPress={() => {}} />
-        <Appbar.Action icon="email" onPress={() => {}} />
-        <Appbar.Action icon="label" onPress={() => {}} />
-        <Appbar.Action icon="delete" onPress={() => {}} />
-      </Appbar>
-      <FAB icon="reply" onPress={() => {}} style={styles.fab} />
+      {
+        <Appbar
+          style={[
+            styles.bottom,
+            {
+              height: height + bottom,
+              backgroundColor: theme.isV3
+                ? theme.colors.elevation.level2
+                : theme.colors.primary,
+            },
+          ]}
+          safeAreaInsets={{ bottom, left, right }}
+          theme={{ mode: showExactTheme ? 'exact' : 'adaptive' }}
+        >
+          <Appbar.Action icon="archive" onPress={() => {}} />
+          <Appbar.Action icon="email" onPress={() => {}} />
+          <Appbar.Action icon="label" onPress={() => {}} />
+          <Appbar.Action icon="delete" onPress={() => {}} />
+          {renderFAB()}
+        </Appbar>
+      }
+      {!theme.isV3 && renderFAB()}
     </>
   );
 };
@@ -214,7 +247,6 @@ const styles = StyleSheet.create({
   fab: {
     position: 'absolute',
     right: 16,
-    bottom: 28,
   },
   customColor: {
     backgroundColor: yellowA200,

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -42,6 +42,16 @@ type Props = Partial<React.ComponentPropsWithRef<typeof View>> & {
    */
   elevated?: boolean;
   /**
+   * @supported Available in v5.x
+   * Safe area insets for the Appbar. This can be used to avoid elements like the navigation bar on Android and bottom safe area on iOS.
+   */
+  safeAreaInsets?: {
+    bottom?: number;
+    top?: number;
+    left?: number;
+    right?: number;
+  };
+  /**
    * @optional
    */
   theme: Theme;
@@ -53,44 +63,86 @@ type Props = Partial<React.ComponentPropsWithRef<typeof View>> & {
  * The top bar usually contains the screen title, controls such as navigation buttons, menu button etc.
  * The bottom bar usually provides access to a drawer and up to four actions.
  *
- * By default Appbar uses primary color as a background, in dark theme with `adaptive` mode it will use surface colour instead.
- * See [Dark Theme](https://callstack.github.io/react-native-paper/theming.html#dark-theme) for more informations
- *
  * <div class="screenshots">
  *   <img class="small" src="screenshots/appbar.png" />
  * </div>
  *
  * ## Usage
+ * ### Top bar
  * ```js
  * import * as React from 'react';
  * import { Appbar } from 'react-native-paper';
- * import { StyleSheet } from 'react-native';
  *
  * const MyComponent = () => (
- *  <Appbar style={styles.bottom}>
- *    <Appbar.Action
- *      icon="archive"
- *      onPress={() => console.log('Pressed archive')}
- *     />
- *     <Appbar.Action icon="mail" onPress={() => console.log('Pressed mail')} />
- *     <Appbar.Action icon="label" onPress={() => console.log('Pressed label')} />
- *     <Appbar.Action
- *       icon="delete"
- *       onPress={() => console.log('Pressed delete')}
- *     />
- *   </Appbar>
- *  );
+ *   <Appbar.Header>
+ *     <Appbar.BackAction onPress={() => {}} />
+ *     <Appbar.Content title="Title" />
+ *     <Appbar.Action icon="calendar" onPress={() => {}} />
+ *     <Appbar.Action icon="magnify" onPress={() => {}} />
+ *   </Appbar.Header>
+ * );
  *
- * export default MyComponent
+ * export default MyComponent;
+ * ```
+ *
+ * ### Bottom bar
+ * ```js
+ * import * as React from 'react';
+ * import { StyleSheet } from 'react-native';
+ * import { Appbar, FAB, useTheme } from 'react-native-paper';
+ * import { useSafeAreaInsets } from 'react-native-safe-area-context';
+ *
+ * const BOTTOM_APPBAR_HEIGHT = 80;
+ * const MEDIUM_FAB_HEIGHT = 56;
+ *
+ * const MyComponent = () => {
+ *   const { bottom } = useSafeAreaInsets();
+ *   const theme = useTheme();
+ *
+ *   return (
+ *     <Appbar
+ *       style={[
+ *         styles.bottom,
+ *         {
+ *           height: BOTTOM_APPBAR_HEIGHT + bottom,
+ *           backgroundColor: theme.colors.elevation.level2,
+ *         },
+ *       ]}
+ *       safeAreaInsets={{ bottom }}
+ *     >
+ *       <Appbar.Action icon="archive" onPress={() => {}} />
+ *       <Appbar.Action icon="email" onPress={() => {}} />
+ *       <Appbar.Action icon="label" onPress={() => {}} />
+ *       <Appbar.Action icon="delete" onPress={() => {}} />
+ *       <FAB
+ *         mode="flat"
+ *         size="medium"
+ *         icon="plus"
+ *         onPress={() => {}}
+ *         style={[
+ *           styles.fab,
+ *           { top: (BOTTOM_APPBAR_HEIGHT - MEDIUM_FAB_HEIGHT) / 2 },
+ *         ]}
+ *       />
+ *     </Appbar>
+ *   );
+ * };
  *
  * const styles = StyleSheet.create({
  *   bottom: {
+ *     backgroundColor: 'aquamarine',
  *     position: 'absolute',
  *     left: 0,
  *     right: 0,
  *     bottom: 0,
  *   },
+ *   fab: {
+ *     position: 'absolute',
+ *     right: 16,
+ *   },
  * });
+ *
+ * export default MyComponent;
  * ```
  */
 const Appbar = ({
@@ -100,6 +152,7 @@ const Appbar = ({
   theme,
   mode = 'small',
   elevated,
+  safeAreaInsets,
   ...rest
 }: Props) => {
   const { isV3 } = theme;
@@ -174,6 +227,13 @@ const Appbar = ({
 
   const spacingStyle = isV3 ? styles.v3Spacing : styles.spacing;
 
+  const insets = {
+    paddingBottom: safeAreaInsets?.bottom,
+    paddingTop: safeAreaInsets?.top,
+    paddingLeft: safeAreaInsets?.left,
+    paddingRight: safeAreaInsets?.right,
+  };
+
   return (
     <Surface
       style={[
@@ -182,6 +242,7 @@ const Appbar = ({
         {
           height: isV3 ? modeAppbarHeight[mode] : DEFAULT_APPBAR_HEIGHT,
         },
+        insets,
         restStyle,
         !theme.isV3 && { elevation },
       ]}

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
@@ -43,7 +43,11 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
           "backgroundColor": "rgba(255, 251, 254, 1)",
           "flexDirection": "row",
           "height": 64,
+          "paddingBottom": undefined,
           "paddingHorizontal": 4,
+          "paddingLeft": undefined,
+          "paddingRight": undefined,
+          "paddingTop": undefined,
         }
       }
     >
@@ -390,7 +394,11 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
           "backgroundColor": "rgba(255, 251, 254, 1)",
           "flexDirection": "row",
           "height": 64,
+          "paddingBottom": undefined,
           "paddingHorizontal": 4,
+          "paddingLeft": undefined,
+          "paddingRight": undefined,
+          "paddingTop": undefined,
         }
       }
     >


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/3231

### Summary

PR introduces `safeAreaInsets` prop to the `Appbar` component to make it easier for users to build the `BottomBar`, formed on the `Appbar` components. 
According to that, the documentation received new examples indicating how to build the top and bottom bars.

<img width="1920" alt="image" src="https://user-images.githubusercontent.com/22746080/183394976-27689011-2f31-4cb1-989a-097288ee3773.png">


* MD3

ios | android
--- | ---
<img width="525" alt="Zrzut ekranu 2022-08-8 o 12 05 51" src="https://user-images.githubusercontent.com/22746080/183393870-73d959f4-7452-44de-ab0b-8a0c96a81131.png"> | <img width="468" alt="Zrzut ekranu 2022-08-8 o 12 05 54" src="https://user-images.githubusercontent.com/22746080/183393948-e8e3dd32-9e2b-4a0f-a86b-3d300b0d0830.png">


* MD2

ios | android
--- | ---
<img width="525" alt="Zrzut ekranu 2022-08-8 o 12 05 37" src="https://user-images.githubusercontent.com/22746080/183394106-4a37eb89-ab78-43bf-a6f9-c7e313654726.png"> | <img width="468" alt="Zrzut ekranu 2022-08-8 o 12 05 39" src="https://user-images.githubusercontent.com/22746080/183394120-c68f2dec-15d2-4dcb-9839-7ce97b56c6b8.png">




<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

- [ ] - add test for handling `safeAreaInsets`

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
