### PR TITLE
fix: added offscreenAlphaCompositing for android only

### DIFF
--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -733,6 +733,10 @@ const BottomNavigation = ({
               }
             >
               <Animated.View
+                {...(Platform.OS === 'android' && {
+                  needsOffscreenAlphaCompositing: sceneAnimationEnabled,
+                })}
+                renderToHardwareTextureAndroid={sceneAnimationEnabled}
                 style={[
                   styles.content,
                   {

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
@@ -50,6 +50,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
     >
       <View
         collapsable={false}
+        renderToHardwareTextureAndroid={false}
         style={
           Object {
             "flex": 1,
@@ -691,6 +692,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
     >
       <View
         collapsable={false}
+        renderToHardwareTextureAndroid={false}
         style={
           Object {
             "flex": 1,
@@ -1353,6 +1355,7 @@ exports[`renders bottom navigation with scene animation 1`] = `
     >
       <View
         collapsable={false}
+        renderToHardwareTextureAndroid={true}
         style={
           Object {
             "flex": 1,
@@ -2668,6 +2671,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
     >
       <View
         collapsable={false}
+        renderToHardwareTextureAndroid={false}
         style={
           Object {
             "flex": 1,
@@ -3339,6 +3343,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
     >
       <View
         collapsable={false}
+        renderToHardwareTextureAndroid={false}
         style={
           Object {
             "flex": 1,
@@ -4314,6 +4319,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
     >
       <View
         collapsable={false}
+        renderToHardwareTextureAndroid={false}
         style={
           Object {
             "flex": 1,
@@ -5301,6 +5307,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
     >
       <View
         collapsable={false}
+        renderToHardwareTextureAndroid={false}
         style={
           Object {
             "flex": 1,
@@ -6165,6 +6172,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
     >
       <View
         collapsable={false}
+        renderToHardwareTextureAndroid={false}
         style={
           Object {
             "flex": 1,
@@ -7151,6 +7159,7 @@ exports[`renders shifting bottom navigation 1`] = `
     >
       <View
         collapsable={false}
+        renderToHardwareTextureAndroid={false}
         style={
           Object {
             "flex": 1,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes #3263 

We add `needsOffscreenAlphaCompositing` to the `Animated.View` wrapping the scene to preserve the alpha. We also use `renderToHardwareTextureAndroid` in combination with the former to avoid re-calculating for hardware texture.

More info: [here](https://reactnative.dev/docs/view#needsoffscreenalphacompositing)

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Updated snapshot 🧪

Previous output on android:

https://user-images.githubusercontent.com/47336142/197985504-3f3461c2-000f-4380-a205-c1a600896ca1.mp4

Updated output on android:

https://user-images.githubusercontent.com/47336142/197985570-b1bcf67d-6bda-4ca1-8dda-11ccb8aec180.mp4

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
