### PR TITLE
fix: add default property to the v3 theme fonts

### DIFF
--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -8,7 +8,6 @@ import {
 } from 'react-native';
 
 import { useInternalTheme } from '../../core/theming';
-import { tokens } from '../../styles/themes/v3/tokens';
 import { Font, MD3TypescaleKey, ThemeProp } from '../../types';
 
 export type Props = React.ComponentProps<typeof NativeText> & {
@@ -129,13 +128,7 @@ const Text: React.ForwardRefRenderFunction<{}, Props> = (
       />
     );
   } else {
-    const { brandRegular, weightRegular } = tokens.md.ref.typeface;
-    const font = theme.isV3
-      ? {
-          fontFamily: brandRegular,
-          fontWeight: weightRegular,
-        }
-      : theme.fonts?.regular;
+    const font = theme.isV3 ? theme.fonts.default : theme.fonts?.regular;
     const textStyle = {
       ...font,
       color: theme.isV3 ? theme.colors?.onSurface : theme.colors.text,

--- a/src/components/__tests__/__snapshots__/Avatar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Avatar.test.js.snap
@@ -141,6 +141,7 @@ exports[`renders avatar with text 1`] = `
           "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontWeight": "400",
+          "letterSpacing": 0,
         },
         Object {
           "writingDirection": "ltr",
@@ -194,6 +195,7 @@ exports[`renders avatar with text and custom background color 1`] = `
           "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontWeight": "400",
+          "letterSpacing": 0,
         },
         Object {
           "writingDirection": "ltr",
@@ -247,6 +249,7 @@ exports[`renders avatar with text and custom colors 1`] = `
           "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontWeight": "400",
+          "letterSpacing": 0,
         },
         Object {
           "writingDirection": "ltr",
@@ -300,6 +303,7 @@ exports[`renders avatar with text and custom size 1`] = `
           "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontWeight": "400",
+          "letterSpacing": 0,
         },
         Object {
           "writingDirection": "ltr",

--- a/src/components/__tests__/__snapshots__/Banner.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.js.snap
@@ -92,6 +92,7 @@ exports[`render visible banner, with custom theme 1`] = `
                     "color": "rgba(28, 27, 31, 1)",
                     "fontFamily": "System",
                     "fontWeight": "400",
+                    "letterSpacing": 0,
                   },
                   Object {
                     "writingDirection": "ltr",
@@ -376,6 +377,7 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
                     "color": "rgba(28, 27, 31, 1)",
                     "fontFamily": "System",
                     "fontWeight": "400",
+                    "letterSpacing": 0,
                   },
                   Object {
                     "writingDirection": "ltr",
@@ -504,6 +506,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                     "color": "rgba(28, 27, 31, 1)",
                     "fontFamily": "System",
                     "fontWeight": "400",
+                    "letterSpacing": 0,
                   },
                   Object {
                     "writingDirection": "ltr",
@@ -776,6 +779,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                     "color": "rgba(28, 27, 31, 1)",
                     "fontFamily": "System",
                     "fontWeight": "400",
+                    "letterSpacing": 0,
                   },
                   Object {
                     "writingDirection": "ltr",
@@ -1193,6 +1197,7 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
                     "color": "rgba(28, 27, 31, 1)",
                     "fontFamily": "System",
                     "fontWeight": "400",
+                    "letterSpacing": 0,
                   },
                   Object {
                     "writingDirection": "ltr",
@@ -1320,6 +1325,7 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
                     "color": "rgba(28, 27, 31, 1)",
                     "fontFamily": "System",
                     "fontWeight": "400",
+                    "letterSpacing": 0,
                   },
                   Object {
                     "writingDirection": "ltr",

--- a/src/components/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.js.snap
@@ -46,6 +46,7 @@ exports[`renders data table cell 1`] = `
           "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontWeight": "400",
+          "letterSpacing": 0,
         },
         Object {
           "writingDirection": "ltr",
@@ -115,6 +116,7 @@ exports[`renders data table header 1`] = `
             "color": "rgba(28, 27, 31, 1)",
             "fontFamily": "System",
             "fontWeight": "400",
+            "letterSpacing": 0,
           },
           Object {
             "writingDirection": "ltr",
@@ -180,6 +182,7 @@ exports[`renders data table header 1`] = `
             "color": "rgba(28, 27, 31, 1)",
             "fontFamily": "System",
             "fontWeight": "400",
+            "letterSpacing": 0,
           },
           Object {
             "writingDirection": "ltr",
@@ -237,6 +240,7 @@ exports[`renders data table pagination 1`] = `
           "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontWeight": "400",
+          "letterSpacing": 0,
         },
         Object {
           "writingDirection": "ltr",
@@ -528,6 +532,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontWeight": "400",
+          "letterSpacing": 0,
         },
         Object {
           "writingDirection": "ltr",
@@ -1057,6 +1062,7 @@ exports[`renders data table pagination with label 1`] = `
           "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontWeight": "400",
+          "letterSpacing": 0,
         },
         Object {
           "writingDirection": "ltr",
@@ -1360,6 +1366,7 @@ exports[`renders data table pagination with options select 1`] = `
             "color": "rgba(28, 27, 31, 1)",
             "fontFamily": "System",
             "fontWeight": "400",
+            "letterSpacing": 0,
           },
           Object {
             "writingDirection": "ltr",
@@ -1576,6 +1583,7 @@ exports[`renders data table pagination with options select 1`] = `
           "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontWeight": "400",
+          "letterSpacing": 0,
         },
         Object {
           "writingDirection": "ltr",
@@ -2151,6 +2159,7 @@ exports[`renders data table title with press handler 1`] = `
           "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontWeight": "400",
+          "letterSpacing": 0,
         },
         Object {
           "writingDirection": "ltr",
@@ -2253,6 +2262,7 @@ exports[`renders data table title with sort icon 1`] = `
           "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontWeight": "400",
+          "letterSpacing": 0,
         },
         Object {
           "writingDirection": "ltr",
@@ -2329,6 +2339,7 @@ exports[`renders right aligned data table cell 1`] = `
           "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontWeight": "400",
+          "letterSpacing": 0,
         },
         Object {
           "writingDirection": "ltr",
@@ -2384,6 +2395,7 @@ exports[`renders right aligned data table title 1`] = `
           "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontWeight": "400",
+          "letterSpacing": 0,
         },
         Object {
           "writingDirection": "ltr",

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.js.snap
@@ -78,6 +78,7 @@ exports[`renders expanded accordion 1`] = `
                   "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontWeight": "400",
+                  "letterSpacing": 0,
                 },
                 Object {
                   "writingDirection": "ltr",
@@ -194,6 +195,7 @@ exports[`renders expanded accordion 1`] = `
                 "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontWeight": "400",
+                "letterSpacing": 0,
               },
               Object {
                 "writingDirection": "ltr",
@@ -331,6 +333,7 @@ exports[`renders list accordion with children 1`] = `
                   "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontWeight": "400",
+                  "letterSpacing": 0,
                 },
                 Object {
                   "writingDirection": "ltr",
@@ -464,6 +467,7 @@ exports[`renders list accordion with custom title and description styles 1`] = `
                   "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontWeight": "400",
+                  "letterSpacing": 0,
                 },
                 Object {
                   "writingDirection": "ltr",
@@ -496,6 +500,7 @@ exports[`renders list accordion with custom title and description styles 1`] = `
                   "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontWeight": "400",
+                  "letterSpacing": 0,
                 },
                 Object {
                   "writingDirection": "ltr",
@@ -670,6 +675,7 @@ exports[`renders list accordion with left items 1`] = `
                   "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontWeight": "400",
+                  "letterSpacing": 0,
                 },
                 Object {
                   "writingDirection": "ltr",
@@ -803,6 +809,7 @@ exports[`renders multiline list accordion 1`] = `
                   "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontWeight": "400",
+                  "letterSpacing": 0,
                 },
                 Object {
                   "writingDirection": "ltr",
@@ -833,6 +840,7 @@ exports[`renders multiline list accordion 1`] = `
                   "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontWeight": "400",
+                  "letterSpacing": 0,
                 },
                 Object {
                   "writingDirection": "ltr",

--- a/src/components/__tests__/__snapshots__/ListItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.js.snap
@@ -65,6 +65,7 @@ exports[`renders list item with custom description 1`] = `
               "color": "rgba(28, 27, 31, 1)",
               "fontFamily": "System",
               "fontWeight": "400",
+              "letterSpacing": 0,
             },
             Object {
               "writingDirection": "ltr",
@@ -354,6 +355,7 @@ exports[`renders list item with custom title and description styles 1`] = `
               "color": "rgba(28, 27, 31, 1)",
               "fontFamily": "System",
               "fontWeight": "400",
+              "letterSpacing": 0,
             },
             Object {
               "writingDirection": "ltr",
@@ -386,6 +388,7 @@ exports[`renders list item with custom title and description styles 1`] = `
               "color": "rgba(28, 27, 31, 1)",
               "fontFamily": "System",
               "fontWeight": "400",
+              "letterSpacing": 0,
             },
             Object {
               "writingDirection": "ltr",
@@ -479,6 +482,7 @@ exports[`renders list item with left and right items 1`] = `
               "color": "rgba(28, 27, 31, 1)",
               "fontFamily": "System",
               "fontWeight": "400",
+              "letterSpacing": 0,
             },
             Object {
               "writingDirection": "ltr",
@@ -509,6 +513,7 @@ exports[`renders list item with left and right items 1`] = `
               "color": "rgba(28, 27, 31, 1)",
               "fontFamily": "System",
               "fontWeight": "400",
+              "letterSpacing": 0,
             },
             Object {
               "writingDirection": "ltr",
@@ -673,6 +678,7 @@ exports[`renders list item with left item 1`] = `
               "color": "rgba(28, 27, 31, 1)",
               "fontFamily": "System",
               "fontWeight": "400",
+              "letterSpacing": 0,
             },
             Object {
               "writingDirection": "ltr",
@@ -761,6 +767,7 @@ exports[`renders list item with right item 1`] = `
               "color": "rgba(28, 27, 31, 1)",
               "fontFamily": "System",
               "fontWeight": "400",
+              "letterSpacing": 0,
             },
             Object {
               "writingDirection": "ltr",
@@ -852,6 +859,7 @@ exports[`renders list item with title and description 1`] = `
               "color": "rgba(28, 27, 31, 1)",
               "fontFamily": "System",
               "fontWeight": "400",
+              "letterSpacing": 0,
             },
             Object {
               "writingDirection": "ltr",
@@ -882,6 +890,7 @@ exports[`renders list item with title and description 1`] = `
               "color": "rgba(28, 27, 31, 1)",
               "fontFamily": "System",
               "fontWeight": "400",
+              "letterSpacing": 0,
             },
             Object {
               "writingDirection": "ltr",
@@ -970,6 +979,7 @@ exports[`renders with a description with typeof number 1`] = `
               "color": "rgba(28, 27, 31, 1)",
               "fontFamily": "System",
               "fontWeight": "400",
+              "letterSpacing": 0,
             },
             Object {
               "writingDirection": "ltr",
@@ -1002,6 +1012,7 @@ exports[`renders with a description with typeof number 1`] = `
               "color": "rgba(28, 27, 31, 1)",
               "fontFamily": "System",
               "fontWeight": "400",
+              "letterSpacing": 0,
             },
             Object {
               "writingDirection": "ltr",

--- a/src/components/__tests__/__snapshots__/ListSection.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.js.snap
@@ -80,6 +80,11 @@ exports[`renders list section with custom title style 1`] = `
           "letterSpacing": 0.4,
           "lineHeight": 16,
         },
+        "default": Object {
+          "fontFamily": "System",
+          "fontWeight": "400",
+          "letterSpacing": 0,
+        },
         "displayLarge": Object {
           "fontFamily": "System",
           "fontSize": 57,
@@ -314,6 +319,7 @@ exports[`renders list section with custom title style 1`] = `
                 "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontWeight": "400",
+                "letterSpacing": 0,
               },
               Object {
                 "writingDirection": "ltr",
@@ -438,6 +444,7 @@ exports[`renders list section with custom title style 1`] = `
                 "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontWeight": "400",
+                "letterSpacing": 0,
               },
               Object {
                 "writingDirection": "ltr",
@@ -541,6 +548,11 @@ exports[`renders list section with subheader 1`] = `
           "fontWeight": "400",
           "letterSpacing": 0.4,
           "lineHeight": 16,
+        },
+        "default": Object {
+          "fontFamily": "System",
+          "fontWeight": "400",
+          "letterSpacing": 0,
         },
         "displayLarge": Object {
           "fontFamily": "System",
@@ -774,6 +786,7 @@ exports[`renders list section with subheader 1`] = `
                 "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontWeight": "400",
+                "letterSpacing": 0,
               },
               Object {
                 "writingDirection": "ltr",
@@ -898,6 +911,7 @@ exports[`renders list section with subheader 1`] = `
                 "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontWeight": "400",
+                "letterSpacing": 0,
               },
               Object {
                 "writingDirection": "ltr",
@@ -1001,6 +1015,11 @@ exports[`renders list section without subheader 1`] = `
           "fontWeight": "400",
           "letterSpacing": 0.4,
           "lineHeight": 16,
+        },
+        "default": Object {
+          "fontFamily": "System",
+          "fontWeight": "400",
+          "letterSpacing": 0,
         },
         "displayLarge": Object {
           "fontFamily": "System",
@@ -1196,6 +1215,7 @@ exports[`renders list section without subheader 1`] = `
                 "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontWeight": "400",
+                "letterSpacing": 0,
               },
               Object {
                 "writingDirection": "ltr",
@@ -1320,6 +1340,7 @@ exports[`renders list section without subheader 1`] = `
                 "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontWeight": "400",
+                "letterSpacing": 0,
               },
               Object {
                 "writingDirection": "ltr",

--- a/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
@@ -302,6 +302,7 @@ exports[`renders snackbar with action button 1`] = `
                 "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontWeight": "400",
+                "letterSpacing": 0,
               },
               Object {
                 "writingDirection": "ltr",
@@ -553,6 +554,7 @@ exports[`renders snackbar with content 1`] = `
                 "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontWeight": "400",
+                "letterSpacing": 0,
               },
               Object {
                 "writingDirection": "ltr",

--- a/src/styles/themes/v3/tokens.tsx
+++ b/src/styles/themes/v3/tokens.tsx
@@ -212,6 +212,10 @@ export const typescale = {
     lineHeight: 16,
     fontSize: 12,
   },
+
+  default: {
+    ...regularType,
+  },
 };
 
 export const tokens = {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -173,11 +173,7 @@ export type MD3Typescale =
   | {
       [key in MD3TypescaleKey]: MD3Type;
     } & {
-      ['default']: {
-        fontFamily: string;
-        fontWeight: Font['fontWeight'];
-        letterSpacing: number;
-      };
+      ['default']: Omit<MD3Type, 'lineHeight' | 'fontSize'>;
     };
 
 export type MD3Elevation = 0 | 1 | 2 | 3 | 4 | 5;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -169,9 +169,16 @@ export type MD3Type = {
   fontSize: number;
 };
 
-export type MD3Typescale = {
-  [key in MD3TypescaleKey]: MD3Type;
-};
+export type MD3Typescale =
+  | {
+      [key in MD3TypescaleKey]: MD3Type;
+    } & {
+      ['default']: {
+        fontFamily: string;
+        fontWeight: Font['fontWeight'];
+        letterSpacing: number;
+      };
+    };
 
 export type MD3Elevation = 0 | 1 | 2 | 3 | 4 | 5;
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes https://github.com/callstack/react-native-paper/issues/3435

Support the possibility to override the default `Text`s component font styles, via theme property `theme.fonts.default`

#### Related issue

- #3435 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Updated snapshots

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
