### PR TITLE
fix: correct border radius in icon button and card components

### DIFF
--- a/example/src/Examples/IconButtonExample.tsx
+++ b/example/src/Examples/IconButtonExample.tsx
@@ -123,6 +123,14 @@ const ButtonExample = () => {
             iconColor={MD3Colors.tertiary50}
             onPress={() => {}}
           />
+          <IconButton
+            icon="eye"
+            mode="contained"
+            style={styles.square}
+            size={24}
+            iconColor={MD3Colors.tertiary50}
+            onPress={() => {}}
+          />
           <IconButton icon="camera" size={36} onPress={() => {}} />
           <IconButton
             icon="lock"
@@ -150,6 +158,9 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: 'row',
     paddingHorizontal: 12,
+  },
+  square: {
+    borderRadius: 0,
   },
 });
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -134,7 +134,7 @@ const Card = ({
   children,
   style,
   theme,
-  testID,
+  testID = 'card',
   accessible,
   ...rest
 }: (OutlinedCardProps | ElevatedCardProps | ContainedCardProps) & Props) => {
@@ -224,7 +224,9 @@ const Card = ({
     mode: cardMode,
   });
 
-  const borderRadius = (isV3 ? 3 : 1) * roundness;
+  const { borderRadius = (isV3 ? 3 : 1) * roundness } = (StyleSheet.flatten(
+    style
+  ) || {}) as ViewStyle;
 
   return (
     <Surface
@@ -249,6 +251,7 @@ const Card = ({
       {isMode('outlined') && (
         <View
           pointerEvents="none"
+          testID={`${testID}-outline`}
           style={[
             {
               borderRadius,

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -147,9 +147,14 @@ const IconButton = React.forwardRef<View, Props>(
 
     const buttonSize = isV3 ? size + 2 * PADDING : size * 1.5;
 
+    const {
+      borderWidth = isV3 && mode === 'outlined' && !selected ? 1 : 0,
+      borderRadius = buttonSize / 2,
+    } = (StyleSheet.flatten(style) || {}) as ViewStyle;
+
     const borderStyles = {
-      borderWidth: isV3 && mode === 'outlined' && !selected ? 1 : 0,
-      borderRadius: buttonSize / 2,
+      borderWidth,
+      borderRadius,
       borderColor,
     };
 
@@ -177,10 +182,7 @@ const IconButton = React.forwardRef<View, Props>(
           onPress={onPress}
           rippleColor={rippleColor}
           accessibilityLabel={accessibilityLabel}
-          style={[
-            styles.touchable,
-            { borderRadius: borderStyles.borderRadius },
-          ]}
+          style={[styles.touchable, { borderRadius }]}
           // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
           accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
           accessibilityComponentType="button"

--- a/src/components/__tests__/Card/Card.test.js
+++ b/src/components/__tests__/Card/Card.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { StyleSheet } from 'react-native';
 
 import { render } from '@testing-library/react-native';
 import color from 'color';
@@ -10,11 +11,32 @@ import Button from '../../Button/Button';
 import Card from '../../Card/Card';
 import { getCardColors, getCardCoverStyle } from '../../Card/utils';
 
+const styles = StyleSheet.create({
+  customBorderRadius: {
+    borderRadius: 32,
+  },
+});
+
 describe('Card', () => {
   it('renders an outlined card', () => {
     const tree = renderer.create(<Card mode="outlined" />).toJSON();
 
     expect(tree).toMatchSnapshot();
+  });
+
+  it('renders an outlined card with custom border radius and color', () => {
+    const { getByTestId } = render(
+      <Card
+        mode="outlined"
+        theme={{ colors: { outline: 'purple' } }}
+        style={styles.customBorderRadius}
+      />
+    );
+
+    expect(getByTestId('card-outline')).toHaveStyle({
+      borderRadius: 32,
+      borderColor: 'purple',
+    });
   });
 
   it('renders with a custom theme', () => {

--- a/src/components/__tests__/Card/__snapshots__/Card.test.js.snap
+++ b/src/components/__tests__/Card/__snapshots__/Card.test.js.snap
@@ -62,6 +62,7 @@ exports[`Card renders an outlined card 1`] = `
             },
           ]
         }
+        testID="card-outline"
       />
       <View
         accessibilityState={
@@ -83,6 +84,7 @@ exports[`Card renders an outlined card 1`] = `
             "flexShrink": 1,
           }
         }
+        testID="card"
       />
     </View>
   </View>

--- a/src/components/__tests__/IconButton.test.js
+++ b/src/components/__tests__/IconButton.test.js
@@ -1,5 +1,7 @@
 import * as React from 'react';
+import { StyleSheet } from 'react-native';
 
+import { render } from '@testing-library/react-native';
 import color from 'color';
 import renderer from 'react-test-renderer';
 
@@ -7,6 +9,12 @@ import { getTheme } from '../../core/theming';
 import { pink500 } from '../../styles/themes/v2/colors';
 import IconButton from '../IconButton/IconButton.tsx';
 import { getIconButtonColor } from '../IconButton/utils';
+
+const styles = StyleSheet.create({
+  square: {
+    borderRadius: 0,
+  },
+});
 
 it('renders icon button by default', () => {
   const tree = renderer.create(<IconButton icon="camera" />).toJSON();
@@ -38,6 +46,20 @@ it('renders icon change animated', () => {
   const tree = renderer.create(<IconButton icon="camera" animated />).toJSON();
 
   expect(tree).toMatchSnapshot();
+});
+
+it('renders icon button with custom border radius', () => {
+  const { getByTestId } = render(
+    <IconButton
+      icon="camera"
+      testID="icon-button"
+      size={36}
+      onPress={() => {}}
+      style={styles.square}
+    />
+  );
+
+  expect(getByTestId('icon-button')).toHaveStyle({ borderRadius: 0 });
 });
 
 describe('getIconButtonColor - icon color', () => {

--- a/src/components/__tests__/__snapshots__/ToggleButton.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ToggleButton.test.js.snap
@@ -99,7 +99,7 @@ exports[`renders disabled toggle button 1`] = `
                 "justifyContent": "center",
               },
               Object {
-                "borderRadius": 20,
+                "borderRadius": 4,
               },
             ],
           ]
@@ -240,7 +240,7 @@ exports[`renders toggle button 1`] = `
                 "justifyContent": "center",
               },
               Object {
-                "borderRadius": 20,
+                "borderRadius": 4,
               },
             ],
           ]
@@ -387,7 +387,7 @@ exports[`renders unchecked toggle button 1`] = `
                 "justifyContent": "center",
               },
               Object {
-                "borderRadius": 20,
+                "borderRadius": 4,
               },
             ],
           ]


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Corrects the border behavior in `IconButton` which affects the `ToggleButton` and makes it circle, after merging https://github.com/callstack/react-native-paper/pull/3531. Additionally within the `Card` component, there was no option to override the `outline` radius which is going to be supported after merging that PR. 

#### Related issue

- #3563 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Added appropriate unit tests.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
