### PR TITLE
docs: fixed <Swtich> example for  Theming with React Navigation - Using Context

### DIFF
--- a/docs/pages/8.theming-with-react-navigation.md
+++ b/docs/pages/8.theming-with-react-navigation.md
@@ -329,12 +329,11 @@ const Header = ({ scene }) => {
       }}
     >
       <Appbar.Content title={scene.route?.name} />
-      <TouchableRipple onPress={() => toggleTheme()}>
         <Switch
           color={'red'}
           value={isThemeDark}
+          onValueChange={toggleTheme}
         />
-      </TouchableRipple>
     </Appbar.Header>
   );
 };


### PR DESCRIPTION
### Summary

Documentation code fix on page: https://callstack.github.io/react-native-paper/theming-with-react-navigation.html under the 2nd part of _Using Context_.

Problems using `<TouchableRipple onPress={() => toggleTheme()}>` wrapper on `<Switch>`  causes:

1. Not to work on mobile (it does work on web).
2. Causes the whole width of the screen to toggle the switch, instead of the switch itself.

In addition, adding the `onValueChange={onToggleSwitch}` prop to `<Switch>` enables it to toggle after removing `<TouchableRipple>`.

### Test plan

[Expo snack](https://snack.expo.dev/@m0de/switch?name=Switch&description=https%3A%2F%2Fcallstack.github.io%2Freact-native-paper%2Fswitch.html&code=import%20*%20as%20React%20from%20%27react%27%3B%0Aimport%20%7B%20Switch%20%7D%20from%20%27react-native-paper%27%3B%0A%0Aconst%20MyComponent%20%3D%20()%20%3D%3E%20%7B%0A%20%20const%20%5BisSwitchOn%2C%20setIsSwitchOn%5D%20%3D%20React.useState(false)%3B%0A%0A%20%20const%20onToggleSwitch%20%3D%20()%20%3D%3E%20setIsSwitchOn(!isSwitchOn)%3B%0A%0A%20%20return%20%3CSwitch%20value%3D%7BisSwitchOn%7D%20onValueChange%3D%7BonToggleSwitch%7D%20%2F%3E%3B%0A%7D%3B%0A%0Aexport%20default%20MyComponent%3B&dependencies=react-native-paper%405.0.0,@expo/vector-icons%40%5E13.0.0,react-native-safe-area-context). Tested between all devices.