### PR TITLE
fix: unblock using custom color in AppbarAction

### DIFF
--- a/src/components/Appbar/utils.ts
+++ b/src/components/Appbar/utils.ts
@@ -102,13 +102,14 @@ export const renderAppbarContent = ({
           style?: StyleProp<ViewStyle>;
           mode?: AppbarModes;
         } = {
-          color: isV3
-            ? undefined
-            : typeof child.props.color !== 'undefined'
-            ? child.props.color
-            : isDark
-            ? white
-            : black,
+          color:
+            typeof child.props.color !== 'undefined'
+              ? child.props.color
+              : isV3
+              ? undefined
+              : isDark
+              ? white
+              : black,
         };
 
         if (child.type === AppbarContent) {

--- a/src/components/__tests__/Appbar/Appbar.test.js
+++ b/src/components/__tests__/Appbar/Appbar.test.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
+import { Platform } from 'react-native';
 import Menu from '../../Menu/Menu';
 import Appbar from '../../Appbar';
 import AppbarAction from '../../Appbar/AppbarAction';
@@ -11,7 +13,6 @@ import Searchbar from '../../Searchbar';
 import { tokens } from '../../../styles/themes/v3/tokens';
 import { getTheme } from '../../../core/theming';
 import overlay from '../../../styles/overlay';
-import { Platform } from 'react-native';
 
 describe('Appbar', () => {
   it('does not pass any additional props to Searchbar', () => {
@@ -185,6 +186,50 @@ describe('renderAppbarContent', () => {
     expect(renderResult(false, true)[1].props.style).toEqual(
       expect.arrayContaining([expect.objectContaining(v2Spacing)])
     );
+  });
+});
+
+describe('AppbarAction', () => {
+  it('should be rendered with default theme color', () => {
+    const { getByTestId } = render(
+      <Appbar>
+        <Appbar.Action icon="menu" testID="appbar-action" />
+      </Appbar>
+    );
+    const appbarActionIcon = getByTestId('appbar-action').props.children[0];
+    expect(appbarActionIcon.props.color).toBe(
+      getTheme().colors.onSurfaceVariant
+    );
+  });
+
+  it('should be rendered with specific theme color if is leading', () => {
+    const { getByTestId } = render(
+      <Appbar>
+        <Appbar.Action icon="menu" testID="appbar-action" isLeading />
+      </Appbar>
+    );
+    const appbarActionIcon = getByTestId('appbar-action').props.children[0];
+    expect(appbarActionIcon.props.color).toBe(getTheme().colors.onSurface);
+  });
+
+  it('should be rendered with custom color', () => {
+    const { getByTestId } = render(
+      <Appbar>
+        <Appbar.Action icon="menu" color="purple" testID="appbar-action" />
+      </Appbar>
+    );
+    const appbarActionIcon = getByTestId('appbar-action').props.children[0];
+    expect(appbarActionIcon.props.color).toBe('purple');
+  });
+
+  it('should render AppbarBackAction with custom color', () => {
+    const { getByTestId } = render(
+      <Appbar>
+        <Appbar.BackAction icon="menu" color="purple" testID="appbar-action" />
+      </Appbar>
+    );
+    const appbarBackActionIcon = getByTestId('appbar-action').props.children[0];
+    expect(appbarBackActionIcon.props.color).toBe('purple');
   });
 });
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/3368

### Summary

PR unblocks the possibility to customize `AppbarAction` color.

#### Light theme
ios | android
--- | ---
<img width="479" alt="Zrzut ekranu 2022-09-16 o 15 38 44" src="https://user-images.githubusercontent.com/22746080/190652435-2fbb934f-630c-4297-b45a-33fa3358b4c2.png"> | <img width="490" alt="Zrzut ekranu 2022-09-16 o 15 38 41" src="https://user-images.githubusercontent.com/22746080/190652462-b67d036d-6018-4f1c-b953-9f76e2436318.png">

#### Dark theme
ios | android
--- | ---
<img width="479" alt="Zrzut ekranu 2022-09-16 o 15 39 14" src="https://user-images.githubusercontent.com/22746080/190652534-1ef3dd1d-3e3e-4ad6-a6c7-8b814f5e675c.png"> | <img width="490" alt="Zrzut ekranu 2022-09-16 o 15 39 02" src="https://user-images.githubusercontent.com/22746080/190652569-0c11c972-ad7d-46b8-aecb-aceea5ed50ba.png">



<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Added unit tests.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
