### PR TITLE
fix(regression): BottomNavigation can't render a single tab

### DIFF
--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -609,14 +609,14 @@ const BottomNavigation = ({
     ? overlay(elevation, colors?.surface)
     : colors?.primary;
 
-  const v2BackgroundColorInterpolation = indexAnim.interpolate({
+  const v2BackgroundColorInterpolation = shifting ? indexAnim.interpolate({
     inputRange: routes.map((_, i) => i),
     // FIXME: does outputRange support ColorValue or just strings?
     // @ts-expect-error
     outputRange: routes.map(
       (route) => getColor({ route }) || approxBackgroundColor
     ),
-  });
+  }) : approxBackgroundColor;
 
   const backgroundColor = isV3
     ? customBackground || theme.colors.elevation.level2

--- a/src/components/__tests__/BottomNavigation.test.js
+++ b/src/components/__tests__/BottomNavigation.test.js
@@ -339,7 +339,7 @@ it('renders custom background color passed to barStyle property', () => {
 });
 
 it('renders a single tab', () => {
-  const { getByTestId } = render(
+  const { queryByTestId } = render(
     <BottomNavigation
       shifting={false}
       navigationState={createState(0, 1)}
@@ -349,5 +349,5 @@ it('renders a single tab', () => {
     />
   );
 
-  getByTestId('bottom-navigation')
+  expect(queryByTestId('bottom-navigation')).not.toBeNull();
 })

--- a/src/components/__tests__/BottomNavigation.test.js
+++ b/src/components/__tests__/BottomNavigation.test.js
@@ -337,3 +337,17 @@ it('renders custom background color passed to barStyle property', () => {
   const wrapper = getByTestId('bottom-navigation-bar-content');
   expect(wrapper).toHaveStyle({ backgroundColor: red300 });
 });
+
+it('renders a single tab', () => {
+  const { getByTestId } = render(
+    <BottomNavigation
+      shifting={false}
+      navigationState={createState(0, 1)}
+      onIndexChange={jest.fn()}
+      renderScene={({ route }) => route.title}
+      testID={'bottom-navigation'}
+    />
+  );
+
+  getByTestId('bottom-navigation')
+})


### PR DESCRIPTION
### Summary

After rebasing #3408 I noticed that this regression has been introduced in V5. The BottomNavigation breaks when you try to render it with a single tab.

![Issue](https://user-images.githubusercontent.com/6487206/196339830-dddd1b48-bc39-4362-9638-d33622de17d0.jpeg)

### Test plan

1. Open the example APP
2. Go to the example/src/Examples/BottomNavigationExample.tsx
4. Modify the routes to have a single one instead
5. Should render a single tab as in the following screenshot

![Fixed](https://user-images.githubusercontent.com/6487206/196339702-b12b0c56-0950-4926-bee8-95f4b3fe6929.jpeg)

