### PR TITLE
removing incorrect onPress params type

### DIFF
--- a/src/components/RadioButton/RadioButtonAndroid.tsx
+++ b/src/components/RadioButton/RadioButtonAndroid.tsx
@@ -24,7 +24,7 @@ export type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * Function to execute on press.
    */
-  onPress?: (param?: any) => void;
+  onPress?: () => void;
   /**
    * Custom color for unchecked radio.
    */


### PR DESCRIPTION
### Summary
The type for onPress was incorrect for Android (default) Radio button

### Test plan
Fixed warning in TS
