### PR TITLE
fix: BottomNavigation warn when shifting with the wrong number of tabs

### DIFF
--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -65,6 +65,7 @@ export type Props = {
    *
    * By default, this is `false` with theme version 3 and `true` when you have more than 3 tabs.
    * Pass `shifting={false}` to explicitly disable this animation, or `shifting={true}` to always use this animation.
+   * Note that you need at least 2 tabs be able to run this animation.
    */
   shifting?: boolean;
   /**
@@ -386,6 +387,14 @@ const BottomNavigation = ({
   testID = 'bottom-navigation',
 }: Props) => {
   const { scale } = theme.animation;
+
+  if (shifting && navigationState.routes.length < 2) {
+    shifting = false;
+
+    console.warn(
+      'BottomNavigation needs at least 2 tabs to run shifting animation'
+    );
+  }
 
   const focusedKey = navigationState.routes[navigationState.index].key;
 

--- a/src/components/__tests__/BottomNavigation.test.js
+++ b/src/components/__tests__/BottomNavigation.test.js
@@ -175,6 +175,25 @@ it('renders non-shifting bottom navigation', () => {
   expect(tree).toMatchSnapshot();
 });
 
+it('does not crash when shifting is true and the number of tabs in the navigationState is less than 2', () => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+  render(
+    <BottomNavigation
+      shifting={true}
+      navigationState={createState(0, 1)}
+      onIndexChange={jest.fn()}
+      renderScene={({ route }) => route.title}
+    />
+  );
+
+  expect(console.warn).toHaveBeenCalledWith(
+    'BottomNavigation needs at least 2 tabs to run shifting animation'
+  );
+
+  jest.restoreAllMocks();
+});
+
 it('renders custom icon and label in shifting bottom navigation', () => {
   const tree = renderer
     .create(


### PR DESCRIPTION
### Summary

Recently when working on a new feature I realized that the component BottomNavigation crashes when the prop `shifting` is true but the number of tabs is < 2 as in the following screenshot

![Error message](https://user-images.githubusercontent.com/6487206/195161213-4d2b57eb-4730-4bc6-a69b-d37cded037af.jpeg)

### Test plan

1. Open the example APP
2. Go to the example/src/Examples/BottomNavigationExample.tsx
3. Pass the prop `shifting` to the BottomNavigation component
4. Modify the routes to have a single one instead
5. See the warning popping up

![Warning message](https://user-images.githubusercontent.com/6487206/195161044-86c64e5b-bf0c-4c5e-8d91-ddcf47a2be00.jpeg)