### PR TITLE
fix: Surface to correctly set start and end on iOS

### DIFF
--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -218,10 +218,10 @@ const Surface = React.forwardRef<View, Props>(
 
     const shadowColor = '#000';
 
-    const { position, alignSelf, top, left, right, bottom, ...restStyle } =
+    const { position, alignSelf, top, left, right, bottom, start, end, ...restStyle } =
       (StyleSheet.flatten(style) || {}) as ViewStyle;
 
-    const absoluteStyles = { position, alignSelf, top, right, bottom, left };
+    const absoluteStyles = { position, alignSelf, top, right, bottom, left, start, end };
     const sharedStyle = [{ backgroundColor }, restStyle];
 
     if (isAnimatedValue(elevation)) {

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
@@ -7,6 +7,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -17,6 +18,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -57,6 +59,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
           Object {
             "alignSelf": undefined,
             "bottom": undefined,
+            "end": undefined,
             "left": undefined,
             "position": undefined,
             "right": undefined,
@@ -67,6 +70,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
             },
             "shadowOpacity": 0.15,
             "shadowRadius": 3,
+            "start": undefined,
             "top": undefined,
           }
         }
@@ -102,6 +106,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                 Object {
                   "alignSelf": undefined,
                   "bottom": undefined,
+                  "end": undefined,
                   "left": undefined,
                   "position": undefined,
                   "right": undefined,
@@ -112,6 +117,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                   },
                   "shadowOpacity": 0,
                   "shadowRadius": 0,
+                  "start": undefined,
                   "top": undefined,
                 }
               }
@@ -275,6 +281,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                   Object {
                     "alignSelf": undefined,
                     "bottom": undefined,
+                    "end": undefined,
                     "left": undefined,
                     "position": undefined,
                     "right": undefined,
@@ -285,6 +292,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                     },
                     "shadowOpacity": 0,
                     "shadowRadius": 0,
+                    "start": undefined,
                     "top": undefined,
                   }
                 }
@@ -425,6 +433,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -435,6 +444,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -475,6 +485,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
           Object {
             "alignSelf": undefined,
             "bottom": undefined,
+            "end": undefined,
             "left": undefined,
             "position": undefined,
             "right": undefined,
@@ -485,6 +496,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "start": undefined,
             "top": undefined,
           }
         }
@@ -725,6 +737,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
           Object {
             "alignSelf": undefined,
             "bottom": undefined,
+            "end": undefined,
             "left": undefined,
             "position": undefined,
             "right": undefined,
@@ -735,6 +748,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "start": undefined,
             "top": undefined,
           }
         }

--- a/src/components/__tests__/Card/__snapshots__/Card.test.js.snap
+++ b/src/components/__tests__/Card/__snapshots__/Card.test.js.snap
@@ -7,6 +7,7 @@ exports[`Card renders an outlined card 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -17,6 +18,7 @@ exports[`Card renders an outlined card 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }

--- a/src/components/__tests__/Surface.test.js
+++ b/src/components/__tests__/Surface.test.js
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { StyleSheet } from 'react-native';
+import { Platform } from 'react-native';
 
 import { render } from '@testing-library/react-native';
 
@@ -11,5 +13,55 @@ describe('Surface', () => {
       <Surface pointerEvents="box-none" testID={testID} />
     );
     expect(getByTestId(testID).props.pointerEvents).toBe('box-none');
+  });
+
+  describe('on iOS', () => {
+    Platform.OS = 'ios';
+    const style = StyleSheet.create({
+      absoluteStyles: {
+        bottom: 10,
+        end: 20,
+        left: 30,
+        position: 'absolute',
+        right: 40,
+        start: 50,
+        top: 60,
+        flex: 1,
+      },
+    });
+
+    it('should not render absolute position properties on the bottom layer', () => {
+      const testID = 'surface-test-bottom-layer';
+
+      const { getByTestId } = render(
+        <Surface testID={testID} style={style.absoluteStyles} />
+      );
+
+      expect(getByTestId(testID).props.style).toHaveProperty('flex');
+      expect(getByTestId(testID).props.style).toHaveProperty('backgroundColor');
+      expect(getByTestId(testID).props.style).not.toHaveProperty('bottom');
+      expect(getByTestId(testID).props.style).not.toHaveProperty('end');
+      expect(getByTestId(testID).props.style).not.toHaveProperty('left');
+      expect(getByTestId(testID).props.style).not.toHaveProperty('position');
+      expect(getByTestId(testID).props.style).not.toHaveProperty('right');
+      expect(getByTestId(testID).props.style).not.toHaveProperty('start');
+      expect(getByTestId(testID).props.style).not.toHaveProperty('top');
+    });
+
+    it('should render absolute position properties on shadow layer 0', () => {
+      const testID = 'surface-test-shadow-layer-0';
+
+      const { container } = render(
+        <Surface testID={testID} style={style.absoluteStyles} />
+      );
+
+      expect(container.props.style).toHaveProperty('bottom');
+      expect(container.props.style).toHaveProperty('end');
+      expect(container.props.style).toHaveProperty('left');
+      expect(container.props.style).toHaveProperty('position');
+      expect(container.props.style).toHaveProperty('right');
+      expect(container.props.style).toHaveProperty('start');
+      expect(container.props.style).toHaveProperty('top');
+    });
   });
 });

--- a/src/components/__tests__/__snapshots__/AnimatedFAB.test.js.snap
+++ b/src/components/__tests__/__snapshots__/AnimatedFAB.test.js.snap
@@ -7,6 +7,7 @@ exports[`renders animated fab 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": "absolute",
       "right": undefined,
@@ -17,6 +18,7 @@ exports[`renders animated fab 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -295,6 +297,7 @@ exports[`renders animated fab with label on the left 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": "absolute",
       "right": undefined,
@@ -305,6 +308,7 @@ exports[`renders animated fab with label on the left 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -586,6 +590,7 @@ exports[`renders animated fab with label on the right by default 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": "absolute",
       "right": undefined,
@@ -596,6 +601,7 @@ exports[`renders animated fab with label on the right by default 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "start": undefined,
       "top": undefined,
     }
   }

--- a/src/components/__tests__/__snapshots__/Banner.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.js.snap
@@ -7,6 +7,7 @@ exports[`render visible banner, with custom theme 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -17,6 +18,7 @@ exports[`render visible banner, with custom theme 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -127,6 +129,7 @@ exports[`render visible banner, with custom theme 1`] = `
                 Object {
                   "alignSelf": undefined,
                   "bottom": undefined,
+                  "end": undefined,
                   "left": undefined,
                   "position": undefined,
                   "right": undefined,
@@ -137,6 +140,7 @@ exports[`render visible banner, with custom theme 1`] = `
                   },
                   "shadowOpacity": 0,
                   "shadowRadius": 0,
+                  "start": undefined,
                   "top": undefined,
                 }
               }
@@ -281,6 +285,7 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -291,6 +296,7 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -421,6 +427,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -431,6 +438,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -542,6 +550,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                 Object {
                   "alignSelf": undefined,
                   "bottom": undefined,
+                  "end": undefined,
                   "left": undefined,
                   "position": undefined,
                   "right": undefined,
@@ -552,6 +561,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                   },
                   "shadowOpacity": 0,
                   "shadowRadius": 0,
+                  "start": undefined,
                   "top": undefined,
                 }
               }
@@ -696,6 +706,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -706,6 +717,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -816,6 +828,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                 Object {
                   "alignSelf": undefined,
                   "bottom": undefined,
+                  "end": undefined,
                   "left": undefined,
                   "position": undefined,
                   "right": undefined,
@@ -826,6 +839,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   },
                   "shadowOpacity": 0,
                   "shadowRadius": 0,
+                  "start": undefined,
                   "top": undefined,
                 }
               }
@@ -961,6 +975,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                 Object {
                   "alignSelf": undefined,
                   "bottom": undefined,
+                  "end": undefined,
                   "left": undefined,
                   "position": undefined,
                   "right": undefined,
@@ -971,6 +986,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   },
                   "shadowOpacity": 0,
                   "shadowRadius": 0,
+                  "start": undefined,
                   "top": undefined,
                 }
               }
@@ -1115,6 +1131,7 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1125,6 +1142,7 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -1244,6 +1262,7 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1254,6 +1273,7 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
+      "start": undefined,
       "top": undefined,
     }
   }

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
@@ -76,6 +76,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
       Object {
         "alignSelf": undefined,
         "bottom": 0,
+        "end": undefined,
         "left": 0,
         "position": undefined,
         "right": 0,
@@ -86,6 +87,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "start": undefined,
         "top": undefined,
       }
     }
@@ -820,6 +822,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
       Object {
         "alignSelf": undefined,
         "bottom": 0,
+        "end": undefined,
         "left": 0,
         "position": undefined,
         "right": 0,
@@ -830,6 +833,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "start": undefined,
         "top": undefined,
       }
     }
@@ -1717,6 +1721,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
       Object {
         "alignSelf": undefined,
         "bottom": 0,
+        "end": undefined,
         "left": 0,
         "position": undefined,
         "right": 0,
@@ -1727,6 +1732,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "start": undefined,
         "top": undefined,
       }
     }
@@ -3422,6 +3428,7 @@ exports[`renders bottom navigation with scene animation 1`] = `
       Object {
         "alignSelf": undefined,
         "bottom": 0,
+        "end": undefined,
         "left": 0,
         "position": undefined,
         "right": 0,
@@ -3432,6 +3439,7 @@ exports[`renders bottom navigation with scene animation 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "start": undefined,
         "top": undefined,
       }
     }
@@ -4908,6 +4916,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
       Object {
         "alignSelf": undefined,
         "bottom": 0,
+        "end": undefined,
         "left": 0,
         "position": undefined,
         "right": 0,
@@ -4918,6 +4927,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "start": undefined,
         "top": undefined,
       }
     }
@@ -5580,6 +5590,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
       Object {
         "alignSelf": undefined,
         "bottom": 0,
+        "end": undefined,
         "left": 0,
         "position": undefined,
         "right": 0,
@@ -5590,6 +5601,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "start": undefined,
         "top": undefined,
       }
     }
@@ -6556,6 +6568,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
       Object {
         "alignSelf": undefined,
         "bottom": 0,
+        "end": undefined,
         "left": 0,
         "position": undefined,
         "right": 0,
@@ -6566,6 +6579,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "start": undefined,
         "top": undefined,
       }
     }
@@ -7646,6 +7660,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
       Object {
         "alignSelf": undefined,
         "bottom": 0,
+        "end": undefined,
         "left": 0,
         "position": undefined,
         "right": 0,
@@ -7656,6 +7671,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "start": undefined,
         "top": undefined,
       }
     }
@@ -8613,6 +8629,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
       Object {
         "alignSelf": undefined,
         "bottom": 0,
+        "end": undefined,
         "left": 0,
         "position": undefined,
         "right": 0,
@@ -8623,6 +8640,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "start": undefined,
         "top": undefined,
       }
     }
@@ -9702,6 +9720,7 @@ exports[`renders shifting bottom navigation 1`] = `
       Object {
         "alignSelf": undefined,
         "bottom": 0,
+        "end": undefined,
         "left": 0,
         "position": undefined,
         "right": 0,
@@ -9712,6 +9731,7 @@ exports[`renders shifting bottom navigation 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "start": undefined,
         "top": undefined,
       }
     }

--- a/src/components/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.js.snap
@@ -7,6 +7,7 @@ exports[`renders button with an accessibility hint 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -17,6 +18,7 @@ exports[`renders button with an accessibility hint 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -153,6 +155,7 @@ exports[`renders button with an accessibility label 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -163,6 +166,7 @@ exports[`renders button with an accessibility label 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -299,6 +303,7 @@ exports[`renders button with button color 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -309,6 +314,7 @@ exports[`renders button with button color 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -444,6 +450,7 @@ exports[`renders button with color 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -454,6 +461,7 @@ exports[`renders button with color 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -589,6 +597,7 @@ exports[`renders button with custom testID 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -599,6 +608,7 @@ exports[`renders button with custom testID 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -734,6 +744,7 @@ exports[`renders button with icon 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -744,6 +755,7 @@ exports[`renders button with icon 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -935,6 +947,7 @@ exports[`renders button with icon in reverse order 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -945,6 +958,7 @@ exports[`renders button with icon in reverse order 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -1138,6 +1152,7 @@ exports[`renders contained contained with mode 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1148,6 +1163,7 @@ exports[`renders contained contained with mode 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -1284,6 +1300,7 @@ exports[`renders disabled button 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1294,6 +1311,7 @@ exports[`renders disabled button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -1429,6 +1447,7 @@ exports[`renders loading button 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1439,6 +1458,7 @@ exports[`renders loading button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -1782,6 +1802,7 @@ exports[`renders outlined button with mode 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1792,6 +1813,7 @@ exports[`renders outlined button with mode 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -1928,6 +1950,7 @@ exports[`renders text button by default 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1938,6 +1961,7 @@ exports[`renders text button by default 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -2073,6 +2097,7 @@ exports[`renders text button with mode 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -2083,6 +2108,7 @@ exports[`renders text button with mode 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }

--- a/src/components/__tests__/__snapshots__/Chip.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.js.snap
@@ -7,6 +7,7 @@ exports[`renders chip with close button 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -17,6 +18,7 @@ exports[`renders chip with close button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -290,6 +292,7 @@ exports[`renders chip with custom close button 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -300,6 +303,7 @@ exports[`renders chip with custom close button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -573,6 +577,7 @@ exports[`renders chip with icon 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -583,6 +588,7 @@ exports[`renders chip with icon 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -779,6 +785,7 @@ exports[`renders chip with onPress 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -789,6 +796,7 @@ exports[`renders chip with onPress 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -933,6 +941,7 @@ exports[`renders outlined disabled chip 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -943,6 +952,7 @@ exports[`renders outlined disabled chip 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -1087,6 +1097,7 @@ exports[`renders selected chip 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1097,6 +1108,7 @@ exports[`renders selected chip 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }

--- a/src/components/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.js.snap
@@ -270,6 +270,7 @@ exports[`renders data table pagination 1`] = `
         Object {
           "alignSelf": undefined,
           "bottom": undefined,
+          "end": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -280,6 +281,7 @@ exports[`renders data table pagination 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "start": undefined,
           "top": undefined,
         }
       }
@@ -410,6 +412,7 @@ exports[`renders data table pagination 1`] = `
         Object {
           "alignSelf": undefined,
           "bottom": undefined,
+          "end": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -420,6 +423,7 @@ exports[`renders data table pagination 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "start": undefined,
           "top": undefined,
         }
       }
@@ -608,6 +612,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
         Object {
           "alignSelf": undefined,
           "bottom": undefined,
+          "end": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -618,6 +623,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "start": undefined,
           "top": undefined,
         }
       }
@@ -748,6 +754,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
         Object {
           "alignSelf": undefined,
           "bottom": undefined,
+          "end": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -758,6 +765,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "start": undefined,
           "top": undefined,
         }
       }
@@ -888,6 +896,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
         Object {
           "alignSelf": undefined,
           "bottom": undefined,
+          "end": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -898,6 +907,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "start": undefined,
           "top": undefined,
         }
       }
@@ -1028,6 +1038,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
         Object {
           "alignSelf": undefined,
           "bottom": undefined,
+          "end": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -1038,6 +1049,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "start": undefined,
           "top": undefined,
         }
       }
@@ -1226,6 +1238,7 @@ exports[`renders data table pagination with label 1`] = `
         Object {
           "alignSelf": undefined,
           "bottom": undefined,
+          "end": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -1236,6 +1249,7 @@ exports[`renders data table pagination with label 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "start": undefined,
           "top": undefined,
         }
       }
@@ -1366,6 +1380,7 @@ exports[`renders data table pagination with label 1`] = `
         Object {
           "alignSelf": undefined,
           "bottom": undefined,
+          "end": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -1376,6 +1391,7 @@ exports[`renders data table pagination with label 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "start": undefined,
           "top": undefined,
         }
       }
@@ -1570,6 +1586,7 @@ exports[`renders data table pagination with options select 1`] = `
           Object {
             "alignSelf": undefined,
             "bottom": undefined,
+            "end": undefined,
             "left": undefined,
             "position": undefined,
             "right": undefined,
@@ -1580,6 +1597,7 @@ exports[`renders data table pagination with options select 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "start": undefined,
             "top": undefined,
           }
         }
@@ -1810,6 +1828,7 @@ exports[`renders data table pagination with options select 1`] = `
         Object {
           "alignSelf": undefined,
           "bottom": undefined,
+          "end": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -1820,6 +1839,7 @@ exports[`renders data table pagination with options select 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "start": undefined,
           "top": undefined,
         }
       }
@@ -1950,6 +1970,7 @@ exports[`renders data table pagination with options select 1`] = `
         Object {
           "alignSelf": undefined,
           "bottom": undefined,
+          "end": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -1960,6 +1981,7 @@ exports[`renders data table pagination with options select 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "start": undefined,
           "top": undefined,
         }
       }
@@ -2090,6 +2112,7 @@ exports[`renders data table pagination with options select 1`] = `
         Object {
           "alignSelf": undefined,
           "bottom": undefined,
+          "end": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -2100,6 +2123,7 @@ exports[`renders data table pagination with options select 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "start": undefined,
           "top": undefined,
         }
       }
@@ -2230,6 +2254,7 @@ exports[`renders data table pagination with options select 1`] = `
         Object {
           "alignSelf": undefined,
           "bottom": undefined,
+          "end": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -2240,6 +2265,7 @@ exports[`renders data table pagination with options select 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "start": undefined,
           "top": undefined,
         }
       }

--- a/src/components/__tests__/__snapshots__/FAB.test.js.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.js.snap
@@ -7,6 +7,7 @@ exports[`renders FAB with custom size prop 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -17,6 +18,7 @@ exports[`renders FAB with custom size prop 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -185,6 +187,7 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -195,6 +198,7 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -363,6 +367,7 @@ exports[`renders default FAB 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -373,6 +378,7 @@ exports[`renders default FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -541,6 +547,7 @@ exports[`renders disabled FAB 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -551,6 +558,7 @@ exports[`renders disabled FAB 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -719,6 +727,7 @@ exports[`renders extended FAB 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -729,6 +738,7 @@ exports[`renders extended FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -935,6 +945,7 @@ exports[`renders extended FAB with custom size prop 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -945,6 +956,7 @@ exports[`renders extended FAB with custom size prop 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -1150,6 +1162,7 @@ exports[`renders large FAB 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1160,6 +1173,7 @@ exports[`renders large FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -1328,6 +1342,7 @@ exports[`renders loading FAB 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1338,6 +1353,7 @@ exports[`renders loading FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -1631,6 +1647,7 @@ exports[`renders loading FAB with custom size prop 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1641,6 +1658,7 @@ exports[`renders loading FAB with custom size prop 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -1934,6 +1952,7 @@ exports[`renders not visible FAB 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1944,6 +1963,7 @@ exports[`renders not visible FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -2112,6 +2132,7 @@ exports[`renders small FAB 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -2122,6 +2143,7 @@ exports[`renders small FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -2290,6 +2312,7 @@ exports[`renders visible FAB 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -2300,6 +2323,7 @@ exports[`renders visible FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
+      "start": undefined,
       "top": undefined,
     }
   }

--- a/src/components/__tests__/__snapshots__/IconButton.test.js.snap
+++ b/src/components/__tests__/__snapshots__/IconButton.test.js.snap
@@ -7,6 +7,7 @@ exports[`renders disabled icon button 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -17,6 +18,7 @@ exports[`renders disabled icon button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -154,6 +156,7 @@ exports[`renders icon button by default 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -164,6 +167,7 @@ exports[`renders icon button by default 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -296,6 +300,7 @@ exports[`renders icon button with color 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -306,6 +311,7 @@ exports[`renders icon button with color 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -438,6 +444,7 @@ exports[`renders icon button with size 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -448,6 +455,7 @@ exports[`renders icon button with size 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -580,6 +588,7 @@ exports[`renders icon change animated 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -590,6 +599,7 @@ exports[`renders icon change animated 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }

--- a/src/components/__tests__/__snapshots__/ListItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.js.snap
@@ -104,6 +104,7 @@ exports[`renders list item with custom description 1`] = `
               Object {
                 "alignSelf": undefined,
                 "bottom": undefined,
+                "end": undefined,
                 "left": undefined,
                 "position": undefined,
                 "right": undefined,
@@ -114,6 +115,7 @@ exports[`renders list item with custom description 1`] = `
                 },
                 "shadowOpacity": 0,
                 "shadowRadius": 0,
+                "start": undefined,
                 "top": undefined,
               }
             }

--- a/src/components/__tests__/__snapshots__/Menu.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.js.snap
@@ -20,6 +20,7 @@ Array [
           Object {
             "alignSelf": undefined,
             "bottom": undefined,
+            "end": undefined,
             "left": undefined,
             "position": undefined,
             "right": undefined,
@@ -30,6 +31,7 @@ Array [
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "start": undefined,
             "top": undefined,
           }
         }
@@ -233,6 +235,7 @@ Array [
             Object {
               "alignSelf": undefined,
               "bottom": undefined,
+              "end": undefined,
               "left": undefined,
               "position": undefined,
               "right": undefined,
@@ -243,6 +246,7 @@ Array [
               },
               "shadowOpacity": 0.15,
               "shadowRadius": 6,
+              "start": undefined,
               "top": undefined,
             }
           }
@@ -518,6 +522,7 @@ exports[`renders not visible menu 1`] = `
         Object {
           "alignSelf": undefined,
           "bottom": undefined,
+          "end": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -528,6 +533,7 @@ exports[`renders not visible menu 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "start": undefined,
           "top": undefined,
         }
       }
@@ -679,6 +685,7 @@ Array [
           Object {
             "alignSelf": undefined,
             "bottom": undefined,
+            "end": undefined,
             "left": undefined,
             "position": undefined,
             "right": undefined,
@@ -689,6 +696,7 @@ Array [
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "start": undefined,
             "top": undefined,
           }
         }
@@ -892,6 +900,7 @@ Array [
             Object {
               "alignSelf": undefined,
               "bottom": undefined,
+              "end": undefined,
               "left": undefined,
               "position": undefined,
               "right": undefined,
@@ -902,6 +911,7 @@ Array [
               },
               "shadowOpacity": 0.15,
               "shadowRadius": 6,
+              "start": undefined,
               "top": undefined,
             }
           }

--- a/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.js.snap
@@ -7,6 +7,7 @@ exports[`activity indicator snapshot test 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -17,6 +18,7 @@ exports[`activity indicator snapshot test 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -52,6 +54,7 @@ exports[`activity indicator snapshot test 1`] = `
           Object {
             "alignSelf": undefined,
             "bottom": undefined,
+            "end": undefined,
             "left": undefined,
             "position": undefined,
             "right": undefined,
@@ -62,6 +65,7 @@ exports[`activity indicator snapshot test 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "start": undefined,
             "top": undefined,
           }
         }
@@ -425,6 +429,7 @@ exports[`renders with placeholder 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -435,6 +440,7 @@ exports[`renders with placeholder 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -470,6 +476,7 @@ exports[`renders with placeholder 1`] = `
           Object {
             "alignSelf": undefined,
             "bottom": undefined,
+            "end": undefined,
             "left": undefined,
             "position": undefined,
             "right": undefined,
@@ -480,6 +487,7 @@ exports[`renders with placeholder 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "start": undefined,
             "top": undefined,
           }
         }
@@ -643,6 +651,7 @@ exports[`renders with placeholder 1`] = `
             Object {
               "alignSelf": undefined,
               "bottom": undefined,
+              "end": undefined,
               "left": undefined,
               "position": undefined,
               "right": undefined,
@@ -653,6 +662,7 @@ exports[`renders with placeholder 1`] = `
               },
               "shadowOpacity": 0,
               "shadowRadius": 0,
+              "start": undefined,
               "top": undefined,
             }
           }
@@ -790,6 +800,7 @@ exports[`renders with text 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -800,6 +811,7 @@ exports[`renders with text 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -835,6 +847,7 @@ exports[`renders with text 1`] = `
           Object {
             "alignSelf": undefined,
             "bottom": undefined,
+            "end": undefined,
             "left": undefined,
             "position": undefined,
             "right": undefined,
@@ -845,6 +858,7 @@ exports[`renders with text 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "start": undefined,
             "top": undefined,
           }
         }
@@ -1009,6 +1023,7 @@ exports[`renders with text 1`] = `
             Object {
               "alignSelf": undefined,
               "bottom": undefined,
+              "end": undefined,
               "left": undefined,
               "position": undefined,
               "right": undefined,
@@ -1019,6 +1034,7 @@ exports[`renders with text 1`] = `
               },
               "shadowOpacity": 0,
               "shadowRadius": 0,
+              "start": undefined,
               "top": undefined,
             }
           }

--- a/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.js.snap
@@ -26,6 +26,7 @@ exports[`renders snackbar with Text as a child 1`] = `
       Object {
         "alignSelf": undefined,
         "bottom": undefined,
+        "end": undefined,
         "left": undefined,
         "position": undefined,
         "right": undefined,
@@ -36,6 +37,7 @@ exports[`renders snackbar with Text as a child 1`] = `
         },
         "shadowOpacity": 0.15,
         "shadowRadius": 6,
+        "start": undefined,
         "top": undefined,
       }
     }
@@ -120,6 +122,7 @@ exports[`renders snackbar with View & Text as a child 1`] = `
       Object {
         "alignSelf": undefined,
         "bottom": undefined,
+        "end": undefined,
         "left": undefined,
         "position": undefined,
         "right": undefined,
@@ -130,6 +133,7 @@ exports[`renders snackbar with View & Text as a child 1`] = `
         },
         "shadowOpacity": 0.15,
         "shadowRadius": 6,
+        "start": undefined,
         "top": undefined,
       }
     }
@@ -240,6 +244,7 @@ exports[`renders snackbar with action button 1`] = `
       Object {
         "alignSelf": undefined,
         "bottom": undefined,
+        "end": undefined,
         "left": undefined,
         "position": undefined,
         "right": undefined,
@@ -250,6 +255,7 @@ exports[`renders snackbar with action button 1`] = `
         },
         "shadowOpacity": 0.15,
         "shadowRadius": 6,
+        "start": undefined,
         "top": undefined,
       }
     }
@@ -342,6 +348,7 @@ exports[`renders snackbar with action button 1`] = `
               Object {
                 "alignSelf": undefined,
                 "bottom": undefined,
+                "end": undefined,
                 "left": undefined,
                 "position": undefined,
                 "right": undefined,
@@ -352,6 +359,7 @@ exports[`renders snackbar with action button 1`] = `
                 },
                 "shadowOpacity": 0,
                 "shadowRadius": 0,
+                "start": undefined,
                 "top": undefined,
               }
             }
@@ -511,6 +519,7 @@ exports[`renders snackbar with content 1`] = `
       Object {
         "alignSelf": undefined,
         "bottom": undefined,
+        "end": undefined,
         "left": undefined,
         "position": undefined,
         "right": undefined,
@@ -521,6 +530,7 @@ exports[`renders snackbar with content 1`] = `
         },
         "shadowOpacity": 0.15,
         "shadowRadius": 6,
+        "start": undefined,
         "top": undefined,
       }
     }

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -1290,6 +1290,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
         Object {
           "alignSelf": undefined,
           "bottom": undefined,
+          "end": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -1300,6 +1301,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "start": undefined,
           "top": undefined,
         }
       }
@@ -1644,6 +1646,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
         Object {
           "alignSelf": undefined,
           "bottom": undefined,
+          "end": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -1654,6 +1657,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "start": undefined,
           "top": undefined,
         }
       }

--- a/src/components/__tests__/__snapshots__/ToggleButton.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ToggleButton.test.js.snap
@@ -7,6 +7,7 @@ exports[`renders disabled toggle button 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -17,6 +18,7 @@ exports[`renders disabled toggle button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -154,6 +156,7 @@ exports[`renders toggle button 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -164,6 +167,7 @@ exports[`renders toggle button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }
@@ -295,6 +299,7 @@ exports[`renders unchecked toggle button 1`] = `
     Object {
       "alignSelf": undefined,
       "bottom": undefined,
+      "end": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -305,6 +310,7 @@ exports[`renders unchecked toggle button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
+      "start": undefined,
       "top": undefined,
     }
   }


### PR DESCRIPTION
Fixes #3542 

### Summary

- Added `start` and `end` into absolute styles that get applied to the top level shadow layer of `<Surface>` on iOS, to correctly apply these styles to Surface-based components.
- Added negative tests to ensure these properties do not get applied on the bottom of the component hierarchy as well as positive tests to make sure they do appear on the 0th shadow layer - both of these would fail without the changes introduced in this PR.
- Components that compose `<Surface>` had their snapshots updated due to the inclusion of these properties.

### Test plan

As described in #3542, in current version applying start/end for example to `<Card>` will result in incorrect behavior, see screenshot:

<img src="https://raw.githubusercontent.com/szaboopeeter/rnp-card-absolute-end-ios-bug/main/BugDescriptionAssets/end-aligned-wrapper.png" width="800" />

After these changes, this behavior gets fixed, and the appropriate styles get added to the first `<AnimatedComponentWrapper>`, resulting in the component being right-aligned as visible on screenshot below (it's the same component added to the `/example` project after making the changes on this branch): 

<img src="https://user-images.githubusercontent.com/5929156/210300265-0d4a81bc-f011-456d-ac9c-ddac60a81404.png" width="800" />
