### PR TITLE
refactor: adjust Snackbar to Material You

### DIFF
--- a/docs/pages/10.migration-guide-to-5.0.md
+++ b/docs/pages/10.migration-guide-to-5.0.md
@@ -518,18 +518,6 @@ At the same time, by analogy to the second new prop, the `icon` prop was renamed
 >
 ```
 
-## Surface
-
-`Surface` component received one new prop:
-* `elevation` - accepts values from `0` to `5` and applies background color and shadows to the `Surface` component. Supports both iOS and Android.
-
-Previously `elevation` was passed inside the `style` prop. Since it supported not only Android, but also iOS, we decided to extract it from `style` and create a separate `elevation` prop for that.
-
-```diff
-- <Surface style={{ elevation: 1 }} />
-+ <Surface elevation={1} />
-```
-
 ## SegmentedButtons
 
 `SegmentedButtons` is a completely new component introduced in the latest version. It allows people to select options, switch views, or sort elements. It supports single and multiselect select variant and provide a lot of customization options.
@@ -561,6 +549,26 @@ const MyComponent = () => {
       />
   );
 };
+```
+
+## Snackbar
+
+`Snackbar` due to the optional close affordance, in form of `IconButton` <i>(located on the right side of action button)</i>, received three new props:
+
+* `icon` - icon to display when `onIconPress` is defined. Default will be `close` icon.
+* `onIconPress` - function to execute on icon button press. The icon button appears only when this prop is specified.
+* `iconAccessibilityLabel` - accessibility label for the icon button.
+
+## Surface
+
+`Surface` component received one new prop:
+* `elevation` - accepts values from `0` to `5` and applies background color and shadows to the `Surface` component. Supports both iOS and Android.
+
+Previously `elevation` was passed inside the `style` prop. Since it supported not only Android, but also iOS, we decided to extract it from `style` and create a separate `elevation` prop for that.
+
+```diff
+- <Surface style={{ elevation: 1 }} />
++ <Surface elevation={1} />
 ```
 
 ## TextInput.Icon

--- a/example/src/Examples/SnackbarExample.tsx
+++ b/example/src/Examples/SnackbarExample.tsx
@@ -1,30 +1,114 @@
 import * as React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
-import { Snackbar, Button } from 'react-native-paper';
+import { Snackbar, Button, List, Text, Switch } from 'react-native-paper';
 
+import { PreferencesContext, useExampleTheme } from '..';
 import ScreenWrapper from '../ScreenWrapper';
 
+const SHORT_MESSAGE = 'Single-line snackbar';
+const LONG_MESSAGE =
+  'Snackbar with longer message which does not fit in one line';
+
 const SnackbarExample = () => {
-  const [visible, setVisible] = React.useState<boolean>(false);
+  const preferences = React.useContext(PreferencesContext);
+  const theme = useExampleTheme();
+
+  const [options, setOptions] = React.useState({
+    showSnackbar: false,
+    showAction: true,
+    showCloseIcon: false,
+    showLongerMessage: false,
+    showLongerAction: false,
+  });
+
+  const {
+    showSnackbar,
+    showAction,
+    showCloseIcon,
+    showLongerMessage,
+    showLongerAction,
+  } = options;
+
+  const action = {
+    label: showLongerAction ? 'Toggle Theme' : 'Action',
+    onPress: () => {
+      preferences.toggleTheme();
+    },
+  };
 
   return (
     <ScreenWrapper contentContainerStyle={styles.container}>
-      <Button mode="outlined" onPress={() => setVisible(!visible)}>
-        {visible ? 'Hide' : 'Show'}
-      </Button>
+      <List.Section title="Snackbar options">
+        <View style={styles.row}>
+          <Text>Action button</Text>
+          <Switch
+            value={showAction}
+            onValueChange={() =>
+              setOptions({ ...options, showAction: !showAction })
+            }
+          />
+        </View>
+        {theme.isV3 && (
+          <View style={styles.row}>
+            <Text>Close icon button</Text>
+            <Switch
+              value={showCloseIcon}
+              onValueChange={() =>
+                setOptions({ ...options, showCloseIcon: !showCloseIcon })
+              }
+            />
+          </View>
+        )}
+        <View style={styles.row}>
+          <Text>Longer message</Text>
+          <Switch
+            value={showLongerMessage}
+            onValueChange={() =>
+              setOptions({ ...options, showLongerMessage: !showLongerMessage })
+            }
+          />
+        </View>
+        <View style={styles.row}>
+          <Text>Longer action</Text>
+          <Switch
+            value={showLongerAction}
+            onValueChange={() =>
+              setOptions({
+                ...options,
+                showLongerMessage: true,
+                showCloseIcon: true,
+                showLongerAction: !showLongerAction,
+              })
+            }
+          />
+        </View>
+      </List.Section>
+
+      <View style={styles.wrapper}>
+        <Button
+          mode="outlined"
+          onPress={() =>
+            setOptions({ ...options, showSnackbar: !showSnackbar })
+          }
+        >
+          {showSnackbar ? 'Hide' : 'Show'}
+        </Button>
+      </View>
+
       <Snackbar
-        visible={visible}
-        onDismiss={() => setVisible(false)}
-        action={{
-          label: 'Undo',
-          onPress: () => {
-            // Do something
-          },
-        }}
+        visible={showSnackbar}
+        onDismiss={() => setOptions({ ...options, showSnackbar: false })}
+        action={showAction ? action : undefined}
+        onIconPress={
+          showCloseIcon
+            ? () => setOptions({ ...options, showSnackbar: false })
+            : undefined
+        }
         duration={Snackbar.DURATION_MEDIUM}
+        style={showLongerAction && styles.longerAction}
       >
-        Hey there! I&apos;m a Snackbar.
+        {showLongerMessage ? LONG_MESSAGE : SHORT_MESSAGE}
       </Snackbar>
     </ScreenWrapper>
   );
@@ -35,8 +119,20 @@ SnackbarExample.title = 'Snackbar';
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
+  },
+  wrapper: {
     justifyContent: 'center',
+    alignItems: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+  },
+  longerAction: {
+    flexDirection: 'column',
   },
 });
 

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -34,7 +34,7 @@ export type Props = React.ComponentProps<typeof Surface> & {
   };
   /**
    * @supported Available in v5.x with theme version 3
-   * Icon to display when `onIconPress` is defined. Default will be close icon.
+   * Icon to display when `onIconPress` is defined. Default will be `close` icon.
    */
   icon?: IconSource;
   /**
@@ -148,7 +148,7 @@ const Snackbar = ({
   );
   const hideTimeout = React.useRef<NodeJS.Timeout | undefined>(undefined);
 
-  const [hidden, setHidden] = React.useState<boolean>(!visible);
+  const [hidden, setHidden] = React.useState(!visible);
 
   const { scale } = theme.animation;
 

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {
   Animated,
   Easing,
+  I18nManager,
   SafeAreaView,
   StyleProp,
   StyleSheet,
@@ -12,6 +13,9 @@ import {
 import { withInternalTheme } from '../core/theming';
 import type { InternalTheme } from '../types';
 import Button from './Button/Button';
+import type { IconSource } from './Icon';
+import IconButton from './IconButton/IconButton';
+import MaterialCommunityIcon from './MaterialCommunityIcon';
 import Surface from './Surface';
 import Text from './Typography/Text';
 
@@ -28,6 +32,21 @@ export type Props = React.ComponentProps<typeof Surface> & {
   action?: Omit<React.ComponentProps<typeof Button>, 'children'> & {
     label: string;
   };
+  /**
+   * @supported Available in v5.x with theme version 3
+   * Icon to display when `onIconPress` is defined. Default will be close icon.
+   */
+  icon?: IconSource;
+  /**
+   * @supported Available in v5.x with theme version 3
+   * Function to execute on icon button press. The icon button appears only when this prop is specified.
+   */
+  onIconPress?: () => void;
+  /**
+   * @supported Available in v5.x with theme version 3
+   * Accessibility label for the icon button. This is read by the screen reader when the user taps the button.
+   */
+  iconAccessibilityLabel?: string;
   /**
    * The duration for which the Snackbar is shown.
    */
@@ -112,6 +131,9 @@ const DURATION_LONG = 10000;
 const Snackbar = ({
   visible,
   action,
+  icon,
+  onIconPress,
+  iconAccessibilityLabel = 'Close icon',
   duration = DURATION_MEDIUM,
   onDismiss,
   children,
@@ -124,9 +146,9 @@ const Snackbar = ({
   const { current: opacity } = React.useRef<Animated.Value>(
     new Animated.Value(0.0)
   );
-  const [hidden, setHidden] = React.useState<boolean>(!visible);
-
   const hideTimeout = React.useRef<NodeJS.Timeout | undefined>(undefined);
+
+  const [hidden, setHidden] = React.useState<boolean>(!visible);
 
   const { scale } = theme.animation;
 
@@ -191,23 +213,28 @@ const Snackbar = ({
     ...actionProps
   } = action || {};
 
-  const marginRight = action ? 0 : 16;
-  const textColor = theme.isV3
-    ? theme.colors.inversePrimary
-    : theme.colors.accent;
+  const buttonTextColor = isV3 ? colors.inversePrimary : colors.accent;
+  const textColor = isV3 ? colors.inverseOnSurface : colors?.surface;
+  const backgroundColor = isV3 ? colors.inverseSurface : colors?.onSurface;
+
+  const isIconButton = isV3 && onIconPress;
+
+  const marginLeft = action ? -12 : -16;
 
   const renderChildrenWithWrapper = () => {
-    const viewStyles = [
-      styles.content,
-      { marginRight, color: colors?.surface },
-    ];
-
     if (typeof children === 'string') {
-      return <Text style={viewStyles}>{children}</Text>;
+      return (
+        <Text
+          variant="bodyMedium"
+          style={[styles.content, { color: textColor }]}
+        >
+          {children}
+        </Text>
+      );
     }
 
     return (
-      <View style={viewStyles}>
+      <View style={styles.content}>
         {/* View is added to allow multiple lines support for Text component as children */}
         <View>{children}</View>
       </View>
@@ -227,6 +254,7 @@ const Snackbar = ({
             !isV3 && styles.elevation,
             styles.container,
             {
+              backgroundColor,
               borderRadius: roundness,
               opacity: opacity,
               transform: [
@@ -240,7 +268,6 @@ const Snackbar = ({
                 },
               ],
             },
-            { backgroundColor: colors?.onSurface },
             style,
           ] as StyleProp<ViewStyle>
         }
@@ -248,21 +275,50 @@ const Snackbar = ({
         {...rest}
       >
         {renderChildrenWithWrapper()}
-        {action ? (
-          <Button
-            onPress={(event) => {
-              onPressAction?.(event);
-              onDismiss();
-            }}
-            style={[styles.button, actionStyle]}
-            textColor={textColor}
-            compact
-            mode="text"
-            {...actionProps}
-          >
-            {actionLabel}
-          </Button>
-        ) : null}
+        {(action || isIconButton) && (
+          <View style={[styles.actionsContainer, { marginLeft }]}>
+            {action ? (
+              <Button
+                onPress={(event) => {
+                  onPressAction?.(event);
+                  onDismiss();
+                }}
+                style={[styles.button, actionStyle]}
+                textColor={buttonTextColor}
+                compact={!isV3}
+                mode="text"
+                {...actionProps}
+              >
+                {actionLabel}
+              </Button>
+            ) : null}
+            {isIconButton ? (
+              <IconButton
+                accessibilityRole="button"
+                borderless
+                onPress={onIconPress}
+                iconColor={theme.colors.inverseOnSurface}
+                icon={
+                  icon ||
+                  (({ size, color }) => {
+                    return (
+                      <MaterialCommunityIcon
+                        name="close"
+                        color={color}
+                        size={size}
+                        direction={
+                          I18nManager.getConstants().isRTL ? 'rtl' : 'ltr'
+                        }
+                      />
+                    );
+                  })
+                }
+                accessibilityLabel={iconAccessibilityLabel}
+                style={styles.icon}
+              />
+            ) : null}
+          </View>
+        )}
       </Surface>
     </SafeAreaView>
   );
@@ -292,21 +348,32 @@ const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    alignItems: 'center',
     margin: 8,
     borderRadius: 4,
+    minHeight: 48,
   },
   content: {
-    marginLeft: 16,
+    marginHorizontal: 16,
     marginVertical: 14,
     flex: 1,
   },
+  actionsContainer: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    minHeight: 48,
+  },
   button: {
-    marginHorizontal: 8,
-    marginVertical: 6,
+    marginRight: 8,
+    marginLeft: 4,
   },
   elevation: {
     elevation: 6,
+  },
+  icon: {
+    width: 40,
+    height: 40,
+    margin: 0,
   },
 });
 

--- a/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
@@ -57,12 +57,12 @@ exports[`renders snackbar with Text as a child 1`] = `
         pointerEvents="box-none"
         style={
           Object {
-            "alignItems": "center",
-            "backgroundColor": "rgba(28, 27, 31, 1)",
+            "backgroundColor": "rgba(49, 48, 51, 1)",
             "borderRadius": 4,
             "flexDirection": "row",
             "justifyContent": "space-between",
             "margin": 8,
+            "minHeight": 48,
             "opacity": 1,
             "transform": Array [
               Object {
@@ -74,17 +74,11 @@ exports[`renders snackbar with Text as a child 1`] = `
       >
         <View
           style={
-            Array [
-              Object {
-                "flex": 1,
-                "marginLeft": 16,
-                "marginVertical": 14,
-              },
-              Object {
-                "color": "rgba(255, 251, 254, 1)",
-                "marginRight": 16,
-              },
-            ]
+            Object {
+              "flex": 1,
+              "marginHorizontal": 16,
+              "marginVertical": 14,
+            }
           }
         >
           <View>
@@ -154,12 +148,12 @@ exports[`renders snackbar with View & Text as a child 1`] = `
         pointerEvents="box-none"
         style={
           Object {
-            "alignItems": "center",
-            "backgroundColor": "rgba(28, 27, 31, 1)",
+            "backgroundColor": "rgba(49, 48, 51, 1)",
             "borderRadius": 4,
             "flexDirection": "row",
             "justifyContent": "space-between",
             "margin": 8,
+            "minHeight": 48,
             "opacity": 1,
             "transform": Array [
               Object {
@@ -171,17 +165,11 @@ exports[`renders snackbar with View & Text as a child 1`] = `
       >
         <View
           style={
-            Array [
-              Object {
-                "flex": 1,
-                "marginLeft": 16,
-                "marginVertical": 14,
-              },
-              Object {
-                "color": "rgba(255, 251, 254, 1)",
-                "marginRight": 16,
-              },
-            ]
+            Object {
+              "flex": 1,
+              "marginHorizontal": 16,
+              "marginVertical": 14,
+            }
           }
         >
           <View>
@@ -277,12 +265,12 @@ exports[`renders snackbar with action button 1`] = `
         pointerEvents="box-none"
         style={
           Object {
-            "alignItems": "center",
-            "backgroundColor": "rgba(28, 27, 31, 1)",
+            "backgroundColor": "rgba(49, 48, 51, 1)",
             "borderRadius": 4,
             "flexDirection": "row",
             "justifyContent": "space-between",
             "margin": 8,
+            "minHeight": 48,
             "opacity": 1,
             "transform": Array [
               Object {
@@ -296,13 +284,15 @@ exports[`renders snackbar with action button 1`] = `
           style={
             Array [
               Object {
-                "textAlign": "left",
-              },
-              Object {
                 "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
+                "fontSize": 14,
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": 0.25,
+                "lineHeight": 20,
+              },
+              Object {
+                "textAlign": "left",
               },
               Object {
                 "writingDirection": "ltr",
@@ -310,12 +300,11 @@ exports[`renders snackbar with action button 1`] = `
               Array [
                 Object {
                   "flex": 1,
-                  "marginLeft": 16,
+                  "marginHorizontal": 16,
                   "marginVertical": 14,
                 },
                 Object {
-                  "color": "rgba(255, 251, 254, 1)",
-                  "marginRight": 0,
+                  "color": "rgba(244, 239, 244, 1)",
                 },
               ],
             ]
@@ -324,29 +313,29 @@ exports[`renders snackbar with action button 1`] = `
           Snackbar content
         </Text>
         <View
-          collapsable={false}
           style={
-            Object {
-              "alignSelf": undefined,
-              "bottom": undefined,
-              "left": undefined,
-              "position": undefined,
-              "right": undefined,
-              "shadowColor": "#000",
-              "shadowOffset": Object {
-                "height": 0,
-                "width": 0,
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "flex-end",
+                "minHeight": 48,
               },
-              "shadowOpacity": 0,
-              "shadowRadius": 0,
-              "top": undefined,
-            }
+              Object {
+                "marginLeft": -12,
+              },
+            ]
           }
         >
           <View
             collapsable={false}
             style={
               Object {
+                "alignSelf": undefined,
+                "bottom": undefined,
+                "left": undefined,
+                "position": undefined,
+                "right": undefined,
                 "shadowColor": "#000",
                 "shadowOffset": Object {
                   "height": 0,
@@ -354,6 +343,7 @@ exports[`renders snackbar with action button 1`] = `
                 },
                 "shadowOpacity": 0,
                 "shadowRadius": 0,
+                "top": undefined,
               }
             }
           >
@@ -361,108 +351,121 @@ exports[`renders snackbar with action button 1`] = `
               collapsable={false}
               style={
                 Object {
-                  "backgroundColor": "transparent",
-                  "borderColor": "transparent",
-                  "borderRadius": 20,
-                  "borderStyle": "solid",
-                  "borderWidth": 0,
-                  "marginHorizontal": 8,
-                  "marginVertical": 6,
-                  "minWidth": "auto",
+                  "shadowColor": "#000",
+                  "shadowOffset": Object {
+                    "height": 0,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0,
+                  "shadowRadius": 0,
                 }
               }
             >
               <View
-                accessibilityRole="button"
-                accessibilityState={
-                  Object {
-                    "disabled": false,
-                  }
-                }
-                accessible={true}
                 collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
-                  Array [
-                    Object {
-                      "overflow": "hidden",
-                    },
-                    false,
-                    Object {
-                      "borderRadius": 20,
-                    },
-                  ]
+                  Object {
+                    "backgroundColor": "transparent",
+                    "borderColor": "transparent",
+                    "borderRadius": 20,
+                    "borderStyle": "solid",
+                    "borderWidth": 0,
+                    "marginLeft": 4,
+                    "marginRight": 8,
+                    "minWidth": 64,
+                  }
                 }
               >
                 <View
+                  accessibilityRole="button"
+                  accessibilityState={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
                   style={
                     Array [
                       Object {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                        "justifyContent": "center",
+                        "overflow": "hidden",
                       },
-                      undefined,
+                      false,
+                      Object {
+                        "borderRadius": 20,
+                      },
                     ]
                   }
                 >
-                  <Text
-                    numberOfLines={1}
-                    selectable={false}
+                  <View
                     style={
                       Array [
                         Object {
-                          "color": "rgba(28, 27, 31, 1)",
-                          "fontFamily": "System",
-                          "fontSize": 14,
-                          "fontWeight": "500",
-                          "letterSpacing": 0.1,
-                          "lineHeight": 20,
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "justifyContent": "center",
                         },
-                        Object {
-                          "textAlign": "left",
-                        },
-                        Object {
-                          "writingDirection": "ltr",
-                        },
+                        undefined,
+                      ]
+                    }
+                  >
+                    <Text
+                      numberOfLines={1}
+                      selectable={false}
+                      style={
                         Array [
                           Object {
-                            "marginHorizontal": 16,
-                            "marginVertical": 9,
-                            "textAlign": "center",
-                          },
-                          false,
-                          Object {
-                            "marginHorizontal": 12,
-                          },
-                          Object {
-                            "marginHorizontal": 8,
-                          },
-                          false,
-                          Object {
-                            "color": "rgba(208, 188, 255, 1)",
+                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 14,
                             "fontWeight": "500",
                             "letterSpacing": 0.1,
                             "lineHeight": 20,
                           },
-                          undefined,
-                        ],
-                      ]
-                    }
-                  >
-                    Undo
-                  </Text>
+                          Object {
+                            "textAlign": "left",
+                          },
+                          Object {
+                            "writingDirection": "ltr",
+                          },
+                          Array [
+                            Object {
+                              "marginHorizontal": 16,
+                              "marginVertical": 9,
+                              "textAlign": "center",
+                            },
+                            false,
+                            Object {
+                              "marginHorizontal": 12,
+                            },
+                            false,
+                            false,
+                            Object {
+                              "color": "rgba(208, 188, 255, 1)",
+                              "fontFamily": "System",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": 0.1,
+                              "lineHeight": 20,
+                            },
+                            undefined,
+                          ],
+                        ]
+                      }
+                    >
+                      Undo
+                    </Text>
+                  </View>
                 </View>
               </View>
             </View>
@@ -529,12 +532,12 @@ exports[`renders snackbar with content 1`] = `
         pointerEvents="box-none"
         style={
           Object {
-            "alignItems": "center",
-            "backgroundColor": "rgba(28, 27, 31, 1)",
+            "backgroundColor": "rgba(49, 48, 51, 1)",
             "borderRadius": 4,
             "flexDirection": "row",
             "justifyContent": "space-between",
             "margin": 8,
+            "minHeight": 48,
             "opacity": 1,
             "transform": Array [
               Object {
@@ -548,13 +551,15 @@ exports[`renders snackbar with content 1`] = `
           style={
             Array [
               Object {
-                "textAlign": "left",
-              },
-              Object {
                 "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
+                "fontSize": 14,
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": 0.25,
+                "lineHeight": 20,
+              },
+              Object {
+                "textAlign": "left",
               },
               Object {
                 "writingDirection": "ltr",
@@ -562,12 +567,11 @@ exports[`renders snackbar with content 1`] = `
               Array [
                 Object {
                   "flex": 1,
-                  "marginLeft": 16,
+                  "marginHorizontal": 16,
                   "marginVertical": 14,
                 },
                 Object {
-                  "color": "rgba(255, 251, 254, 1)",
-                  "marginRight": 16,
+                  "color": "rgba(244, 239, 244, 1)",
                 },
               ],
             ]


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Updates `Snackbar` according to the latest [guidelines](https://m3.material.io/components/snackbar/specs#06833484-2cc8-491a-8869-0224835ebae3)

<img width="501" alt="image" src="https://user-images.githubusercontent.com/22746080/204376240-02f74b56-31c5-46cc-9120-02f53d36e9b4.png">

There are 3 new props related to the optional Icon button -optional close affordance - placed after action button:

*  icon - icon to display when `onIconPress` is defined. The default will be `close` icon.
*  onIconPress - function to execute on icon button press. The icon button appears **only** when this prop is specified.
*  iconAccessibilityLabel - accessibility label for the icon button. This is read by the screen reader when the user taps the button.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
