### PR TITLE
fix: correct padding offset in TextInput on Android when RTL

### DIFF
--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -252,7 +252,12 @@ const TextInputFlat = ({
     labelScale,
     wiggleOffsetX: LABEL_WIGGLE_X_OFFSET,
     topPosition,
-    paddingOffset: { paddingLeft, paddingRight },
+    paddingOffset: isAndroid
+      ? {
+          paddingLeft: I18nManager.isRTL ? paddingRight : paddingLeft,
+          paddingRight: I18nManager.isRTL ? paddingLeft : paddingRight,
+        }
+      : { paddingRight, paddingLeft },
     hasActiveOutline,
     activeColor,
     placeholderColor,

--- a/src/components/__tests__/TextInput.test.js
+++ b/src/components/__tests__/TextInput.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import color from 'color';
-import { StyleSheet, Text, Platform } from 'react-native';
+import { StyleSheet, Text, Platform, I18nManager } from 'react-native';
 import { fireEvent, render } from '@testing-library/react-native';
 import TextInput from '../TextInput/TextInput';
 import { red500 } from '../../styles/themes/v2/colors';
@@ -216,6 +216,55 @@ it('renders input placeholder initially with an empty space character', () => {
   );
 
   expect(getByTestId('text-input-flat').props.placeholder).toBe(' ');
+});
+
+it('correctly applies padding offset to input label on Android when RTL', () => {
+  Platform.OS = 'android';
+  I18nManager.isRTL = true;
+
+  const { getByTestId } = render(
+    <TextInput
+      label="Flat input"
+      mode="flat"
+      testID="text-input-flat"
+      left={
+        <TextInput.Affix text={affixTextValue} textStyle={style.inputStyle} />
+      }
+      right={
+        <TextInput.Affix text={affixTextValue} textStyle={style.inputStyle} />
+      }
+    />
+  );
+
+  expect(getByTestId('text-input-flat-label-active')).toHaveStyle({
+    paddingLeft: 56,
+    paddingRight: 16,
+  });
+
+  I18nManager.isRTL = false;
+});
+
+it('correctly applies padding offset to input label on Android when LTR', () => {
+  Platform.OS = 'android';
+
+  const { getByTestId } = render(
+    <TextInput
+      label="Flat input"
+      mode="flat"
+      testID="text-input-flat"
+      left={
+        <TextInput.Affix text={affixTextValue} textStyle={style.inputStyle} />
+      }
+      right={
+        <TextInput.Affix text={affixTextValue} textStyle={style.inputStyle} />
+      }
+    />
+  );
+
+  expect(getByTestId('text-input-flat-label-active')).toHaveStyle({
+    paddingLeft: 16,
+    paddingRight: 56,
+  });
 });
 
 describe('maxFontSizeMultiplier', () => {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes: https://github.com/callstack/react-native-paper/issues/3132

PR corrects padding passed to the `InputLabel` within `TextInput` on Android in the RTL mode.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

before | after
--- | ---
<img width="423" alt="Zrzut ekranu 2022-08-22 o 14 29 16" src="https://user-images.githubusercontent.com/22746080/185922355-d4d89e1e-2bd9-4ea5-b9f9-a37de0fe2706.png"> | <img width="467" alt="Zrzut ekranu 2022-08-22 o 14 28 15" src="https://user-images.githubusercontent.com/22746080/185922365-c46b2a32-504d-4ba9-9698-db94f177727c.png">


### Test plan

Added tests.


<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
