### PR TITLE
fix: activeColor and inactiveColor to match icon colors

### DIFF
--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -28,6 +28,11 @@ import Surface from '../Surface';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import Text from '../Typography/Text';
 import BottomNavigationRouteScreen from './BottomNavigationRouteScreen';
+import {
+  getActiveTintColor,
+  getInactiveTintColor,
+  getLabelColor,
+} from './utils';
 
 type Route = {
   key: string;
@@ -645,18 +650,17 @@ const BottomNavigation = ({
 
   const textColor = isDark ? white : black;
 
-  const activeTintColor = activeColor
-    ? activeColor
-    : isV3
-    ? theme.colors.onSecondaryContainer
-    : textColor;
+  const activeTintColor = getActiveTintColor({
+    activeColor,
+    defaultColor: textColor,
+    theme,
+  });
 
-  const inactiveTintColor = inactiveColor
-    ? inactiveColor
-    : isV3
-    ? theme.colors.onSurfaceVariant
-    : color(textColor).alpha(0.5).rgb().string();
-
+  const inactiveTintColor = getInactiveTintColor({
+    inactiveColor,
+    defaultColor: textColor,
+    theme,
+  });
   const touchColor = color(activeTintColor).alpha(0.12).rgb().string();
 
   const maxTabWidth = routes.length > 3 ? MIN_TAB_WIDTH : MAX_TAB_WIDTH;
@@ -883,21 +887,21 @@ const BottomNavigation = ({
 
               const badge = getBadge({ route });
 
-              const activeLabelColor = activeColor
-                ? activeTintColor
-                : focused
-                ? theme.colors.onSurface
-                : isV3
-                ? theme.colors.onSurfaceVariant
-                : textColor;
+              const activeLabelColor = getLabelColor({
+                tintColor: activeTintColor,
+                hasColor: Boolean(activeColor),
+                focused,
+                defaultColor: textColor,
+                theme,
+              });
 
-              const inactiveLabelColor = inactiveColor
-                ? inactiveTintColor
-                : focused
-                ? theme.colors.onSurface
-                : isV3
-                ? theme.colors.onSurfaceVariant
-                : textColor;
+              const inactiveLabelColor = getLabelColor({
+                tintColor: inactiveTintColor,
+                hasColor: Boolean(inactiveColor),
+                focused,
+                defaultColor: textColor,
+                theme,
+              });
 
               const badgeStyle = {
                 top: !isV3 ? -2 : typeof badge === 'boolean' ? 4 : 2,

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -645,24 +645,19 @@ const BottomNavigation = ({
 
   const textColor = isDark ? white : black;
 
-  const activeTintColor =
-    typeof activeColor !== 'undefined'
-      ? activeColor
-      : isV3
-      ? theme.colors.onSecondaryContainer
-      : textColor;
+  const activeTintColor = activeColor
+    ? activeColor
+    : isV3
+    ? theme.colors.onSecondaryContainer
+    : textColor;
 
-  const inactiveTintColor =
-    typeof inactiveColor !== 'undefined'
-      ? inactiveColor
-      : isV3
-      ? theme.colors.onSurfaceVariant
-      : color(textColor).alpha(0.5).rgb().string();
+  const inactiveTintColor = inactiveColor
+    ? inactiveColor
+    : isV3
+    ? theme.colors.onSurfaceVariant
+    : color(textColor).alpha(0.5).rgb().string();
 
-  const touchColor = color(activeColor || activeTintColor)
-    .alpha(0.12)
-    .rgb()
-    .string();
+  const touchColor = color(activeTintColor).alpha(0.12).rgb().string();
 
   const maxTabWidth = routes.length > 3 ? MIN_TAB_WIDTH : MAX_TAB_WIDTH;
   const maxTabBarWidth = maxTabWidth * routes.length;
@@ -743,7 +738,7 @@ const BottomNavigation = ({
                 style={[
                   styles.content,
                   {
-                    opacity: opacity,
+                    opacity,
                     transform: [{ translateX: left }, { translateY: top }],
                   },
                 ]}
@@ -888,17 +883,21 @@ const BottomNavigation = ({
 
               const badge = getBadge({ route });
 
-              const activeLabelColor = !isV3
+              const activeLabelColor = activeColor
                 ? activeTintColor
                 : focused
                 ? theme.colors.onSurface
-                : theme.colors.onSurfaceVariant;
+                : isV3
+                ? theme.colors.onSurfaceVariant
+                : textColor;
 
-              const inactiveLabelColor = !isV3
+              const inactiveLabelColor = inactiveColor
                 ? inactiveTintColor
                 : focused
                 ? theme.colors.onSurface
-                : theme.colors.onSurfaceVariant;
+                : isV3
+                ? theme.colors.onSurfaceVariant
+                : textColor;
 
               const badgeStyle = {
                 top: !isV3 ? -2 : typeof badge === 'boolean' ? 4 : 2,

--- a/src/components/BottomNavigation/utils.ts
+++ b/src/components/BottomNavigation/utils.ts
@@ -3,7 +3,7 @@ import type { InternalTheme } from 'src/types';
 
 import type { black, white } from '../../styles/themes/v2/colors';
 
-type BaseConfig = {
+type BaseProps = {
   defaultColor: typeof black | typeof white;
   theme: InternalTheme;
 };
@@ -12,28 +12,36 @@ export const getActiveTintColor = ({
   activeColor,
   defaultColor,
   theme,
-}: {
+}: BaseProps & {
   activeColor: string | undefined;
-} & BaseConfig) => {
-  return activeColor
-    ? activeColor
-    : theme.isV3
-    ? theme.colors.onSecondaryContainer
-    : defaultColor;
+}) => {
+  if (typeof activeColor === 'string') {
+    return activeColor;
+  }
+
+  if (theme.isV3) {
+    return theme.colors.onSecondaryContainer;
+  }
+
+  return defaultColor;
 };
 
 export const getInactiveTintColor = ({
   inactiveColor,
   defaultColor,
   theme,
-}: {
+}: BaseProps & {
   inactiveColor: string | undefined;
-} & BaseConfig) => {
-  return inactiveColor
-    ? inactiveColor
-    : theme.isV3
-    ? theme.colors.onSurfaceVariant
-    : color(defaultColor).alpha(0.5).rgb().string();
+}) => {
+  if (typeof inactiveColor === 'string') {
+    return inactiveColor;
+  }
+
+  if (theme.isV3) {
+    return theme.colors.onSurfaceVariant;
+  }
+
+  return color(defaultColor).alpha(0.5).rgb().string();
 };
 
 export const getLabelColor = ({
@@ -42,16 +50,22 @@ export const getLabelColor = ({
   focused,
   defaultColor,
   theme,
-}: {
+}: BaseProps & {
   tintColor: string;
   hasColor: boolean;
   focused: boolean;
-} & BaseConfig) => {
-  return hasColor
-    ? tintColor
-    : focused
-    ? theme.colors.onSurface
-    : theme.isV3
-    ? theme.colors.onSurfaceVariant
-    : defaultColor;
+}) => {
+  if (hasColor) {
+    return tintColor;
+  }
+
+  if (focused) {
+    return theme.colors.onSurface;
+  }
+
+  if (theme.isV3) {
+    return theme.colors.onSurfaceVariant;
+  }
+
+  return defaultColor;
 };

--- a/src/components/BottomNavigation/utils.ts
+++ b/src/components/BottomNavigation/utils.ts
@@ -1,0 +1,57 @@
+import color from 'color';
+import type { InternalTheme } from 'src/types';
+
+import type { black, white } from '../../styles/themes/v2/colors';
+
+type BaseConfig = {
+  defaultColor: typeof black | typeof white;
+  theme: InternalTheme;
+};
+
+export const getActiveTintColor = ({
+  activeColor,
+  defaultColor,
+  theme,
+}: {
+  activeColor: string | undefined;
+} & BaseConfig) => {
+  return activeColor
+    ? activeColor
+    : theme.isV3
+    ? theme.colors.onSecondaryContainer
+    : defaultColor;
+};
+
+export const getInactiveTintColor = ({
+  inactiveColor,
+  defaultColor,
+  theme,
+}: {
+  inactiveColor: string | undefined;
+} & BaseConfig) => {
+  return inactiveColor
+    ? inactiveColor
+    : theme.isV3
+    ? theme.colors.onSurfaceVariant
+    : color(defaultColor).alpha(0.5).rgb().string();
+};
+
+export const getLabelColor = ({
+  tintColor,
+  hasColor,
+  focused,
+  defaultColor,
+  theme,
+}: {
+  tintColor: string;
+  hasColor: boolean;
+  focused: boolean;
+} & BaseConfig) => {
+  return hasColor
+    ? tintColor
+    : focused
+    ? theme.colors.onSurface
+    : theme.isV3
+    ? theme.colors.onSurfaceVariant
+    : defaultColor;
+};

--- a/src/components/__tests__/BottomNavigation.test.js
+++ b/src/components/__tests__/BottomNavigation.test.js
@@ -2,11 +2,19 @@ import * as React from 'react';
 import { StyleSheet, Easing, Animated, Platform } from 'react-native';
 
 import { fireEvent, render } from '@testing-library/react-native';
+import color from 'color';
 import renderer from 'react-test-renderer';
 
+import { getTheme } from '../../core/theming';
 import { red300 } from '../../styles/themes/v2/colors';
+import { MD3Colors } from '../../styles/themes/v3/tokens';
 import BottomNavigation from '../BottomNavigation/BottomNavigation.tsx';
 import BottomNavigationRouteScreen from '../BottomNavigation/BottomNavigationRouteScreen.tsx';
+import {
+  getActiveTintColor,
+  getInactiveTintColor,
+  getLabelColor,
+} from '../BottomNavigation/utils';
 
 const styles = StyleSheet.create({
   labelColor: {
@@ -388,4 +396,64 @@ it('renders bottom navigation with getLazy', () => {
   expect(tree).toMatchSnapshot();
 
   expect(tree.queryByTestId('RouteScreen: 2')).toBeNull();
+});
+
+describe('getActiveTintColor', () => {
+  it.each`
+    activeColor  | defaultColor | useV3    | expected
+    ${'#FBF7DB'} | ${'#fff'}    | ${true}  | ${'#FBF7DB'}
+    ${undefined} | ${'#fff'}    | ${true}  | ${MD3Colors.secondary10}
+    ${undefined} | ${'#fff'}    | ${false} | ${'#fff'}
+  `(
+    'returns $expected when activeColor: $activeColor and useV3: $useV3',
+    ({ activeColor, defaultColor, useV3, expected }) => {
+      const theme = getTheme(false, useV3);
+      const color = getActiveTintColor({ activeColor, defaultColor, theme });
+      expect(color).toBe(expected);
+    }
+  );
+});
+
+describe('getInactiveTintColor', () => {
+  it.each`
+    inactiveColor | defaultColor | useV3    | expected
+    ${'#853D4B'}  | ${'#fff'}    | ${true}  | ${'#853D4B'}
+    ${undefined}  | ${'#fff'}    | ${true}  | ${MD3Colors.neutralVariant30}
+    ${undefined}  | ${'#fff'}    | ${false} | ${color('#fff').alpha(0.5).rgb().string()}
+  `(
+    'returns $expected when inactiveColor: $inactiveColor and useV3: $useV3',
+    ({ inactiveColor, defaultColor, useV3, expected }) => {
+      const theme = getTheme(false, useV3);
+      const color = getInactiveTintColor({
+        inactiveColor,
+        defaultColor,
+        theme,
+      });
+      expect(color).toBe(expected);
+    }
+  );
+});
+
+describe('getLabelColor', () => {
+  it.each`
+    tintColor    | focused  | defaultColor | useV3    | expected
+    ${'#FBF7DB'} | ${true}  | ${'#fff'}    | ${true}  | ${'#FBF7DB'}
+    ${'#853D4B'} | ${true}  | ${'#fff'}    | ${true}  | ${'#853D4B'}
+    ${undefined} | ${true}  | ${'#fff'}    | ${true}  | ${MD3Colors.neutral10}
+    ${undefined} | ${false} | ${'#fff'}    | ${true}  | ${MD3Colors.neutralVariant30}
+    ${undefined} | ${false} | ${'#fff'}    | ${false} | ${'#fff'}
+  `(
+    'returns $expected when tintColor: $tintColor, focused: $focused useV3: $useV3',
+    ({ tintColor, focused, defaultColor, useV3, expected }) => {
+      const theme = getTheme(false, useV3);
+      const color = getLabelColor({
+        tintColor,
+        hasColor: Boolean(tintColor),
+        focused,
+        defaultColor,
+        theme,
+      });
+      expect(color).toBe(expected);
+    }
+  );
 });

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.js.snap
@@ -6889,7 +6889,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                               "textAlign": "center",
                             },
                             Object {
-                              "color": "rgba(28, 27, 31, 1)",
+                              "color": "#FBF7DB",
                               "fontFamily": "System",
                               "fontSize": 12,
                               "fontWeight": "500",
@@ -6943,7 +6943,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                               "textAlign": "center",
                             },
                             Object {
-                              "color": "rgba(28, 27, 31, 1)",
+                              "color": "#853D4B",
                               "fontFamily": "System",
                               "fontSize": 12,
                               "fontWeight": "500",
@@ -7197,7 +7197,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                               "textAlign": "center",
                             },
                             Object {
-                              "color": "rgba(73, 69, 79, 1)",
+                              "color": "#FBF7DB",
                               "fontFamily": "System",
                               "fontSize": 12,
                               "fontWeight": "500",
@@ -7251,7 +7251,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                               "textAlign": "center",
                             },
                             Object {
-                              "color": "rgba(73, 69, 79, 1)",
+                              "color": "#853D4B",
                               "fontFamily": "System",
                               "fontSize": 12,
                               "fontWeight": "500",
@@ -7505,7 +7505,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                               "textAlign": "center",
                             },
                             Object {
-                              "color": "rgba(73, 69, 79, 1)",
+                              "color": "#FBF7DB",
                               "fontFamily": "System",
                               "fontSize": 12,
                               "fontWeight": "500",
@@ -7559,7 +7559,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                               "textAlign": "center",
                             },
                             Object {
-                              "color": "rgba(73, 69, 79, 1)",
+                              "color": "#853D4B",
                               "fontFamily": "System",
                               "fontSize": 12,
                               "fontWeight": "500",
@@ -8008,7 +8008,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                               "textAlign": "center",
                             },
                             Object {
-                              "color": "rgba(28, 27, 31, 1)",
+                              "color": "#FBF7DB",
                               "fontFamily": "System",
                               "fontSize": 12,
                               "fontWeight": "500",
@@ -8268,7 +8268,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                               "textAlign": "center",
                             },
                             Object {
-                              "color": "rgba(73, 69, 79, 1)",
+                              "color": "#FBF7DB",
                               "fontFamily": "System",
                               "fontSize": 12,
                               "fontWeight": "500",
@@ -8528,7 +8528,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                               "textAlign": "center",
                             },
                             Object {
-                              "color": "rgba(73, 69, 79, 1)",
+                              "color": "#FBF7DB",
                               "fontFamily": "System",
                               "fontSize": 12,
                               "fontWeight": "500",


### PR DESCRIPTION
### Summary

Made available the props `activeColor` and `inactiveColor` to the labels

https://user-images.githubusercontent.com/1676818/211879937-e3888c34-c84d-46f7-8ac9-f05e90b6d9c3.mov

### Related Issue

- #3576

### Test plan

Cover by tests
Use `@react-navigation/material-bottom-tabs` 
Use `BottomNavigation` from Paper
