### PR TITLE
feat: add icon prop in RadioButton.IOS

### DIFF
--- a/example/src/Examples/RadioButtonExample.tsx
+++ b/example/src/Examples/RadioButtonExample.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-native-paper';
 import ScreenWrapper from '../ScreenWrapper';
 
-type State = 'normal' | 'normal-ios' | 'normal-item' | 'custom';
+type State = 'normal' | 'normal-ios' | 'normal-item' | 'custom' | 'custom-ios';
 
 const RadioButtonExample = () => {
   const [checked, setChecked] = React.useState<State>('normal');
@@ -50,6 +50,19 @@ const RadioButtonExample = () => {
               value="custom"
               color={isV3 ? MD3Colors.error70 : MD2Colors.blue500}
               status={checked === 'custom' ? 'checked' : 'unchecked'}
+            />
+          </View>
+        </View>
+      </TouchableRipple>
+      <TouchableRipple onPress={() => setChecked('custom-ios')}>
+        <View style={styles.row}>
+          <TextComponent>Custom 2 - IOS (Icon)</TextComponent>
+          <View pointerEvents="none">
+            <RadioButton.IOS
+              value="custom-ios"
+              color={isV3 ? MD3Colors.error70 : MD2Colors.blue500}
+              status={checked === 'custom-ios' ? 'checked' : 'unchecked'}
+              icon="check-underline-circle"
             />
           </View>
         </View>

--- a/src/components/RadioButton/RadioButtonIOS.tsx
+++ b/src/components/RadioButton/RadioButtonIOS.tsx
@@ -30,6 +30,10 @@ export type Props = $RemoveChildren<typeof TouchableRipple> & {
    */
   color?: string;
   /**
+   * Custom icon to display for the checked radio button.
+   */
+  icon?: string;
+  /**
    * @optional
    */
   theme: Theme;
@@ -61,6 +65,7 @@ const RadioButtonIOS = ({
   theme,
   status,
   value,
+  icon = 'check',
   testID,
   ...rest
 }: Props) => {
@@ -105,7 +110,7 @@ const RadioButtonIOS = ({
             <View style={{ opacity: checked ? 1 : 0 }}>
               <MaterialCommunityIcon
                 allowFontScaling={false}
-                name="check"
+                name={icon}
                 size={24}
                 color={checkedColor}
                 direction="ltr"

--- a/src/components/__tests__/RadioButton/RadioButtonItem.test.js
+++ b/src/components/__tests__/RadioButton/RadioButtonItem.test.js
@@ -26,6 +26,7 @@ it('can render the iOS radio button on different platforms', () => {
         label="iOS Radio button"
         mode="ios"
         value="ios"
+        icon="check-outline"
       />
     )
     .toJSON();


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Add `icon` property to the `RadioButton.IOS` component to display a custom icon whether it's checked.

```javascript
<RadioButton.IOS
  value="custom-ios"
  color={isV3 ? MD3Colors.error70 : MD2Colors.blue500}
  status={checked === 'custom-ios' ? 'checked' : 'unchecked'}
  icon="check-underline-circle"
/>
```

<table><tr><td>
<img src="https://user-images.githubusercontent.com/8459537/184917431-bb41e5c3-54aa-4d0b-99a0-17200f6f26e2.png">
</td><td>
<img src="https://user-images.githubusercontent.com/8459537/184917504-b42a5542-927d-4056-9693-cbfe12083ee5.png">
</td></tr></table>

### Test plan

Adapted existing test case with new property.
