### PR TITLE
refactor: extend adaptNavigationTheme

### DIFF
--- a/docs/pages/2.theming.mdx
+++ b/docs/pages/2.theming.mdx
@@ -238,8 +238,10 @@ adaptNavigationTheme(themes)
 
 Valid `themes` keys are:
 
-  * `light` () - React Navigation compliant light theme.
-  * `dark` () - React Navigation compliant dark theme.
+  * `reactNavigationLight` () - React Navigation compliant light theme.
+  * `reactNavigationDark` () - React Navigation compliant dark theme.
+  * `materialLight` () - React Native Paper compliant light theme.
+  * `materialDark` () - React Native Paper compliant dark theme.
 
 ```ts
 // App.tsx
@@ -247,7 +249,7 @@ import { NavigationContainer, DefaultTheme } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import { Provider, MD3LightTheme, adaptNavigationTheme } from 'react-native-paper';
 const Stack = createStackNavigator();
-const { LightTheme } = adaptNavigationTheme({ light: DefaultTheme });
+const { LightTheme } = adaptNavigationTheme({ reactNavigationLight: DefaultTheme });
 export default function App() {
   return (
     <Provider theme={MD3LightTheme}>

--- a/src/core/__tests__/theming.test.js
+++ b/src/core/__tests__/theming.test.js
@@ -39,11 +39,27 @@ const NavigationCustomLightTheme = {
   },
 };
 
+const AppCustomLightTheme = {
+  ...MD3LightTheme,
+  colors: {
+    ...MD3LightTheme.colors,
+    primary: 'purple',
+  },
+};
+
+const AppCustomDarkTheme = {
+  ...MD3DarkTheme,
+  colors: {
+    ...MD3DarkTheme.colors,
+    primary: 'orchid',
+  },
+};
+
 describe('adaptNavigationTheme', () => {
   it('should return adapted both navigation themes', () => {
     const themes = adaptNavigationTheme({
-      light: NavigationLightTheme,
-      dark: NavigationDarkTheme,
+      reactNavigationLight: NavigationLightTheme,
+      reactNavigationDark: NavigationDarkTheme,
     });
 
     expect(themes).toMatchObject({
@@ -76,7 +92,7 @@ describe('adaptNavigationTheme', () => {
 
   it('should return adapted navigation light theme', () => {
     const { LightTheme } = adaptNavigationTheme({
-      light: NavigationLightTheme,
+      reactNavigationLight: NavigationLightTheme,
     });
 
     const { colors } = MD3LightTheme;
@@ -97,7 +113,7 @@ describe('adaptNavigationTheme', () => {
 
   it('should return adapted navigation dark theme', () => {
     const { DarkTheme } = adaptNavigationTheme({
-      dark: NavigationDarkTheme,
+      reactNavigationDark: NavigationDarkTheme,
     });
 
     const { colors } = MD3DarkTheme;
@@ -118,7 +134,7 @@ describe('adaptNavigationTheme', () => {
 
   it('should return adapted custom navigation theme', () => {
     const { LightTheme } = adaptNavigationTheme({
-      light: NavigationCustomLightTheme,
+      reactNavigationLight: NavigationCustomLightTheme,
     });
 
     const { colors } = MD3LightTheme;
@@ -135,6 +151,50 @@ describe('adaptNavigationTheme', () => {
         notification: colors.error,
         secondary: 'rgb(150,45,85)',
         tertiary: 'rgb(105,45,85)',
+      },
+    });
+  });
+
+  it('should return adapted navigation light theme based on custom app light theme', () => {
+    const { LightTheme } = adaptNavigationTheme({
+      reactNavigationLight: NavigationLightTheme,
+      materialLight: AppCustomLightTheme,
+    });
+
+    const { colors } = AppCustomLightTheme;
+
+    expect(LightTheme).toMatchObject({
+      ...NavigationLightTheme,
+      colors: {
+        ...NavigationLightTheme.colors,
+        primary: colors.primary,
+        background: colors.background,
+        card: colors.elevation.level2,
+        text: colors.onSurface,
+        border: colors.outline,
+        notification: colors.error,
+      },
+    });
+  });
+
+  it('should return adapted navigation dark theme based on custom app dark theme', () => {
+    const { DarkTheme } = adaptNavigationTheme({
+      reactNavigationDark: NavigationDarkTheme,
+      materialDark: AppCustomDarkTheme,
+    });
+
+    const { colors } = AppCustomDarkTheme;
+
+    expect(DarkTheme).toMatchObject({
+      ...NavigationDarkTheme,
+      colors: {
+        ...NavigationDarkTheme.colors,
+        primary: colors.primary,
+        background: colors.background,
+        card: colors.elevation.level2,
+        text: colors.onSurface,
+        border: colors.outline,
+        notification: colors.error,
       },
     });
   });

--- a/src/core/theming.tsx
+++ b/src/core/theming.tsx
@@ -55,21 +55,34 @@ export const getTheme = (isDark = false, isV3 = true) => {
 };
 
 // eslint-disable-next-line no-redeclare
-export function adaptNavigationTheme(themes: { light: NavigationTheme }): {
+export function adaptNavigationTheme(themes: {
+  reactNaivgationLight: NavigationTheme;
+  materialLight?: MD3Theme;
+}): {
   LightTheme: NavigationTheme;
 };
 // eslint-disable-next-line no-redeclare
-export function adaptNavigationTheme(themes: { dark: NavigationTheme }): {
+export function adaptNavigationTheme(themes: {
+  reactNavigationDark: NavigationTheme;
+  materialDark?: MD3Theme;
+}): {
   DarkTheme: NavigationTheme;
 };
 // eslint-disable-next-line no-redeclare
 export function adaptNavigationTheme(themes: {
-  light: NavigationTheme;
-  dark: NavigationTheme;
+  reactNavigationLight: NavigationTheme;
+  reactNavigationDark: NavigationTheme;
+  materialLight?: MD3Theme;
+  materialDark?: MD3Theme;
 }): { LightTheme: NavigationTheme; DarkTheme: NavigationTheme };
 // eslint-disable-next-line no-redeclare
 export function adaptNavigationTheme(themes: any) {
-  const { light, dark } = themes;
+  const {
+    reactNavigationLight,
+    reactNavigationDark,
+    materialLight,
+    materialDark,
+  } = themes;
 
   const getAdaptedTheme = (
     navigationTheme: NavigationTheme,
@@ -89,17 +102,17 @@ export function adaptNavigationTheme(themes: any) {
     };
   };
 
-  if (light && dark) {
+  const MD3Themes = {
+    light: materialLight || MD3LightTheme,
+    dark: materialDark || MD3DarkTheme,
+  };
+
+  if (reactNavigationLight && reactNavigationDark) {
     const modes = ['light', 'dark'] as const;
 
-    const MD3Themes = {
-      light: MD3LightTheme,
-      dark: MD3DarkTheme,
-    };
-
     const NavigationThemes = {
-      light,
-      dark,
+      light: reactNavigationLight,
+      dark: reactNavigationDark,
     };
 
     const { light: adaptedLight, dark: adaptedDark } = modes.reduce(
@@ -110,8 +123,8 @@ export function adaptNavigationTheme(themes: any) {
         };
       },
       {
-        light,
-        dark,
+        light: reactNavigationLight,
+        dark: reactNavigationDark,
       }
     );
 
@@ -121,14 +134,14 @@ export function adaptNavigationTheme(themes: any) {
     };
   }
 
-  if (!light) {
+  if (reactNavigationDark) {
     return {
-      DarkTheme: getAdaptedTheme(dark, MD3DarkTheme),
+      DarkTheme: getAdaptedTheme(reactNavigationDark, MD3Themes.dark),
     };
   }
 
   return {
-    LightTheme: getAdaptedTheme(light, MD3LightTheme),
+    LightTheme: getAdaptedTheme(reactNavigationLight, MD3Themes.light),
   };
 }
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Extended `adaptNavigationTheme` to accept custom, but compliant with MD, user themes in both modes.

* extends `adaptNavigationThemes` by two new (optional) themes object properties: `materialLight` and `materialDark`where the user can pass custom theme compliant with MD and Paper.
* currently existing properties `light` and `dark` were renamed to `reactNavigationLight` and `reactNavigationDark`

#### Related issue

- #3476 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Covered by the additional unit test.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
