### PR TITLE
refactor: make Banner actions optional

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -32,7 +32,7 @@ export type Props = $RemoveChildren<typeof Surface> & {
    *
    * To customize button you can pass other props that button component takes.
    */
-  actions: Array<
+  actions?: Array<
     {
       label: string;
     } & Omit<React.ComponentProps<typeof Button>, 'children'>
@@ -128,7 +128,7 @@ const Banner = ({
   visible,
   icon,
   children,
-  actions,
+  actions = [],
   contentStyle,
   elevation = 1,
   style,

--- a/src/components/__tests__/Banner.test.js
+++ b/src/components/__tests__/Banner.test.js
@@ -8,7 +8,7 @@ import Banner from '../Banner.tsx';
 it('renders hidden banner, without action buttons and without image', () => {
   const tree = renderer
     .create(
-      <Banner visible={false} actions={[]}>
+      <Banner visible={false}>
         Two line text string with two actions. One to two lines is preferable on
         mobile.
       </Banner>
@@ -21,7 +21,7 @@ it('renders hidden banner, without action buttons and without image', () => {
 it('renders visible banner, without action buttons and without image', () => {
   const tree = renderer
     .create(
-      <Banner visible actions={[]}>
+      <Banner visible>
         Two line text string with two actions. One to two lines is preferable on
         mobile.
       </Banner>
@@ -62,7 +62,6 @@ it('renders visible banner, without action buttons and with image', () => {
             accessibilityIgnoresInvertColors
           />
         )}
-        actions={[]}
       >
         Two line text string with two actions. One to two lines is preferable on
         mobile.


### PR DESCRIPTION
### Summary

This PR is a proposal to make the prop `actions` of the Banner component optional. Although not specified in MUI docs(https://material.io/components/banners) RNP supports non-actionable banners. So I thought defaulting the prop `actions` to `[]` would be a nice API change

### Test plan

N/A