### PR TITLE
docs: update Menu docs for RN Modal

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -147,7 +147,7 @@ const WINDOW_LAYOUT = Dimensions.get('window');
  * ```
  *
  * ### Note
- * When using Menu within a React Native `Modal`, you need to wrap all
+ * When using `Menu` within a React Native's `Modal` component, you need to wrap all
  * `Modal` contents within a `Provider` in order for the menu to show. This
  * wrapping is not necessary if you use Paper's `Modal` instead.
  */

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -4,8 +4,11 @@ import {
   BackHandler,
   Dimensions,
   Easing,
+  EmitterSubscription,
   findNodeHandle,
   I18nManager,
+  Keyboard,
+  KeyboardEvent as RNKeyboardEvent,
   LayoutRectangle,
   NativeEventSubscription,
   Platform,
@@ -15,10 +18,7 @@ import {
   StyleSheet,
   TouchableWithoutFeedback,
   View,
-  ViewStyle,
-  Keyboard,
-  KeyboardEvent as RNKeyboardEvent,
-  EmitterSubscription,
+  ViewStyle
 } from 'react-native';
 
 import color from 'color';
@@ -145,6 +145,11 @@ const WINDOW_LAYOUT = Dimensions.get('window');
  *
  * export default MyComponent;
  * ```
+ *
+ * ### Note
+ * When using Menu within a React Native `Modal`, you need to wrap all
+ * `Modal` contents within a `Provider` in order for the menu to show. This
+ * wrapping is not necessary if you use Paper's `Modal` instead.
  */
 class Menu extends React.Component<Props, State> {
   // @component ./MenuItem.tsx


### PR DESCRIPTION
### Summary

Menus currently don't show correctly in RN `Modal`, but do work correctly within Paper `Modal`. Updating the docs to caution users who hit #2593 because of this.

### Test plan

`yarn serve` within /docs, and verified the new stuff shows correctly:
![image](https://user-images.githubusercontent.com/39933441/205157072-0e2cd45b-eed7-4a6d-b2e5-d4b77d7b59f7.png)
