### PR TITLE
feat: added List.Item examples

### DIFF
--- a/example/src/ExampleList.tsx
+++ b/example/src/ExampleList.tsx
@@ -24,6 +24,7 @@ import FABExample from './Examples/FABExample';
 import IconButtonExample from './Examples/IconButtonExample';
 import ListAccordionExample from './Examples/ListAccordionExample';
 import ListAccordionExampleGroup from './Examples/ListAccordionGroupExample';
+import ListItemExample from './Examples/ListItemExample';
 import ListSectionExample from './Examples/ListSectionExample';
 import MenuExample from './Examples/MenuExample';
 import ProgressBarExample from './Examples/ProgressBarExample';
@@ -67,6 +68,7 @@ export const examples: Record<
   listAccordion: ListAccordionExample,
   listAccordionGroup: ListAccordionExampleGroup,
   listSection: ListSectionExample,
+  listItem: ListItemExample,
   menu: MenuExample,
   progressbar: ProgressBarExample,
   radio: RadioButtonExample,

--- a/example/src/Examples/ListItemExample.tsx
+++ b/example/src/Examples/ListItemExample.tsx
@@ -1,0 +1,294 @@
+import * as React from 'react';
+
+import { List, Divider, Checkbox, Avatar, Switch } from 'react-native-paper';
+
+import ScreenWrapper from '../ScreenWrapper';
+const ListItemExample = () => {
+  return (
+    <ScreenWrapper>
+      <List.Section title="Text-only">
+        <List.Item title="Headline" />
+        <List.Item title="Headline" description="Supporting text" />
+        <List.Item
+          title="Headline"
+          description="Supporting text that is long enough to fill up multiple lines in the item"
+        />
+        <Divider />
+        <List.Item
+          title="Headline"
+          right={() => <Checkbox.Android status="checked" />}
+        />
+        <List.Item
+          title="Headline"
+          description="Supporting text"
+          right={() => <Checkbox.Android status="checked" />}
+        />
+        <List.Item
+          title="Headline"
+          description="Supporting text that is long enough to fill up multiple lines in the item"
+          right={() => <Checkbox.Android status="checked" />}
+        />
+        <Divider />
+      </List.Section>
+
+      <List.Section title="With icon">
+        <List.Item
+          title="Headline"
+          left={(props) => <List.Icon {...props} icon="account-outline" />}
+        />
+        <List.Item
+          title="Headline"
+          description="Supporting text"
+          left={(props) => <List.Icon {...props} icon="account-outline" />}
+        />
+        <List.Item
+          title="Headline"
+          description="Supporting text that is long enough to fill up multiple lines in the item"
+          left={(props) => <List.Icon {...props} icon="account-outline" />}
+        />
+        <Divider />
+        <List.Item
+          title="Headline"
+          left={(props) => <List.Icon {...props} icon="account-outline" />}
+          right={() => <Checkbox.Android status="checked" />}
+        />
+        <List.Item
+          title="Headline"
+          description="Supporting text"
+          left={(props) => <List.Icon {...props} icon="account-outline" />}
+          right={() => <Checkbox.Android status="checked" />}
+        />
+        <List.Item
+          title="Headline"
+          description="Supporting text that is long enough to fill up multiple lines in the item"
+          left={(props) => <List.Icon {...props} icon="account-outline" />}
+          right={() => <Checkbox.Android status="checked" />}
+        />
+        <Divider />
+      </List.Section>
+
+      <List.Section title="With avatar">
+        <List.Item
+          title="Headline"
+          left={(props) => (
+            <Avatar.Text style={props.style} label="A" size={40} />
+          )}
+        />
+        <List.Item
+          title="Headline"
+          description="Supporting text"
+          left={(props) => (
+            <Avatar.Text style={props.style} label="A" size={40} />
+          )}
+        />
+        <List.Item
+          title="Headline"
+          description="Supporting text that is long enough to fill up multiple lines in the item"
+          left={(props) => (
+            <Avatar.Text style={props.style} label="A" size={40} />
+          )}
+        />
+        <Divider />
+        <List.Item
+          title="Headline"
+          left={(props) => (
+            <Avatar.Text style={props.style} label="A" size={40} />
+          )}
+          right={() => <Checkbox.Android status="checked" />}
+        />
+        <List.Item
+          title="Headline"
+          description="Supporting text"
+          left={(props) => (
+            <Avatar.Text style={props.style} label="A" size={40} />
+          )}
+          right={() => <Checkbox.Android status="checked" />}
+        />
+        <List.Item
+          title="Headline"
+          description="Supporting text that is long enough to fill up multiple lines in the item"
+          left={(props) => (
+            <Avatar.Text style={props.style} label="A" size={40} />
+          )}
+          right={() => <Checkbox.Android status="checked" />}
+        />
+        <Divider />
+      </List.Section>
+
+      <List.Section title="With image">
+        <List.Item
+          title="Headline"
+          left={(props) => (
+            <List.Image
+              style={props.style}
+              source={require('../../../example/assets/images/strawberries.jpg')}
+            />
+          )}
+        />
+        <List.Item
+          title="Headline"
+          description="Supporting text"
+          left={(props) => (
+            <List.Image
+              style={props.style}
+              source={require('../../../example/assets/images/strawberries.jpg')}
+            />
+          )}
+        />
+        <List.Item
+          title="Headline"
+          description="Supporting text that is long enough to fill up multiple lines in the item"
+          left={(props) => (
+            <List.Image
+              style={props.style}
+              source={require('../../../example/assets/images/strawberries.jpg')}
+            />
+          )}
+        />
+        <Divider />
+        <List.Item
+          title="Headline"
+          left={(props) => (
+            <List.Image
+              style={props.style}
+              source={require('../../../example/assets/images/strawberries.jpg')}
+            />
+          )}
+          right={() => <Checkbox.Android status="checked" />}
+        />
+        <List.Item
+          title="Headline"
+          description="Supporting text"
+          left={(props) => (
+            <List.Image
+              style={props.style}
+              source={require('../../../example/assets/images/strawberries.jpg')}
+            />
+          )}
+          right={() => <Checkbox.Android status="checked" />}
+        />
+        <List.Item
+          title="Headline"
+          description="Supporting text that is long enough to fill up multiple lines in the item"
+          left={(props) => (
+            <List.Image
+              style={props.style}
+              source={require('../../../example/assets/images/strawberries.jpg')}
+            />
+          )}
+          right={() => <Checkbox.Android status="checked" />}
+        />
+        <Divider />
+      </List.Section>
+
+      <List.Section title="With video">
+        <List.Item
+          title="Headline"
+          left={(props) => (
+            <List.Image
+              variant="video"
+              style={props.style}
+              source={require('../../../example/assets/images/strawberries.jpg')}
+            />
+          )}
+        />
+        <List.Item
+          title="Headline"
+          description="Supporting text"
+          left={(props) => (
+            <List.Image
+              variant="video"
+              style={props.style}
+              source={require('../../../example/assets/images/strawberries.jpg')}
+            />
+          )}
+        />
+        <List.Item
+          title="Headline"
+          description="Supporting text that is long enough to fill up multiple lines in the item"
+          left={(props) => (
+            <List.Image
+              variant="video"
+              style={props.style}
+              source={require('../../../example/assets/images/strawberries.jpg')}
+            />
+          )}
+        />
+        <Divider />
+        <List.Item
+          title="Headline"
+          left={(props) => (
+            <List.Image
+              variant="video"
+              style={props.style}
+              source={require('../../../example/assets/images/strawberries.jpg')}
+            />
+          )}
+          right={() => <Checkbox.Android status="checked" />}
+        />
+        <List.Item
+          title="Headline"
+          description="Supporting text"
+          left={(props) => (
+            <List.Image
+              variant="video"
+              style={props.style}
+              source={require('../../../example/assets/images/strawberries.jpg')}
+            />
+          )}
+          right={() => <Checkbox.Android status="checked" />}
+        />
+        <List.Item
+          title="Headline"
+          description="Supporting text that is long enough to fill up multiple lines in the item"
+          left={(props) => (
+            <List.Image
+              variant="video"
+              style={props.style}
+              source={require('../../../example/assets/images/strawberries.jpg')}
+            />
+          )}
+          right={() => <Checkbox.Android status="checked" />}
+        />
+        <Divider />
+      </List.Section>
+
+      <List.Section title="With switch">
+        <List.Item title="Headline" right={() => <Switch disabled />} />
+        <List.Item
+          title="Headline"
+          description="Supporting text"
+          right={() => <Switch disabled />}
+        />
+        <List.Item
+          title="Headline"
+          description="Supporting text that is long enough to fill up multiple lines in the item"
+          right={() => <Switch disabled />}
+        />
+        <Divider />
+        <List.Item
+          title="Headline"
+          left={(props) => <List.Icon {...props} icon="account-outline" />}
+          right={() => <Switch disabled />}
+        />
+        <List.Item
+          title="Headline"
+          description="Supporting text"
+          left={(props) => <List.Icon {...props} icon="account-outline" />}
+          right={() => <Switch disabled />}
+        />
+        <List.Item
+          title="Headline"
+          description="Supporting text that is long enough to fill up multiple lines in the item"
+          left={(props) => <List.Icon {...props} icon="account-outline" />}
+          right={() => <Switch disabled />}
+        />
+        <Divider />
+      </List.Section>
+    </ScreenWrapper>
+  );
+};
+
+ListItemExample.title = 'List.Item';
+
+export default ListItemExample;

--- a/example/src/Examples/ListItemExample.tsx
+++ b/example/src/Examples/ListItemExample.tsx
@@ -1,8 +1,16 @@
 import * as React from 'react';
+import { View, StyleSheet } from 'react-native';
 
 import { List, Divider, Checkbox, Avatar, Switch } from 'react-native-paper';
 
 import ScreenWrapper from '../ScreenWrapper';
+
+const CenteredCheckbox = () => (
+  <View style={styles.centered}>
+    <Checkbox status="checked" />
+  </View>
+);
+
 const ListItemExample = () => {
   return (
     <ScreenWrapper>
@@ -14,19 +22,16 @@ const ListItemExample = () => {
           description="Supporting text that is long enough to fill up multiple lines in the item"
         />
         <Divider />
-        <List.Item
-          title="Headline"
-          right={() => <Checkbox.Android status="checked" />}
-        />
+        <List.Item title="Headline" right={() => <CenteredCheckbox />} />
         <List.Item
           title="Headline"
           description="Supporting text"
-          right={() => <Checkbox.Android status="checked" />}
+          right={() => <CenteredCheckbox />}
         />
         <List.Item
           title="Headline"
           description="Supporting text that is long enough to fill up multiple lines in the item"
-          right={() => <Checkbox.Android status="checked" />}
+          right={() => <Checkbox status="checked" />}
         />
         <Divider />
       </List.Section>
@@ -50,19 +55,19 @@ const ListItemExample = () => {
         <List.Item
           title="Headline"
           left={(props) => <List.Icon {...props} icon="account-outline" />}
-          right={() => <Checkbox.Android status="checked" />}
+          right={() => <CenteredCheckbox />}
         />
         <List.Item
           title="Headline"
           description="Supporting text"
           left={(props) => <List.Icon {...props} icon="account-outline" />}
-          right={() => <Checkbox.Android status="checked" />}
+          right={() => <CenteredCheckbox />}
         />
         <List.Item
           title="Headline"
           description="Supporting text that is long enough to fill up multiple lines in the item"
           left={(props) => <List.Icon {...props} icon="account-outline" />}
-          right={() => <Checkbox.Android status="checked" />}
+          right={() => <Checkbox status="checked" />}
         />
         <Divider />
       </List.Section>
@@ -94,7 +99,7 @@ const ListItemExample = () => {
           left={(props) => (
             <Avatar.Text style={props.style} label="A" size={40} />
           )}
-          right={() => <Checkbox.Android status="checked" />}
+          right={() => <CenteredCheckbox />}
         />
         <List.Item
           title="Headline"
@@ -102,7 +107,7 @@ const ListItemExample = () => {
           left={(props) => (
             <Avatar.Text style={props.style} label="A" size={40} />
           )}
-          right={() => <Checkbox.Android status="checked" />}
+          right={() => <CenteredCheckbox />}
         />
         <List.Item
           title="Headline"
@@ -110,7 +115,7 @@ const ListItemExample = () => {
           left={(props) => (
             <Avatar.Text style={props.style} label="A" size={40} />
           )}
-          right={() => <Checkbox.Android status="checked" />}
+          right={() => <Checkbox status="checked" />}
         />
         <Divider />
       </List.Section>
@@ -154,7 +159,7 @@ const ListItemExample = () => {
               source={require('../../../example/assets/images/strawberries.jpg')}
             />
           )}
-          right={() => <Checkbox.Android status="checked" />}
+          right={() => <CenteredCheckbox />}
         />
         <List.Item
           title="Headline"
@@ -165,7 +170,7 @@ const ListItemExample = () => {
               source={require('../../../example/assets/images/strawberries.jpg')}
             />
           )}
-          right={() => <Checkbox.Android status="checked" />}
+          right={() => <CenteredCheckbox />}
         />
         <List.Item
           title="Headline"
@@ -176,7 +181,7 @@ const ListItemExample = () => {
               source={require('../../../example/assets/images/strawberries.jpg')}
             />
           )}
-          right={() => <Checkbox.Android status="checked" />}
+          right={() => <Checkbox status="checked" />}
         />
         <Divider />
       </List.Section>
@@ -224,7 +229,7 @@ const ListItemExample = () => {
               source={require('../../../example/assets/images/strawberries.jpg')}
             />
           )}
-          right={() => <Checkbox.Android status="checked" />}
+          right={() => <CenteredCheckbox />}
         />
         <List.Item
           title="Headline"
@@ -236,7 +241,7 @@ const ListItemExample = () => {
               source={require('../../../example/assets/images/strawberries.jpg')}
             />
           )}
-          right={() => <Checkbox.Android status="checked" />}
+          right={() => <CenteredCheckbox />}
         />
         <List.Item
           title="Headline"
@@ -248,17 +253,20 @@ const ListItemExample = () => {
               source={require('../../../example/assets/images/strawberries.jpg')}
             />
           )}
-          right={() => <Checkbox.Android status="checked" />}
+          right={() => <Checkbox status="checked" />}
         />
         <Divider />
       </List.Section>
 
       <List.Section title="With switch">
-        <List.Item title="Headline" right={() => <Switch disabled />} />
+        <List.Item
+          title="Headline"
+          right={() => <Switch disabled style={styles.centered} />}
+        />
         <List.Item
           title="Headline"
           description="Supporting text"
-          right={() => <Switch disabled />}
+          right={() => <Switch disabled style={styles.centered} />}
         />
         <List.Item
           title="Headline"
@@ -269,13 +277,13 @@ const ListItemExample = () => {
         <List.Item
           title="Headline"
           left={(props) => <List.Icon {...props} icon="account-outline" />}
-          right={() => <Switch disabled />}
+          right={() => <Switch disabled style={styles.centered} />}
         />
         <List.Item
           title="Headline"
           description="Supporting text"
           left={(props) => <List.Icon {...props} icon="account-outline" />}
-          right={() => <Switch disabled />}
+          right={() => <Switch disabled style={styles.centered} />}
         />
         <List.Item
           title="Headline"
@@ -288,6 +296,12 @@ const ListItemExample = () => {
     </ScreenWrapper>
   );
 };
+
+const styles = StyleSheet.create({
+  centered: {
+    alignSelf: 'center',
+  },
+});
 
 ListItemExample.title = 'List.Item';
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Introduces the `List.Item` examples to the _example app_ following the [configurations](https://m3.material.io/components/lists/specs#e00879ab-2633-473f-8317-30c96b14645d) from MD3 guidelines.

This also requires [PR](https://github.com/callstack/react-native-paper/pull/3442) to be merged, which allows the `List.Item` and `List.Icon` adjustments a/c to MD3.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<details>
<summary>web</summary>

https://user-images.githubusercontent.com/47336142/198975614-56b32e7a-b85f-41ef-8a83-a46a24150733.mp4

</details>

<details>
<summary>android</summary>

https://user-images.githubusercontent.com/47336142/198975678-fe6a36ce-6913-4f9b-8655-5705b6872363.mp4

</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/47336142/198975709-2ef90b09-652c-4b0f-8e11-16e660a2866b.mp4

</details>

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
