### PR TITLE
fix: correct Searchbar clear icon

### DIFF
--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -9,6 +9,7 @@ import {
   ViewStyle,
   TextStyle,
   Animated,
+  View,
 } from 'react-native';
 
 import color from 'color';
@@ -60,10 +61,6 @@ export type Props = React.ComponentPropsWithRef<typeof TextInput> & {
   inputStyle?: StyleProp<TextStyle>;
   style?: StyleProp<ViewStyle>;
   /**
-   * @optional
-   */
-  theme: Theme;
-  /**
    * Custom color for icon, default will be derived from theme
    */
   iconColor?: string;
@@ -76,6 +73,14 @@ export type Props = React.ComponentPropsWithRef<typeof TextInput> & {
    * Custom flag for replacing clear button with activity indicator.
    */
   loading?: Boolean;
+  /**
+   * TestID used for testing purposes
+   */
+  testID?: string;
+  /**
+   * @optional
+   */
+  theme: Theme;
 };
 
 type TextInputHandles = Pick<
@@ -129,6 +134,7 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
       theme,
       value,
       loading = false,
+      testID = 'search-bar',
       ...rest
     }: Props,
     ref
@@ -223,6 +229,7 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
           accessibilityRole="search"
           ref={root}
           value={value}
+          testID={testID}
           {...rest}
         />
         {loading ? (
@@ -231,26 +238,34 @@ const Searchbar = React.forwardRef<TextInputHandles, Props>(
             style={styles.loader}
           />
         ) : (
-          <IconButton
-            borderless
-            disabled={!value}
-            accessibilityLabel={clearAccessibilityLabel}
-            iconColor={value ? iconColor : 'rgba(255, 255, 255, 0)'}
-            rippleColor={rippleColor}
-            onPress={handleClearPress}
-            icon={
-              clearIcon ||
-              (({ size, color }) => (
-                <MaterialCommunityIcon
-                  name="close"
-                  color={color}
-                  size={size}
-                  direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
-                />
-              ))
-            }
-            accessibilityRole="button"
-          />
+          // Clear icon should be always rendered within Searchbar – it's transparent,
+          // without touch events, when there is no value. It's done to avoid issues
+          // with the abruptly stopping ripple effect and changing bar width on web,
+          // when clearing the value.
+          <View
+            pointerEvents={value ? 'auto' : 'none'}
+            testID={`${testID}-icon-wrapper`}
+          >
+            <IconButton
+              borderless
+              accessibilityLabel={clearAccessibilityLabel}
+              iconColor={value ? iconColor : 'rgba(255, 255, 255, 0)'}
+              rippleColor={rippleColor}
+              onPress={handleClearPress}
+              icon={
+                clearIcon ||
+                (({ size, color }) => (
+                  <MaterialCommunityIcon
+                    name="close"
+                    color={color}
+                    size={size}
+                    direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
+                  />
+                ))
+              }
+              accessibilityRole="button"
+            />
+          </View>
         )}
       </Surface>
     );

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
@@ -230,32 +230,22 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                   undefined,
                 ]
               }
+              testID="search-bar"
               underlineColorAndroid="transparent"
             />
             <View
-              collapsable={false}
-              style={
-                Object {
-                  "alignSelf": undefined,
-                  "bottom": undefined,
-                  "left": undefined,
-                  "position": undefined,
-                  "right": undefined,
-                  "shadowColor": "#000",
-                  "shadowOffset": Object {
-                    "height": 0,
-                    "width": 0,
-                  },
-                  "shadowOpacity": 0,
-                  "shadowRadius": 0,
-                  "top": undefined,
-                }
-              }
+              pointerEvents="none"
+              testID="search-bar-icon-wrapper"
             >
               <View
                 collapsable={false}
                 style={
                   Object {
+                    "alignSelf": undefined,
+                    "bottom": undefined,
+                    "left": undefined,
+                    "position": undefined,
+                    "right": undefined,
                     "shadowColor": "#000",
                     "shadowOffset": Object {
                       "height": 0,
@@ -263,6 +253,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                     },
                     "shadowOpacity": 0,
                     "shadowRadius": 0,
+                    "top": undefined,
                   }
                 }
               >
@@ -270,75 +261,90 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "backgroundColor": undefined,
-                      "borderColor": "rgba(28, 27, 31, 0.12)",
-                      "borderRadius": 20,
-                      "borderWidth": 0,
-                      "elevation": 0,
-                      "height": 40,
-                      "margin": 6,
-                      "overflow": "hidden",
-                      "width": 40,
+                      "shadowColor": "#000",
+                      "shadowOffset": Object {
+                        "height": 0,
+                        "width": 0,
+                      },
+                      "shadowOpacity": 0,
+                      "shadowRadius": 0,
                     }
                   }
                 >
                   <View
-                    accessibilityLabel="clear"
-                    accessibilityRole="button"
-                    accessibilityState={
-                      Object {
-                        "disabled": true,
-                      }
-                    }
-                    accessible={true}
-                    focusable={true}
-                    hitSlop={
-                      Object {
-                        "bottom": 6,
-                        "left": 6,
-                        "right": 6,
-                        "top": 6,
-                      }
-                    }
-                    onClick={[Function]}
-                    onResponderGrant={[Function]}
-                    onResponderMove={[Function]}
-                    onResponderRelease={[Function]}
-                    onResponderTerminate={[Function]}
-                    onResponderTerminationRequest={[Function]}
-                    onStartShouldSetResponder={[Function]}
+                    collapsable={false}
                     style={
-                      Array [
-                        Object {
-                          "overflow": "hidden",
-                        },
-                        Object {
-                          "alignItems": "center",
-                          "flexGrow": 1,
-                          "justifyContent": "center",
-                        },
-                      ]
+                      Object {
+                        "backgroundColor": undefined,
+                        "borderColor": "rgba(121, 116, 126, 1)",
+                        "borderRadius": 20,
+                        "borderWidth": 0,
+                        "elevation": 0,
+                        "height": 40,
+                        "margin": 6,
+                        "overflow": "hidden",
+                        "width": 40,
+                      }
                     }
                   >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
+                    <View
+                      accessibilityLabel="clear"
+                      accessibilityRole="button"
+                      accessibilityState={
+                        Object {
+                          "disabled": false,
+                        }
+                      }
+                      accessible={true}
+                      focusable={true}
+                      hitSlop={
+                        Object {
+                          "bottom": 6,
+                          "left": 6,
+                          "right": 6,
+                          "top": 6,
+                        }
+                      }
+                      onClick={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
                       style={
                         Array [
                           Object {
-                            "backgroundColor": "transparent",
+                            "overflow": "hidden",
                           },
                           Object {
-                            "color": "rgba(28, 27, 31, 0.38)",
-                            "fontSize": 24,
+                            "alignItems": "center",
+                            "flexGrow": 1,
+                            "justifyContent": "center",
                           },
                         ]
                       }
                     >
-                      □
-                    </Text>
+                      <Text
+                        accessibilityElementsHidden={true}
+                        importantForAccessibility="no-hide-descendants"
+                        pointerEvents="none"
+                        selectable={false}
+                        style={
+                          Array [
+                            Object {
+                              "backgroundColor": "transparent",
+                            },
+                            Object {
+                              "color": "rgba(255, 255, 255, 0)",
+                              "fontSize": 24,
+                            },
+                          ]
+                        }
+                      >
+                        □
+                      </Text>
+                    </View>
                   </View>
                 </View>
               </View>

--- a/src/components/__tests__/Searchbar.test.js
+++ b/src/components/__tests__/Searchbar.test.js
@@ -30,7 +30,35 @@ it('renders with ActivityIndicator', () => {
 });
 
 it('renders without ActivityIndicator', () => {
-  const tree = render(<Searchbar loading={false} />);
+  const { getByTestId } = render(<Searchbar loading={false} />);
 
-  expect(() => tree.getByTestId('activity-indicator')).toThrow();
+  expect(() => getByTestId('activity-indicator')).toThrow();
+});
+
+it('renders clear icon with custom color', () => {
+  const { getByTestId } = render(
+    <Searchbar testID="search-bar" value="value" iconColor="purple" />
+  );
+
+  const iconComponent = getByTestId('search-bar-icon-wrapper').props.children;
+
+  expect(iconComponent.props.iconColor).toBe('purple');
+});
+
+it('renders clear icon wrapper, which can be the target of touch events, if search has value', () => {
+  const { getByTestId } = render(
+    <Searchbar testID="search-bar" value="value" />
+  );
+
+  expect(getByTestId('search-bar-icon-wrapper').props.pointerEvents).toBe(
+    'auto'
+  );
+});
+
+it('renders clear icon wrapper, which is never target of touch events, if search has no value', () => {
+  const { getByTestId } = render(<Searchbar testID="search-bar" value="" />);
+
+  expect(getByTestId('search-bar-icon-wrapper').props.pointerEvents).toBe(
+    'none'
+  );
 });

--- a/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
@@ -180,6 +180,7 @@ exports[`activity indicator snapshot test 1`] = `
             undefined,
           ]
         }
+        testID="search-bar"
         underlineColorAndroid="transparent"
       />
       <View
@@ -565,32 +566,22 @@ exports[`renders with placeholder 1`] = `
             undefined,
           ]
         }
+        testID="search-bar"
         underlineColorAndroid="transparent"
       />
       <View
-        collapsable={false}
-        style={
-          Object {
-            "alignSelf": undefined,
-            "bottom": undefined,
-            "left": undefined,
-            "position": undefined,
-            "right": undefined,
-            "shadowColor": "#000",
-            "shadowOffset": Object {
-              "height": 0,
-              "width": 0,
-            },
-            "shadowOpacity": 0,
-            "shadowRadius": 0,
-            "top": undefined,
-          }
-        }
+        pointerEvents="none"
+        testID="search-bar-icon-wrapper"
       >
         <View
           collapsable={false}
           style={
             Object {
+              "alignSelf": undefined,
+              "bottom": undefined,
+              "left": undefined,
+              "position": undefined,
+              "right": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -598,6 +589,7 @@ exports[`renders with placeholder 1`] = `
               },
               "shadowOpacity": 0,
               "shadowRadius": 0,
+              "top": undefined,
             }
           }
         >
@@ -605,75 +597,90 @@ exports[`renders with placeholder 1`] = `
             collapsable={false}
             style={
               Object {
-                "backgroundColor": undefined,
-                "borderColor": "rgba(28, 27, 31, 0.12)",
-                "borderRadius": 20,
-                "borderWidth": 0,
-                "elevation": 0,
-                "height": 40,
-                "margin": 6,
-                "overflow": "hidden",
-                "width": 40,
+                "shadowColor": "#000",
+                "shadowOffset": Object {
+                  "height": 0,
+                  "width": 0,
+                },
+                "shadowOpacity": 0,
+                "shadowRadius": 0,
               }
             }
           >
             <View
-              accessibilityLabel="clear"
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "disabled": true,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              hitSlop={
-                Object {
-                  "bottom": 6,
-                  "left": 6,
-                  "right": 6,
-                  "top": 6,
-                }
-              }
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              collapsable={false}
               style={
-                Array [
-                  Object {
-                    "overflow": "hidden",
-                  },
-                  Object {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                  },
-                ]
+                Object {
+                  "backgroundColor": undefined,
+                  "borderColor": "rgba(121, 116, 126, 1)",
+                  "borderRadius": 20,
+                  "borderWidth": 0,
+                  "elevation": 0,
+                  "height": 40,
+                  "margin": 6,
+                  "overflow": "hidden",
+                  "width": 40,
+                }
               }
             >
-              <Text
-                accessibilityElementsHidden={true}
-                importantForAccessibility="no-hide-descendants"
-                pointerEvents="none"
-                selectable={false}
+              <View
+                accessibilityLabel="clear"
+                accessibilityRole="button"
+                accessibilityState={
+                  Object {
+                    "disabled": false,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                hitSlop={
+                  Object {
+                    "bottom": 6,
+                    "left": 6,
+                    "right": 6,
+                    "top": 6,
+                  }
+                }
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
                   Array [
                     Object {
-                      "backgroundColor": "transparent",
+                      "overflow": "hidden",
                     },
                     Object {
-                      "color": "rgba(28, 27, 31, 0.38)",
-                      "fontSize": 24,
+                      "alignItems": "center",
+                      "flexGrow": 1,
+                      "justifyContent": "center",
                     },
                   ]
                 }
               >
-                □
-              </Text>
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    Array [
+                      Object {
+                        "backgroundColor": "transparent",
+                      },
+                      Object {
+                        "color": "rgba(255, 255, 255, 0)",
+                        "fontSize": 24,
+                      },
+                    ]
+                  }
+                >
+                  □
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -863,33 +870,23 @@ exports[`renders with text 1`] = `
             undefined,
           ]
         }
+        testID="search-bar"
         underlineColorAndroid="transparent"
         value="query"
       />
       <View
-        collapsable={false}
-        style={
-          Object {
-            "alignSelf": undefined,
-            "bottom": undefined,
-            "left": undefined,
-            "position": undefined,
-            "right": undefined,
-            "shadowColor": "#000",
-            "shadowOffset": Object {
-              "height": 0,
-              "width": 0,
-            },
-            "shadowOpacity": 0,
-            "shadowRadius": 0,
-            "top": undefined,
-          }
-        }
+        pointerEvents="auto"
+        testID="search-bar-icon-wrapper"
       >
         <View
           collapsable={false}
           style={
             Object {
+              "alignSelf": undefined,
+              "bottom": undefined,
+              "left": undefined,
+              "position": undefined,
+              "right": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -897,6 +894,7 @@ exports[`renders with text 1`] = `
               },
               "shadowOpacity": 0,
               "shadowRadius": 0,
+              "top": undefined,
             }
           }
         >
@@ -904,75 +902,90 @@ exports[`renders with text 1`] = `
             collapsable={false}
             style={
               Object {
-                "backgroundColor": undefined,
-                "borderColor": "rgba(121, 116, 126, 1)",
-                "borderRadius": 20,
-                "borderWidth": 0,
-                "elevation": 0,
-                "height": 40,
-                "margin": 6,
-                "overflow": "hidden",
-                "width": 40,
+                "shadowColor": "#000",
+                "shadowOffset": Object {
+                  "height": 0,
+                  "width": 0,
+                },
+                "shadowOpacity": 0,
+                "shadowRadius": 0,
               }
             }
           >
             <View
-              accessibilityLabel="clear"
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "disabled": false,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              hitSlop={
-                Object {
-                  "bottom": 6,
-                  "left": 6,
-                  "right": 6,
-                  "top": 6,
-                }
-              }
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              collapsable={false}
               style={
-                Array [
-                  Object {
-                    "overflow": "hidden",
-                  },
-                  Object {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                  },
-                ]
+                Object {
+                  "backgroundColor": undefined,
+                  "borderColor": "rgba(121, 116, 126, 1)",
+                  "borderRadius": 20,
+                  "borderWidth": 0,
+                  "elevation": 0,
+                  "height": 40,
+                  "margin": 6,
+                  "overflow": "hidden",
+                  "width": 40,
+                }
               }
             >
-              <Text
-                accessibilityElementsHidden={true}
-                importantForAccessibility="no-hide-descendants"
-                pointerEvents="none"
-                selectable={false}
+              <View
+                accessibilityLabel="clear"
+                accessibilityRole="button"
+                accessibilityState={
+                  Object {
+                    "disabled": false,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                hitSlop={
+                  Object {
+                    "bottom": 6,
+                    "left": 6,
+                    "right": 6,
+                    "top": 6,
+                  }
+                }
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
                   Array [
                     Object {
-                      "backgroundColor": "transparent",
+                      "overflow": "hidden",
                     },
                     Object {
-                      "color": "rgba(28, 27, 31, 0.54)",
-                      "fontSize": 24,
+                      "alignItems": "center",
+                      "flexGrow": 1,
+                      "justifyContent": "center",
                     },
                   ]
                 }
               >
-                □
-              </Text>
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    Array [
+                      Object {
+                        "backgroundColor": "transparent",
+                      },
+                      Object {
+                        "color": "rgba(28, 27, 31, 0.54)",
+                        "fontSize": 24,
+                      },
+                    ]
+                  }
+                >
+                  □
+                </Text>
+              </View>
             </View>
           </View>
         </View>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/3371

### Summary

Replaced `disabled={!value}` in favour of a clear icon view wrapper with conditional `pointerEvents`, because custom `iconColor` is overwritten by disabled color.

Clear icon should always be rendered within Searchbar – it's transparent, without touch events, when there is no value. It's done to avoid issues with the abruptly stopping ripple effect and changing bar width on web, when clearing the value.

Related: https://github.com/callstack/react-native-paper/pull/748.


<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Added tests.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
