### PR TITLE
fix: allow to override card border color using styles

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -219,14 +219,15 @@ const Card = ({
   const computedElevation =
     dark && isAdaptiveMode ? elevationDarkAdaptive : elevation;
 
-  const { backgroundColor, borderColor } = getCardColors({
+  const { backgroundColor, borderColor: themedBorderColor } = getCardColors({
     theme,
     mode: cardMode,
   });
 
-  const { borderRadius = (isV3 ? 3 : 1) * roundness } = (StyleSheet.flatten(
-    style
-  ) || {}) as ViewStyle;
+  const {
+    borderRadius = (isV3 ? 3 : 1) * roundness,
+    borderColor = themedBorderColor,
+  } = (StyleSheet.flatten(style) || {}) as ViewStyle;
 
   return (
     <Surface

--- a/src/components/__tests__/Card/Card.test.js
+++ b/src/components/__tests__/Card/Card.test.js
@@ -7,6 +7,7 @@ import renderer from 'react-test-renderer';
 
 import { getTheme } from '../../../core/theming';
 import { black, white } from '../../../styles/themes/v2/colors';
+import { MD3Colors } from '../../../styles/themes/v3/tokens';
 import Button from '../../Button/Button';
 import Card from '../../Card/Card';
 import { getCardColors, getCardCoverStyle } from '../../Card/utils';
@@ -36,6 +37,20 @@ describe('Card', () => {
     expect(getByTestId('card-outline')).toHaveStyle({
       borderRadius: 32,
       borderColor: 'purple',
+    });
+  });
+
+  it('renders an outlined card with custom border color', () => {
+    const { getByLabelText } = render(
+      <Card
+        mode="outlined"
+        accessibilityLabel="card"
+        style={{ borderColor: MD3Colors.error50 }}
+      />
+    );
+
+    expect(getByLabelText('card')).toHaveStyle({
+      borderColor: MD3Colors.error50,
     });
   });
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

PR unifies the approach of the possibility to override the `borderColor` in `Card` via styles.

#### Related issue

- #3563 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Covered by a unit test.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
