### PR TITLE
fix: adjust avatar text line height to font scale

### DIFF
--- a/src/components/Avatar/AvatarText.tsx
+++ b/src/components/Avatar/AvatarText.tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   StyleProp,
   TextStyle,
+  useWindowDimensions,
 } from 'react-native';
 import Text from '../Typography/Text';
 import { withTheme } from '../../core/theming';
@@ -74,6 +75,7 @@ const AvatarText = ({
   const textColor =
     customColor ??
     getContrastingColor(backgroundColor, white, 'rgba(0, 0, 0, .54)');
+  const { fontScale } = useWindowDimensions();
 
   return (
     <View
@@ -95,7 +97,7 @@ const AvatarText = ({
           {
             color: textColor,
             fontSize: size / 2,
-            lineHeight: size,
+            lineHeight: size / fontScale,
           },
           labelStyle,
         ]}

--- a/src/components/__tests__/__snapshots__/Avatar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Avatar.test.js.snap
@@ -147,7 +147,7 @@ exports[`renders avatar with text 1`] = `
           Object {
             "color": "#ffffff",
             "fontSize": 32,
-            "lineHeight": 64,
+            "lineHeight": 32,
           },
           undefined,
         ],
@@ -195,7 +195,7 @@ exports[`renders avatar with text and custom background color 1`] = `
           Object {
             "color": "#ffffff",
             "fontSize": 32,
-            "lineHeight": 64,
+            "lineHeight": 32,
           },
           undefined,
         ],
@@ -243,7 +243,7 @@ exports[`renders avatar with text and custom colors 1`] = `
           Object {
             "color": "#FFFFFF",
             "fontSize": 32,
-            "lineHeight": 64,
+            "lineHeight": 32,
           },
           undefined,
         ],
@@ -291,7 +291,7 @@ exports[`renders avatar with text and custom size 1`] = `
           Object {
             "color": "#ffffff",
             "fontSize": 48,
-            "lineHeight": 96,
+            "lineHeight": 48,
           },
           undefined,
         ],


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Similarly to #3264 , this PR adjusts the `Avatar.Text` component's text line height to the font scale. Fixes the following bug in `Avatar.Text`:

<img width="237" alt="Screen Shot 2022-08-29 at 7 34 51 AM" src="https://user-images.githubusercontent.com/99039683/187226454-4ded845f-5f5c-47ab-bcc3-bf67bb4e765b.png">

### Test plan

Updated test snapshots.
