### PR TITLE
fix: button ripple radius

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -253,7 +253,7 @@ const Button = ({
   };
   const touchableStyle = {
     borderRadius: style
-      ? ((StyleSheet.flatten(style) || {}) as ViewStyle).borderRadius ||
+      ? ((StyleSheet.flatten(style) || {}) as ViewStyle).borderRadius ??
         borderRadius
       : borderRadius,
   };


### PR DESCRIPTION
### Summary
Fix: #3387 

In the case when the` borderRadius` was `0` the condition was treating it as a falsy value.
Replaced it  with a check of `Nullish coalescing operator` so that it check only for null and undefined values

### Test plan
Checked manually by applying a style with borderRadius : 0 in the button component
