### PR TITLE
feat: numberOfLines prop added to Button

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -120,6 +120,10 @@ export type Props = React.ComponentProps<typeof Surface> & {
    * testID to be used on tests.
    */
   testID?: string;
+  /**
+   * Number of lines the text in the button should display.
+   */
+  numberOfLines?: number;
 };
 
 /**
@@ -185,6 +189,7 @@ const Button = ({
   labelStyle,
   testID,
   accessible,
+  numberOfLines,
   ...rest
 }: Props) => {
   const isMode = React.useCallback(
@@ -341,7 +346,7 @@ const Button = ({
           <Text
             variant="labelLarge"
             selectable={false}
-            numberOfLines={1}
+            numberOfLines={numberOfLines ?? 1}
             style={[
               styles.label,
               !isV3 && styles.md2Label,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Allows developers to specify how many lines of text can be displayed by a Button component. 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Wasn't able to figure out an easier method of displaying multiple lines of text inside of a button.

### Test plan
By default, nothing visibly changes. When `numberOfLines` is set, it behaves as expected (see screenshot).

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
Example of what it looks like with `numberOfLines={3}`
![image](https://user-images.githubusercontent.com/102814897/206224874-9a5e1030-136e-41c4-ad2e-e4a0d1103ea0.png)
