### PR TITLE
fix: adjust icon styles in compact button

### DIFF
--- a/example/src/Examples/ButtonExample.tsx
+++ b/example/src/Examples/ButtonExample.tsx
@@ -285,6 +285,32 @@ const ButtonExample = () => {
           </Button>
         </View>
       </List.Section>
+      <List.Section title="Compact">
+        <View style={styles.row}>
+          {(
+            [
+              'text',
+              'outlined',
+              'contained',
+              'elevated',
+              'contained-tonal',
+            ] as const
+          ).map((mode) => {
+            return (
+              <Button
+                key={mode}
+                mode={mode}
+                compact
+                onPress={() => {}}
+                style={styles.button}
+                icon="camera"
+              >
+                Compact {mode}
+              </Button>
+            );
+          })}
+        </View>
+      </List.Section>
     </ScreenWrapper>
   );
 };

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -274,20 +274,17 @@ const Button = ({
     StyleSheet.flatten(contentStyle)?.flexDirection === 'row-reverse'
       ? [
           styles.iconReverse,
-          isV3 &&
-            (compact ? styles.md3IconReverseCompact : styles.md3IconReverse),
+          isV3 && styles[`md3IconReverse${compact ? 'Compact' : ''}`],
           isV3 &&
             isMode('text') &&
-            (compact
-              ? styles.md3IconReverseTextModeCompact
-              : styles.md3IconReverseTextMode),
+            styles[`md3IconReverseTextMode${compact ? 'Compact' : ''}`],
         ]
       : [
           styles.icon,
-          isV3 && (compact ? styles.md3IconCompact : styles.md3Icon),
+          isV3 && styles[`md3Icon${compact ? 'Compact' : ''}`],
           isV3 &&
             isMode('text') &&
-            (compact ? styles.md3IconTextModeCompact : styles.md3IconTextMode),
+            styles[`md3IconTextMode${compact ? 'Compact' : ''}`],
         ];
 
   return (
@@ -394,6 +391,7 @@ const styles = StyleSheet.create({
     marginRight: 12,
     marginLeft: -4,
   },
+  /* eslint-disable react-native/no-unused-styles */
   md3Icon: {
     marginLeft: 16,
     marginRight: -16,
@@ -426,6 +424,7 @@ const styles = StyleSheet.create({
     marginLeft: 0,
     marginRight: 6,
   },
+  /* eslint-enable react-native/no-unused-styles */
   label: {
     textAlign: 'center',
     marginVertical: 9,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -183,7 +183,7 @@ const Button = ({
   uppercase = !theme.isV3,
   contentStyle,
   labelStyle,
-  testID,
+  testID = 'button',
   accessible,
   ...rest
 }: Props) => {
@@ -274,13 +274,20 @@ const Button = ({
     StyleSheet.flatten(contentStyle)?.flexDirection === 'row-reverse'
       ? [
           styles.iconReverse,
-          isV3 && styles.md3IconReverse,
-          isV3 && isMode('text') && styles.md3IconReverseTextMode,
+          isV3 &&
+            (compact ? styles.md3IconReverseCompact : styles.md3IconReverse),
+          isV3 &&
+            isMode('text') &&
+            (compact
+              ? styles.md3IconReverseTextModeCompact
+              : styles.md3IconReverseTextMode),
         ]
       : [
           styles.icon,
-          isV3 && styles.md3Icon,
-          isV3 && isMode('text') && styles.md3IconTextMode,
+          isV3 && (compact ? styles.md3IconCompact : styles.md3Icon),
+          isV3 &&
+            isMode('text') &&
+            (compact ? styles.md3IconTextModeCompact : styles.md3IconTextMode),
         ];
 
   return (
@@ -316,7 +323,7 @@ const Button = ({
       >
         <View style={[styles.content, contentStyle]}>
           {icon && loading !== true ? (
-            <View style={iconStyle}>
+            <View style={iconStyle} testID={`${testID}-icon-container`}>
               <Icon
                 source={icon}
                 size={customLabelSize ?? iconSize}
@@ -391,17 +398,33 @@ const styles = StyleSheet.create({
     marginLeft: 16,
     marginRight: -16,
   },
+  md3IconCompact: {
+    marginLeft: 8,
+    marginRight: 0,
+  },
   md3IconReverse: {
     marginLeft: -16,
     marginRight: 16,
+  },
+  md3IconReverseCompact: {
+    marginLeft: 0,
+    marginRight: 8,
   },
   md3IconTextMode: {
     marginLeft: 12,
     marginRight: -8,
   },
+  md3IconTextModeCompact: {
+    marginLeft: 6,
+    marginRight: 0,
+  },
   md3IconReverseTextMode: {
     marginLeft: -8,
     marginRight: 12,
+  },
+  md3IconReverseTextModeCompact: {
+    marginLeft: 0,
+    marginRight: 6,
   },
   label: {
     textAlign: 'center',

--- a/src/components/__tests__/Button.test.js
+++ b/src/components/__tests__/Button.test.js
@@ -150,6 +150,60 @@ it('should execute onPressOut', () => {
   expect(onPressOutMock).toHaveBeenCalledTimes(1);
 });
 
+describe('button icon styles', () => {
+  it('should return correct icon styles for compact text button', () => {
+    const { getByTestId } = render(
+      <Button mode={'text'} compact icon="camera" testID="compact-button">
+        Compact text button
+      </Button>
+    );
+    expect(getByTestId('compact-button-icon-container')).toHaveStyle({
+      marginLeft: 6,
+      marginRight: 0,
+    });
+  });
+
+  [('outlined', 'contained', 'contained-tonal', 'elevated')].forEach((mode) =>
+    it(`should return correct icon styles for compact ${mode} button`, () => {
+      const { getByTestId } = render(
+        <Button mode={mode} compact icon="camera" testID="compact-button">
+          Compact {mode} button
+        </Button>
+      );
+      expect(getByTestId('compact-button-icon-container')).toHaveStyle({
+        marginLeft: 8,
+        marginRight: 0,
+      });
+    })
+  );
+
+  it('should return correct icon styles for text button', () => {
+    const { getByTestId } = render(
+      <Button mode={'text'} icon="camera" testID="compact-button">
+        text button
+      </Button>
+    );
+    expect(getByTestId('compact-button-icon-container')).toHaveStyle({
+      marginLeft: 12,
+      marginRight: -8,
+    });
+  });
+
+  ['outlined', 'contained', 'contained-tonal', 'elevated'].forEach((mode) =>
+    it(`should return correct icon styles for compact ${mode} button`, () => {
+      const { getByTestId } = render(
+        <Button mode={mode} icon="camera" testID="compact-button">
+          {mode} button
+        </Button>
+      );
+      expect(getByTestId('compact-button-icon-container')).toHaveStyle({
+        marginLeft: 16,
+        marginRight: -16,
+      });
+    })
+  );
+});
+
 describe('getButtonColors - background color', () => {
   const customButtonColor = '#111111';
 

--- a/src/components/__tests__/__snapshots__/Banner.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.js.snap
@@ -199,6 +199,7 @@ exports[`render visible banner, with custom theme 1`] = `
                         },
                       ]
                     }
+                    testID="button"
                   >
                     <View
                       style={
@@ -613,6 +614,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                         },
                       ]
                     }
+                    testID="button"
                   >
                     <View
                       style={
@@ -886,6 +888,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                         },
                       ]
                     }
+                    testID="button"
                   >
                     <View
                       style={
@@ -1030,6 +1033,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                         },
                       ]
                     }
+                    testID="button"
                   >
                     <View
                       style={

--- a/src/components/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.js.snap
@@ -79,6 +79,7 @@ exports[`renders button with an accessibility hint 1`] = `
             },
           ]
         }
+        testID="button"
       >
         <View
           style={
@@ -224,6 +225,7 @@ exports[`renders button with an accessibility label 1`] = `
             },
           ]
         }
+        testID="button"
       >
         <View
           style={
@@ -368,6 +370,7 @@ exports[`renders button with button color 1`] = `
             },
           ]
         }
+        testID="button"
       >
         <View
           style={
@@ -512,6 +515,7 @@ exports[`renders button with color 1`] = `
             },
           ]
         }
+        testID="button"
       >
         <View
           style={
@@ -801,6 +805,7 @@ exports[`renders button with icon 1`] = `
             },
           ]
         }
+        testID="button"
       >
         <View
           style={
@@ -831,6 +836,7 @@ exports[`renders button with icon 1`] = `
                 },
               ]
             }
+            testID="button-icon-container"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -1000,6 +1006,7 @@ exports[`renders button with icon in reverse order 1`] = `
             },
           ]
         }
+        testID="button"
       >
         <View
           style={
@@ -1032,6 +1039,7 @@ exports[`renders button with icon in reverse order 1`] = `
                 },
               ]
             }
+            testID="button-icon-container"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -1201,6 +1209,7 @@ exports[`renders contained contained with mode 1`] = `
             },
           ]
         }
+        testID="button"
       >
         <View
           style={
@@ -1346,6 +1355,7 @@ exports[`renders disabled button 1`] = `
             },
           ]
         }
+        testID="button"
       >
         <View
           style={
@@ -1490,6 +1500,7 @@ exports[`renders loading button 1`] = `
             },
           ]
         }
+        testID="button"
       >
         <View
           style={
@@ -1842,6 +1853,7 @@ exports[`renders outlined button with mode 1`] = `
             },
           ]
         }
+        testID="button"
       >
         <View
           style={
@@ -1987,6 +1999,7 @@ exports[`renders text button by default 1`] = `
             },
           ]
         }
+        testID="button"
       >
         <View
           style={
@@ -2131,6 +2144,7 @@ exports[`renders text button with mode 1`] = `
             },
           ]
         }
+        testID="button"
       >
         <View
           style={

--- a/src/components/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.js.snap
@@ -1643,6 +1643,7 @@ exports[`renders data table pagination with options select 1`] = `
                   },
                 ]
               }
+              testID="button"
             >
               <View
                 style={
@@ -1672,6 +1673,7 @@ exports[`renders data table pagination with options select 1`] = `
                       false,
                     ]
                   }
+                  testID="button-icon-container"
                 >
                   <Text
                     accessibilityElementsHidden={true}

--- a/src/components/__tests__/__snapshots__/Menu.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.js.snap
@@ -91,6 +91,7 @@ Array [
                   },
                 ]
               }
+              testID="button"
             >
               <View
                 style={
@@ -588,6 +589,7 @@ exports[`renders not visible menu 1`] = `
                 },
               ]
             }
+            testID="button"
           >
             <View
               style={
@@ -748,6 +750,7 @@ Array [
                   },
                 ]
               }
+              testID="button"
             >
               <View
                 style={

--- a/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
@@ -415,6 +415,7 @@ exports[`renders snackbar with action button 1`] = `
                       },
                     ]
                   }
+                  testID="button"
                 >
                   <View
                     style={


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Adjust icon styles for the `compact` Button to avoid overlapping icon and label.

#### Related issue

- #3550 

### Test plan

Added units tests.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
