### PR TITLE
feat: add prop keyboardShouldPersistTaps for Menu

### DIFF
--- a/docs/component-docs.config.js
+++ b/docs/component-docs.config.js
@@ -137,5 +137,7 @@ module.exports = {
       'https://reactnative.dev/docs/accessibility#accessibilitystate',
     'StyleProp<ViewStyle>': 'https://reactnative.dev/docs/view-style-props',
     'StyleProp<TextStyle>': 'https://reactnative.dev/docs/text-style-props',
+    "ScrollViewProps['keyboardShouldPersistTaps']":
+      'https://reactnative.dev/docs/scrollview#keyboardshouldpersisttaps',
   },
 };

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -10,6 +10,7 @@ import {
   NativeEventSubscription,
   Platform,
   ScrollView,
+  ScrollViewProps,
   StyleProp,
   StyleSheet,
   TouchableWithoutFeedback,
@@ -64,6 +65,10 @@ export type Props = {
    * @optional
    */
   theme: InternalTheme;
+  /**
+   * Inner ScrollView prop
+   */
+  keyboardShouldPersistTaps?: ScrollViewProps['keyboardShouldPersistTaps'];
 };
 
 type Layout = $Omit<$Omit<LayoutRectangle, 'x'>, 'y'>;
@@ -358,6 +363,7 @@ class Menu extends React.Component<Props, State> {
       statusBarHeight,
       onDismiss,
       overlayAccessibilityLabel,
+      keyboardShouldPersistTaps,
     } = this.props;
 
     const {
@@ -585,7 +591,11 @@ class Menu extends React.Component<Props, State> {
                   {...(theme.isV3 && { elevation: 2 })}
                 >
                   {(scrollableMenuHeight && (
-                    <ScrollView>{children}</ScrollView>
+                    <ScrollView
+                      keyboardShouldPersistTaps={keyboardShouldPersistTaps}
+                    >
+                      {children}
+                    </ScrollView>
                   )) || <React.Fragment>{children}</React.Fragment>}
                 </Surface>
               </Animated.View>


### PR DESCRIPTION
### Summary

There's a Dropdown component built using TextInput + Menu in a project that I work and the only way to make the inner ScrollView with the MenuItem components able to capture taps was to patch `keyboardShouldPersistTaps` with the value "always" or "handled"

Before(Notice how a double tap is needed) | After
--- | ---
![before](https://user-images.githubusercontent.com/6487206/196589064-6ed68d7b-33c3-494e-8035-d20d594e182b.gif)|![after](https://user-images.githubusercontent.com/6487206/196589380-0b133944-cc34-48fd-879c-7950537845c8.gif)


### Test plan

N/A - just exposing a new prop for the Menu component