### PR TITLE
fix Text fontFamily (Material 3)

### DIFF
--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -134,7 +134,7 @@ const Text: React.ForwardRefRenderFunction<{}, Props> = (
         ref={root}
         style={[
           {
-            ...(!theme.isV3 && theme.fonts?.regular),
+            ...(theme.isV3 ? theme.typescale.bodyMedium : theme.fonts?.regular),
             color: theme.isV3 ? theme.colors?.onSurface : theme.colors.text,
           },
           styles.text,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Text doesn't have default font family

In this PR text have bodyMedium as default 
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
