### PR TITLE
fix: Made ToggleButton.Group TS compatible

### DIFF
--- a/example/src/Examples/ToggleButtonExample.tsx
+++ b/example/src/Examples/ToggleButtonExample.tsx
@@ -6,7 +6,7 @@ import { ToggleButton, List } from 'react-native-paper';
 import ScreenWrapper from '../ScreenWrapper';
 
 type StatusState = 'checked' | 'unchecked';
-type Fruits = 'watermelon' | 'strawberries' | 'apple';
+type Fruits = 'watermelon' | 'strawberries';
 
 enum FontsEnum {
   NoFormat = 'no-format',

--- a/example/src/Examples/ToggleButtonExample.tsx
+++ b/example/src/Examples/ToggleButtonExample.tsx
@@ -6,11 +6,23 @@ import { ToggleButton, List } from 'react-native-paper';
 import ScreenWrapper from '../ScreenWrapper';
 
 type StatusState = 'checked' | 'unchecked';
+type Fruits = 'watermelon' | 'strawberries' | 'apple';
+
+enum FontsEnum {
+  NoFormat = 'no-format',
+  Italic = 'italic',
+  Bold = 'bold',
+  Underline = 'underlined',
+  ColorText = 'format-color',
+}
 
 const ToggleButtonExample = () => {
-  const [first, setFirst] = React.useState<string>('bold');
-  const [fruit, setFruit] = React.useState<string>('watermelon');
+  const [first, setFirst] = React.useState('bold');
+  const [fruit, setFruit] = React.useState<Fruits>('watermelon');
   const [status, setStatus] = React.useState<StatusState>('checked');
+  const [font, setFont] = React.useState<FontsEnum>(FontsEnum.NoFormat);
+
+  const handleFruit = (value: Fruits) => setFruit(value);
 
   return (
     <ScreenWrapper>
@@ -26,7 +38,7 @@ const ToggleButtonExample = () => {
           />
         </View>
       </List.Section>
-      <List.Section title="Group">
+      <List.Section title="Row">
         <ToggleButton.Row
           value={first}
           onValueChange={(value: string) => setFirst(value)}
@@ -38,12 +50,21 @@ const ToggleButtonExample = () => {
           <ToggleButton icon="format-color-text" value="format-color" />
         </ToggleButton.Row>
       </List.Section>
-      <List.Section title="Custom">
+      <List.Section title="Group & enums">
+        <ToggleButton.Group value={font} onValueChange={setFont}>
+          <ToggleButton
+            disabled
+            icon="format-italic"
+            value={FontsEnum.Italic}
+          />
+          <ToggleButton icon="format-bold" value={FontsEnum.Bold} />
+          <ToggleButton icon="format-underline" value={FontsEnum.Underline} />
+          <ToggleButton icon="format-color-text" value={FontsEnum.ColorText} />
+        </ToggleButton.Group>
+      </List.Section>
+      <List.Section title="Custom & union types">
         <View style={[styles.padding, styles.row]}>
-          <ToggleButton.Group
-            value={fruit}
-            onValueChange={(value: string) => setFruit(value)}
-          >
+          <ToggleButton.Group value={fruit} onValueChange={handleFruit}>
             <ImageBackground
               style={styles.customImage}
               source={{

--- a/src/components/ToggleButton/ToggleButtonGroup.tsx
+++ b/src/components/ToggleButton/ToggleButtonGroup.tsx
@@ -1,26 +1,27 @@
 import * as React from 'react';
 
-export type Props<TData = string> = {
+export type Props<Value = string> = {
   /**
    * Function to execute on selection change.
    */
-  onValueChange: (value: TData) => void | null;
+  onValueChange: (value: Value) => void;
   /**
    * Value of the currently selected toggle button.
    */
-  value: TData | null;
+  value: Value | null;
   /**
    * React elements containing toggle buttons.
    */
   children: React.ReactNode;
 };
 
-type ToggleButtonContextType<TData = any> = {
-  value: TData | null;
-  onValueChange: (item: TData) => void | null;
+type ToggleButtonContextType<Value> = {
+  value: Value | null;
+  onValueChange: (item: Value) => void;
 };
 
 export const ToggleButtonGroupContext =
+  //@ts-ignore: so we avoid using `any` into the type
   React.createContext<ToggleButtonContextType>(null as any);
 
 /**
@@ -54,11 +55,11 @@ export const ToggleButtonGroupContext =
  * export default MyComponent;
  *```
  */
-const ToggleButtonGroup = <TData = string,>({
+const ToggleButtonGroup = <Value = string,>({
   value,
   onValueChange,
   children,
-}: Props<TData>) => (
+}: Props<Value>) => (
   <ToggleButtonGroupContext.Provider
     value={{
       value,

--- a/src/components/ToggleButton/ToggleButtonGroup.tsx
+++ b/src/components/ToggleButton/ToggleButtonGroup.tsx
@@ -1,23 +1,23 @@
 import * as React from 'react';
 
-export type Props = {
+export type Props<TData = string> = {
   /**
    * Function to execute on selection change.
    */
-  onValueChange: (value: string) => void | null;
+  onValueChange: (value: TData) => void | null;
   /**
    * Value of the currently selected toggle button.
    */
-  value: string | null;
+  value: TData | null;
   /**
    * React elements containing toggle buttons.
    */
   children: React.ReactNode;
 };
 
-type ToggleButtonContextType = {
-  value: string | null;
-  onValueChange: (item: string) => void | null;
+type ToggleButtonContextType<TData = any> = {
+  value: TData | null;
+  onValueChange: (item: TData) => void | null;
 };
 
 export const ToggleButtonGroupContext =
@@ -54,7 +54,11 @@ export const ToggleButtonGroupContext =
  * export default MyComponent;
  *```
  */
-const ToggleButtonGroup = ({ value, onValueChange, children }: Props) => (
+const ToggleButtonGroup = <TData = string,>({
+  value,
+  onValueChange,
+  children,
+}: Props<TData>) => (
   <ToggleButtonGroupContext.Provider
     value={{
       value,

--- a/src/components/ToggleButton/ToggleButtonGroup.tsx
+++ b/src/components/ToggleButton/ToggleButtonGroup.tsx
@@ -21,7 +21,7 @@ type ToggleButtonContextType<Value> = {
 };
 
 export const ToggleButtonGroupContext =
-  //@ts-ignore: so we avoid using `any` into the type
+  //@ts-ignore: so we avoid using `any`, TS can't ensure the type from Group to children
   React.createContext<ToggleButtonContextType>(null as any);
 
 /**

--- a/src/components/ToggleButton/ToggleButtonGroup.tsx
+++ b/src/components/ToggleButton/ToggleButtonGroup.tsx
@@ -21,7 +21,7 @@ type ToggleButtonContextType<Value> = {
 };
 
 export const ToggleButtonGroupContext =
-  //@ts-ignore: so we avoid using `any`, TS can't ensure the type from Group to children
+  //@ts-expect-error: TS can't ensure the type from Group to children
   React.createContext<ToggleButtonContextType>(null as any);
 
 /**


### PR DESCRIPTION
fix: Now you can use `ToggleButton.Group` with Union Types and Enums (default string)

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Before you couldn't use Union types or enums without TS complaining about the type

```
type Fruits = 'watermelon' | 'strawberries' | 'apple';
```
<img width="679" alt="ts_error_type_string" src="https://user-images.githubusercontent.com/1676818/208864169-5ec3bb78-dc43-4f37-ab10-c3b17f582a5a.png">

with this new change, TS will get the right type and won't complain

<img width="873" alt="new_toggleButton_unionT_function" src="https://user-images.githubusercontent.com/1676818/208864686-d6ec1951-2469-44d5-81fc-296761cd265f.png">


### Test plan

- Use different types, like string, enums and union types
- Check if the IDE get the right type