### PR TITLE
feat: add customInputStyle to TextInput

### DIFF
--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -32,6 +32,7 @@ const initialState: State = {
   outlinedLargeText: '',
   outlinedTextPassword: '',
   nameNoPadding: '',
+  customStyleText: '',
   nameRequired: '',
   flatDenseText: '',
   flatDense: '',
@@ -86,6 +87,7 @@ const TextInputExample = () => {
     outlinedLargeText,
     outlinedTextPassword,
     nameNoPadding,
+    customStyleText,
     nameRequired,
     flatDenseText,
     flatDense,
@@ -529,6 +531,18 @@ const TextInputExample = () => {
             onChangeText={(outlinedLongLabel) =>
               inputActionHandler('outlinedLongLabel', outlinedLongLabel)
             }
+          />
+
+          <TextInput
+            mode="flat"
+            style={styles.inputContainerStyle}
+            label="Custom style input"
+            placeholder="Input with custom padding"
+            value={customStyleText}
+            onChangeText={(customStyleText) =>
+              inputActionHandler('customStyleText', customStyleText)
+            }
+            customInputStyle={{ paddingLeft: 50 }}
           />
 
           <View style={styles.inputContainerStyle}>

--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -542,7 +542,7 @@ const TextInputExample = () => {
             onChangeText={(customStyleText) =>
               inputActionHandler('customStyleText', customStyleText)
             }
-            customInputStyle={{ paddingLeft: 50 }}
+            containerStyle={{ paddingLeft: 50 }}
           />
 
           <View style={styles.inputContainerStyle}>

--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -542,7 +542,7 @@ const TextInputExample = () => {
             onChangeText={(customStyleText) =>
               inputActionHandler('customStyleText', customStyleText)
             }
-            containerStyle={{ paddingLeft: 50 }}
+            contentStyle={{ paddingLeft: 50 }}
           />
 
           <View style={styles.inputContainerStyle}>

--- a/example/utils/index.ts
+++ b/example/utils/index.ts
@@ -25,6 +25,7 @@ export type State = {
   outlinedLargeText: string;
   outlinedTextPassword: string;
   nameNoPadding: string;
+  customStyleText: string;
   nameRequired: string;
   flatDenseText: string;
   flatDense: string;

--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -29,6 +29,7 @@ const InputLabel = (props: InputLabelProps) => {
     labelTranslationXOffset,
     maxFontSizeMultiplier,
     testID,
+    customInputStyle,
   } = props.labelProps;
 
   const labelTranslationX = {
@@ -138,6 +139,7 @@ const InputLabel = (props: InputLabelProps) => {
             color: textColor,
             opacity: placeholderOpacity,
           },
+          customInputStyle,
         ]}
         numberOfLines={1}
         maxFontSizeMultiplier={maxFontSizeMultiplier}

--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -29,7 +29,7 @@ const InputLabel = (props: InputLabelProps) => {
     labelTranslationXOffset,
     maxFontSizeMultiplier,
     testID,
-    containerStyle,
+    contentStyle,
   } = props.labelProps;
 
   const labelTranslationX = {
@@ -139,7 +139,7 @@ const InputLabel = (props: InputLabelProps) => {
             color: textColor,
             opacity: placeholderOpacity,
           },
-          containerStyle,
+          contentStyle,
         ]}
         numberOfLines={1}
         maxFontSizeMultiplier={maxFontSizeMultiplier}

--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -29,7 +29,7 @@ const InputLabel = (props: InputLabelProps) => {
     labelTranslationXOffset,
     maxFontSizeMultiplier,
     testID,
-    customInputStyle,
+    containerStyle,
   } = props.labelProps;
 
   const labelTranslationX = {
@@ -139,7 +139,7 @@ const InputLabel = (props: InputLabelProps) => {
             color: textColor,
             opacity: placeholderOpacity,
           },
-          customInputStyle,
+          containerStyle,
         ]}
         numberOfLines={1}
         maxFontSizeMultiplier={maxFontSizeMultiplier}

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -232,7 +232,7 @@ const TextInput = React.forwardRef<TextInputHandles, Props>(
       error: errorProp = false,
       multiline = false,
       editable = true,
-      customInputStyle = null,
+      containerStyle,
       render = (props: RenderProps) => <NativeTextInput {...props} />,
       ...rest
     }: Props,
@@ -468,7 +468,7 @@ const TextInput = React.forwardRef<TextInputHandles, Props>(
           onLeftAffixLayoutChange={onLeftAffixLayoutChange}
           onRightAffixLayoutChange={onRightAffixLayoutChange}
           maxFontSizeMultiplier={maxFontSizeMultiplier}
-          customInputStyle={customInputStyle}
+          containerStyle={containerStyle}
         />
       );
     }
@@ -504,7 +504,7 @@ const TextInput = React.forwardRef<TextInputHandles, Props>(
         onLeftAffixLayoutChange={onLeftAffixLayoutChange}
         onRightAffixLayoutChange={onRightAffixLayoutChange}
         maxFontSizeMultiplier={maxFontSizeMultiplier}
-        customInputStyle={customInputStyle}
+        containerStyle={containerStyle}
       />
     );
   }

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -149,9 +149,8 @@ export type Props = React.ComponentPropsWithRef<typeof NativeTextInput> & {
    * Overrides input style
    * Example: `paddingLeft`, `backgroundColor`
    */
-  customInputStyle?: StyleProp<ViewStyle>;
+  containerStyle?: StyleProp<ViewStyle>;
   /**
-   * @supported Available in v5.x
    * Pass style to override the default style of outlined wrapper.
    * Overrides style when mode is set to `outlined`
    * Example: `borderRadius`, `borderColor`

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -145,6 +145,13 @@ export type Props = React.ComponentPropsWithRef<typeof NativeTextInput> & {
   testID?: string;
   /**
    * @supported Available in v5.x
+   * Pass custom style directly to the input itself.
+   * Overrides input style
+   * Example: `paddingLeft`, `backgroundColor`
+   */
+  customInputStyle?: StyleProp<ViewStyle>;
+  /**
+   * @supported Available in v5.x
    * Pass style to override the default style of outlined wrapper.
    * Overrides style when mode is set to `outlined`
    * Example: `borderRadius`, `borderColor`
@@ -226,6 +233,7 @@ const TextInput = React.forwardRef<TextInputHandles, Props>(
       error: errorProp = false,
       multiline = false,
       editable = true,
+      customInputStyle = null,
       render = (props: RenderProps) => <NativeTextInput {...props} />,
       ...rest
     }: Props,
@@ -461,6 +469,7 @@ const TextInput = React.forwardRef<TextInputHandles, Props>(
           onLeftAffixLayoutChange={onLeftAffixLayoutChange}
           onRightAffixLayoutChange={onRightAffixLayoutChange}
           maxFontSizeMultiplier={maxFontSizeMultiplier}
+          customInputStyle={customInputStyle}
         />
       );
     }
@@ -496,6 +505,7 @@ const TextInput = React.forwardRef<TextInputHandles, Props>(
         onLeftAffixLayoutChange={onLeftAffixLayoutChange}
         onRightAffixLayoutChange={onRightAffixLayoutChange}
         maxFontSizeMultiplier={maxFontSizeMultiplier}
+        customInputStyle={customInputStyle}
       />
     );
   }

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -147,7 +147,7 @@ export type Props = React.ComponentPropsWithRef<typeof NativeTextInput> & {
    * Overrides input style
    * Example: `paddingLeft`, `backgroundColor`
    */
-  containerStyle?: StyleProp<ViewStyle>;
+  contentStyle?: StyleProp<ViewStyle>;
   /**
    * Pass style to override the default style of outlined wrapper.
    * Overrides style when mode is set to `outlined`
@@ -229,7 +229,7 @@ const TextInput = React.forwardRef<TextInputHandles, Props>(
       error: errorProp = false,
       multiline = false,
       editable = true,
-      containerStyle,
+      contentStyle,
       render = (props: RenderProps) => <NativeTextInput {...props} />,
       ...rest
     }: Props,
@@ -465,7 +465,7 @@ const TextInput = React.forwardRef<TextInputHandles, Props>(
           onLeftAffixLayoutChange={onLeftAffixLayoutChange}
           onRightAffixLayoutChange={onRightAffixLayoutChange}
           maxFontSizeMultiplier={maxFontSizeMultiplier}
-          containerStyle={containerStyle}
+          contentStyle={contentStyle}
         />
       );
     }
@@ -501,7 +501,7 @@ const TextInput = React.forwardRef<TextInputHandles, Props>(
         onLeftAffixLayoutChange={onLeftAffixLayoutChange}
         onRightAffixLayoutChange={onRightAffixLayoutChange}
         maxFontSizeMultiplier={maxFontSizeMultiplier}
-        containerStyle={containerStyle}
+        contentStyle={contentStyle}
       />
     );
   }

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -73,7 +73,7 @@ const TextInputFlat = ({
   right,
   placeholderTextColor,
   testID = 'text-input-flat',
-  customInputStyle,
+  containerStyle: customContainerStyle,
   ...rest
 }: ChildTextInputProps) => {
   const isAndroid = Platform.OS === 'android';
@@ -275,7 +275,7 @@ const TextInputFlat = ({
     roundness,
     maxFontSizeMultiplier: rest.maxFontSizeMultiplier,
     testID,
-    customInputStyle,
+    customContainerStyle,
   };
   const affixTopPosition = {
     [AdornmentSide.Left]: leftAffixTopPosition,
@@ -382,7 +382,7 @@ const TextInputFlat = ({
             },
             Platform.OS === 'web' && { outline: 'none' },
             adornmentStyleAdjustmentForNativeInput,
-            customInputStyle,
+            customContainerStyle,
           ],
         })}
       </View>

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -73,7 +73,7 @@ const TextInputFlat = ({
   right,
   placeholderTextColor,
   testID = 'text-input-flat',
-  containerStyle: customContainerStyle,
+  contentStyle: customContainerStyle,
   ...rest
 }: ChildTextInputProps) => {
   const isAndroid = Platform.OS === 'android';
@@ -150,7 +150,7 @@ const TextInputFlat = ({
     theme,
   });
 
-  const containerStyle = {
+  const contentStyle = {
     backgroundColor,
     borderTopLeftRadius: theme.roundness,
     borderTopRightRadius: theme.roundness,
@@ -309,7 +309,7 @@ const TextInputFlat = ({
   }
 
   return (
-    <View style={[containerStyle, viewStyle]}>
+    <View style={[contentStyle, viewStyle]}>
       <Underline
         style={underlineStyle}
         hasActiveOutline={hasActiveOutline}
@@ -338,7 +338,7 @@ const TextInputFlat = ({
               dense ? styles.densePatchContainer : styles.patchContainer,
               {
                 backgroundColor:
-                  viewStyle.backgroundColor || containerStyle.backgroundColor,
+                  viewStyle.backgroundColor || contentStyle.backgroundColor,
                 left: paddingLeft,
                 right: paddingRight,
               },

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -73,6 +73,7 @@ const TextInputFlat = ({
   right,
   placeholderTextColor,
   testID = 'text-input-flat',
+  customInputStyle,
   ...rest
 }: ChildTextInputProps) => {
   const isAndroid = Platform.OS === 'android';
@@ -274,6 +275,7 @@ const TextInputFlat = ({
     roundness,
     maxFontSizeMultiplier: rest.maxFontSizeMultiplier,
     testID,
+    customInputStyle,
   };
   const affixTopPosition = {
     [AdornmentSide.Left]: leftAffixTopPosition,
@@ -380,6 +382,7 @@ const TextInputFlat = ({
             },
             Platform.OS === 'web' && { outline: 'none' },
             adornmentStyleAdjustmentForNativeInput,
+            customInputStyle,
           ],
         })}
       </View>

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -73,7 +73,7 @@ const TextInputFlat = ({
   right,
   placeholderTextColor,
   testID = 'text-input-flat',
-  contentStyle: customContainerStyle,
+  contentStyle,
   ...rest
 }: ChildTextInputProps) => {
   const isAndroid = Platform.OS === 'android';
@@ -150,7 +150,7 @@ const TextInputFlat = ({
     theme,
   });
 
-  const contentStyle = {
+  const containerStyle = {
     backgroundColor,
     borderTopLeftRadius: theme.roundness,
     borderTopRightRadius: theme.roundness,
@@ -275,7 +275,7 @@ const TextInputFlat = ({
     roundness,
     maxFontSizeMultiplier: rest.maxFontSizeMultiplier,
     testID,
-    customContainerStyle,
+    contentStyle,
   };
   const affixTopPosition = {
     [AdornmentSide.Left]: leftAffixTopPosition,
@@ -309,7 +309,7 @@ const TextInputFlat = ({
   }
 
   return (
-    <View style={[contentStyle, viewStyle]}>
+    <View style={[containerStyle, viewStyle]}>
       <Underline
         style={underlineStyle}
         hasActiveOutline={hasActiveOutline}
@@ -338,7 +338,7 @@ const TextInputFlat = ({
               dense ? styles.densePatchContainer : styles.patchContainer,
               {
                 backgroundColor:
-                  viewStyle.backgroundColor || contentStyle.backgroundColor,
+                  viewStyle.backgroundColor || containerStyle.backgroundColor,
                 left: paddingLeft,
                 right: paddingRight,
               },
@@ -382,7 +382,7 @@ const TextInputFlat = ({
             },
             Platform.OS === 'web' && { outline: 'none' },
             adornmentStyleAdjustmentForNativeInput,
-            customContainerStyle,
+            contentStyle,
           ],
         })}
       </View>

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -71,7 +71,7 @@ const TextInputOutlined = ({
   right,
   placeholderTextColor,
   testID = 'text-input-outlined',
-  containerStyle,
+  contentStyle,
   ...rest
 }: ChildTextInputProps) => {
   const adornmentConfig = getAdornmentConfig({ left, right });
@@ -210,7 +210,7 @@ const TextInputOutlined = ({
     roundness,
     maxFontSizeMultiplier: rest.maxFontSizeMultiplier,
     testID,
-    containerStyle,
+    contentStyle,
   };
 
   const minHeight = (height ||
@@ -356,7 +356,7 @@ const TextInputOutlined = ({
               },
               Platform.OS === 'web' && { outline: 'none' },
               adornmentStyleAdjustmentForNativeInput,
-              containerStyle,
+              contentStyle,
             ],
           } as RenderProps)}
         </View>

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -71,6 +71,7 @@ const TextInputOutlined = ({
   right,
   placeholderTextColor,
   testID = 'text-input-outlined',
+  customInputStyle,
   ...rest
 }: ChildTextInputProps) => {
   const adornmentConfig = getAdornmentConfig({ left, right });
@@ -209,6 +210,7 @@ const TextInputOutlined = ({
     roundness,
     maxFontSizeMultiplier: rest.maxFontSizeMultiplier,
     testID,
+    customInputStyle,
   };
 
   const minHeight = (height ||
@@ -354,6 +356,7 @@ const TextInputOutlined = ({
               },
               Platform.OS === 'web' && { outline: 'none' },
               adornmentStyleAdjustmentForNativeInput,
+              customInputStyle,
             ],
           } as RenderProps)}
         </View>

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -71,7 +71,7 @@ const TextInputOutlined = ({
   right,
   placeholderTextColor,
   testID = 'text-input-outlined',
-  customInputStyle,
+  containerStyle,
   ...rest
 }: ChildTextInputProps) => {
   const adornmentConfig = getAdornmentConfig({ left, right });
@@ -210,7 +210,7 @@ const TextInputOutlined = ({
     roundness,
     maxFontSizeMultiplier: rest.maxFontSizeMultiplier,
     testID,
-    customInputStyle,
+    containerStyle,
   };
 
   const minHeight = (height ||
@@ -356,7 +356,7 @@ const TextInputOutlined = ({
               },
               Platform.OS === 'web' && { outline: 'none' },
               adornmentStyleAdjustmentForNativeInput,
-              customInputStyle,
+              containerStyle,
             ],
           } as RenderProps)}
         </View>

--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -4,6 +4,8 @@ import type {
   TextStyle,
   LayoutChangeEvent,
   ColorValue,
+  StyleProp,
+  ViewProps,
 } from 'react-native';
 
 import type { $Omit } from './../../types';
@@ -38,6 +40,7 @@ export type State = {
   labelLayout: { measured: boolean; width: number; height: number };
   leftLayout: { height: number | null; width: number | null };
   rightLayout: { height: number | null; width: number | null };
+  customInputStyle?: StyleProp<ViewProps>;
 };
 export type ChildTextInputProps = {
   parentState: State;
@@ -79,6 +82,7 @@ export type LabelProps = {
   roundness: number;
   maxFontSizeMultiplier?: number | undefined | null;
   testID?: string;
+  customInputStyle?: StyleProp<ViewProps>;
 };
 export type InputLabelProps = {
   parentState: State;

--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -40,7 +40,7 @@ export type State = {
   labelLayout: { measured: boolean; width: number; height: number };
   leftLayout: { height: number | null; width: number | null };
   rightLayout: { height: number | null; width: number | null };
-  customInputStyle?: StyleProp<ViewProps>;
+  containerStyle?: StyleProp<ViewProps>;
 };
 export type ChildTextInputProps = {
   parentState: State;
@@ -82,7 +82,7 @@ export type LabelProps = {
   roundness: number;
   maxFontSizeMultiplier?: number | undefined | null;
   testID?: string;
-  customInputStyle?: StyleProp<ViewProps>;
+  containerStyle?: StyleProp<ViewProps>;
 };
 export type InputLabelProps = {
   parentState: State;

--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -40,7 +40,7 @@ export type State = {
   labelLayout: { measured: boolean; width: number; height: number };
   leftLayout: { height: number | null; width: number | null };
   rightLayout: { height: number | null; width: number | null };
-  containerStyle?: StyleProp<ViewProps>;
+  contentStyle?: StyleProp<ViewProps>;
 };
 export type ChildTextInputProps = {
   parentState: State;
@@ -82,7 +82,7 @@ export type LabelProps = {
   roundness: number;
   maxFontSizeMultiplier?: number | undefined | null;
   testID?: string;
-  containerStyle?: StyleProp<ViewProps>;
+  contentStyle?: StyleProp<ViewProps>;
 };
 export type InputLabelProps = {
   parentState: State;

--- a/src/components/__tests__/TextInput.test.js
+++ b/src/components/__tests__/TextInput.test.js
@@ -181,13 +181,13 @@ it('correctly applies a component as the text label', () => {
   expect(toJSON()).toMatchSnapshot();
 });
 
-it('correctly applies paddingLeft from containerStyleProp', () => {
+it('correctly applies paddingLeft from contentStyleProp', () => {
   const { toJSON } = render(
     <TextInput
       label="With padding"
       placeholder="Type something"
       value={'Some test value'}
-      containerStyle={{ paddingLeft: 20 }}
+      contentStyle={{ paddingLeft: 20 }}
     />
   );
 

--- a/src/components/__tests__/TextInput.test.js
+++ b/src/components/__tests__/TextInput.test.js
@@ -181,6 +181,19 @@ it('correctly applies a component as the text label', () => {
   expect(toJSON()).toMatchSnapshot();
 });
 
+it('correctly applies paddingLeft from containerStyleProp', () => {
+  const { toJSON } = render(
+    <TextInput
+      label="With padding"
+      placeholder="Type something"
+      value={'Some test value'}
+      containerStyle={{ paddingLeft: 20 }}
+    />
+  );
+
+  expect(toJSON()).toMatchSnapshot();
+});
+
 it('renders label with correct color when active', () => {
   const { getByTestId } = render(
     <TextInput

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -1621,7 +1621,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
 </View>
 `;
 
-exports[`correctly applies paddingLeft from containerStyleProp 1`] = `
+exports[`correctly applies paddingLeft from contentStyleProp 1`] = `
 <View
   style={
     Array [

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -1739,7 +1739,7 @@ exports[`correctly applies paddingLeft from contentStyleProp 1`] = `
             "letterSpacing": 0.15,
             "lineHeight": undefined,
             "opacity": 0,
-            "paddingLeft": 16,
+            "paddingLeft": 20,
             "paddingRight": 16,
             "position": "absolute",
             "textAlign": "left",

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -199,6 +199,7 @@ exports[`correctly applies a component as the text label 1`] = `
           Array [
             Object {},
           ],
+          null,
         ]
       }
       testID="text-input-flat"
@@ -392,6 +393,7 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
           Array [
             Object {},
           ],
+          null,
         ]
       }
       testID="text-input-flat"
@@ -637,6 +639,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
             Array [
               Object {},
             ],
+            null,
           ]
         }
         testID="text-input-outlined"
@@ -831,6 +834,7 @@ exports[`correctly applies textAlign center 1`] = `
           Array [
             Object {},
           ],
+          null,
         ]
       }
       testID="text-input-flat"
@@ -1027,6 +1031,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
             "paddingLeft": 40,
             "paddingRight": 16,
           },
+          null,
         ]
       }
       testID="text-input-flat"
@@ -1414,6 +1419,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
             "paddingLeft": 16,
             "paddingRight": 40,
           },
+          null,
         ]
       }
       testID="text-input-flat"

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -199,7 +199,7 @@ exports[`correctly applies a component as the text label 1`] = `
           Array [
             Object {},
           ],
-          null,
+          undefined,
         ]
       }
       testID="text-input-flat"
@@ -393,7 +393,7 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
           Array [
             Object {},
           ],
-          null,
+          undefined,
         ]
       }
       testID="text-input-flat"
@@ -639,7 +639,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
             Array [
               Object {},
             ],
-            null,
+            undefined,
           ]
         }
         testID="text-input-outlined"
@@ -834,7 +834,7 @@ exports[`correctly applies textAlign center 1`] = `
           Array [
             Object {},
           ],
-          null,
+          undefined,
         ]
       }
       testID="text-input-flat"
@@ -1031,7 +1031,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
             "paddingLeft": 40,
             "paddingRight": 16,
           },
-          null,
+          undefined,
         ]
       }
       testID="text-input-flat"
@@ -1419,7 +1419,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
             "paddingLeft": 16,
             "paddingRight": 40,
           },
-          null,
+          undefined,
         ]
       }
       testID="text-input-flat"
@@ -1620,3 +1620,200 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
   </View>
 </View>
 `;
+
+exports[`correctly applies paddingLeft from containerStyleProp 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "rgba(231, 224, 236, 1)",
+        "borderTopLeftRadius": 4,
+        "borderTopRightRadius": 4,
+      },
+      Object {},
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      Object {
+        "backgroundColor": "rgba(28, 27, 31, 1)",
+        "bottom": 0,
+        "height": 1,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "transform": Array [
+          Object {
+            "scaleY": 0.5,
+          },
+        ],
+        "zIndex": 1,
+      }
+    }
+    testID="text-input-underline"
+  />
+  <View
+    style={
+      Array [
+        Object {
+          "paddingBottom": 0,
+          "paddingTop": 0,
+        },
+        Object {
+          "minHeight": 56,
+        },
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      pointerEvents="none"
+      style={
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "transform": Array [
+            Object {
+              "translateX": 4,
+            },
+          ],
+          "zIndex": 3,
+        }
+      }
+    >
+      <Text
+        collapsable={false}
+        maxFontSizeMultiplier={1.5}
+        numberOfLines={1}
+        onLayout={[Function]}
+        style={
+          Object {
+            "color": "rgba(103, 80, 164, 1)",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": undefined,
+            "left": 0,
+            "letterSpacing": 0.15,
+            "lineHeight": undefined,
+            "opacity": 0,
+            "paddingLeft": 16,
+            "paddingRight": 16,
+            "position": "absolute",
+            "textAlign": "left",
+            "top": 30,
+            "transform": Array [
+              Object {
+                "translateX": 0,
+              },
+              Object {
+                "translateY": -12,
+              },
+              Object {
+                "scale": 0.75,
+              },
+            ],
+            "writingDirection": "ltr",
+          }
+        }
+        testID="text-input-flat-label-active"
+      >
+        With padding
+      </Text>
+      <Text
+        collapsable={false}
+        maxFontSizeMultiplier={1.5}
+        numberOfLines={1}
+        style={
+          Object {
+            "color": "rgba(73, 69, 79, 1)",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": undefined,
+            "left": 0,
+            "letterSpacing": 0.15,
+            "lineHeight": undefined,
+            "opacity": 0,
+            "paddingLeft": 16,
+            "paddingRight": 16,
+            "position": "absolute",
+            "textAlign": "left",
+            "top": 30,
+            "transform": Array [
+              Object {
+                "translateX": 0,
+              },
+              Object {
+                "translateY": -12,
+              },
+              Object {
+                "scale": 0.75,
+              },
+            ],
+            "writingDirection": "ltr",
+          }
+        }
+        testID="text-input-flat-label-inactive"
+      >
+        With padding
+      </Text>
+    </View>
+    <TextInput
+      editable={true}
+      maxFontSizeMultiplier={1.5}
+      multiline={false}
+      onBlur={[Function]}
+      onChangeText={[Function]}
+      onFocus={[Function]}
+      placeholder=" "
+      placeholderTextColor="rgba(73, 69, 79, 1)"
+      selectionColor="rgba(103, 80, 164, 1)"
+      style={
+        Array [
+          Object {
+            "flexGrow": 1,
+            "margin": 0,
+          },
+          Object {
+            "paddingLeft": 16,
+            "paddingRight": 16,
+          },
+          Object {
+            "height": 56,
+          },
+          Object {
+            "paddingBottom": 4,
+            "paddingTop": 24,
+          },
+          Object {
+            "color": "rgba(73, 69, 79, 1)",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": undefined,
+            "letterSpacing": 0.15,
+            "lineHeight": undefined,
+            "textAlign": "left",
+            "textAlignVertical": "center",
+          },
+          false,
+          Array [
+            Object {},
+          ],
+          Object {
+            "paddingLeft": 20,
+          },
+        ]
+      }
+      testID="text-input-flat"
+      underlineColorAndroid="transparent"
+      value="Some test value"
+    />
+  </View>
+</View>
+`;
+


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Adds `customInputStyle` prop to `TextInput` as requested in #3434 
This prop allows to pass style props directly to the input itself, not the container. 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

The tests and examples are already updated.
Tested on both IOS and Android with `StyleProp<ViewStyle>` props like `paddingLeft`, `backgroundColor` etc.

**Custom style input example:**

`customInputStyle={{ paddingLeft: 50  }}`

<img width="339" alt="Captura de Tela 2022-12-06 às 23 06 18" src="https://user-images.githubusercontent.com/62260157/206069984-0e4776fd-0105-4637-8c2f-c029cfd3b61d.png">

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
