### PR TITLE
refactor: adjust searchbar to the latest md guidelines

### DIFF
--- a/example/src/Examples/SearchbarExample.tsx
+++ b/example/src/Examples/SearchbarExample.tsx
@@ -191,9 +191,9 @@ const SearchExample = ({ navigation }: Props) => {
               Keyboard.dismiss();
               navigation.goBack();
             }}
-            // onClearIconPress={() => {
-            //   Keyboard.dismiss();
-            // }}
+            onClearIconPress={() => {
+              Keyboard.dismiss();
+            }}
             icon={{ source: 'arrow-left', direction: 'auto' }}
             style={styles.searchbar}
           />

--- a/example/src/Examples/SearchbarExample.tsx
+++ b/example/src/Examples/SearchbarExample.tsx
@@ -1,8 +1,15 @@
 import * as React from 'react';
 import { Keyboard, StyleSheet } from 'react-native';
 
+import type { DrawerNavigationProp } from '@react-navigation/drawer';
 import type { StackNavigationProp } from '@react-navigation/stack';
-import { Caption, Searchbar, Text } from 'react-native-paper';
+import {
+  List,
+  MD3Colors,
+  Searchbar,
+  Snackbar,
+  Avatar,
+} from 'react-native-paper';
 
 import { useExampleTheme } from '..';
 import ScreenWrapper from '../ScreenWrapper';
@@ -12,65 +19,228 @@ type Props = {
 };
 
 const SearchExample = ({ navigation }: Props) => {
-  const [firstQuery, setFirstQuery] = React.useState<string>('');
-  const [secondQuery, setSecondQuery] = React.useState<string>('');
-  const [thirdQuery, setThirdQuery] = React.useState<string>('');
-  const [fourthQuery, setFourthQuery] = React.useState<string>('');
+  const [isVisible, setIsVisible] = React.useState(false);
+  const [searchQueries, setSearchQuery] = React.useState({
+    searchBarMode: '',
+    traileringIcon: '',
+    traileringIconWithRightItem: '',
+    rightItem: '',
+    loadingBarMode: '',
+    searchViewMode: '',
+    searchWithoutBottomLine: '',
+    loadingViewMode: '',
+    clickableBack: '',
+    clickableDrawer: '',
+    clickableLoading: '',
+  });
 
-  const { isV3 } = useExampleTheme();
-
-  const TextComponent = isV3 ? Text : Caption;
+  const { isV3, colors } = useExampleTheme();
 
   return (
-    <ScreenWrapper>
-      <Searchbar
-        placeholder="Search"
-        onChangeText={(query: string) => setFirstQuery(query)}
-        value={firstQuery}
-        style={styles.searchbar}
-      />
-      <TextComponent variant="bodySmall" style={styles.caption}>
-        Clickable icon
-      </TextComponent>
-      <Searchbar
-        placeholder="Search"
-        onChangeText={(query: string) => setSecondQuery(query)}
-        value={secondQuery}
-        onIconPress={() => navigation.goBack()}
-        icon={{ source: 'arrow-left', direction: 'auto' }}
-        style={styles.searchbar}
-      />
-      <Searchbar
-        placeholder="Search"
-        onChangeText={(query: string) => setThirdQuery(query)}
-        value={thirdQuery}
-        onIconPress={/* In real code, this will open the drawer */ () => {}}
-        onClearIconPress={
-          /* delete query text (default behavior) and dismiss keyboard */ () =>
-            Keyboard.dismiss()
-        }
-        icon="menu"
-        style={styles.searchbar}
-      />
-
-      <Searchbar
-        placeholder="Search"
-        onChangeText={(query: string) => setFourthQuery(query)}
-        value={fourthQuery}
-        loading
-        style={styles.searchbar}
-      />
-    </ScreenWrapper>
+    <>
+      <ScreenWrapper>
+        {!isV3 && (
+          <Searchbar
+            placeholder="Search"
+            onChangeText={(query) =>
+              setSearchQuery({ ...searchQueries, searchBarMode: query })
+            }
+            value={searchQueries.searchBarMode}
+            style={styles.searchbar}
+          />
+        )}
+        {isV3 && (
+          <List.Section title="Bar mode">
+            <Searchbar
+              placeholder="Search"
+              onChangeText={(query) =>
+                setSearchQuery({ ...searchQueries, searchBarMode: query })
+              }
+              value={searchQueries.searchBarMode}
+              style={styles.searchbar}
+              mode="bar"
+            />
+            <Searchbar
+              placeholder="Trailering icon"
+              onChangeText={(query) =>
+                setSearchQuery({ ...searchQueries, traileringIcon: query })
+              }
+              value={searchQueries.traileringIcon}
+              traileringIcon={'microphone'}
+              traileringIconColor={
+                isVisible ? MD3Colors.error40 : colors.onSurfaceVariant
+              }
+              traileringIconAccessibilityLabel={'microphone button'}
+              onTraileringIconPress={() => setIsVisible(true)}
+              style={styles.searchbar}
+              mode="bar"
+            />
+            <Searchbar
+              mode="bar"
+              placeholder="Trailering icon with right item"
+              onChangeText={(query) =>
+                setSearchQuery({
+                  ...searchQueries,
+                  traileringIconWithRightItem: query,
+                })
+              }
+              value={searchQueries.traileringIconWithRightItem}
+              traileringIcon={'microphone'}
+              traileringIconColor={
+                isVisible ? MD3Colors.error40 : colors.onSurfaceVariant
+              }
+              traileringIconAccessibilityLabel={'microphone button'}
+              onTraileringIconPress={() => setIsVisible(true)}
+              right={(props) => (
+                <Avatar.Image
+                  {...props}
+                  size={30}
+                  source={require('../../assets/images/avatar.png')}
+                />
+              )}
+              style={styles.searchbar}
+            />
+            <Searchbar
+              mode="bar"
+              placeholder="Right item"
+              onChangeText={(query) =>
+                setSearchQuery({
+                  ...searchQueries,
+                  rightItem: query,
+                })
+              }
+              value={searchQueries.rightItem}
+              right={(props) => (
+                <Avatar.Image
+                  {...props}
+                  size={30}
+                  source={require('../../assets/images/avatar.png')}
+                />
+              )}
+              style={styles.searchbar}
+            />
+            <Searchbar
+              placeholder="Loading"
+              onChangeText={(query) =>
+                setSearchQuery({
+                  ...searchQueries,
+                  loadingBarMode: query,
+                })
+              }
+              value={searchQueries.loadingBarMode}
+              style={styles.searchbar}
+              mode="bar"
+              loading
+              traileringIcon={'microphone'}
+            />
+          </List.Section>
+        )}
+        {isV3 && (
+          <List.Section title="View mode">
+            <Searchbar
+              placeholder="Search"
+              onChangeText={(query) =>
+                setSearchQuery({
+                  ...searchQueries,
+                  searchViewMode: query,
+                })
+              }
+              value={searchQueries.searchViewMode}
+              style={styles.searchbar}
+              mode="view"
+            />
+            <Searchbar
+              placeholder="Search without bottom line"
+              onChangeText={(query) =>
+                setSearchQuery({
+                  ...searchQueries,
+                  searchWithoutBottomLine: query,
+                })
+              }
+              value={searchQueries.searchWithoutBottomLine}
+              style={styles.searchbar}
+              mode="view"
+              showDivider={false}
+            />
+            <Searchbar
+              placeholder="Loading"
+              onChangeText={(query) =>
+                setSearchQuery({
+                  ...searchQueries,
+                  loadingViewMode: query,
+                })
+              }
+              value={searchQueries.loadingViewMode}
+              style={styles.searchbar}
+              mode="view"
+              loading
+            />
+          </List.Section>
+        )}
+        <List.Section title="Clickable icon">
+          <Searchbar
+            placeholder="Search"
+            onChangeText={(query) =>
+              setSearchQuery({
+                ...searchQueries,
+                clickableBack: query,
+              })
+            }
+            value={searchQueries.clickableBack}
+            onIconPress={() => {
+              Keyboard.dismiss();
+              navigation.goBack();
+            }}
+            // onClearIconPress={() => {
+            //   Keyboard.dismiss();
+            // }}
+            icon={{ source: 'arrow-left', direction: 'auto' }}
+            style={styles.searchbar}
+          />
+          <Searchbar
+            placeholder="Search"
+            onChangeText={(query) =>
+              setSearchQuery({
+                ...searchQueries,
+                clickableDrawer: query,
+              })
+            }
+            value={searchQueries.clickableDrawer}
+            onIconPress={() => {
+              Keyboard.dismiss();
+              (navigation as any as DrawerNavigationProp<{}>).openDrawer();
+            }}
+            icon="menu"
+            style={styles.searchbar}
+          />
+          <Searchbar
+            placeholder="Search"
+            onChangeText={(query) =>
+              setSearchQuery({
+                ...searchQueries,
+                clickableLoading: query,
+              })
+            }
+            value={searchQueries.clickableLoading}
+            loading
+            style={styles.searchbar}
+          />
+        </List.Section>
+      </ScreenWrapper>
+      <Snackbar
+        visible={isVisible}
+        onDismiss={() => setIsVisible(false)}
+        duration={Snackbar.DURATION_SHORT}
+      >
+        Microphone button pressed
+      </Snackbar>
+    </>
   );
 };
 
 SearchExample.title = 'Searchbar';
 
 const styles = StyleSheet.create({
-  caption: {
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-  },
   searchbar: {
     margin: 4,
   },

--- a/example/src/ScreenWrapper.tsx
+++ b/example/src/ScreenWrapper.tsx
@@ -46,6 +46,7 @@ export default function ScreenWrapper({
         <ScrollView
           {...rest}
           contentContainerStyle={contentContainerStyle}
+          keyboardShouldPersistTaps="always"
           alwaysBounceVertical={false}
           showsVerticalScrollIndicator={false}
           style={[containerStyle, style]}

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -236,24 +236,35 @@ const Searchbar = forwardRef<TextInputHandles, Props>(
       onClearIconPress?.(e);
     };
 
-    const { colors, roundness, dark, isV3 } = theme;
-    const placeholderTextColor = theme.isV3
+    const { roundness, dark, isV3, fonts } = theme;
+
+    const placeholderTextColor = isV3
       ? theme.colors.onSurface
       : theme.colors?.placeholder;
-
     const textColor = isV3 ? theme.colors.onSurfaceVariant : theme.colors.text;
-
     const md2IconColor = dark
       ? textColor
       : color(textColor).alpha(0.54).rgb().string();
     const iconColor =
       customIconColor || (isV3 ? theme.colors.onSurfaceVariant : md2IconColor);
-
     const rippleColor = color(textColor).alpha(0.32).rgb().string();
 
-    const font = theme.isV3 ? theme.fonts.bodyLarge : theme.fonts.regular;
+    const font = isV3
+      ? {
+          ...fonts.bodyLarge,
+          lineHeight: Platform.select({
+            ios: 0,
+            default: fonts.bodyLarge.lineHeight,
+          }),
+        }
+      : theme.fonts.regular;
 
     const isBarMode = isV3 && mode === 'bar';
+    const shouldRenderTraileringIcon =
+      isBarMode &&
+      traileringIcon &&
+      !loading &&
+      (!value || right !== undefined);
 
     return (
       <Surface
@@ -304,7 +315,7 @@ const Searchbar = forwardRef<TextInputHandles, Props>(
           ]}
           placeholder={placeholder || ''}
           placeholderTextColor={placeholderTextColor}
-          selectionColor={colors?.primary}
+          selectionColor={theme.colors?.primary}
           underlineColorAndroid="transparent"
           returnKeyType="search"
           keyboardAppearance={dark ? 'dark' : 'light'}
@@ -354,10 +365,7 @@ const Searchbar = forwardRef<TextInputHandles, Props>(
             />
           </View>
         )}
-        {isBarMode &&
-        traileringIcon &&
-        !loading &&
-        (!value || right !== undefined) ? (
+        {shouldRenderTraileringIcon ? (
           <IconButton
             accessibilityRole="button"
             borderless

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -19,20 +19,17 @@ import { useInternalTheme } from '../core/theming';
 import type { ThemeProp } from '../types';
 import { forwardRef } from '../utils/forwardRef';
 import ActivityIndicator from './ActivityIndicator';
+import Divider from './Divider';
 import type { IconSource } from './Icon';
 import Icon from './Icon';
 import IconButton from './IconButton/IconButton';
 import Surface from './Surface';
 
+interface Style {
+  marginRight: number;
+}
+
 export type Props = React.ComponentPropsWithRef<typeof TextInput> & {
-  /**
-   * Accessibility label for the button. This is read by the screen reader when the user taps the button.
-   */
-  clearAccessibilityLabel?: string;
-  /**
-   * Accessibility label for the button. This is read by the screen reader when the user taps the button.
-   */
-  searchAccessibilityLabel?: string;
   /**
    * Hint text shown when the input is empty.
    */
@@ -42,13 +39,22 @@ export type Props = React.ComponentPropsWithRef<typeof TextInput> & {
    */
   value: string;
   /**
+   * Callback that is called when the text input's text changes.
+   */
+  onChangeText?: (query: string) => void;
+  /**
+   * @supported Available in v5.x with theme version 3
+   * Search layout mode, the default value is "bar".
+   */
+  mode?: 'bar' | 'view';
+  /**
    * Icon name for the left icon button (see `onIconPress`).
    */
   icon?: IconSource;
   /**
-   * Callback that is called when the text input's text changes.
+   * Custom color for icon, default will be derived from theme
    */
-  onChangeText?: (query: string) => void;
+  iconColor?: string;
   /**
    * Callback to execute if we want the left icon to act as button.
    */
@@ -59,6 +65,55 @@ export type Props = React.ComponentPropsWithRef<typeof TextInput> & {
    */
   onClearIconPress?: (e: GestureResponderEvent) => void;
   /**
+   * Accessibility label for the button. This is read by the screen reader when the user taps the button.
+   */
+  searchAccessibilityLabel?: string;
+  /**
+   * Custom icon for clear button, default will be icon close. It's visible when `loading` is set to `false`.
+   * In v5.x with theme version 3, `clearIcon` is visible only `right` prop is not defined.
+   */
+  clearIcon?: IconSource;
+  /**
+   * Accessibility label for the button. This is read by the screen reader when the user taps the button.
+   */
+  clearAccessibilityLabel?: string;
+  /**
+   * @supported Available in v5.x with theme version 3
+   * Icon name for the right trailering icon button.
+   * Works only when `mode` is set to "bar". It won't be displayed if `loading` is set to `true`.
+   */
+  traileringIcon?: IconSource;
+  /**
+   * @supported Available in v5.x with theme version 3
+   * Custom color for the right trailering icon, default will be derived from theme
+   */
+  traileringIconColor?: string;
+  /**
+   * @supported Available in v5.x with theme version 3
+   * Callback to execute on the right trailering icon button press.
+   */
+  onTraileringIconPress?: (e: GestureResponderEvent) => void;
+  /**
+   * Accessibility label for the right trailering icon button. This is read by the screen reader when the user taps the button.
+   */
+  traileringIconAccessibilityLabel?: string;
+  /**
+   * @supported Available in v5.x with theme version 3
+   * Callback which returns a React element to display on the right side.
+   * Works only when `mode` is set to "bar".
+   */
+  right?: (props: {
+    color: string;
+    style: Style;
+    testID: string;
+  }) => React.ReactNode;
+  /**
+   * @supported Available in v5.x with theme version 3
+   * Whether to show `Divider` at the bottom of the search.
+   * Works only when `mode` is set to "view". True by default.
+   */
+  showDivider?: boolean;
+  /**
    * @supported Available in v5.x with theme version 3
    * Changes Searchbar shadow and background on iOS and Android.
    */
@@ -68,14 +123,6 @@ export type Props = React.ComponentPropsWithRef<typeof TextInput> & {
    */
   inputStyle?: StyleProp<TextStyle>;
   style?: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
-  /**
-   * Custom color for icon, default will be derived from theme
-   */
-  iconColor?: string;
-  /**
-   * Custom icon for clear button, default will be icon close
-   */
-  clearIcon?: IconSource;
   /**
    * Custom flag for replacing clear button with activity indicator.
    */
@@ -128,16 +175,23 @@ type TextInputHandles = Pick<
 const Searchbar = forwardRef<TextInputHandles, Props>(
   (
     {
-      clearAccessibilityLabel = 'clear',
-      clearIcon,
       icon,
       iconColor: customIconColor,
-      inputStyle,
       onIconPress,
-      onClearIconPress,
-      placeholder,
       searchAccessibilityLabel = 'search',
-      elevation = 1,
+      clearIcon,
+      clearAccessibilityLabel = 'clear',
+      onClearIconPress,
+      traileringIcon,
+      traileringIconColor,
+      traileringIconAccessibilityLabel,
+      onTraileringIconPress,
+      right,
+      mode = 'bar',
+      showDivider = true,
+      inputStyle,
+      placeholder,
+      elevation = 0,
       style,
       theme: themeOverrides,
       value,
@@ -183,23 +237,39 @@ const Searchbar = forwardRef<TextInputHandles, Props>(
     };
 
     const { colors, roundness, dark, isV3 } = theme;
-    const textColor = isV3 ? theme.colors.onSurface : theme.colors.text;
+    const placeholderTextColor = theme.isV3
+      ? theme.colors.onSurface
+      : theme.colors?.placeholder;
+
+    const textColor = isV3 ? theme.colors.onSurfaceVariant : theme.colors.text;
+
+    const md2IconColor = dark
+      ? textColor
+      : color(textColor).alpha(0.54).rgb().string();
     const iconColor =
-      customIconColor ||
-      (dark ? textColor : color(textColor).alpha(0.54).rgb().string());
+      customIconColor || (isV3 ? theme.colors.onSurfaceVariant : md2IconColor);
+
     const rippleColor = color(textColor).alpha(0.32).rgb().string();
+
+    const font = theme.isV3 ? theme.fonts.bodyLarge : theme.fonts.regular;
+
+    const isBarMode = isV3 && mode === 'bar';
 
     return (
       <Surface
         style={[
           { borderRadius: roundness },
           !isV3 && styles.elevation,
+          isV3 && {
+            backgroundColor: theme.colors.elevation.level3,
+            borderRadius: roundness * (isBarMode ? 7 : 0),
+          },
           styles.container,
           style,
         ]}
+        testID={`${testID}-container`}
         {...(theme.isV3 && { elevation })}
         theme={theme}
-        testID={`${testID}-container`}
       >
         <IconButton
           accessibilityRole="button"
@@ -226,15 +296,14 @@ const Searchbar = forwardRef<TextInputHandles, Props>(
             styles.input,
             {
               color: textColor,
-              ...(theme.isV3 ? theme.fonts.default : theme.fonts.regular),
+              ...font,
               ...Platform.select({ web: { outline: 'none' } }),
             },
+            isV3 && (isBarMode ? styles.barModeInput : styles.viewModeInput),
             inputStyle,
           ]}
           placeholder={placeholder || ''}
-          placeholderTextColor={
-            theme.isV3 ? theme.colors.onSurface : theme.colors?.placeholder
-          }
+          placeholderTextColor={placeholderTextColor}
           selectionColor={colors?.primary}
           underlineColorAndroid="transparent"
           returnKeyType="search"
@@ -248,7 +317,7 @@ const Searchbar = forwardRef<TextInputHandles, Props>(
         {loading ? (
           <ActivityIndicator
             testID="activity-indicator"
-            style={styles.loader}
+            style={isV3 ? styles.v3Loader : styles.loader}
           />
         ) : (
           // Clear icon should be always rendered within Searchbar – it's transparent,
@@ -258,6 +327,10 @@ const Searchbar = forwardRef<TextInputHandles, Props>(
           <View
             pointerEvents={value ? 'auto' : 'none'}
             testID={`${testID}-icon-wrapper`}
+            style={[
+              isV3 && !value && styles.v3ClearIcon,
+              isV3 && right !== undefined && styles.v3ClearIconHidden,
+            ]}
           >
             <IconButton
               borderless
@@ -269,7 +342,7 @@ const Searchbar = forwardRef<TextInputHandles, Props>(
                 clearIcon ||
                 (({ size, color }) => (
                   <Icon
-                    source="close"
+                    source={isV3 ? 'close' : 'close-circle-outline'}
                     color={color}
                     size={size}
                     direction={I18nManager.getConstants().isRTL ? 'rtl' : 'ltr'}
@@ -280,6 +353,34 @@ const Searchbar = forwardRef<TextInputHandles, Props>(
               theme={theme}
             />
           </View>
+        )}
+        {isBarMode &&
+        traileringIcon &&
+        !loading &&
+        (!value || right !== undefined) ? (
+          <IconButton
+            accessibilityRole="button"
+            borderless
+            onPress={onTraileringIconPress}
+            iconColor={traileringIconColor || theme.colors.onSurfaceVariant}
+            icon={traileringIcon}
+            accessibilityLabel={traileringIconAccessibilityLabel}
+            testID={`${testID}-trailering-icon`}
+          />
+        ) : null}
+        {isBarMode &&
+          right?.({ color: textColor, style: styles.rightStyle, testID })}
+        {isV3 && !isBarMode && showDivider && (
+          <Divider
+            bold
+            style={[
+              styles.divider,
+              {
+                backgroundColor: theme.colors.outline,
+              },
+            ]}
+            testID={`${testID}-divider`}
+          />
         )}
       </Surface>
     );
@@ -299,11 +400,38 @@ const styles = StyleSheet.create({
     textAlign: I18nManager.getConstants().isRTL ? 'right' : 'left',
     minWidth: 0,
   },
+  barModeInput: {
+    paddingLeft: 0,
+    minHeight: 56,
+  },
+  viewModeInput: {
+    paddingLeft: 0,
+    minHeight: 72,
+  },
   elevation: {
     elevation: 4,
   },
   loader: {
     margin: 10,
+  },
+  v3Loader: {
+    marginHorizontal: 16,
+  },
+  rightStyle: {
+    marginRight: 16,
+  },
+  v3ClearIcon: {
+    position: 'absolute',
+    right: 0,
+    marginLeft: 16,
+  },
+  v3ClearIconHidden: {
+    display: 'none',
+  },
+  divider: {
+    position: 'absolute',
+    bottom: 0,
+    width: '100%',
   },
 });
 

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
@@ -72,11 +72,11 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
             "right": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
-              "height": 1,
+              "height": 0,
               "width": 0,
             },
-            "shadowOpacity": 0.15,
-            "shadowRadius": 3,
+            "shadowOpacity": 0,
+            "shadowRadius": 0,
             "start": undefined,
             "top": undefined,
           }
@@ -90,11 +90,11 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
               "flex": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
-                "height": 1,
+                "height": 0,
                 "width": 0,
               },
-              "shadowOpacity": 0.3,
-              "shadowRadius": 1,
+              "shadowOpacity": 0,
+              "shadowRadius": 0,
             }
           }
           testID="search-bar-container-inner-layer"
@@ -104,8 +104,8 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
             style={
               Object {
                 "alignItems": "center",
-                "backgroundColor": "rgb(247, 243, 249)",
-                "borderRadius": 4,
+                "backgroundColor": "rgb(238, 232, 244)",
+                "borderRadius": 28,
                 "flex": undefined,
                 "flexDirection": "row",
               }
@@ -230,7 +230,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 0.54)",
+                            "color": "rgba(73, 69, 79, 1)",
                             "fontSize": 24,
                           },
                           Array [
@@ -279,10 +279,16 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                     "textAlign": "left",
                   },
                   Object {
-                    "color": "rgba(28, 27, 31, 1)",
+                    "color": "rgba(73, 69, 79, 1)",
                     "fontFamily": "System",
+                    "fontSize": 16,
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": 0.15,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "minHeight": 56,
+                    "paddingLeft": 0,
                   },
                   undefined,
                 ]
@@ -293,6 +299,16 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
             />
             <View
               pointerEvents="none"
+              style={
+                Array [
+                  Object {
+                    "marginLeft": 16,
+                    "position": "absolute",
+                    "right": 0,
+                  },
+                  false,
+                ]
+              }
               testID="search-bar-icon-wrapper"
             >
               <View

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
@@ -284,7 +284,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                     "fontSize": 16,
                     "fontWeight": "400",
                     "letterSpacing": 0.15,
-                    "lineHeight": 24,
+                    "lineHeight": 0,
                   },
                   Object {
                     "minHeight": 56,

--- a/src/components/__tests__/Searchbar.test.tsx
+++ b/src/components/__tests__/Searchbar.test.tsx
@@ -4,6 +4,7 @@ import { Animated } from 'react-native';
 import { fireEvent, render } from '@testing-library/react-native';
 import renderer from 'react-test-renderer';
 
+import * as Avatar from '../Avatar/Avatar';
 import Searchbar from '../Searchbar';
 
 it('renders with placeholder', () => {
@@ -107,4 +108,91 @@ it('defines onClearIconPress action and checks if it is called when close button
 
   fireEvent(iconComponent, 'onPress');
   expect(onClearIconPressMock).toHaveBeenCalledTimes(1);
+});
+
+it('renders clear icon wrapper, with appropriate style for v3', () => {
+  const { getByTestId, update } = render(
+    <Searchbar testID="search-bar" value="" />
+  );
+
+  expect(getByTestId('search-bar-icon-wrapper')).toHaveStyle({
+    position: 'absolute',
+    right: 0,
+    marginLeft: 16,
+  });
+
+  update(
+    <Searchbar
+      testID="search-bar"
+      value=""
+      right={() => <Avatar.Text label="AB" size={30} />}
+    />
+  );
+
+  expect(getByTestId('search-bar-icon-wrapper')).toHaveStyle({
+    display: 'none',
+  });
+});
+
+it('renders trailering icon when mode is set to "bar"', () => {
+  const { getByTestId } = render(
+    <Searchbar
+      testID="search-bar"
+      value={''}
+      traileringIcon={'microphone'}
+      mode="bar"
+    />
+  );
+
+  expect(getByTestId('search-bar-trailering-icon')).toBeTruthy();
+});
+
+it('renders trailering icon with press functionality', () => {
+  const onTraileringIconPressMock = jest.fn();
+
+  const { getByTestId } = render(
+    <Searchbar
+      testID="search-bar"
+      value={''}
+      traileringIcon={'microphone'}
+      onTraileringIconPress={onTraileringIconPressMock}
+      mode="bar"
+    />
+  );
+
+  fireEvent(getByTestId('search-bar-trailering-icon'), 'onPress');
+  expect(onTraileringIconPressMock).toHaveBeenCalledTimes(1);
+});
+
+it('renders clear icon instead of trailering icon', () => {
+  const { getByTestId, update, queryByTestId } = render(
+    <Searchbar
+      testID="search-bar"
+      value={''}
+      traileringIcon={'microphone'}
+      mode="bar"
+    />
+  );
+
+  expect(getByTestId('search-bar-trailering-icon')).toBeTruthy();
+
+  update(
+    <Searchbar
+      testID="search-bar"
+      value={'test'}
+      traileringIcon={'microphone'}
+      mode="bar"
+    />
+  );
+
+  expect(queryByTestId('search-bar-trailering-icon')).toBeNull();
+  expect(getByTestId('search-bar-icon-wrapper')).toBeTruthy();
+});
+
+it('renders searchbar in "view" mode', () => {
+  const { getByTestId } = render(
+    <Searchbar testID="search-bar" value={''} mode="view" />
+  );
+
+  expect(getByTestId('search-bar-container')).toHaveStyle({ borderRadius: 0 });
 });

--- a/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
@@ -14,11 +14,11 @@ exports[`activity indicator snapshot test 1`] = `
       "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 0,
         "width": 0,
       },
-      "shadowOpacity": 0.15,
-      "shadowRadius": 3,
+      "shadowOpacity": 0,
+      "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
     }
@@ -32,11 +32,11 @@ exports[`activity indicator snapshot test 1`] = `
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
-          "height": 1,
+          "height": 0,
           "width": 0,
         },
-        "shadowOpacity": 0.3,
-        "shadowRadius": 1,
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
       }
     }
     testID="search-bar-container-inner-layer"
@@ -46,8 +46,8 @@ exports[`activity indicator snapshot test 1`] = `
       style={
         Object {
           "alignItems": "center",
-          "backgroundColor": "rgb(247, 243, 249)",
-          "borderRadius": 4,
+          "backgroundColor": "rgb(238, 232, 244)",
+          "borderRadius": 28,
           "flex": undefined,
           "flexDirection": "row",
         }
@@ -172,7 +172,7 @@ exports[`activity indicator snapshot test 1`] = `
                 style={
                   Array [
                     Object {
-                      "color": "rgba(28, 27, 31, 0.54)",
+                      "color": "rgba(73, 69, 79, 1)",
                       "fontSize": 24,
                     },
                     Array [
@@ -221,10 +221,16 @@ exports[`activity indicator snapshot test 1`] = `
               "textAlign": "left",
             },
             Object {
-              "color": "rgba(28, 27, 31, 1)",
+              "color": "rgba(73, 69, 79, 1)",
               "fontFamily": "System",
+              "fontSize": 16,
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": 0.15,
+              "lineHeight": 24,
+            },
+            Object {
+              "minHeight": 56,
+              "paddingLeft": 0,
             },
             undefined,
           ]
@@ -248,7 +254,7 @@ exports[`activity indicator snapshot test 1`] = `
               "justifyContent": "center",
             },
             Object {
-              "margin": 10,
+              "marginHorizontal": 16,
             },
           ]
         }
@@ -450,11 +456,11 @@ exports[`renders with placeholder 1`] = `
       "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 0,
         "width": 0,
       },
-      "shadowOpacity": 0.15,
-      "shadowRadius": 3,
+      "shadowOpacity": 0,
+      "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
     }
@@ -468,11 +474,11 @@ exports[`renders with placeholder 1`] = `
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
-          "height": 1,
+          "height": 0,
           "width": 0,
         },
-        "shadowOpacity": 0.3,
-        "shadowRadius": 1,
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
       }
     }
     testID="search-bar-container-inner-layer"
@@ -482,8 +488,8 @@ exports[`renders with placeholder 1`] = `
       style={
         Object {
           "alignItems": "center",
-          "backgroundColor": "rgb(247, 243, 249)",
-          "borderRadius": 4,
+          "backgroundColor": "rgb(238, 232, 244)",
+          "borderRadius": 28,
           "flex": undefined,
           "flexDirection": "row",
         }
@@ -608,7 +614,7 @@ exports[`renders with placeholder 1`] = `
                 style={
                   Array [
                     Object {
-                      "color": "rgba(28, 27, 31, 0.54)",
+                      "color": "rgba(73, 69, 79, 1)",
                       "fontSize": 24,
                     },
                     Array [
@@ -657,10 +663,16 @@ exports[`renders with placeholder 1`] = `
               "textAlign": "left",
             },
             Object {
-              "color": "rgba(28, 27, 31, 1)",
+              "color": "rgba(73, 69, 79, 1)",
               "fontFamily": "System",
+              "fontSize": 16,
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": 0.15,
+              "lineHeight": 24,
+            },
+            Object {
+              "minHeight": 56,
+              "paddingLeft": 0,
             },
             undefined,
           ]
@@ -671,6 +683,16 @@ exports[`renders with placeholder 1`] = `
       />
       <View
         pointerEvents="none"
+        style={
+          Array [
+            Object {
+              "marginLeft": 16,
+              "position": "absolute",
+              "right": 0,
+            },
+            false,
+          ]
+        }
         testID="search-bar-icon-wrapper"
       >
         <View
@@ -842,11 +864,11 @@ exports[`renders with text 1`] = `
       "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
-        "height": 1,
+        "height": 0,
         "width": 0,
       },
-      "shadowOpacity": 0.15,
-      "shadowRadius": 3,
+      "shadowOpacity": 0,
+      "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
     }
@@ -860,11 +882,11 @@ exports[`renders with text 1`] = `
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
-          "height": 1,
+          "height": 0,
           "width": 0,
         },
-        "shadowOpacity": 0.3,
-        "shadowRadius": 1,
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
       }
     }
     testID="search-bar-container-inner-layer"
@@ -874,8 +896,8 @@ exports[`renders with text 1`] = `
       style={
         Object {
           "alignItems": "center",
-          "backgroundColor": "rgb(247, 243, 249)",
-          "borderRadius": 4,
+          "backgroundColor": "rgb(238, 232, 244)",
+          "borderRadius": 28,
           "flex": undefined,
           "flexDirection": "row",
         }
@@ -1000,7 +1022,7 @@ exports[`renders with text 1`] = `
                 style={
                   Array [
                     Object {
-                      "color": "rgba(28, 27, 31, 0.54)",
+                      "color": "rgba(73, 69, 79, 1)",
                       "fontSize": 24,
                     },
                     Array [
@@ -1049,10 +1071,16 @@ exports[`renders with text 1`] = `
               "textAlign": "left",
             },
             Object {
-              "color": "rgba(28, 27, 31, 1)",
+              "color": "rgba(73, 69, 79, 1)",
               "fontFamily": "System",
+              "fontSize": 16,
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": 0.15,
+              "lineHeight": 24,
+            },
+            Object {
+              "minHeight": 56,
+              "paddingLeft": 0,
             },
             undefined,
           ]
@@ -1063,6 +1091,12 @@ exports[`renders with text 1`] = `
       />
       <View
         pointerEvents="auto"
+        style={
+          Array [
+            false,
+            false,
+          ]
+        }
         testID="search-bar-icon-wrapper"
       >
         <View
@@ -1183,7 +1217,7 @@ exports[`renders with text 1`] = `
                   style={
                     Array [
                       Object {
-                        "color": "rgba(28, 27, 31, 0.54)",
+                        "color": "rgba(73, 69, 79, 1)",
                         "fontSize": 24,
                       },
                       Array [

--- a/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
@@ -226,7 +226,7 @@ exports[`activity indicator snapshot test 1`] = `
               "fontSize": 16,
               "fontWeight": "400",
               "letterSpacing": 0.15,
-              "lineHeight": 24,
+              "lineHeight": 0,
             },
             Object {
               "minHeight": 56,
@@ -668,7 +668,7 @@ exports[`renders with placeholder 1`] = `
               "fontSize": 16,
               "fontWeight": "400",
               "letterSpacing": 0.15,
-              "lineHeight": 24,
+              "lineHeight": 0,
             },
             Object {
               "minHeight": 56,
@@ -1076,7 +1076,7 @@ exports[`renders with text 1`] = `
               "fontSize": 16,
               "fontWeight": "400",
               "letterSpacing": 0.15,
-              "lineHeight": 24,
+              "lineHeight": 0,
             },
             Object {
               "minHeight": 56,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

PR is about adjusting `Searchbar` to the latest MD guidelines. According to the [specs](https://m3.material.io/components/search/specs) there is Search View and Search Bar, that's why there was introduced property `mode`:

* `mode="bar"`


* `mode="view"`

Additionally, the `Searchbar` with `mode="bar"` can receive the `traileringIcon` with its `onPress` and `accessibility`  or custom color properties. 

```
  <Searchbar
    mode="bar"
    placeholder="Trailering icon"
    onChangeText={(query) =>
      setSearchQuery({ ...searchQueries, traileringIcon: query })
    }
    value={searchQueries.traileringIcon}
    traileringIcon={'microphone'}
    traileringIconColor={
      isVisible ? MD3Colors.error40 : colors.onSurfaceVariant
    }
    traileringIconAccessibilityLabel={'microphone button'}
    onTraileringIconPress={() => setIsVisible(true)}
    style={styles.searchbar}
  />
```

For the same mode, there is a possibility to add one more item on the right side e.g. `Avatar`, by using `right` property:

```
  <Searchbar
    mode="bar"
    placeholder="Right item"
    onChangeText={(query) =>
      setSearchQuery({
        ...searchQueries,
        rightItem: query,
      })
    }
    value={searchQueries.rightItem}
    right={(props) => (
      <Avatar.Image
        {...props}
        size={30}
        source={require('../../assets/images/avatar.png')}
      />
    )}
    style={styles.searchbar}
  />
```            

In terms of `Searchbar` with `mode="view"` there is a new prop called `showDivider` which handles the visibility of the bottom border.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
