### PR TITLE
refactor: adjust drawer collapsed item icons

### DIFF
--- a/docs/pages/10.migration-guide-to-5.0.md
+++ b/docs/pages/10.migration-guide-to-5.0.md
@@ -396,11 +396,32 @@ Additionally prop `inset` was renamed to `leftInset`.
 ```js
 <Drawer.Section>
   <Drawer.CollapsedItem
-    icon="inbox"
+    focusedIcon="inbox"
+    unfocusedIcon="inbox-outline"
     label="Inbox"
   />
   <Drawer.CollapsedItem
-    icon="star"
+    focusedIcon="star"
+    unfocusedIcon="star-outline"
+    label="Starred"
+  />
+</Drawer.Section>
+```
+
+## Drawer.Section
+
+With the latest version, there is a possibility to specify whether `Drawer.Section` should have a separator, in form of `Divider` component, displayed at the end of the section. To adjust it, a new property called `showDivider` was introduced, which by default is `true`:
+
+```js
+<Drawer.Section showDivider={false}>
+  <Drawer.CollapsedItem
+    focusedIcon="inbox"
+    unfocusedIcon="inbox-outline"
+    label="Inbox"
+  />
+  <Drawer.CollapsedItem
+    focusedIcon="star"
+    unfocusedIcon="star-outline"
     label="Starred"
   />
 </Drawer.Section>

--- a/example/src/DrawerItems.tsx
+++ b/example/src/DrawerItems.tsx
@@ -59,24 +59,37 @@ const DrawerItemsData = [
 const DrawerCollapsedItemsData = [
   {
     label: 'Inbox',
-    icon: 'inbox',
+    focusedIcon: 'inbox',
+    unfocusedIcon: 'inbox-outline',
     key: 0,
     badge: 44,
   },
   {
     label: 'Starred',
-    icon: 'star',
+    focusedIcon: 'star',
+    unfocusedIcon: 'star-outline',
     key: 1,
   },
-  { label: 'Sent mail', icon: 'send', key: 2 },
+  {
+    label: 'Sent mail',
+    focusedIcon: 'send',
+    unfocusedIcon: 'send-outline',
+    key: 2,
+  },
   {
     label: 'A very long title that will be truncated',
-    icon: 'delete',
+    focusedIcon: 'delete',
+    unfocusedIcon: 'delete-outline',
     key: 3,
   },
-  { label: 'Full width', icon: 'arrow-all', key: 4 },
   {
-    icon: 'bell',
+    label: 'Full width',
+    focusedIcon: 'arrow-all',
+    key: 4,
+  },
+  {
+    focusedIcon: 'bell',
+    unfocusedIcon: 'bell-outline',
     key: 5,
     badge: true,
   },
@@ -128,7 +141,7 @@ const DrawerItems = ({
       ]}
     >
       {isV3 && collapsed && (
-        <Drawer.Section>
+        <Drawer.Section style={styles.collapsedSection}>
           {DrawerCollapsedItemsData.map((props, index) => (
             <Drawer.CollapsedItem
               {...props}
@@ -218,6 +231,9 @@ const styles = StyleSheet.create({
   },
   badge: {
     alignSelf: 'center',
+  },
+  collapsedSection: {
+    marginTop: 16,
   },
 });
 

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { I18nManager, StyleSheet } from 'react-native';
+import { I18nManager } from 'react-native';
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createDrawerNavigator } from '@react-navigation/drawer';
@@ -17,7 +17,10 @@ import {
   MD3Theme,
   useTheme,
 } from 'react-native-paper';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
+import {
+  SafeAreaInsetsContext,
+  SafeAreaProvider,
+} from 'react-native-safe-area-context';
 
 import { isWeb } from '../utils';
 import DrawerItems from './DrawerItems';
@@ -175,18 +178,28 @@ export default function PaperExample() {
               {isWeb ? (
                 <App />
               ) : (
-                <Drawer.Navigator
-                  screenOptions={{
-                    drawerStyle: collapsed && styles.collapsed,
+                <SafeAreaInsetsContext.Consumer>
+                  {(insets) => {
+                    const { left, right } = insets || { left: 0, right: 0 };
+                    const collapsedDrawerWidth = 80 + Math.max(left, right);
+                    return (
+                      <Drawer.Navigator
+                        screenOptions={{
+                          drawerStyle: collapsed && {
+                            width: collapsedDrawerWidth,
+                          },
+                        }}
+                        drawerContent={() => <DrawerContent />}
+                      >
+                        <Drawer.Screen
+                          name="Home"
+                          component={App}
+                          options={{ headerShown: false }}
+                        />
+                      </Drawer.Navigator>
+                    );
                   }}
-                  drawerContent={() => <DrawerContent />}
-                >
-                  <Drawer.Screen
-                    name="Home"
-                    component={App}
-                    options={{ headerShown: false }}
-                  />
-                </Drawer.Navigator>
+                </SafeAreaInsetsContext.Consumer>
               )}
               <StatusBar style={!theme.isV3 || theme.dark ? 'light' : 'dark'} />
             </NavigationContainer>
@@ -196,9 +209,3 @@ export default function PaperExample() {
     </PaperProvider>
   );
 }
-
-const styles = StyleSheet.create({
-  collapsed: {
-    width: 80,
-  },
-});

--- a/src/components/Drawer/DrawerCollapsedItem.tsx
+++ b/src/components/Drawer/DrawerCollapsedItem.tsx
@@ -23,9 +23,17 @@ export type Props = React.ComponentPropsWithRef<typeof View> & {
    */
   label?: string;
   /**
-   * Icon to display for the `DrawerCollapsedItem`.
+   * Badge to show on the icon, can be `true` to show a dot, `string` or `number` to show text.
    */
-  icon?: IconSource;
+  badge?: string | number | boolean;
+  /**
+   * Icon to use as the focused destination icon, can be a string, an image source or a react component @renamed Renamed from 'icon' to 'focusedIcon' in v5.x
+   */
+  focusedIcon?: IconSource;
+  /**
+   * Icon to use as the unfocused destination icon, can be a string, an image source or a react component @renamed Renamed from 'icon' to 'focusedIcon' in v5.x
+   */
+  unfocusedIcon?: IconSource;
   /**
    * Whether to highlight the drawer item as active.
    */
@@ -43,10 +51,11 @@ export type Props = React.ComponentPropsWithRef<typeof View> & {
    * @optional
    */
   theme: InternalTheme;
+
   /**
-   * Badge to show on the icon, can be `true` to show a dot, `string` or `number` to show text.
+   * TestID used for testing purposes
    */
-  badge?: string | number | boolean;
+  testID?: string;
 };
 
 const badgeSize = 8;
@@ -71,7 +80,8 @@ const outlineHeight = 32;
  *
  * const MyComponent = () => (
  *    <Drawer.CollapsedItem
- *      icon="inbox"
+ *      focusedIcon="inbox"
+ *      unfocusedIcon="inbox-outline"
  *      label="Inbox"
  *    />
  * );
@@ -80,7 +90,8 @@ const outlineHeight = 32;
  * ```
  */
 const DrawerCollapsedItem = ({
-  icon,
+  focusedIcon,
+  unfocusedIcon,
   label,
   active,
   theme,
@@ -88,6 +99,7 @@ const DrawerCollapsedItem = ({
   onPress,
   accessibilityLabel,
   badge = false,
+  testID = 'drawer-collapsed-item',
   ...rest
 }: Props) => {
   const { isV3 } = theme;
@@ -145,6 +157,9 @@ const DrawerCollapsedItem = ({
     ...(isV3 ? theme.fonts.labelMedium : {}),
   };
 
+  const icon =
+    !active && unfocusedIcon !== undefined ? unfocusedIcon : focusedIcon;
+
   return (
     <View {...rest}>
       {/* eslint-disable-next-line react-native-a11y/has-accessibility-props */}
@@ -157,6 +172,7 @@ const DrawerCollapsedItem = ({
         accessibilityRole="button"
         accessibilityState={{ selected: active }}
         accessibilityLabel={accessibilityLabel}
+        testID={testID}
       >
         <View style={styles.wrapper}>
           <Animated.View
@@ -175,9 +191,13 @@ const DrawerCollapsedItem = ({
               },
               style,
             ]}
+            testID={`${testID}-outline`}
           />
 
-          <View style={[styles.icon, { top: iconPadding }]}>
+          <View
+            style={[styles.icon, { top: iconPadding }]}
+            testID={`${testID}-container`}
+          >
             {badge && (
               <View style={styles.badgeContainer}>
                 {typeof badge === 'boolean' ? (

--- a/src/components/Drawer/DrawerSection.tsx
+++ b/src/components/Drawer/DrawerSection.tsx
@@ -18,6 +18,11 @@ export type Props = React.ComponentPropsWithRef<typeof View> & {
    * Content of the `Drawer.Section`.
    */
   children: React.ReactNode;
+  /**
+   * @supported Available in v5.x.
+   * Whether to show `Divider` at the end of the section. True by default.
+   */
+  showDivider?: boolean;
   style?: StyleProp<ViewStyle>;
   /**
    * @optional
@@ -61,7 +66,14 @@ export type Props = React.ComponentPropsWithRef<typeof View> & {
  * export default MyComponent;
  * ```
  */
-const DrawerSection = ({ children, title, theme, style, ...rest }: Props) => {
+const DrawerSection = ({
+  children,
+  title,
+  theme,
+  style,
+  showDivider = true,
+  ...rest
+}: Props) => {
   const { isV3 } = theme;
   const titleColor = isV3
     ? theme.colors.onSurfaceVariant
@@ -91,10 +103,12 @@ const DrawerSection = ({ children, title, theme, style, ...rest }: Props) => {
         </View>
       )}
       {children}
-      <Divider
-        {...(isV3 && { horizontalInset: true, bold: true })}
-        style={[styles.divider, isV3 && styles.v3Divider]}
-      />
+      {showDivider && (
+        <Divider
+          {...(isV3 && { horizontalInset: true, bold: true })}
+          style={[styles.divider, isV3 && styles.v3Divider]}
+        />
+      )}
     </View>
   );
 };

--- a/src/components/__tests__/Drawer/DrawerCollapsedItem.test.js
+++ b/src/components/__tests__/Drawer/DrawerCollapsedItem.test.js
@@ -1,0 +1,66 @@
+import React from 'react';
+
+import { render } from '@testing-library/react-native';
+
+import DrawerCollapsedItem from '../../Drawer/DrawerCollapsedItem';
+
+describe('DrawerCollapsedItem', () => {
+  it('should have regular outline if label is specified', () => {
+    const { getByTestId } = render(
+      <DrawerCollapsedItem
+        label="starred"
+        focusedIcon="star"
+        unfocusedIcon="star-outline"
+      />
+    );
+
+    expect(getByTestId('drawer-collapsed-item-outline')).toHaveStyle({
+      height: 32,
+    });
+  });
+
+  it('should have rounded outline if label is not specified', () => {
+    const { getByTestId } = render(
+      <DrawerCollapsedItem focusedIcon="star" unfocusedIcon="star-outline" />
+    );
+
+    expect(getByTestId('drawer-collapsed-item-outline')).toHaveStyle({
+      height: 56,
+    });
+  });
+
+  it('should display unfocused icon in inactive state, if unfocused icon is specified', () => {
+    const { getByTestId } = render(
+      <DrawerCollapsedItem focusedIcon="star" unfocusedIcon="star-outline" />
+    );
+
+    expect(
+      getByTestId('drawer-collapsed-item-container').props.children[1].props
+        .source
+    ).toBe('star-outline');
+  });
+
+  it('should display focused icon in inactive state, if unfocused icon is not specified', () => {
+    const { getByTestId } = render(<DrawerCollapsedItem focusedIcon="star" />);
+
+    expect(
+      getByTestId('drawer-collapsed-item-container').props.children[1].props
+        .source
+    ).toBe('star');
+  });
+
+  it('should display focused icon in active state', () => {
+    const { getByTestId } = render(
+      <DrawerCollapsedItem
+        active
+        focusedIcon="star"
+        unfocusedIcon="star-outline"
+      />
+    );
+
+    expect(
+      getByTestId('drawer-collapsed-item-container').props.children[1].props
+        .source
+    ).toBe('star');
+  });
+});


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Reactor `Drawer.CollapsedItem` to support both `focusedIcon` and `unfocusedIcon`.
In `Drawer.Section` there is a new property for handling `Divider` visibility.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Covered by unit tests.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
