### PR TITLE
refactor: rename TextInputIcon prop from name to icon

### DIFF
--- a/docs/pages/10.migration-guide-to-5.0.md
+++ b/docs/pages/10.migration-guide-to-5.0.md
@@ -491,6 +491,15 @@ Previously `elevation` was passed inside the `style` prop. Since it supported no
 + <Surface elevation={1} />
 ```
 
+## TextInput.Icon
+
+The property `name` was renamed to `icon`, since the scope and type of that prop is much wider than just the icon name – it accepts also the function which receives an object with color and size properties and 
+
+```diff
+- <TextInput.Icon name="magnify" />
++ <TextInput.Icon icon="magnify" />
+```
+
 ## Credits
 
 <i>With this, that’s a wrap.</i>

--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -150,7 +150,7 @@ const TextInputExample = () => {
             onChangeText={(text) => inputActionHandler('text', text)}
             left={
               <TextInput.Icon
-                name="magnify"
+                icon="magnify"
                 color={flatLeftIcon}
                 onPress={() => {
                   changeIconColor('flatLeftIcon');
@@ -168,7 +168,7 @@ const TextInputExample = () => {
             right={<TextInput.Affix text="/100" />}
             left={
               <TextInput.Icon
-                name={() => (
+                icon={() => (
                   <Icon
                     name="home"
                     size={24}
@@ -192,7 +192,7 @@ const TextInputExample = () => {
             left={<TextInput.Affix text="#" />}
             right={
               <TextInput.Icon
-                name="magnify"
+                icon="magnify"
                 color={flatRightIcon}
                 onPress={() => {
                   changeIconColor('flatRightIcon');
@@ -211,7 +211,7 @@ const TextInputExample = () => {
             secureTextEntry={flatTextSecureEntry}
             right={
               <TextInput.Icon
-                name={flatTextSecureEntry ? 'eye' : 'eye-off'}
+                icon={flatTextSecureEntry ? 'eye' : 'eye-off'}
                 onPress={() =>
                   dispatch({
                     type: 'flatTextSecureEntry',
@@ -235,7 +235,7 @@ const TextInputExample = () => {
             }
             left={
               <TextInput.Icon
-                name="magnify"
+                icon="magnify"
                 color={outlineLeftIcon}
                 onPress={() => {
                   changeIconColor('outlineLeftIcon');
@@ -256,7 +256,7 @@ const TextInputExample = () => {
             left={<TextInput.Affix text="$" />}
             right={
               <TextInput.Icon
-                name="magnify"
+                icon="magnify"
                 color={outlineRightIcon}
                 onPress={() => {
                   changeIconColor('outlineRightIcon');
@@ -276,7 +276,7 @@ const TextInputExample = () => {
             secureTextEntry={outlineTextSecureEntry}
             right={
               <TextInput.Icon
-                name={outlineTextSecureEntry ? 'eye' : 'eye-off'}
+                icon={outlineTextSecureEntry ? 'eye' : 'eye-off'}
                 onPress={() =>
                   dispatch({
                     type: 'outlineTextSecureEntry',
@@ -326,7 +326,7 @@ const TextInputExample = () => {
             left={<TextInput.Affix text="#" />}
             right={
               <TextInput.Icon
-                name="chevron-up"
+                icon="chevron-up"
                 color={(focused) =>
                   focused ? theme.colors?.primary : undefined
                 }

--- a/src/components/TextInput/Adornment/TextInputIcon.tsx
+++ b/src/components/TextInput/Adornment/TextInputIcon.tsx
@@ -13,9 +13,10 @@ export type Props = $Omit<
   'icon' | 'theme' | 'color'
 > & {
   /**
+   * @renamed Renamed from 'name' to 'icon` in v5.x
    * Icon to show.
    */
-  name: IconSource;
+  icon: IconSource;
   /**
    * Function to execute on press.
    */
@@ -92,7 +93,7 @@ const IconAdornment: React.FunctionComponent<
  *     <TextInput
  *       label="Password"
  *       secureTextEntry
- *       right={<TextInput.Icon name="eye" />}
+ *       right={<TextInput.Icon icon="eye" />}
  *     />
  *   );
  * };
@@ -102,7 +103,7 @@ const IconAdornment: React.FunctionComponent<
  */
 
 const TextInputIcon = ({
-  name,
+  icon,
   onPress,
   forceTextInputFocus,
   color,
@@ -134,7 +135,7 @@ const TextInputIcon = ({
   return (
     <View style={[styles.container, style]}>
       <IconButton
-        icon={name}
+        icon={icon}
         style={styles.iconButton}
         size={ICON_SIZE}
         onPress={onPressWithFocusControl}

--- a/src/components/__tests__/TextInput.test.js
+++ b/src/components/__tests__/TextInput.test.js
@@ -33,7 +33,7 @@ it('correctly renders left-side icon adornment, and right-side affix adornment',
       onChangeText={(text) => this.setState({ text })}
       left={
         <TextInput.Icon
-          name="heart"
+          icon="heart"
           onPress={() => {
             console.log('!@# press left');
           }}
@@ -62,7 +62,7 @@ it('correctly renders left-side icon adornment, and right-side affix adornment '
       }
       right={
         <TextInput.Icon
-          name="heart"
+          icon="heart"
           onPress={() => {
             console.log('!@# press left');
           }}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/3258

### Summary

Renamed `TextInput.Icon` prop `name` to `icon` since the name is inappropriate - it accepts not only the icon name but also the function.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Updated tests. 
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
