### PR TITLE
fix: fixed onLongPress not working on touchableRipple

### DIFF
--- a/src/components/TouchableRipple/TouchableRipple.native.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.native.tsx
@@ -40,7 +40,7 @@ const TouchableRipple = ({
   theme,
   ...rest
 }: Props) => {
-  const disabled = disabledProp || !rest.onPress;
+  const disabled = disabledProp || (!rest.onPress && !rest.onLongPress);
   const { calculatedRippleColor, calculatedUnderlayColor } =
     getTouchableRippleColors({
       theme,

--- a/src/components/TouchableRipple/TouchableRipple.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.tsx
@@ -229,7 +229,7 @@ const TouchableRipple = ({
     });
   };
 
-  const disabled = disabledProp || !rest.onPress;
+  const disabled = disabledProp || (!rest.onPress && !rest.onLongPress);
 
   return (
     <TouchableWithoutFeedback


### PR DESCRIPTION
### Summary
if we don't pass the `onPress` props then `onLongPress` was also not working in the `TouchableRipple` component.

Fixes: #3303 

### Test plan
I checked it by running the `yarn run test`, this change is simple and does not affect any files.
