### PR TITLE
docs: Fix link to DefaultTheme.tsx in "getting started"

### DIFF
--- a/docs/pages/1.getting-started.md
+++ b/docs/pages/1.getting-started.md
@@ -119,7 +119,7 @@ export default function Main() {
 
 ## Customization
 
-You can provide a custom theme to customize the colors, fonts etc. with the `Provider` component. Check the [default theme](https://github.com/callstack/react-native-paper/blob/main/src/styles/DefaultTheme.tsx) to see what customization options are supported.
+You can provide a custom theme to customize the colors, fonts etc. with the `Provider` component. Check the [default theme](https://github.com/callstack/react-native-paper/blob/4.0/src/styles/DefaultTheme.tsx) to see what customization options are supported.
 
 Example:
 


### PR DESCRIPTION


### Summary
DefaultTheme.tsx doesn't exist in the main branch, link should stick to the 4.0 branch

### Test plan
Go to "Getting started" docs page, link should now work

