### PR TITLE
feat: Content (text) alignment added to Snackbar

### DIFF
--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -55,6 +55,10 @@ export type Props = React.ComponentProps<typeof Surface> & {
    * @optional
    */
   theme: InternalTheme;
+  /**
+   * Text align of content
+   */
+  textAlign?: 'left' | 'center' | 'right';
 };
 
 const DURATION_SHORT = 4000;
@@ -119,6 +123,7 @@ const Snackbar = ({
   wrapperStyle,
   style,
   theme,
+  textAlign = 'left',
   ...rest
 }: Props) => {
   const { current: opacity } = React.useRef<Animated.Value>(
@@ -199,7 +204,7 @@ const Snackbar = ({
   const renderChildrenWithWrapper = () => {
     const viewStyles = [
       styles.content,
-      { marginRight, color: colors?.surface },
+      { marginRight, color: colors?.surface, textAlign },
     ];
 
     if (typeof children === 'string') {

--- a/src/components/__tests__/Snackbar.test.js
+++ b/src/components/__tests__/Snackbar.test.js
@@ -68,6 +68,42 @@ it('renders snackbar with Text as a child', () => {
   expect(tree).toMatchSnapshot();
 });
 
+it('renders snackbar with Left align text', () => {
+  const tree = renderer
+    .create(
+      <Snackbar textAlign={'left'} visible onDismiss={jest.fn()}>
+        <Text>Snackbar content</Text>
+      </Snackbar>
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders snackbar with Right Align text', () => {
+  const tree = renderer
+    .create(
+      <Snackbar textAlign={'right'} visible onDismiss={jest.fn()}>
+        <Text>Snackbar content</Text>
+      </Snackbar>
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders snackbar with Center align text', () => {
+  const tree = renderer
+    .create(
+      <Snackbar textAlign={'center'} visible onDismiss={jest.fn()}>
+        <Text>Snackbar content</Text>
+      </Snackbar>
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
 it('renders snackbar with action button', () => {
   const tree = renderer
     .create(

--- a/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
@@ -83,6 +83,300 @@ exports[`renders snackbar with Text as a child 1`] = `
               Object {
                 "color": "rgba(255, 251, 254, 1)",
                 "marginRight": 16,
+                "textAlign": "left",
+              },
+            ]
+          }
+        >
+          <View>
+            <Text>
+              Snackbar content
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</RCTSafeAreaView>
+`;
+
+exports[`renders snackbar with Left align text 1`] = `
+<RCTSafeAreaView
+  emulateUnlessSupported={true}
+  pointerEvents="box-none"
+  style={
+    Array [
+      Object {
+        "bottom": 0,
+        "position": "absolute",
+        "width": "100%",
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      Object {
+        "alignSelf": undefined,
+        "bottom": undefined,
+        "left": undefined,
+        "position": undefined,
+        "right": undefined,
+        "shadowColor": "#000",
+        "shadowOffset": Object {
+          "height": 2,
+          "width": 0,
+        },
+        "shadowOpacity": 0.15,
+        "shadowRadius": 6,
+        "top": undefined,
+      }
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        Object {
+          "shadowColor": "#000",
+          "shadowOffset": Object {
+            "height": 1,
+            "width": 0,
+          },
+          "shadowOpacity": 0.3,
+          "shadowRadius": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLiveRegion="polite"
+        collapsable={false}
+        pointerEvents="box-none"
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "rgba(28, 27, 31, 1)",
+            "borderRadius": 4,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "margin": 8,
+            "opacity": 1,
+            "transform": Array [
+              Object {
+                "scale": 1,
+              },
+            ],
+          }
+        }
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "flex": 1,
+                "marginLeft": 16,
+                "marginVertical": 14,
+              },
+              Object {
+                "color": "rgba(255, 251, 254, 1)",
+                "marginRight": 16,
+                "textAlign": "left",
+              },
+            ]
+          }
+        >
+          <View>
+            <Text>
+              Snackbar content
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</RCTSafeAreaView>
+`;
+exports[`renders snackbar with Right align text 1`] = `
+<RCTSafeAreaView
+  emulateUnlessSupported={true}
+  pointerEvents="box-none"
+  style={
+    Array [
+      Object {
+        "bottom": 0,
+        "position": "absolute",
+        "width": "100%",
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      Object {
+        "alignSelf": undefined,
+        "bottom": undefined,
+        "left": undefined,
+        "position": undefined,
+        "right": undefined,
+        "shadowColor": "#000",
+        "shadowOffset": Object {
+          "height": 2,
+          "width": 0,
+        },
+        "shadowOpacity": 0.15,
+        "shadowRadius": 6,
+        "top": undefined,
+      }
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        Object {
+          "shadowColor": "#000",
+          "shadowOffset": Object {
+            "height": 1,
+            "width": 0,
+          },
+          "shadowOpacity": 0.3,
+          "shadowRadius": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLiveRegion="polite"
+        collapsable={false}
+        pointerEvents="box-none"
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "rgba(28, 27, 31, 1)",
+            "borderRadius": 4,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "margin": 8,
+            "opacity": 1,
+            "transform": Array [
+              Object {
+                "scale": 1,
+              },
+            ],
+          }
+        }
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "flex": 1,
+                "marginLeft": 16,
+                "marginVertical": 14,
+              },
+              Object {
+                "color": "rgba(255, 251, 254, 1)",
+                "marginRight": 16,
+                "textAlign": "right",
+              },
+            ]
+          }
+        >
+          <View>
+            <Text>
+              Snackbar content
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</RCTSafeAreaView>
+`;
+
+exports[`renders snackbar with Center align text 1`] = `
+<RCTSafeAreaView
+  emulateUnlessSupported={true}
+  pointerEvents="box-none"
+  style={
+    Array [
+      Object {
+        "bottom": 0,
+        "position": "absolute",
+        "width": "100%",
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      Object {
+        "alignSelf": undefined,
+        "bottom": undefined,
+        "left": undefined,
+        "position": undefined,
+        "right": undefined,
+        "shadowColor": "#000",
+        "shadowOffset": Object {
+          "height": 2,
+          "width": 0,
+        },
+        "shadowOpacity": 0.15,
+        "shadowRadius": 6,
+        "top": undefined,
+      }
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        Object {
+          "shadowColor": "#000",
+          "shadowOffset": Object {
+            "height": 1,
+            "width": 0,
+          },
+          "shadowOpacity": 0.3,
+          "shadowRadius": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLiveRegion="polite"
+        collapsable={false}
+        pointerEvents="box-none"
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "rgba(28, 27, 31, 1)",
+            "borderRadius": 4,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "margin": 8,
+            "opacity": 1,
+            "transform": Array [
+              Object {
+                "scale": 1,
+              },
+            ],
+          }
+        }
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "flex": 1,
+                "marginLeft": 16,
+                "marginVertical": 14,
+              },
+              Object {
+                "color": "rgba(255, 251, 254, 1)",
+                "marginRight": 16,
+                "textAlign": "center",
               },
             ]
           }
@@ -180,6 +474,7 @@ exports[`renders snackbar with View & Text as a child 1`] = `
               Object {
                 "color": "rgba(255, 251, 254, 1)",
                 "marginRight": 16,
+                "textAlign": "left",
               },
             ]
           }
@@ -316,6 +611,7 @@ exports[`renders snackbar with action button 1`] = `
                 Object {
                   "color": "rgba(255, 251, 254, 1)",
                   "marginRight": 0,
+                  "textAlign": "left",
                 },
               ],
             ]
@@ -568,6 +864,7 @@ exports[`renders snackbar with content 1`] = `
                 Object {
                   "color": "rgba(255, 251, 254, 1)",
                   "marginRight": 16,
+                  "textAlign": "left",
                 },
               ],
             ]


### PR DESCRIPTION
<div align="center">
<h2><b>textAlign prop with default value of 'left' added to Snackbar component.</b></h2>
</div>

### Overview
You can easily change text alignment inside of **Snackbar**. Just type `textAlign={'center'}` as a new prop of component.

### Changes
**File:** . / src / components / Snackbar.tsx

1. `textAlign?: 'left' | 'center' | 'right'` defined inside of **Props**
2. `textAlign = 'left'` added as a prop of **Snackbar** function with default value of `left`
3. Defined `textAlign` added as a new child of `viewStyles`

### Usage
![code](https://user-images.githubusercontent.com/62894314/200190402-bfb0931e-8ba0-40ce-bb29-84bc740d8afa.png)

### Example
![snack bar text align](https://user-images.githubusercontent.com/62894314/200190457-ada415da-b6c2-4e82-85c4-855b8efcf282.png)



