### PR TITLE
fix: adjust menu layout when keyboard opens

### DIFF
--- a/example/src/Examples/MenuExample.tsx
+++ b/example/src/Examples/MenuExample.tsx
@@ -81,66 +81,87 @@ const MenuExample = ({ navigation }: Props) => {
           <Menu.Item onPress={() => {}} title="Paste" />
         </Menu>
       </Appbar.Header>
-      <ScreenWrapper style={styles.container}>
-        <View style={styles.alignCenter}>
+      <ScreenWrapper
+        contentContainerStyle={styles.contentContainer}
+        style={styles.container}
+      >
+        <View>
+          <View style={styles.alignCenter}>
+            <Menu
+              visible={_getVisible('menu2')}
+              onDismiss={_toggleMenu('menu2')}
+              anchor={
+                <Button mode="outlined" onPress={_toggleMenu('menu2')}>
+                  Menu with icons
+                </Button>
+              }
+            >
+              <Menu.Item leadingIcon="undo" onPress={() => {}} title="Undo" />
+              <Menu.Item leadingIcon="redo" onPress={() => {}} title="Redo" />
+
+              <Divider style={isV3 && styles.md3Divider} />
+
+              <Menu.Item
+                leadingIcon="content-cut"
+                onPress={() => {}}
+                title="Cut"
+                disabled
+              />
+              <Menu.Item
+                leadingIcon="content-copy"
+                onPress={() => {}}
+                title="Copy"
+                disabled
+              />
+              <Menu.Item
+                leadingIcon="content-paste"
+                onPress={() => {}}
+                title="Paste"
+              />
+              {isV3 && (
+                <Menu.Item
+                  trailingIcon="share-variant"
+                  onPress={() => {}}
+                  title="Share"
+                />
+              )}
+            </Menu>
+          </View>
           <Menu
-            visible={_getVisible('menu2')}
-            onDismiss={_toggleMenu('menu2')}
+            visible={_getVisible('menu3')}
+            onDismiss={_toggleMenu('menu3')}
+            anchor={contextualMenuCoord}
+          >
+            <Menu.Item onPress={() => {}} title="Item 1" />
+            <Menu.Item onPress={() => {}} title="Item 2" />
+            <Divider style={isV3 && styles.md3Divider} />
+            <Menu.Item onPress={() => {}} title="Item 3" disabled />
+          </Menu>
+          <List.Section style={styles.list} title="Contextual menu">
+            <TouchableRipple onPress={() => {}} onLongPress={_handleLongPress}>
+              <List.Item
+                title="List item"
+                description="Long press me to open contextual menu"
+              />
+            </TouchableRipple>
+          </List.Section>
+        </View>
+
+        <View style={styles.bottomMenu}>
+          <Menu
+            visible={_getVisible('menu4')}
+            onDismiss={_toggleMenu('menu4')}
             anchor={
-              <Button mode="outlined" onPress={_toggleMenu('menu2')}>
-                Menu with icons
+              <Button mode="outlined" onPress={_toggleMenu('menu4')}>
+                Menu at bottom
               </Button>
             }
           >
-            <Menu.Item leadingIcon="undo" onPress={() => {}} title="Undo" />
-            <Menu.Item leadingIcon="redo" onPress={() => {}} title="Redo" />
-
-            <Divider style={isV3 && styles.md3Divider} />
-
-            <Menu.Item
-              leadingIcon="content-cut"
-              onPress={() => {}}
-              title="Cut"
-              disabled
-            />
-            <Menu.Item
-              leadingIcon="content-copy"
-              onPress={() => {}}
-              title="Copy"
-              disabled
-            />
-            <Menu.Item
-              leadingIcon="content-paste"
-              onPress={() => {}}
-              title="Paste"
-            />
-            {isV3 && (
-              <Menu.Item
-                trailingIcon="share-variant"
-                onPress={() => {}}
-                title="Share"
-              />
-            )}
+            <Menu.Item onPress={() => {}} title="Bottom Item 1" />
+            <Menu.Item onPress={() => {}} title="Bottom Item 2" />
+            <Menu.Item onPress={() => {}} title="Bottom Item 3" />
           </Menu>
         </View>
-        <Menu
-          visible={_getVisible('menu3')}
-          onDismiss={_toggleMenu('menu3')}
-          anchor={contextualMenuCoord}
-        >
-          <Menu.Item onPress={() => {}} title="Item 1" />
-          <Menu.Item onPress={() => {}} title="Item 2" />
-          <Divider style={isV3 && styles.md3Divider} />
-          <Menu.Item onPress={() => {}} title="Item 3" disabled />
-        </Menu>
-        <List.Section style={styles.list} title="Contextual menu">
-          <TouchableRipple onPress={() => {}} onLongPress={_handleLongPress}>
-            <List.Item
-              title="List item"
-              description="Long press me to open contextual menu"
-            />
-          </TouchableRipple>
-        </List.Section>
       </ScreenWrapper>
     </View>
   );
@@ -163,6 +184,11 @@ const styles = StyleSheet.create({
   },
   md3Divider: {
     marginVertical: 8,
+  },
+  bottomMenu: { width: '40%' },
+  contentContainer: {
+    justifyContent: 'space-between',
+    flex: 1,
   },
 });
 

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -89,6 +89,7 @@ const ANIMATION_DURATION = 250;
 const EASING = Easing.bezier(0.4, 0, 0.2, 1);
 
 const WINDOW_LAYOUT = Dimensions.get('window');
+const SCREEN_LAYOUT = Dimensions.get('screen');
 
 /**
  * Menus display a list of choices on temporary elevated surfaces. Their placement varies based on the element that opens them.
@@ -421,7 +422,14 @@ class Menu extends React.Component<Props, State> {
     ];
 
     const windowLayout = { ...WINDOW_LAYOUT };
-    windowLayout.height = windowLayout.height - this.keyboardHeight;
+    const softMenuHeight = SCREEN_LAYOUT.height - windowLayout.height;
+    const hasGestureBar = softMenuHeight < 20;
+
+    windowLayout.height =
+      windowLayout.height -
+      this.keyboardHeight -
+      (hasGestureBar ? statusBarHeight ?? 0 : 0);
+
     // We need to translate menu while animating scale to imitate transform origin for scale animation
     const positionTransforms = [];
 

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -89,7 +89,6 @@ const ANIMATION_DURATION = 250;
 const EASING = Easing.bezier(0.4, 0, 0.2, 1);
 
 const WINDOW_LAYOUT = Dimensions.get('window');
-const SCREEN_LAYOUT = Dimensions.get('screen');
 
 /**
  * Menus display a list of choices on temporary elevated surfaces. Their placement varies based on the element that opens them.
@@ -422,13 +421,7 @@ class Menu extends React.Component<Props, State> {
     ];
 
     const windowLayout = { ...WINDOW_LAYOUT };
-    const softMenuHeight = SCREEN_LAYOUT.height - windowLayout.height;
-    const hasGestureBar = softMenuHeight < 20;
-
-    windowLayout.height =
-      windowLayout.height -
-      this.keyboardHeight -
-      (hasGestureBar ? statusBarHeight ?? 0 : 0);
+    windowLayout.height = windowLayout.height - this.keyboardHeight;
 
     // We need to translate menu while animating scale to imitate transform origin for scale animation
     const positionTransforms = [];


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes #2769 

This PR allows the **Menu** to adjust it's layout if keyboard is opened, so that **Menu** doesn't overflow. 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<details>
<summary>android</summary>

https://user-images.githubusercontent.com/47336142/196435075-83b09d1b-b37b-4abe-9154-9327e59e067f.mp4

</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/47336142/196435314-60992e9c-470c-4b76-9f64-8d24e82c4a0e.mp4

</details>

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
