### PR TITLE
feat: make onDismiss optional on Menu

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -47,7 +47,7 @@ export type Props = {
   /**
    * Callback called when Menu is dismissed. The `visible` prop needs to be updated when this is called.
    */
-  onDismiss: () => void;
+  onDismiss?: () => void;
   /**
    * Accessibility label for the overlay. This is read by the screen reader when the user taps outside the menu.
    */
@@ -234,14 +234,14 @@ class Menu extends React.Component<Props, State> {
 
   private handleDismiss = () => {
     if (this.props.visible) {
-      this.props.onDismiss();
+      this.props.onDismiss?.();
     }
     return true;
   };
 
   private handleKeypress = (e: KeyboardEvent) => {
     if (e.key === 'Escape') {
-      this.props.onDismiss();
+      this.props.onDismiss?.();
     }
   };
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes https://github.com/callstack/react-native-paper/issues/3404

### Summary

PR makes the `onDismiss` method optional to allow the user to dismiss the `Menu` component by pressing e.g. the menu item and allowing the user to interact with the background at the same time, without hiding the `Menu`.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Tested manually on device. 

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
