### PR TITLE
refactor: adjust configure fonts overloads

### DIFF
--- a/src/styles/fonts.tsx
+++ b/src/styles/fonts.tsx
@@ -66,9 +66,12 @@ type MD2FontsConfig = {
 
 type MD3FontsConfig =
   | {
-      [key in MD3TypescaleKey | string]: MD3Type;
+      [key in MD3TypescaleKey]: Partial<MD3Type>;
     }
-  | MD3Type;
+  | {
+      [key: string]: MD3Type;
+    }
+  | Partial<MD3Type>;
 
 function configureV2Fonts(config: MD2FontsConfig): Fonts {
   const fonts = Platform.select({ ...fontConfig, ...config }) as Fonts;
@@ -115,21 +118,17 @@ export default function configureFonts(params: {
 }): Fonts;
 // eslint-disable-next-line no-redeclare
 export default function configureFonts(params?: {
-  config?: MD3Type;
+  config?: Partial<MD3Type>;
   isV3?: true;
 }): MD3Typescale;
 // eslint-disable-next-line no-redeclare
 export default function configureFonts(params?: {
-  config?: {
-    [key in MD3TypescaleKey]: MD3Type;
-  };
+  config?: Partial<Record<MD3TypescaleKey, Partial<MD3Type>>>;
   isV3?: true;
 }): MD3Typescale;
 // eslint-disable-next-line no-redeclare
 export default function configureFonts(params: {
-  config: {
-    [key: string]: MD3Type;
-  };
+  config: Record<string, MD3Type>;
   isV3?: true;
 }): MD3Typescale & { [key: string]: MD3Type };
 // eslint-disable-next-line no-redeclare

--- a/src/styles/themes/v3/LightTheme.tsx
+++ b/src/styles/themes/v3/LightTheme.tsx
@@ -1,6 +1,6 @@
 import color from 'color';
 
-import type { MD3Theme, MD3Typescale } from '../../../types';
+import type { MD3Theme } from '../../../types';
 import configureFonts from '../../fonts';
 import { MD3Colors, tokens } from './tokens';
 
@@ -62,7 +62,7 @@ export const MD3LightTheme: MD3Theme = {
       level5: 'rgb(233, 227, 241)', // palette.primary40, alpha 0.14
     },
   },
-  fonts: configureFonts() as MD3Typescale,
+  fonts: configureFonts(),
   animation: {
     scale: 1.0,
   },


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Improve types for `configureFonts` which should display an error when:

* user defines new `variant` without all font properties

in other cases like changing any font property for all variants or a specific one, TS should not raise any error.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

CI passes.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
