### PR TITLE
fix: progress bar animated value

### DIFF
--- a/example/src/Examples/ProgressBarExample.tsx
+++ b/example/src/Examples/ProgressBarExample.tsx
@@ -30,10 +30,11 @@ const ProgressBarExample = () => {
   const [progress, setProgress] = React.useState<number>(0.3);
   const theme = useTheme();
   const { isV3 } = theme;
-  const progressBarValue = React.useRef(new Animated.Value(0));
+  const { current: progressBarValue } = React.useRef(new Animated.Value(0));
 
-  const customAnim = () => {
-    Animated.timing(progressBarValue.current, {
+  const runCustomAnimation = () => {
+    progressBarValue.setValue(0);
+    Animated.timing(progressBarValue, {
       toValue: 1,
       duration: 2000,
       useNativeDriver: false,
@@ -42,10 +43,11 @@ const ProgressBarExample = () => {
 
   return (
     <ScreenWrapper contentContainerStyle={styles.container}>
-      <Button onPress={() => setVisible(!visible)}>Toggle visible</Button>
+      <Button onPress={() => setVisible(!visible)}>Toggle visibility</Button>
       <Button onPress={() => setProgress(Math.random())}>
         Random progress
       </Button>
+      <Button onPress={runCustomAnimation}>Toggle animation</Button>
 
       <View style={styles.row}>
         <Paragraph>Default ProgressBar </Paragraph>
@@ -87,13 +89,15 @@ const ProgressBarExample = () => {
         />
       </View>
 
-      <Button onPress={customAnim}>Animated Value</Button>
-      <AnimatedProgressBar
-        style={styles.progressBar}
-        animatedValue={progressBarValue.current}
-        color={MD2Colors.green200}
-        theme={theme}
-      />
+      <View style={styles.row}>
+        <Paragraph>ProgressBar with animated value</Paragraph>
+        <AnimatedProgressBar
+          style={styles.progressBar}
+          animatedValue={progressBarValue}
+          color={MD2Colors.green200}
+          theme={theme}
+        />
+      </View>
     </ScreenWrapper>
   );
 };
@@ -111,7 +115,6 @@ const styles = StyleSheet.create({
     height: 20,
   },
   progressBar: {
-    borderRadius: 7.5,
     height: 15,
   },
 });

--- a/example/src/Examples/ProgressBarExample.tsx
+++ b/example/src/Examples/ProgressBarExample.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, Animated } from 'react-native';
 
 import {
   Button,
@@ -8,14 +8,37 @@ import {
   MD2Colors,
   MD3Colors,
   useTheme,
+  ProgressBarProps,
 } from 'react-native-paper';
 
 import ScreenWrapper from '../ScreenWrapper';
 
+class ClassProgressBar extends React.Component {
+  constructor(props: ProgressBarProps) {
+    super(props);
+  }
+
+  render() {
+    return <ProgressBar {...this.props} />;
+  }
+}
+
+const AnimatedProgressBar = Animated.createAnimatedComponent(ClassProgressBar);
+
 const ProgressBarExample = () => {
   const [visible, setVisible] = React.useState<boolean>(true);
   const [progress, setProgress] = React.useState<number>(0.3);
-  const { isV3 } = useTheme();
+  const theme = useTheme();
+  const { isV3 } = theme;
+  const progressBarValue = React.useRef(new Animated.Value(0));
+
+  const customAnim = () => {
+    Animated.timing(progressBarValue.current, {
+      toValue: 1,
+      duration: 2000,
+      useNativeDriver: false,
+    }).start();
+  };
 
   return (
     <ScreenWrapper contentContainerStyle={styles.container}>
@@ -63,6 +86,14 @@ const ProgressBarExample = () => {
           style={styles.customHeight}
         />
       </View>
+
+      <Button onPress={customAnim}>Animated Value</Button>
+      <AnimatedProgressBar
+        style={styles.progressBar}
+        animatedValue={progressBarValue.current}
+        color={MD2Colors.green200}
+        theme={theme}
+      />
     </ScreenWrapper>
   );
 };
@@ -78,6 +109,10 @@ const styles = StyleSheet.create({
   },
   customHeight: {
     height: 20,
+  },
+  progressBar: {
+    borderRadius: 7.5,
+    height: 15,
   },
 });
 

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -17,7 +17,13 @@ import type { Theme } from '../types';
 
 export type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
+   * Animated value (between 0 and 1). This tells the progress bar to rely on this value to animate it.
+   * Should not be used with progress prop.
+   */
+  animatedValue?: number;
+  /**
    * Progress value (between 0 and 1).
+   * Should not be used with animatedValue prop.
    */
   progress?: number;
   /**
@@ -69,6 +75,7 @@ const ProgressBar = ({
   progress = 0,
   visible = true,
   theme,
+  animatedValue,
   ...rest
 }: Props) => {
   const { current: timer } = React.useRef<Animated.Value>(
@@ -91,6 +98,10 @@ const ProgressBar = ({
       useNativeDriver: true,
       isInteraction: false,
     }).start();
+
+    if (animatedValue && animatedValue >= 0) {
+      return;
+    }
 
     // Animate progress bar
     if (indeterminate) {
@@ -116,7 +127,13 @@ const ProgressBar = ({
         isInteraction: false,
       }).start();
     }
-  }, [scale, timer, progress, indeterminate, fade]);
+    /**
+     * We shouldn't add @param animatedValue to the
+     * deps array, to avoid the unnecessary loop.
+     * We can only check if the prop is passed initially,
+     * and we do early return.
+     */
+  }, [fade, scale, indeterminate, timer, progress]);
 
   const stopAnimation = React.useCallback(() => {
     // Stop indeterminate animation
@@ -136,6 +153,12 @@ const ProgressBar = ({
     if (visible) startAnimation();
     else stopAnimation();
   }, [visible, startAnimation, stopAnimation]);
+
+  React.useEffect(() => {
+    if (animatedValue && animatedValue >= 0) {
+      timer.setValue(animatedValue);
+    }
+  }, [animatedValue, timer]);
 
   React.useEffect(() => {
     // Start animation the very first time when previously the width was unclear

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -18,12 +18,12 @@ import type { Theme } from '../types';
 export type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
    * Animated value (between 0 and 1). This tells the progress bar to rely on this value to animate it.
-   * Should not be used with progress prop.
+   * Note: It should not be used in parallel with the `progress` prop.
    */
   animatedValue?: number;
   /**
    * Progress value (between 0 and 1).
-   * Should not be used with animatedValue prop.
+   * Note: It should not be used in parallel with the `animatedValue` prop.
    */
   progress?: number;
   /**

--- a/src/components/__tests__/ProgressBar.test.js
+++ b/src/components/__tests__/ProgressBar.test.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { View } from 'react-native';
+import { Animated } from 'react-native';
 
-import { act } from '@testing-library/react-native';
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
 
 import ProgressBar from '../ProgressBar.tsx';
 
@@ -14,37 +13,55 @@ const layoutEvent = {
   },
 };
 
+const a11Role = 'progressbar';
+
+class ClassProgressBar extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return <ProgressBar {...this.props} />;
+  }
+}
+
+const AnimatedProgressBar = Animated.createAnimatedComponent(ClassProgressBar);
+
+it('renders progress bar with animated value', () => {
+  const tree = render(<AnimatedProgressBar animatedValue={0.2} />);
+
+  const props = tree.getByRole(a11Role).props;
+  props.onLayout(layoutEvent);
+
+  tree.update(<AnimatedProgressBar animatedValue={0.4} />);
+
+  expect(tree.container.props['animatedValue']).toBe(0.4);
+});
+
 it('renders progress bar with specific progress', () => {
-  const tree = renderer.create(<ProgressBar progress={0.2} />);
-  act(() => {
-    tree.root.findByType(View).props.onLayout(layoutEvent);
-  });
+  const tree = render(<ProgressBar progress={0.2} />);
+  tree.getByRole(a11Role).props.onLayout(layoutEvent);
 
   expect(tree.toJSON()).toMatchSnapshot();
 });
 
 it('renders hidden progress bar', () => {
-  const tree = renderer.create(<ProgressBar progress={0.2} visible={false} />);
-  act(() => {
-    tree.root.findByType(View).props.onLayout(layoutEvent);
-  });
+  const tree = render(<ProgressBar progress={0.2} visible={false} />);
+  tree.getByRole(a11Role).props.onLayout(layoutEvent);
 
   expect(tree.toJSON()).toMatchSnapshot();
 });
 
 it('renders colored progress bar', () => {
-  const tree = renderer.create(<ProgressBar progress={0.2} color="red" />);
-  act(() => {
-    tree.root.findByType(View).props.onLayout(layoutEvent);
-  });
+  const tree = render(<ProgressBar progress={0.2} color="red" />);
+  tree.getByRole(a11Role).props.onLayout(layoutEvent);
 
   expect(tree.toJSON()).toMatchSnapshot();
 });
 
 it('renders indeterminate progress bar', () => {
-  const tree = renderer.create(<ProgressBar indeterminate />);
-  act(() => {
-    tree.root.findByType(View).props.onLayout(layoutEvent);
-  });
+  const tree = render(<ProgressBar indeterminate />);
+  tree.getByRole(a11Role).props.onLayout(layoutEvent);
+
   expect(tree.toJSON()).toMatchSnapshot();
 });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes #3366

Introduces the `animatedValue` prop to allow usage for controlling the progress bar using animated value created by Animated API. This prop is different when compared to `progress`, since progress isn't designed to support values that change continuously as it triggers another animation under the hood to populate progress bar. So we allowed the users to pass in their own `animatedValue` to control the progress bar.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

<details>
<summary>android</summary>

https://user-images.githubusercontent.com/47336142/196183132-227320fd-1561-47e1-83f6-0e893aeeda41.mp4

</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/47336142/196184210-cba73bab-4dda-46ca-a72c-07bdbd00b8f5.mp4

</details>

<details>
<summary>web</summary>

https://user-images.githubusercontent.com/47336142/196185416-34854a4b-45b4-44d6-9e7d-691da65e3a04.mp4

</details>

