### PR TITLE
fix: disable native driver in Card elevation animation

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -192,7 +192,7 @@ const Card = ({
       Animated.timing(elevation, {
         toValue: isPressTypeIn ? (isV3 ? 2 : 8) : cardElevation,
         duration: animationDuration,
-        useNativeDriver: true,
+        useNativeDriver: false,
       }).start();
     }
   };


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Disable `useNativeDriver` within `Card` animation, to avoid crashes.

#### Related issue

- #3511 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

App cannot crash when tapping last 3 items.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
