### PR TITLE
fix: card border radius

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -218,11 +218,13 @@ const Card = ({
     mode: cardMode,
   });
 
+  const borderRadius = (isV3 ? 3 : 1) * roundness;
+
   return (
     <Surface
       style={[
         {
-          borderRadius: roundness,
+          borderRadius,
         },
         isV3 && { backgroundColor },
         !isV3 && isMode('outlined')

--- a/src/components/Card/utils.tsx
+++ b/src/components/Card/utils.tsx
@@ -16,14 +16,14 @@ export const getCardCoverStyle = ({
 }) => {
   const { isV3, roundness } = theme;
 
+  if (isV3) {
+    return {
+      borderRadius: 3 * roundness,
+    };
+  }
+
   if (index === 0) {
     if (total === 1) {
-      return {
-        borderRadius: roundness,
-      };
-    }
-
-    if (isV3) {
       return {
         borderRadius: roundness,
       };

--- a/src/components/__tests__/Card/Card.test.js
+++ b/src/components/__tests__/Card/Card.test.js
@@ -8,7 +8,7 @@ import { getTheme } from '../../../core/theming';
 import { black, white } from '../../../styles/themes/v2/colors';
 import Button from '../../Button/Button';
 import Card from '../../Card/Card';
-import { getCardColors } from '../../Card/utils';
+import { getCardColors, getCardCoverStyle } from '../../Card/utils';
 
 describe('Card', () => {
   it('renders an outlined card', () => {
@@ -104,6 +104,51 @@ describe('getCardColors - border color', () => {
       })
     ).toMatchObject({
       borderColor: color(black).alpha(0.12).rgb().string(),
+    });
+  });
+});
+
+describe('getCardCoverStyle - border radius', () => {
+  it('should return correct border radius based on roundness, for theme version 3', () => {
+    expect(
+      getCardCoverStyle({
+        theme: getTheme(),
+      })
+    ).toMatchObject({ borderRadius: 3 * getTheme().roundness });
+  });
+
+  it('should return correct border radius based on roundness, for theme version 2, when index is 0 and total is 1', () => {
+    expect(
+      getCardCoverStyle({
+        theme: getTheme(false, false),
+        index: 0,
+        total: 1,
+      })
+    ).toMatchObject({ borderRadius: getTheme(false, false).roundness });
+  });
+
+  it('should return correct border radius based on roundness, for theme version 2, when index is 0 and total is other than 1', () => {
+    expect(
+      getCardCoverStyle({
+        theme: getTheme(false, false),
+        index: 0,
+        total: 2,
+      })
+    ).toMatchObject({
+      borderTopLeftRadius: getTheme(false, false).roundness,
+      borderTopRightRadius: getTheme(false, false).roundness,
+    });
+  });
+
+  it('should return correct border radius based on roundness, for theme version 2, when index is equal to total - 1', () => {
+    expect(
+      getCardCoverStyle({
+        theme: getTheme(false, false),
+        index: 1,
+        total: 2,
+      })
+    ).toMatchObject({
+      borderBottomLeftRadius: getTheme(false, false).roundness,
     });
   });
 });

--- a/src/components/__tests__/Card/__snapshots__/Card.test.js.snap
+++ b/src/components/__tests__/Card/__snapshots__/Card.test.js.snap
@@ -40,7 +40,7 @@ exports[`Card renders an outlined card 1`] = `
       style={
         Object {
           "backgroundColor": "rgba(255, 251, 254, 1)",
-          "borderRadius": 4,
+          "borderRadius": 12,
           "elevation": 1,
         }
       }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fix `Card` and `Card.Cover` border radius

ios | android | web
--- | --- | --- |
<img width="525" alt="Zrzut ekranu 2022-11-11 o 21 27 39" src="https://user-images.githubusercontent.com/22746080/201426750-c7efb5a8-47c8-409a-a554-1996e3530e05.png"> | <img width="490" alt="Zrzut ekranu 2022-11-11 o 21 28 07" src="https://user-images.githubusercontent.com/22746080/201426721-dff5725c-3825-4582-876a-c400f4fdf213.png"> | <img width="1512" alt="image" src="https://user-images.githubusercontent.com/22746080/201426701-ed1a242e-cf36-4a0f-925e-7ef2c01b5af2.png">


<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

#### Related issue

- #3460 

### Test plan

Added unit tests.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
