### PR TITLE
refactor: correct input flex behavior

### DIFF
--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -467,7 +467,6 @@ const styles = StyleSheet.create({
     paddingBottom: 0,
   },
   input: {
-    flexGrow: 1,
     margin: 0,
   },
   inputFlat: {

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -415,7 +415,6 @@ const styles = StyleSheet.create({
     paddingBottom: 0,
   },
   input: {
-    flexGrow: 1,
     margin: 0,
     zIndex: 1,
   },

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -171,7 +171,6 @@ exports[`correctly applies a component as the text label 1`] = `
       style={
         Array [
           Object {
-            "flexGrow": 1,
             "margin": 0,
           },
           Object {
@@ -364,7 +363,6 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
       style={
         Array [
           Object {
-            "flexGrow": 1,
             "margin": 0,
           },
           Object {
@@ -611,7 +609,6 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
         style={
           Array [
             Object {
-              "flexGrow": 1,
               "margin": 0,
               "zIndex": 1,
             },
@@ -803,7 +800,6 @@ exports[`correctly applies textAlign center 1`] = `
       style={
         Array [
           Object {
-            "flexGrow": 1,
             "margin": 0,
           },
           Object {
@@ -996,7 +992,6 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
       style={
         Array [
           Object {
-            "flexGrow": 1,
             "margin": 0,
           },
           Object {
@@ -1383,7 +1378,6 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
       style={
         Array [
           Object {
-            "flexGrow": 1,
             "margin": 0,
           },
           Object {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Change flex behaviour in `TextInput` by removing `flexGrow` which makes wrapped inputs occupy the whole height. 

#### Related issue

- #3530 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Tested manually, on all platforms, checked if doesn't break multiline inputs,

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
