### PR TITLE
fix: correct card size within container

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -289,7 +289,6 @@ Card.Title = CardTitle;
 
 const styles = StyleSheet.create({
   innerContainer: {
-    flexGrow: 1,
     flexShrink: 1,
   },
   outline: {

--- a/src/components/__tests__/Card/__snapshots__/Card.test.js.snap
+++ b/src/components/__tests__/Card/__snapshots__/Card.test.js.snap
@@ -80,7 +80,6 @@ exports[`Card renders an outlined card 1`] = `
         onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "flexGrow": 1,
             "flexShrink": 1,
           }
         }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

#### Related issue

- #1775 

PR correct `Card` sizes when it's contained within another container, by removing the `flexGrow` style from `innerContainer`.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

ios | android | web
--- | --- | ---
<img width="525" alt="Zrzut ekranu 2022-11-14 o 11 56 03" src="https://user-images.githubusercontent.com/22746080/201642868-98352d00-fc01-4004-b5a6-8662a96ee590.png"> | <img width="468" alt="Zrzut ekranu 2022-11-14 o 11 56 25" src="https://user-images.githubusercontent.com/22746080/201642947-d9412133-697e-4f88-bdf7-f6003710cbf9.png"> | <img width="1494" alt="image" src="https://user-images.githubusercontent.com/22746080/201642702-2c6b95eb-fdfb-4e34-bf7c-4ab34a6d89f0.png">


### Test plan

Updated snapshot.
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
