### PR TITLE
feat: Snackbar support for any children

### DIFF
--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -190,6 +190,24 @@ const Snackbar = ({
     ? theme.colors.inversePrimary
     : theme.colors.accent;
 
+  const renderChildrenWithWrapper = () => {
+    const viewStyles = [
+      styles.content,
+      { marginRight, color: colors?.surface },
+    ];
+
+    if (typeof children === 'string') {
+      return <Text style={viewStyles}>{children}</Text>;
+    }
+
+    return (
+      <View style={viewStyles}>
+        {/* View is added to allow multiple lines support for Text component as children */}
+        <View>{children}</View>
+      </View>
+    );
+  };
+
   return (
     <SafeAreaView
       pointerEvents="box-none"
@@ -223,9 +241,7 @@ const Snackbar = ({
         {...(isV3 && { elevation })}
         {...rest}
       >
-        <Text style={[styles.content, { marginRight, color: colors?.surface }]}>
-          {children}
-        </Text>
+        {renderChildrenWithWrapper()}
         {action ? (
           <Button
             onPress={() => {

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -293,7 +293,6 @@ const styles = StyleSheet.create({
   content: {
     marginLeft: 16,
     marginVertical: 14,
-    flexWrap: 'wrap',
     flex: 1,
   },
   button: {

--- a/src/components/__tests__/Snackbar.test.js
+++ b/src/components/__tests__/Snackbar.test.js
@@ -1,9 +1,22 @@
 import * as React from 'react';
-import { Text } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 
 import renderer from 'react-test-renderer';
 
+import { red200, white } from '../../styles/themes/v2/colors';
 import Snackbar from '../Snackbar.tsx';
+
+const styles = StyleSheet.create({
+  snackContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  iconView: {
+    backgroundColor: red200,
+    padding: 15,
+  },
+  text: { color: white, marginLeft: 10, flexWrap: 'wrap', flexShrink: 1 },
+});
 
 // Make sure any animation finishes before checking the snapshot results
 jest.mock('react-native', () => {
@@ -64,6 +77,24 @@ it('renders snackbar with action button', () => {
         action={{ label: 'Undo', onPress: jest.fn() }}
       >
         Snackbar content
+      </Snackbar>
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders snackbar with View & Text as a child', () => {
+  const tree = renderer
+    .create(
+      <Snackbar visible onDismiss={jest.fn()}>
+        <View style={styles.snackContent}>
+          <View style={styles.iconView} />
+          <Text style={styles.text}>
+            Error Message which is veryyyyyyyyyyyy longggggggg Error Message
+            which is veryyyyyyyyyyyy longggggggg
+          </Text>
+        </View>
       </Snackbar>
     )
     .toJSON();

--- a/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
@@ -72,37 +72,150 @@ exports[`renders snackbar with Text as a child 1`] = `
           }
         }
       >
-        <Text
+        <View
           style={
             Array [
               Object {
-                "textAlign": "left",
+                "flex": 1,
+                "marginLeft": 16,
+                "marginVertical": 14,
               },
               Object {
-                "color": "rgba(28, 27, 31, 1)",
+                "color": "rgba(255, 251, 254, 1)",
+                "marginRight": 16,
               },
-              Object {
-                "writingDirection": "ltr",
-              },
-              Array [
-                Object {
-                  "flex": 1,
-                  "flexWrap": "wrap",
-                  "marginLeft": 16,
-                  "marginVertical": 14,
-                },
-                Object {
-                  "color": "rgba(255, 251, 254, 1)",
-                  "marginRight": 16,
-                },
-              ],
             ]
           }
         >
-          <Text>
-            Snackbar content
-          </Text>
-        </Text>
+          <View>
+            <Text>
+              Snackbar content
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</RCTSafeAreaView>
+`;
+
+exports[`renders snackbar with View & Text as a child 1`] = `
+<RCTSafeAreaView
+  emulateUnlessSupported={true}
+  pointerEvents="box-none"
+  style={
+    Array [
+      Object {
+        "bottom": 0,
+        "position": "absolute",
+        "width": "100%",
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      Object {
+        "alignSelf": undefined,
+        "bottom": undefined,
+        "left": undefined,
+        "position": undefined,
+        "right": undefined,
+        "shadowColor": "#000",
+        "shadowOffset": Object {
+          "height": 2,
+          "width": 0,
+        },
+        "shadowOpacity": 0.15,
+        "shadowRadius": 6,
+        "top": undefined,
+      }
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        Object {
+          "shadowColor": "#000",
+          "shadowOffset": Object {
+            "height": 1,
+            "width": 0,
+          },
+          "shadowOpacity": 0.3,
+          "shadowRadius": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLiveRegion="polite"
+        collapsable={false}
+        pointerEvents="box-none"
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "rgba(28, 27, 31, 1)",
+            "borderRadius": 4,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "margin": 8,
+            "opacity": 1,
+            "transform": Array [
+              Object {
+                "scale": 1,
+              },
+            ],
+          }
+        }
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "flex": 1,
+                "marginLeft": 16,
+                "marginVertical": 14,
+              },
+              Object {
+                "color": "rgba(255, 251, 254, 1)",
+                "marginRight": 16,
+              },
+            ]
+          }
+        >
+          <View>
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "backgroundColor": "#ef9a9a",
+                    "padding": 15,
+                  }
+                }
+              />
+              <Text
+                style={
+                  Object {
+                    "color": "#ffffff",
+                    "flexShrink": 1,
+                    "flexWrap": "wrap",
+                    "marginLeft": 10,
+                  }
+                }
+              >
+                Error Message which is veryyyyyyyyyyyy longggggggg Error Message which is veryyyyyyyyyyyy longggggggg
+              </Text>
+            </View>
+          </View>
+        </View>
       </View>
     </View>
   </View>
@@ -194,7 +307,6 @@ exports[`renders snackbar with action button 1`] = `
               Array [
                 Object {
                   "flex": 1,
-                  "flexWrap": "wrap",
                   "marginLeft": 16,
                   "marginVertical": 14,
                 },
@@ -440,7 +552,6 @@ exports[`renders snackbar with content 1`] = `
               Array [
                 Object {
                   "flex": 1,
-                  "flexWrap": "wrap",
                   "marginLeft": 16,
                   "marginVertical": 14,
                 },


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
This PR adds support to snackbar to allow laying out it's non-text children gracefully, without overflowing the view. This effort fixes #3360.

<details>
<summary> Web </summary>
<img width="1728" alt="web" src="https://user-images.githubusercontent.com/47336142/195356234-0b13b4b4-3b38-4fd8-9aa1-b64ccc1f37e2.png">
</details>

<details>
<summary> Android </summary>
<img width="300" height="600" alt="android" src="https://user-images.githubusercontent.com/47336142/195356344-c0220be7-e6be-41d9-af6a-628f4f9b3950.png">
</details>

<details>
<summary> iOS </summary>
<img  width="300" height="600" alt="ios" src="https://user-images.githubusercontent.com/47336142/195356473-88d914b6-e39c-4328-8e69-f6d1f0f93485.png">
</details>


#### Discussion:
With introducing these changes, we get the desired results without breaking the previous functionality. However, the text overflows behind the **Undo** button due to the icon view in snackbar. 

This can be handled by the users by configuring the text styles like so:

```
text: { 
    ...other properties,
    flexWrap: 'wrap',
    flexShrink: 1 
}
```

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
Unit test coverage and tested on Web, Android & iOS. (screenshots above)
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
