### PR TITLE
refactor: replace I18nManager.isRTL with 18nManager.getConstants().isRTL

### DIFF
--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -53,7 +53,9 @@ export default function PaperExample() {
 
   const [isDarkMode, setIsDarkMode] = React.useState(false);
   const [themeVersion, setThemeVersion] = React.useState<2 | 3>(3);
-  const [rtl, setRtl] = React.useState<boolean>(I18nManager.isRTL);
+  const [rtl, setRtl] = React.useState<boolean>(
+    I18nManager.getConstants().isRTL
+  );
   const [collapsed, setCollapsed] = React.useState(false);
 
   const themeMode = isDarkMode ? 'dark' : 'light';
@@ -123,7 +125,7 @@ export default function PaperExample() {
         // ignore error
       }
 
-      if (I18nManager.isRTL !== rtl) {
+      if (I18nManager.getConstants().isRTL !== rtl) {
         I18nManager.forceRTL(rtl);
         if (!isWeb) {
           Updates.reloadAsync();

--- a/src/components/Appbar/AppbarBackIcon.tsx
+++ b/src/components/Appbar/AppbarBackIcon.tsx
@@ -12,7 +12,7 @@ const AppbarBackIcon = ({ size, color }: { size: number; color: string }) => {
         {
           width: size,
           height: size,
-          transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
+          transform: [{ scaleX: I18nManager.getConstants().isRTL ? -1 : 1 }],
         },
       ]}
     >
@@ -29,7 +29,7 @@ const AppbarBackIcon = ({ size, color }: { size: number; color: string }) => {
       name="arrow-left"
       color={color}
       size={size}
-      direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
+      direction={I18nManager.getConstants().isRTL ? 'rtl' : 'ltr'}
     />
   );
 };

--- a/src/components/DataTable/DataTablePagination.tsx
+++ b/src/components/DataTable/DataTablePagination.tsx
@@ -94,7 +94,7 @@ const PaginationControls = ({
               name="page-first"
               color={color}
               size={size}
-              direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
+              direction={I18nManager.getConstants().isRTL ? 'rtl' : 'ltr'}
             />
           )}
           iconColor={textColor}
@@ -109,7 +109,7 @@ const PaginationControls = ({
             name="chevron-left"
             color={color}
             size={size}
-            direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
+            direction={I18nManager.getConstants().isRTL ? 'rtl' : 'ltr'}
           />
         )}
         iconColor={textColor}
@@ -123,7 +123,7 @@ const PaginationControls = ({
             name="chevron-right"
             color={color}
             size={size}
-            direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
+            direction={I18nManager.getConstants().isRTL ? 'rtl' : 'ltr'}
           />
         )}
         iconColor={textColor}
@@ -138,7 +138,7 @@ const PaginationControls = ({
               name="page-last"
               color={color}
               size={size}
-              direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
+              direction={I18nManager.getConstants().isRTL ? 'rtl' : 'ltr'}
             />
           )}
           iconColor={textColor}

--- a/src/components/DataTable/DataTableTitle.tsx
+++ b/src/components/DataTable/DataTableTitle.tsx
@@ -120,7 +120,7 @@ const DataTableTitle = ({
         name="arrow-up"
         size={16}
         color={textColor}
-        direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
+        direction={I18nManager.getConstants().isRTL ? 'rtl' : 'ltr'}
       />
     </Animated.View>
   ) : null;
@@ -138,7 +138,7 @@ const DataTableTitle = ({
             // if numberOfLines causes wrap, center is lost. Align directly, sensitive to numeric and RTL
             numberOfLines > 1
               ? numeric
-                ? I18nManager.isRTL
+                ? I18nManager.getConstants().isRTL
                   ? styles.leftText
                   : styles.rightText
                 : styles.centerText

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -70,7 +70,7 @@ const Icon = ({ source, color, size, theme, ...rest }: Props) => {
   const direction =
     typeof source === 'object' && source.direction && source.source
       ? source.direction === 'auto'
-        ? I18nManager.isRTL
+        ? I18nManager.getConstants().isRTL
           ? 'rtl'
           : 'ltr'
         : source.direction

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -251,7 +251,7 @@ const ListAccordion = ({
                   name={isExpanded ? 'chevron-up' : 'chevron-down'}
                   color={theme.isV3 ? descriptionColor : titleColor}
                   size={24}
-                  direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
+                  direction={I18nManager.getConstants().isRTL ? 'rtl' : 'ltr'}
                 />
               )}
             </View>

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -537,7 +537,7 @@ class Menu extends React.Component<Props, State> {
 
     const positionStyle = {
       top: this.isCoordinate(anchor) ? top : top + additionalVerticalValue,
-      ...(I18nManager.isRTL ? { right: left } : { left }),
+      ...(I18nManager.getConstants().isRTL ? { right: left } : { left }),
     };
 
     return (

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -202,7 +202,7 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
                 name="magnify"
                 color={color}
                 size={size}
-                direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
+                direction={I18nManager.getConstants().isRTL ? 'rtl' : 'ltr'}
               />
             ))
           }
@@ -259,7 +259,7 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
                     name="close"
                     color={color}
                     size={size}
-                    direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
+                    direction={I18nManager.getConstants().isRTL ? 'rtl' : 'ltr'}
                   />
                 ))
               }
@@ -282,7 +282,7 @@ const styles = StyleSheet.create({
     fontSize: 18,
     paddingLeft: 8,
     alignSelf: 'stretch',
-    textAlign: I18nManager.isRTL ? 'right' : 'left',
+    textAlign: I18nManager.getConstants().isRTL ? 'right' : 'left',
     minWidth: 0,
   },
   elevation: {

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -159,9 +159,11 @@ const TextInputFlat = ({
   const labelHalfHeight = labelHeight / 2;
 
   const baseLabelTranslateX =
-    (I18nManager.isRTL ? 1 : -1) *
+    (I18nManager.getConstants().isRTL ? 1 : -1) *
       (labelHalfWidth - (labelScale * labelWidth) / 2) +
-    (1 - labelScale) * (I18nManager.isRTL ? -1 : 1) * paddingLeft;
+    (1 - labelScale) *
+      (I18nManager.getConstants().isRTL ? -1 : 1) *
+      paddingLeft;
 
   const minInputHeight = dense
     ? (label ? MIN_DENSE_HEIGHT_WL : MIN_DENSE_HEIGHT) - LABEL_PADDING_TOP_DENSE
@@ -363,7 +365,7 @@ const TextInputFlat = ({
               textAlignVertical: multiline ? 'top' : 'center',
               textAlign: textAlign
                 ? textAlign
-                : I18nManager.isRTL
+                : I18nManager.getConstants().isRTL
                 ? 'right'
                 : 'left',
             },

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -113,7 +113,7 @@ const TextInputOutlined = ({
   const labelHalfHeight = labelHeight / 2;
 
   const baseLabelTranslateX =
-    (I18nManager.isRTL ? 1 : -1) *
+    (I18nManager.getConstants().isRTL ? 1 : -1) *
     (labelHalfWidth -
       (labelScale * labelWidth) / 2 -
       (fontSize - MINIMIZED_LABEL_FONT_SIZE) * labelScale);
@@ -125,7 +125,7 @@ const TextInputOutlined = ({
   );
   if (isAdornmentLeftIcon) {
     labelTranslationXOffset =
-      (I18nManager.isRTL ? -1 : 1) *
+      (I18nManager.getConstants().isRTL ? -1 : 1) *
       (ADORNMENT_SIZE + ADORNMENT_OFFSET - (isV3 ? 0 : 8));
   }
 
@@ -336,7 +336,7 @@ const TextInputOutlined = ({
                 textAlignVertical: multiline ? 'top' : 'center',
                 textAlign: textAlign
                   ? textAlign
-                  : I18nManager.isRTL
+                  : I18nManager.getConstants().isRTL
                   ? 'right'
                   : 'left',
                 paddingHorizontal: INPUT_PADDING_HORIZONTAL,

--- a/src/components/Typography/AnimatedText.tsx
+++ b/src/components/Typography/AnimatedText.tsx
@@ -39,7 +39,7 @@ type Props = React.ComponentPropsWithRef<typeof Animated.Text> & {
  * @extends Text props https://reactnative.dev/docs/text#props
  */
 function AnimatedText({ style, theme, variant, ...rest }: Props) {
-  const writingDirection = I18nManager.isRTL ? 'rtl' : 'ltr';
+  const writingDirection = I18nManager.getConstants().isRTL ? 'rtl' : 'ltr';
 
   if (theme.isV3 && variant) {
     const stylesByVariant = Object.keys(MD3TypescaleKey).reduce(

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -84,7 +84,7 @@ const Text: React.ForwardRefRenderFunction<{}, Props> = (
   const root = React.useRef<NativeText | null>(null);
   // FIXME: destructure it in TS 4.6+
   const theme = useTheme(initialTheme);
-  const writingDirection = I18nManager.isRTL ? 'rtl' : 'ltr';
+  const writingDirection = I18nManager.getConstants().isRTL ? 'rtl' : 'ltr';
 
   React.useImperativeHandle(ref, () => ({
     setNativeProps: (args: Object) => root.current?.setNativeProps(args),

--- a/src/components/Typography/v2/StyledText.tsx
+++ b/src/components/Typography/v2/StyledText.tsx
@@ -20,7 +20,7 @@ const StyledText = ({ alpha = 1, family, style, ...rest }: Props) => {
     .alpha(alpha)
     .rgb()
     .string();
-  const writingDirection = I18nManager.isRTL ? 'rtl' : 'ltr';
+  const writingDirection = I18nManager.getConstants().isRTL ? 'rtl' : 'ltr';
 
   return (
     <Text


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

PR introduces migration to use `getConstants` from `I18nManager` since `react-native-web`removed `I18nManager.isRTL`

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

CI should pass.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
