### PR TITLE
fix: allow styling fab-group action label, renamings

### DIFF
--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -26,6 +26,7 @@ export type Props = {
    * - `color`: custom icon color of the action item
    * - `labelTextColor`: custom label text color of the action item
    * - `accessibilityLabel`: accessibility label for the action, uses label by default if specified
+   * - `accessibilityHint`: accessibility hint for the action
    * - `style`: pass additional styles for the fab item, for example, `backgroundColor`
    * - `containerStyle`: pass additional styles for the fab item label container, for example, `backgroundColor`
    * - `labelStyle`: pass additional styles for the fab item label, for example, `fontSize`

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -39,6 +39,7 @@ export type Props = {
     color?: string;
     labelTextColor?: string;
     accessibilityLabel?: string;
+    accessibilityHint?: string;
     style?: StyleProp<ViewStyle>;
     containerStyle?: StyleProp<ViewStyle>;
     labelStyle?: StyleProp<TextStyle>;
@@ -323,6 +324,7 @@ const FABGroup = ({
               {it.label && (
                 <View>
                   <Card
+                    accessibilityHint={it.accessibilityHint}
                     style={
                       [
                         styles.containerStyle,
@@ -347,7 +349,6 @@ const FABGroup = ({
                         ? it.accessibilityLabel
                         : it.label
                     }
-                    accessibilityHint="hint"
                     accessibilityRole="button"
                     {...(isV3 && { elevation: 0 })}
                   >

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -347,6 +347,7 @@ const FABGroup = ({
                         ? it.accessibilityLabel
                         : it.label
                     }
+                    accessibilityHint="hint"
                     accessibilityRole="button"
                     {...(isV3 && { elevation: 0 })}
                   >

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -7,6 +7,7 @@ import {
   TouchableWithoutFeedback,
   View,
   ViewStyle,
+  TextStyle,
 } from 'react-native';
 import FAB from './FAB';
 import Text from '../Typography/Text';
@@ -26,7 +27,8 @@ export type Props = {
    * - `labelTextColor`: custom label text color of the action item
    * - `accessibilityLabel`: accessibility label for the action, uses label by default if specified
    * - `style`: pass additional styles for the fab item, for example, `backgroundColor`
-   * - `labelStyle`: pass additional styles for the fab item label, for example, `backgroundColor`
+   * - `containerStyle`: pass additional styles for the fab item label container, for example, `backgroundColor`
+   * - `labelStyle`: pass additional styles for the fab item label, for example, `fontSize`
    * - `onPress`: callback that is called when `FAB` is pressed (required)
    * - `size`: size of action item. Defaults to `small`. @supported Available in v5.x
    * - `testID`: testID to be used on tests
@@ -38,7 +40,8 @@ export type Props = {
     labelTextColor?: string;
     accessibilityLabel?: string;
     style?: StyleProp<ViewStyle>;
-    labelStyle?: StyleProp<ViewStyle>;
+    containerStyle?: StyleProp<ViewStyle>;
+    labelStyle?: StyleProp<TextStyle>;
     onPress: () => void;
     size?: 'small' | 'medium';
     testID?: string;
@@ -322,7 +325,7 @@ const FABGroup = ({
                   <Card
                     style={
                       [
-                        styles.label,
+                        styles.containerStyle,
                         {
                           transform: [
                             isV3
@@ -331,8 +334,8 @@ const FABGroup = ({
                           ],
                           opacity: opacities[i],
                         },
-                        isV3 && styles.v3LabelStyle,
-                        it.labelStyle,
+                        isV3 && styles.v3ContainerStyle,
+                        it.containerStyle,
                       ] as StyleProp<ViewStyle>
                     }
                     onPress={() => {
@@ -349,7 +352,10 @@ const FABGroup = ({
                   >
                     <Text
                       variant="titleMedium"
-                      style={{ color: it.labelTextColor ?? labelColor }}
+                      style={[
+                        { color: it.labelTextColor ?? labelColor },
+                        it.labelStyle,
+                      ]}
                     >
                       {it.label}
                     </Text>
@@ -432,7 +438,7 @@ const styles = StyleSheet.create({
   backdrop: {
     ...StyleSheet.absoluteFillObject,
   },
-  label: {
+  containerStyle: {
     borderRadius: 5,
     paddingHorizontal: 12,
     paddingVertical: 6,
@@ -446,7 +452,7 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
     alignItems: 'center',
   },
-  v3LabelStyle: {
+  v3ContainerStyle: {
     backgroundColor: 'transparent',
     elevation: 0,
   },

--- a/src/components/__tests__/FABGroup.test.js
+++ b/src/components/__tests__/FABGroup.test.js
@@ -1,6 +1,6 @@
 import color from 'color';
 import * as React from 'react';
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
 import { getTheme } from '../../core/theming';
 import { getFABGroupColors } from '../FAB/utils';
 import FAB from '../FAB';
@@ -99,45 +99,51 @@ describe('getFABGroupColors - stacked FAB background color', () => {
 });
 
 describe('FABActions - labelStyle - containerStyle', () => {
-  it('renders actions with custom label style', () => {
-    const tree = renderer
-      .create(
-        <FAB.Group
-          visible
-          open
-          icon="filter"
-          actions={[
-            {
-              label: 'test',
-              icon: 'arrow-up',
-              labelStyle: { fontSize: 24, fontWeight: '500' },
+  it('correctly applies label style', () => {
+    const { getByText } = render(
+      <FAB.Group
+        visible
+        open
+        actions={[
+          {
+            label: 'complete',
+            labelStyle: {
+              fontSize: 24,
+              fontWeight: '500',
             },
-          ]}
-        />
-      )
-      .toJSON();
+          },
+        ]}
+      />
+    );
 
-    expect(tree).toMatchSnapshot();
+    expect(getByText('complete')).toHaveStyle({
+      fontSize: 24,
+      fontWeight: '500',
+    });
   });
 
-  it('renders actions with custom container style', () => {
-    const tree = renderer
-      .create(
-        <FAB.Group
-          visible
-          open
-          icon="filter"
-          actions={[
-            {
-              label: 'test',
-              icon: 'arrow-up',
-              containerStyle: { padding: 16, backgroundColor: 'royalblue' },
+  it('correctly applies containerStyle style', () => {
+    const { getByA11yHint } = render(
+      <FAB.Group
+        visible
+        open
+        actions={[
+          {
+            label: 'remove',
+            containerStyle: {
+              padding: 16,
+              backgroundColor: '#687456',
+              marginLeft: 16,
             },
-          ]}
-        />
-      )
-      .toJSON();
+          },
+        ]}
+      />
+    );
 
-    expect(tree).toMatchSnapshot();
+    expect(getByA11yHint('hint')).toHaveStyle({
+      padding: 16,
+      backgroundColor: '#687456',
+      marginLeft: 16,
+    });
   });
 });

--- a/src/components/__tests__/FABGroup.test.js
+++ b/src/components/__tests__/FABGroup.test.js
@@ -130,6 +130,7 @@ describe('FABActions - labelStyle - containerStyle', () => {
         actions={[
           {
             label: 'remove',
+            accessibilityHint: 'hint',
             containerStyle: {
               padding: 16,
               backgroundColor: '#687456',

--- a/src/components/__tests__/FABGroup.test.js
+++ b/src/components/__tests__/FABGroup.test.js
@@ -1,6 +1,9 @@
 import color from 'color';
-import { getFABGroupColors } from '../FAB/utils';
+import * as React from 'react';
+import renderer from 'react-test-renderer';
 import { getTheme } from '../../core/theming';
+import { getFABGroupColors } from '../FAB/utils';
+import FAB from '../FAB';
 
 describe('getFABGroupColors - backdrop color', () => {
   it('should return custom color', () => {
@@ -92,5 +95,49 @@ describe('getFABGroupColors - stacked FAB background color', () => {
     ).toMatchObject({
       stackedFABBackgroundColor: getTheme(false, false).colors.surface,
     });
+  });
+});
+
+describe('FABActions - labelStyle - containerStyle', () => {
+  it('renders actions with custom label style', () => {
+    const tree = renderer
+      .create(
+        <FAB.Group
+          visible
+          open
+          icon="filter"
+          actions={[
+            {
+              label: 'test',
+              icon: 'arrow-up',
+              labelStyle: { fontSize: 24, fontWeight: '500' },
+            },
+          ]}
+        />
+      )
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders actions with custom container style', () => {
+    const tree = renderer
+      .create(
+        <FAB.Group
+          visible
+          open
+          icon="filter"
+          actions={[
+            {
+              label: 'test',
+              icon: 'arrow-up',
+              containerStyle: { padding: 16, backgroundColor: 'royalblue' },
+            },
+          ]}
+        />
+      )
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Initially `FabGroup` component did not have a `prop` for overriding styling in fab action label. Thus, there was no direct way to override the styling of fab action label. This pr adds `labelStyle` to `actions` prop as well as renaming the previously existing `labelStyle` to `containerStyle` as it might cause further confusion. `labelStyle` should stand for style for label rather than the card style.
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
