### PR TITLE
fix: Visual fix on IconButton when focused

### DIFF
--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -177,7 +177,10 @@ const IconButton = React.forwardRef<View, Props>(
           onPress={onPress}
           rippleColor={rippleColor}
           accessibilityLabel={accessibilityLabel}
-          style={styles.touchable}
+          style={[
+            styles.touchable,
+            { borderRadius: borderStyles.borderRadius },
+          ]}
           // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
           accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
           accessibilityComponentType="button"

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
@@ -183,11 +183,16 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                           "overflow": "hidden",
                         },
                         false,
-                        Object {
-                          "alignItems": "center",
-                          "flexGrow": 1,
-                          "justifyContent": "center",
-                        },
+                        Array [
+                          Object {
+                            "alignItems": "center",
+                            "flexGrow": 1,
+                            "justifyContent": "center",
+                          },
+                          Object {
+                            "borderRadius": 20,
+                          },
+                        ],
                       ]
                     }
                   >
@@ -351,11 +356,16 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                             "overflow": "hidden",
                           },
                           false,
-                          Object {
-                            "alignItems": "center",
-                            "flexGrow": 1,
-                            "justifyContent": "center",
-                          },
+                          Array [
+                            Object {
+                              "alignItems": "center",
+                              "flexGrow": 1,
+                              "justifyContent": "center",
+                            },
+                            Object {
+                              "borderRadius": 20,
+                            },
+                          ],
                         ]
                       }
                     >
@@ -546,11 +556,16 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
                     "overflow": "hidden",
                   },
                   false,
-                  Object {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    },
+                    Object {
+                      "borderRadius": 20,
+                    },
+                  ],
                 ]
               }
             >
@@ -790,11 +805,16 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
                     "overflow": "hidden",
                   },
                   false,
-                  Object {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    },
+                    Object {
+                      "borderRadius": 20,
+                    },
+                  ],
                 ]
               }
             >

--- a/src/components/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.js.snap
@@ -351,11 +351,16 @@ exports[`renders data table pagination 1`] = `
                   "overflow": "hidden",
                 },
                 false,
-                Object {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                  },
+                  Object {
+                    "borderRadius": 20,
+                  },
+                ],
               ]
             }
           >
@@ -486,11 +491,16 @@ exports[`renders data table pagination 1`] = `
                   "overflow": "hidden",
                 },
                 false,
-                Object {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                  },
+                  Object {
+                    "borderRadius": 20,
+                  },
+                ],
               ]
             }
           >
@@ -679,11 +689,16 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
                   "overflow": "hidden",
                 },
                 false,
-                Object {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                  },
+                  Object {
+                    "borderRadius": 20,
+                  },
+                ],
               ]
             }
           >
@@ -814,11 +829,16 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
                   "overflow": "hidden",
                 },
                 false,
-                Object {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                  },
+                  Object {
+                    "borderRadius": 20,
+                  },
+                ],
               ]
             }
           >
@@ -949,11 +969,16 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
                   "overflow": "hidden",
                 },
                 false,
-                Object {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                  },
+                  Object {
+                    "borderRadius": 20,
+                  },
+                ],
               ]
             }
           >
@@ -1084,11 +1109,16 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
                   "overflow": "hidden",
                 },
                 false,
-                Object {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                  },
+                  Object {
+                    "borderRadius": 20,
+                  },
+                ],
               ]
             }
           >
@@ -1277,11 +1307,16 @@ exports[`renders data table pagination with label 1`] = `
                   "overflow": "hidden",
                 },
                 false,
-                Object {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                  },
+                  Object {
+                    "borderRadius": 20,
+                  },
+                ],
               ]
             }
           >
@@ -1412,11 +1447,16 @@ exports[`renders data table pagination with label 1`] = `
                   "overflow": "hidden",
                 },
                 false,
-                Object {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                  },
+                  Object {
+                    "borderRadius": 20,
+                  },
+                ],
               ]
             }
           >
@@ -1849,11 +1889,16 @@ exports[`renders data table pagination with options select 1`] = `
                   "overflow": "hidden",
                 },
                 false,
-                Object {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                  },
+                  Object {
+                    "borderRadius": 20,
+                  },
+                ],
               ]
             }
           >
@@ -1984,11 +2029,16 @@ exports[`renders data table pagination with options select 1`] = `
                   "overflow": "hidden",
                 },
                 false,
-                Object {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                  },
+                  Object {
+                    "borderRadius": 20,
+                  },
+                ],
               ]
             }
           >
@@ -2119,11 +2169,16 @@ exports[`renders data table pagination with options select 1`] = `
                   "overflow": "hidden",
                 },
                 false,
-                Object {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                  },
+                  Object {
+                    "borderRadius": 20,
+                  },
+                ],
               ]
             }
           >
@@ -2254,11 +2309,16 @@ exports[`renders data table pagination with options select 1`] = `
                   "overflow": "hidden",
                 },
                 false,
-                Object {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                  },
+                  Object {
+                    "borderRadius": 20,
+                  },
+                ],
               ]
             }
           >

--- a/src/components/__tests__/__snapshots__/IconButton.test.js.snap
+++ b/src/components/__tests__/__snapshots__/IconButton.test.js.snap
@@ -92,11 +92,16 @@ exports[`renders disabled icon button 1`] = `
               "overflow": "hidden",
             },
             false,
-            Object {
-              "alignItems": "center",
-              "flexGrow": 1,
-              "justifyContent": "center",
-            },
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
+              Object {
+                "borderRadius": 20,
+              },
+            ],
           ]
         }
       >
@@ -229,11 +234,16 @@ exports[`renders icon button by default 1`] = `
               "overflow": "hidden",
             },
             false,
-            Object {
-              "alignItems": "center",
-              "flexGrow": 1,
-              "justifyContent": "center",
-            },
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
+              Object {
+                "borderRadius": 20,
+              },
+            ],
           ]
         }
       >
@@ -366,11 +376,16 @@ exports[`renders icon button with color 1`] = `
               "overflow": "hidden",
             },
             false,
-            Object {
-              "alignItems": "center",
-              "flexGrow": 1,
-              "justifyContent": "center",
-            },
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
+              Object {
+                "borderRadius": 20,
+              },
+            ],
           ]
         }
       >
@@ -503,11 +518,16 @@ exports[`renders icon button with size 1`] = `
               "overflow": "hidden",
             },
             false,
-            Object {
-              "alignItems": "center",
-              "flexGrow": 1,
-              "justifyContent": "center",
-            },
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
+              Object {
+                "borderRadius": 23,
+              },
+            ],
           ]
         }
       >
@@ -640,11 +660,16 @@ exports[`renders icon change animated 1`] = `
               "overflow": "hidden",
             },
             false,
-            Object {
-              "alignItems": "center",
-              "flexGrow": 1,
-              "justifyContent": "center",
-            },
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
+              Object {
+                "borderRadius": 20,
+              },
+            ],
           ]
         }
       >

--- a/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
@@ -133,11 +133,16 @@ exports[`activity indicator snapshot test 1`] = `
                     "overflow": "hidden",
                   },
                   false,
-                  Object {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    },
+                    Object {
+                      "borderRadius": 20,
+                    },
+                  ],
                 ]
               }
             >
@@ -546,11 +551,16 @@ exports[`renders with placeholder 1`] = `
                     "overflow": "hidden",
                   },
                   false,
-                  Object {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    },
+                    Object {
+                      "borderRadius": 20,
+                    },
+                  ],
                 ]
               }
             >
@@ -714,11 +724,16 @@ exports[`renders with placeholder 1`] = `
                       "overflow": "hidden",
                     },
                     false,
-                    Object {
-                      "alignItems": "center",
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    },
+                    Array [
+                      Object {
+                        "alignItems": "center",
+                        "flexGrow": 1,
+                        "justifyContent": "center",
+                      },
+                      Object {
+                        "borderRadius": 20,
+                      },
+                    ],
                   ]
                 }
               >
@@ -901,11 +916,16 @@ exports[`renders with text 1`] = `
                     "overflow": "hidden",
                   },
                   false,
-                  Object {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                  },
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    },
+                    Object {
+                      "borderRadius": 20,
+                    },
+                  ],
                 ]
               }
             >
@@ -1070,11 +1090,16 @@ exports[`renders with text 1`] = `
                       "overflow": "hidden",
                     },
                     false,
-                    Object {
-                      "alignItems": "center",
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    },
+                    Array [
+                      Object {
+                        "alignItems": "center",
+                        "flexGrow": 1,
+                        "justifyContent": "center",
+                      },
+                      Object {
+                        "borderRadius": 20,
+                      },
+                    ],
                   ]
                 }
               >

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -1175,11 +1175,16 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
                   "overflow": "hidden",
                 },
                 false,
-                Object {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                  },
+                  Object {
+                    "borderRadius": 20,
+                  },
+                ],
               ]
             }
             testID="right-icon-adornment"
@@ -1524,11 +1529,16 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
                   "overflow": "hidden",
                 },
                 false,
-                Object {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                  },
+                  Object {
+                    "borderRadius": 20,
+                  },
+                ],
               ]
             }
             testID="left-icon-adornment"

--- a/src/components/__tests__/__snapshots__/ToggleButton.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ToggleButton.test.js.snap
@@ -92,11 +92,16 @@ exports[`renders disabled toggle button 1`] = `
           Array [
             false,
             false,
-            Object {
-              "alignItems": "center",
-              "flexGrow": 1,
-              "justifyContent": "center",
-            },
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
+              Object {
+                "borderRadius": 20,
+              },
+            ],
           ]
         }
       >
@@ -228,11 +233,16 @@ exports[`renders toggle button 1`] = `
           Array [
             false,
             false,
-            Object {
-              "alignItems": "center",
-              "flexGrow": 1,
-              "justifyContent": "center",
-            },
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
+              Object {
+                "borderRadius": 20,
+              },
+            ],
           ]
         }
       >
@@ -370,11 +380,16 @@ exports[`renders unchecked toggle button 1`] = `
           Array [
             false,
             false,
-            Object {
-              "alignItems": "center",
-              "flexGrow": 1,
-              "justifyContent": "center",
-            },
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
+              Object {
+                "borderRadius": 20,
+              },
+            ],
           ]
         }
       >


### PR DESCRIPTION
### Summary

When using the keyboard and you tab to an IconButton, the outline is "cut" on all sides making it hard to see that the button is focused.
The solution was just to add the same `borderRadius` to the `TouchableRipple` as the parent `Surface` has.

### Test plan

Tab to an IconButton. When it is focused, you will now see the whole outline instead of partial one.

Before: 
<img width="170" alt="Skärmavbild 2022-12-15 kl  19 21 30" src="https://user-images.githubusercontent.com/26097801/207950273-46dca758-60b1-4dce-8e3b-7e291c942002.png">

After: 
<img width="175" alt="Skärmavbild 2022-12-15 kl  19 21 44" src="https://user-images.githubusercontent.com/26097801/207950322-68cea37b-e653-444c-ba86-7a93d5e82e46.png">

