### PR TITLE
feat: List Item v3 adjustment

### DIFF
--- a/src/components/List/ListIcon.tsx
+++ b/src/components/List/ListIcon.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { View, ViewStyle, StyleSheet, StyleProp } from 'react-native';
 
+import { withInternalTheme } from '../../core/theming';
+import type { InternalTheme } from '../../types';
 import Icon, { IconSource } from '../Icon';
 
 export type Props = {
@@ -13,6 +15,10 @@ export type Props = {
    */
   color?: string;
   style?: StyleProp<ViewStyle>;
+  /**
+   * @optional
+   */
+  theme: InternalTheme;
 };
 
 const ICON_SIZE = 24;
@@ -42,8 +48,11 @@ const ICON_SIZE = 24;
  * export default MyComponent;
  * ```
  */
-const ListIcon = ({ icon, color: iconColor, style }: Props) => (
-  <View style={[styles.item, style]} pointerEvents="box-none">
+const ListIcon = ({ icon, color: iconColor, style, theme }: Props) => (
+  <View
+    style={[theme.isV3 ? styles.itemV3 : styles.item, style]}
+    pointerEvents="box-none"
+  >
     <Icon source={icon} size={ICON_SIZE} color={iconColor} />
   </View>
 );
@@ -56,8 +65,12 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  itemV3: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
 });
 
 ListIcon.displayName = 'List.Icon';
 
-export default ListIcon;
+export default withInternalTheme(ListIcon);

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -20,6 +20,7 @@ import type {
 } from '../../types';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import Text from '../Typography/Text';
+import { getLeftStyles, getRightStyles } from './utils';
 
 type Title =
   | React.ReactNode
@@ -251,63 +252,6 @@ const ListItem = ({
   );
 };
 
-const getLeftStyles = (
-  alignToTop: boolean,
-  description: Description,
-  isV3: boolean
-) => {
-  const stylesV3 = {
-    marginRight: 0,
-    marginLeft: 16,
-    alignSelf: alignToTop ? 'flex-start' : 'center',
-  };
-
-  if (!description) {
-    return {
-      ...styles.iconMarginLeft,
-      ...styles.marginVerticalNone,
-      ...(isV3 && { ...stylesV3 }),
-    };
-  }
-
-  if (!isV3) {
-    return styles.iconMarginLeft;
-  }
-
-  return {
-    ...styles.iconMarginLeft,
-    ...stylesV3,
-  };
-};
-
-const getRightStyles = (
-  alignToTop: boolean,
-  description: Description,
-  isV3: boolean
-) => {
-  const stylesV3 = {
-    marginLeft: 16,
-    alignSelf: alignToTop ? 'flex-start' : 'center',
-  };
-
-  if (!description) {
-    return {
-      ...styles.iconMarginRight,
-      ...styles.marginVerticalNone,
-      ...(isV3 && { ...stylesV3 }),
-    };
-  }
-
-  if (!isV3) {
-    return styles.iconMarginRight;
-  }
-
-  return {
-    ...styles.iconMarginRight,
-    ...stylesV3,
-  };
-};
-
 ListItem.displayName = 'List.Item';
 
 const styles = StyleSheet.create({
@@ -331,9 +275,6 @@ const styles = StyleSheet.create({
   description: {
     fontSize: 14,
   },
-  marginVerticalNone: { marginVertical: 0 },
-  iconMarginLeft: { marginLeft: 0, marginRight: 16 },
-  iconMarginRight: { marginRight: 0 },
   item: {
     marginVertical: 6,
     paddingLeft: 8,

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  FlexAlignType,
   NativeSyntheticEvent,
   StyleProp,
   StyleSheet,
@@ -38,6 +39,13 @@ type Description =
       fontSize: number;
     }) => React.ReactNode);
 
+interface Style {
+  marginLeft?: number;
+  marginRight?: number;
+  marginVertical?: number;
+  alignSelf?: FlexAlignType;
+}
+
 export type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * Title text for the list item.
@@ -50,11 +58,11 @@ export type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * Callback which returns a React element to display on the left side.
    */
-  left?: (props: { color: string; style: ViewStyle }) => React.ReactNode;
+  left?: (props: { color: string; style: Style }) => React.ReactNode;
   /**
    * Callback which returns a React element to display on the right side.
    */
-  right?: (props: { color: string; style?: ViewStyle }) => React.ReactNode;
+  right?: (props: { color: string; style?: Style }) => React.ReactNode;
   /**
    * Function to execute on press.
    */

--- a/src/components/List/utils.ts
+++ b/src/components/List/utils.ts
@@ -1,0 +1,75 @@
+import { StyleSheet } from 'react-native';
+
+import type { EllipsizeProp } from 'src/types';
+
+type Description =
+  | React.ReactNode
+  | ((props: {
+      selectable: boolean;
+      ellipsizeMode: EllipsizeProp | undefined;
+      color: string;
+      fontSize: number;
+    }) => React.ReactNode);
+
+export const getLeftStyles = (
+  alignToTop: boolean,
+  description: Description,
+  isV3: boolean
+) => {
+  const stylesV3 = {
+    marginRight: 0,
+    marginLeft: 16,
+    alignSelf: alignToTop ? 'flex-start' : 'center',
+  };
+
+  if (!description) {
+    return {
+      ...styles.iconMarginLeft,
+      ...styles.marginVerticalNone,
+      ...(isV3 && { ...stylesV3 }),
+    };
+  }
+
+  if (!isV3) {
+    return styles.iconMarginLeft;
+  }
+
+  return {
+    ...styles.iconMarginLeft,
+    ...stylesV3,
+  };
+};
+
+export const getRightStyles = (
+  alignToTop: boolean,
+  description: Description,
+  isV3: boolean
+) => {
+  const stylesV3 = {
+    marginLeft: 16,
+    alignSelf: alignToTop ? 'flex-start' : 'center',
+  };
+
+  if (!description) {
+    return {
+      ...styles.iconMarginRight,
+      ...styles.marginVerticalNone,
+      ...(isV3 && { ...stylesV3 }),
+    };
+  }
+
+  if (!isV3) {
+    return styles.iconMarginRight;
+  }
+
+  return {
+    ...styles.iconMarginRight,
+    ...stylesV3,
+  };
+};
+
+const styles = StyleSheet.create({
+  marginVerticalNone: { marginVertical: 0 },
+  iconMarginLeft: { marginLeft: 0, marginRight: 16 },
+  iconMarginRight: { marginRight: 0 },
+});

--- a/src/components/__tests__/ListUtils.test.js
+++ b/src/components/__tests__/ListUtils.test.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { getLeftStyles, getRightStyles } from '../List/utils';
+import Text from '../Typography/Text';
+
+const styles = StyleSheet.create({
+  leftItem: {
+    marginLeft: 0,
+    marginRight: 16,
+  },
+  leftItemV3: {
+    marginLeft: 16,
+    marginRight: 0,
+    alignSelf: 'center',
+  },
+  rightItem: {
+    marginRight: 0,
+  },
+  rightItemV3: {
+    marginLeft: 16,
+    marginRight: 0,
+    alignSelf: 'center',
+  },
+});
+
+const description = <Text>Test</Text>;
+
+/**
+ * ********************** getLeftStyles ********************** *
+ */
+
+it('returns styles for left item without description for V2', () => {
+  const style = getLeftStyles(false, null, false);
+  expect(style).toStrictEqual({ ...styles.leftItem, marginVertical: 0 });
+});
+
+it('returns styles for left item w/ desctiption for V2', () => {
+  const style = getLeftStyles(false, description, false);
+  expect(style).toStrictEqual(styles.leftItem);
+});
+
+it('returns styles for left item without description for V3', () => {
+  const style = getLeftStyles(false, null, true);
+  expect(style).toStrictEqual({ ...styles.leftItemV3, marginVertical: 0 });
+});
+
+it('returns styles for left item w/ desctiption for V3', () => {
+  const style = getLeftStyles(true, description, true);
+  expect(style).toStrictEqual({
+    ...styles.leftItemV3,
+    alignSelf: 'flex-start',
+  });
+});
+
+/**
+ * ********************** getRightStyles ********************** *
+ */
+
+it('returns styles for right item without description for V2', () => {
+  const style = getRightStyles(false, null, false);
+  expect(style).toStrictEqual({ ...styles.rightItem, marginVertical: 0 });
+});
+
+it('returns styles for right item w/ desctiption for V2', () => {
+  const style = getRightStyles(false, description, false);
+  expect(style).toStrictEqual(styles.rightItem);
+});
+
+it('returns styles for right item without description for V3', () => {
+  const style = getRightStyles(false, null, true);
+  expect(style).toStrictEqual({ ...styles.rightItemV3, marginVertical: 0 });
+});
+
+it('returns styles for right item w/ desctiption for V3', () => {
+  const style = getRightStyles(true, description, true);
+  expect(style).toStrictEqual({
+    ...styles.rightItemV3,
+    alignSelf: 'flex-start',
+  });
+});

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.js.snap
@@ -154,7 +154,8 @@ exports[`renders expanded accordion 1`] = `
         false,
         Array [
           Object {
-            "padding": 8,
+            "paddingRight": 24,
+            "paddingVertical": 8,
           },
           undefined,
         ],
@@ -165,6 +166,7 @@ exports[`renders expanded accordion 1`] = `
       style={
         Object {
           "flexDirection": "row",
+          "marginVertical": 6,
         }
       }
     >
@@ -172,8 +174,7 @@ exports[`renders expanded accordion 1`] = `
         style={
           Array [
             Object {
-              "marginVertical": 6,
-              "paddingLeft": 8,
+              "paddingLeft": 16,
             },
             Object {
               "flex": 1,
@@ -277,10 +278,7 @@ exports[`renders list accordion with children 1`] = `
             Array [
               Object {
                 "alignItems": "center",
-                "height": 40,
                 "justifyContent": "center",
-                "margin": 8,
-                "width": 40,
               },
               undefined,
             ]
@@ -616,10 +614,7 @@ exports[`renders list accordion with left items 1`] = `
             Array [
               Object {
                 "alignItems": "center",
-                "height": 40,
                 "justifyContent": "center",
-                "margin": 8,
-                "width": 40,
               },
               undefined,
             ]

--- a/src/components/__tests__/__snapshots__/ListItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.js.snap
@@ -25,7 +25,8 @@ exports[`renders list item with custom description 1`] = `
       false,
       Array [
         Object {
-          "padding": 8,
+          "paddingRight": 24,
+          "paddingVertical": 8,
         },
         undefined,
       ],
@@ -36,6 +37,7 @@ exports[`renders list item with custom description 1`] = `
     style={
       Object {
         "flexDirection": "row",
+        "marginVertical": 6,
       }
     }
   >
@@ -43,8 +45,7 @@ exports[`renders list item with custom description 1`] = `
       style={
         Array [
           Object {
-            "marginVertical": 6,
-            "paddingLeft": 8,
+            "paddingLeft": 16,
           },
           Object {
             "flex": 1,
@@ -314,7 +315,8 @@ exports[`renders list item with custom title and description styles 1`] = `
       false,
       Array [
         Object {
-          "padding": 8,
+          "paddingRight": 24,
+          "paddingVertical": 8,
         },
         undefined,
       ],
@@ -325,6 +327,7 @@ exports[`renders list item with custom title and description styles 1`] = `
     style={
       Object {
         "flexDirection": "row",
+        "marginVertical": 6,
       }
     }
   >
@@ -332,8 +335,7 @@ exports[`renders list item with custom title and description styles 1`] = `
       style={
         Array [
           Object {
-            "marginVertical": 6,
-            "paddingLeft": 8,
+            "paddingLeft": 16,
           },
           Object {
             "flex": 1,
@@ -376,6 +378,7 @@ exports[`renders list item with custom title and description styles 1`] = `
       </Text>
       <Text
         numberOfLines={2}
+        onTextLayout={[Function]}
         selectable={false}
         style={
           Array [
@@ -436,7 +439,8 @@ exports[`renders list item with left and right items 1`] = `
       false,
       Array [
         Object {
-          "padding": 8,
+          "paddingRight": 24,
+          "paddingVertical": 8,
         },
         undefined,
       ],
@@ -447,6 +451,7 @@ exports[`renders list item with left and right items 1`] = `
     style={
       Object {
         "flexDirection": "row",
+        "marginVertical": 6,
       }
     }
   >
@@ -457,8 +462,7 @@ exports[`renders list item with left and right items 1`] = `
       style={
         Array [
           Object {
-            "marginVertical": 6,
-            "paddingLeft": 8,
+            "paddingLeft": 16,
           },
           Object {
             "flex": 1,
@@ -499,6 +503,7 @@ exports[`renders list item with left and right items 1`] = `
       </Text>
       <Text
         numberOfLines={2}
+        onTextLayout={[Function]}
         selectable={false}
         style={
           Array [
@@ -534,12 +539,11 @@ exports[`renders list item with left and right items 1`] = `
         Array [
           Object {
             "alignItems": "center",
-            "height": 40,
             "justifyContent": "center",
-            "margin": 8,
-            "width": 40,
           },
           Object {
+            "alignSelf": "center",
+            "marginLeft": 16,
             "marginRight": 0,
           },
         ]
@@ -594,7 +598,8 @@ exports[`renders list item with left item 1`] = `
       false,
       Array [
         Object {
-          "padding": 8,
+          "paddingRight": 24,
+          "paddingVertical": 8,
         },
         undefined,
       ],
@@ -605,6 +610,7 @@ exports[`renders list item with left item 1`] = `
     style={
       Object {
         "flexDirection": "row",
+        "marginVertical": 6,
       }
     }
   >
@@ -614,14 +620,12 @@ exports[`renders list item with left item 1`] = `
         Array [
           Object {
             "alignItems": "center",
-            "height": 40,
             "justifyContent": "center",
-            "margin": 8,
-            "width": 40,
           },
           Object {
-            "marginLeft": 0,
-            "marginRight": 16,
+            "alignSelf": "center",
+            "marginLeft": 16,
+            "marginRight": 0,
             "marginVertical": 0,
           },
         ]
@@ -651,8 +655,7 @@ exports[`renders list item with left item 1`] = `
       style={
         Array [
           Object {
-            "marginVertical": 6,
-            "paddingLeft": 8,
+            "paddingLeft": 16,
           },
           Object {
             "flex": 1,
@@ -721,7 +724,8 @@ exports[`renders list item with right item 1`] = `
       false,
       Array [
         Object {
-          "padding": 8,
+          "paddingRight": 24,
+          "paddingVertical": 8,
         },
         undefined,
       ],
@@ -732,6 +736,7 @@ exports[`renders list item with right item 1`] = `
     style={
       Object {
         "flexDirection": "row",
+        "marginVertical": 6,
       }
     }
   >
@@ -739,8 +744,7 @@ exports[`renders list item with right item 1`] = `
       style={
         Array [
           Object {
-            "marginVertical": 6,
-            "paddingLeft": 8,
+            "paddingLeft": 16,
           },
           Object {
             "flex": 1,
@@ -812,7 +816,8 @@ exports[`renders list item with title and description 1`] = `
       false,
       Array [
         Object {
-          "padding": 8,
+          "paddingRight": 24,
+          "paddingVertical": 8,
         },
         undefined,
       ],
@@ -823,6 +828,7 @@ exports[`renders list item with title and description 1`] = `
     style={
       Object {
         "flexDirection": "row",
+        "marginVertical": 6,
       }
     }
   >
@@ -830,8 +836,7 @@ exports[`renders list item with title and description 1`] = `
       style={
         Array [
           Object {
-            "marginVertical": 6,
-            "paddingLeft": 8,
+            "paddingLeft": 16,
           },
           Object {
             "flex": 1,
@@ -872,6 +877,7 @@ exports[`renders list item with title and description 1`] = `
       </Text>
       <Text
         numberOfLines={2}
+        onTextLayout={[Function]}
         selectable={false}
         style={
           Array [
@@ -930,7 +936,8 @@ exports[`renders with a description with typeof number 1`] = `
       false,
       Array [
         Object {
-          "padding": 8,
+          "paddingRight": 24,
+          "paddingVertical": 8,
         },
         undefined,
       ],
@@ -941,6 +948,7 @@ exports[`renders with a description with typeof number 1`] = `
     style={
       Object {
         "flexDirection": "row",
+        "marginVertical": 6,
       }
     }
   >
@@ -948,8 +956,7 @@ exports[`renders with a description with typeof number 1`] = `
       style={
         Array [
           Object {
-            "marginVertical": 6,
-            "paddingLeft": 8,
+            "paddingLeft": 16,
           },
           Object {
             "flex": 1,
@@ -992,6 +999,7 @@ exports[`renders with a description with typeof number 1`] = `
       </Text>
       <Text
         numberOfLines={2}
+        onTextLayout={[Function]}
         selectable={false}
         style={
           Array [

--- a/src/components/__tests__/__snapshots__/ListSection.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.js.snap
@@ -235,7 +235,8 @@ exports[`renders list section with custom title style 1`] = `
         false,
         Array [
           Object {
-            "padding": 8,
+            "paddingRight": 24,
+            "paddingVertical": 8,
           },
           undefined,
         ],
@@ -246,6 +247,7 @@ exports[`renders list section with custom title style 1`] = `
       style={
         Object {
           "flexDirection": "row",
+          "marginVertical": 6,
         }
       }
     >
@@ -255,14 +257,12 @@ exports[`renders list section with custom title style 1`] = `
           Array [
             Object {
               "alignItems": "center",
-              "height": 40,
               "justifyContent": "center",
-              "margin": 8,
-              "width": 40,
             },
             Object {
-              "marginLeft": 0,
-              "marginRight": 16,
+              "alignSelf": "center",
+              "marginLeft": 16,
+              "marginRight": 0,
               "marginVertical": 0,
             },
           ]
@@ -292,8 +292,7 @@ exports[`renders list section with custom title style 1`] = `
         style={
           Array [
             Object {
-              "marginVertical": 6,
-              "paddingLeft": 8,
+              "paddingLeft": 16,
             },
             Object {
               "flex": 1,
@@ -359,7 +358,8 @@ exports[`renders list section with custom title style 1`] = `
         false,
         Array [
           Object {
-            "padding": 8,
+            "paddingRight": 24,
+            "paddingVertical": 8,
           },
           undefined,
         ],
@@ -370,6 +370,7 @@ exports[`renders list section with custom title style 1`] = `
       style={
         Object {
           "flexDirection": "row",
+          "marginVertical": 6,
         }
       }
     >
@@ -379,14 +380,12 @@ exports[`renders list section with custom title style 1`] = `
           Array [
             Object {
               "alignItems": "center",
-              "height": 40,
               "justifyContent": "center",
-              "margin": 8,
-              "width": 40,
             },
             Object {
-              "marginLeft": 0,
-              "marginRight": 16,
+              "alignSelf": "center",
+              "marginLeft": 16,
+              "marginRight": 0,
               "marginVertical": 0,
             },
           ]
@@ -416,8 +415,7 @@ exports[`renders list section with custom title style 1`] = `
         style={
           Array [
             Object {
-              "marginVertical": 6,
-              "paddingLeft": 8,
+              "paddingLeft": 16,
             },
             Object {
               "flex": 1,
@@ -695,7 +693,8 @@ exports[`renders list section with subheader 1`] = `
         false,
         Array [
           Object {
-            "padding": 8,
+            "paddingRight": 24,
+            "paddingVertical": 8,
           },
           undefined,
         ],
@@ -706,6 +705,7 @@ exports[`renders list section with subheader 1`] = `
       style={
         Object {
           "flexDirection": "row",
+          "marginVertical": 6,
         }
       }
     >
@@ -715,14 +715,12 @@ exports[`renders list section with subheader 1`] = `
           Array [
             Object {
               "alignItems": "center",
-              "height": 40,
               "justifyContent": "center",
-              "margin": 8,
-              "width": 40,
             },
             Object {
-              "marginLeft": 0,
-              "marginRight": 16,
+              "alignSelf": "center",
+              "marginLeft": 16,
+              "marginRight": 0,
               "marginVertical": 0,
             },
           ]
@@ -752,8 +750,7 @@ exports[`renders list section with subheader 1`] = `
         style={
           Array [
             Object {
-              "marginVertical": 6,
-              "paddingLeft": 8,
+              "paddingLeft": 16,
             },
             Object {
               "flex": 1,
@@ -819,7 +816,8 @@ exports[`renders list section with subheader 1`] = `
         false,
         Array [
           Object {
-            "padding": 8,
+            "paddingRight": 24,
+            "paddingVertical": 8,
           },
           undefined,
         ],
@@ -830,6 +828,7 @@ exports[`renders list section with subheader 1`] = `
       style={
         Object {
           "flexDirection": "row",
+          "marginVertical": 6,
         }
       }
     >
@@ -839,14 +838,12 @@ exports[`renders list section with subheader 1`] = `
           Array [
             Object {
               "alignItems": "center",
-              "height": 40,
               "justifyContent": "center",
-              "margin": 8,
-              "width": 40,
             },
             Object {
-              "marginLeft": 0,
-              "marginRight": 16,
+              "alignSelf": "center",
+              "marginLeft": 16,
+              "marginRight": 0,
               "marginVertical": 0,
             },
           ]
@@ -876,8 +873,7 @@ exports[`renders list section with subheader 1`] = `
         style={
           Array [
             Object {
-              "marginVertical": 6,
-              "paddingLeft": 8,
+              "paddingLeft": 16,
             },
             Object {
               "flex": 1,
@@ -1117,7 +1113,8 @@ exports[`renders list section without subheader 1`] = `
         false,
         Array [
           Object {
-            "padding": 8,
+            "paddingRight": 24,
+            "paddingVertical": 8,
           },
           undefined,
         ],
@@ -1128,6 +1125,7 @@ exports[`renders list section without subheader 1`] = `
       style={
         Object {
           "flexDirection": "row",
+          "marginVertical": 6,
         }
       }
     >
@@ -1137,14 +1135,12 @@ exports[`renders list section without subheader 1`] = `
           Array [
             Object {
               "alignItems": "center",
-              "height": 40,
               "justifyContent": "center",
-              "margin": 8,
-              "width": 40,
             },
             Object {
-              "marginLeft": 0,
-              "marginRight": 16,
+              "alignSelf": "center",
+              "marginLeft": 16,
+              "marginRight": 0,
               "marginVertical": 0,
             },
           ]
@@ -1174,8 +1170,7 @@ exports[`renders list section without subheader 1`] = `
         style={
           Array [
             Object {
-              "marginVertical": 6,
-              "paddingLeft": 8,
+              "paddingLeft": 16,
             },
             Object {
               "flex": 1,
@@ -1241,7 +1236,8 @@ exports[`renders list section without subheader 1`] = `
         false,
         Array [
           Object {
-            "padding": 8,
+            "paddingRight": 24,
+            "paddingVertical": 8,
           },
           undefined,
         ],
@@ -1252,6 +1248,7 @@ exports[`renders list section without subheader 1`] = `
       style={
         Object {
           "flexDirection": "row",
+          "marginVertical": 6,
         }
       }
     >
@@ -1261,14 +1258,12 @@ exports[`renders list section without subheader 1`] = `
           Array [
             Object {
               "alignItems": "center",
-              "height": 40,
               "justifyContent": "center",
-              "margin": 8,
-              "width": 40,
             },
             Object {
-              "marginLeft": 0,
-              "marginRight": 16,
+              "alignSelf": "center",
+              "marginLeft": 16,
+              "marginRight": 0,
               "marginVertical": 0,
             },
           ]
@@ -1298,8 +1293,7 @@ exports[`renders list section without subheader 1`] = `
         style={
           Array [
             Object {
-              "marginVertical": 6,
-              "paddingLeft": 8,
+              "paddingLeft": 16,
             },
             Object {
               "flex": 1,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Matches the `List.Item` and `List.Icon` layout specs to the material v3 layout [guidelines](https://m3.material.io/components/lists/specs#eeeb78e0-265d-4e81-96ba-c2340c348a90). It has backward support for paper v2.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Manual testing ✍️

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
