### PR TITLE
fix: allow to fully override testID in TextInput

### DIFF
--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -68,7 +68,7 @@ const TextInputFlat = ({
   left,
   right,
   placeholderTextColor,
-  testID = 'text-input',
+  testID = 'text-input-flat',
   ...rest
 }: ChildTextInputProps) => {
   const isAndroid = Platform.OS === 'android';
@@ -339,7 +339,7 @@ const TextInputFlat = ({
         )}
         <InputLabel parentState={parentState} labelProps={labelProps} />
         {render?.({
-          testID: `${testID}-flat`,
+          testID,
           ...rest,
           ref: innerRef,
           onChangeText,

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -66,7 +66,7 @@ const TextInputOutlined = ({
   left,
   right,
   placeholderTextColor,
-  testID = 'text-input',
+  testID = 'text-input-outlined',
   ...rest
 }: ChildTextInputProps) => {
   const adornmentConfig = getAdornmentConfig({ left, right });
@@ -311,7 +311,7 @@ const TextInputOutlined = ({
             maxFontSizeMultiplier={rest.maxFontSizeMultiplier}
           />
           {render?.({
-            testID: `${testID}-outlined`,
+            testID,
             ...rest,
             ref: innerRef,
             onChangeText,

--- a/src/components/__tests__/TextInput.test.js
+++ b/src/components/__tests__/TextInput.test.js
@@ -188,13 +188,13 @@ it('renders label with correct color when active', () => {
       placeholder="Type something"
       value={'Some test value'}
       onChangeText={(text) => this.setState({ text })}
-      testID={'text-input'}
+      testID={'text-input-flat'}
     />
   );
 
   fireEvent(getByTestId('text-input-flat'), 'focus');
 
-  expect(getByTestId('text-input-label-active')).toHaveStyle({
+  expect(getByTestId('text-input-flat-label-active')).toHaveStyle({
     color: getTheme().colors.primary,
   });
 });
@@ -220,7 +220,7 @@ it('renders input placeholder initially with an empty space character', () => {
     <TextInput multiline label="Multiline input" testID={'text-input'} />
   );
 
-  expect(getByTestId('text-input-flat').props.placeholder).toBe(' ');
+  expect(getByTestId('text-input').props.placeholder).toBe(' ');
 });
 
 it('correctly applies padding offset to input label on Android when RTL', () => {
@@ -278,7 +278,7 @@ it('correctly applies padding offset to input label on Android when LTR', () => 
         mode={mode}
         multiline
         label="Flat input"
-        testID={'text-input'}
+        testID={`text-input-${mode}`}
         style={style.lineHeight}
       />
     );

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -99,7 +99,7 @@ exports[`correctly applies a component as the text label 1`] = `
             "writingDirection": "ltr",
           }
         }
-        testID="text-input-label-active"
+        testID="text-input-flat-label-active"
       >
         <Text
           style={
@@ -144,7 +144,7 @@ exports[`correctly applies a component as the text label 1`] = `
             "writingDirection": "ltr",
           }
         }
-        testID="text-input-label-inactive"
+        testID="text-input-flat-label-inactive"
       >
         <Text
           style={
@@ -307,7 +307,7 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
             "writingDirection": "ltr",
           }
         }
-        testID="text-input-label-active"
+        testID="text-input-flat-label-active"
       >
         Flat input
       </Text>
@@ -344,7 +344,7 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
             "writingDirection": "ltr",
           }
         }
-        testID="text-input-label-inactive"
+        testID="text-input-flat-label-inactive"
       >
         Flat input
       </Text>
@@ -554,7 +554,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
               "writingDirection": "ltr",
             }
           }
-          testID="text-input-label-active"
+          testID="text-input-outlined-label-active"
         >
           Outline Input
         </Text>
@@ -590,7 +590,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
               "writingDirection": "ltr",
             }
           }
-          testID="text-input-label-inactive"
+          testID="text-input-outlined-label-inactive"
         >
           Outline Input
         </Text>
@@ -744,7 +744,7 @@ exports[`correctly applies textAlign center 1`] = `
             "writingDirection": "ltr",
           }
         }
-        testID="text-input-label-active"
+        testID="text-input-flat-label-active"
       >
         Flat input
       </Text>
@@ -781,7 +781,7 @@ exports[`correctly applies textAlign center 1`] = `
             "writingDirection": "ltr",
           }
         }
-        testID="text-input-label-inactive"
+        testID="text-input-flat-label-inactive"
       >
         Flat input
       </Text>
@@ -936,7 +936,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
             "writingDirection": "ltr",
           }
         }
-        testID="text-input-label-active"
+        testID="text-input-flat-label-active"
       >
         Flat input
       </Text>
@@ -973,7 +973,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
             "writingDirection": "ltr",
           }
         }
-        testID="text-input-label-inactive"
+        testID="text-input-flat-label-inactive"
       >
         Flat input
       </Text>
@@ -1298,7 +1298,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
             "writingDirection": "ltr",
           }
         }
-        testID="text-input-label-active"
+        testID="text-input-flat-label-active"
       >
         Flat input
       </Text>
@@ -1335,7 +1335,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
             "writingDirection": "ltr",
           }
         }
-        testID="text-input-label-inactive"
+        testID="text-input-flat-label-inactive"
       >
         Flat input
       </Text>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Due to the [commit](https://github.com/callstack/react-native-paper/commit/25cd448f7eafc62e68844a44056a54b707b7e1e8), where `testID` was extracted from `rest` there was a need to adjust the `testID` in user's tests. After revisiting that change and I've noticed it was not required so current PR is patching the previously mentioned commit.


#### Related issue

- #3376

### Test plan

Adjusted unit tests.
