### PR TITLE
fix: unwanted closing of contextMenu

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -317,12 +317,16 @@ const TextInput = React.forwardRef<TextInputHandles, Props>(
       // We don't show placeholder if there's a label because the label acts as placeholder
       // When focused, the label moves up, so we can show a placeholder
       if (focused || !rest.label) {
-        // Set the placeholder in a delay to offset the label animation
-        // If we show it immediately, they'll overlap and look ugly
-        timer.current = setTimeout(
-          () => setPlaceholder(rest.placeholder),
-          50
-        ) as unknown as NodeJS.Timeout;
+        // If the user wants to use the contextMenu, when changing the placeholder, the contextMenu is closed
+        // This is a workaround to mitigate this behavior in scenarios where the placeholder is not specified.
+        if (rest.placeholder) {
+          // Set the placeholder in a delay to offset the label animation
+          // If we show it immediately, they'll overlap and look ugly
+          timer.current = setTimeout(
+            () => setPlaceholder(rest.placeholder),
+            50
+          ) as unknown as NodeJS.Timeout;
+        }
       } else {
         // hidePlaceholder
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

The TextInput component is having an unexpected behavior. When the user tries to use the contextMenu to paste a text, it's closing itself.

![text-input](https://user-images.githubusercontent.com/58531490/199632257-9ddd5479-6f7e-48b2-8511-f750f99890c0.gif)

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

To test the bug, just press for a long time text input for the context menu to appear and then close.

To test the solution, just press for a long time on an input where the placeholder was not specified.

![text-input-fixed](https://user-images.githubusercontent.com/58531490/199634007-4cd4c9eb-b264-44e8-a2d6-a539a971586f.gif)

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
