### PR TITLE
fix: appbar content title container adjustments

### DIFF
--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -18,17 +18,22 @@ import type { $RemoveChildren, MD3TypescaleKey, ThemeProp } from '../../types';
 import Text from '../Typography/Text';
 import { modeTextVariant } from './utils';
 
+type TitleString = {
+  title: string;
+  titleStyle?: StyleProp<TextStyle>;
+};
+
+type TitleElement = { title: React.ReactNode; titleStyle?: never };
+
 export type Props = $RemoveChildren<typeof View> & {
+  // For `title` and `titleStyle` props their types are duplicated due to the generation of documentation.
+  // Appropriate type for them are either `TitleString` or `TitleElement`, depends on `title` type.
   /**
-   * Custom color for the text.
-   */
-  color?: string;
-  /**
-   * Text for the title.
+   * Text or component for the title.
    */
   title: React.ReactNode;
   /**
-   * Style for the title.
+   * Style for the title, if `title` is a string.
    */
   titleStyle?: StyleProp<TextStyle>;
   /**
@@ -50,6 +55,10 @@ export type Props = $RemoveChildren<typeof View> & {
    */
   onPress?: (e: GestureResponderEvent) => void;
   /**
+   * Custom color for the text.
+   */
+  color?: string;
+  /**
    * @internal
    */
   mode?: 'small' | 'medium' | 'large' | 'center-aligned';
@@ -62,7 +71,7 @@ export type Props = $RemoveChildren<typeof View> & {
    * testID to be used on tests.
    */
   testID?: string;
-};
+} & (TitleString | TitleElement);
 
 /**
  * A component used to display a title and optional subtitle in an appbar.

--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -58,6 +58,10 @@ export type Props = $RemoveChildren<typeof View> & {
    * @optional
    */
   theme?: ThemeProp;
+  /**
+   * testID to be used on tests.
+   */
+  testID?: string;
 };
 
 /**
@@ -92,6 +96,7 @@ const AppbarContent = ({
   title,
   mode = 'small',
   theme: themeOverrides,
+  testID = 'appbar-content',
   ...rest
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
@@ -123,6 +128,7 @@ const AppbarContent = ({
       <View
         pointerEvents="box-none"
         style={[styles.container, isV3 && modeContainerStyles[mode], style]}
+        testID={testID}
         {...rest}
       >
         {typeof title === 'string' ? (
@@ -145,11 +151,12 @@ const AppbarContent = ({
             accessible
             // @ts-ignore Type '"heading"' is not assignable to type ...
             accessibilityRole={Platform.OS === 'web' ? 'heading' : 'header'}
+            testID={`${testID}-title-text`}
           >
             {title}
           </Text>
         ) : (
-          <View>{title}</View>
+          title
         )}
         {!isV3 && subtitle ? (
           <Text

--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -125,28 +125,32 @@ const AppbarContent = ({
         style={[styles.container, isV3 && modeContainerStyles[mode], style]}
         {...rest}
       >
-        <Text
-          {...(isV3 && { variant })}
-          ref={titleRef}
-          style={[
-            {
-              color: titleTextColor,
-              ...(isV3
-                ? theme.fonts[variant]
-                : Platform.OS === 'ios'
-                ? theme.fonts.regular
-                : theme.fonts.medium),
-            },
-            !isV3 && styles.title,
-            titleStyle,
-          ]}
-          numberOfLines={1}
-          accessible
-          // @ts-ignore Type '"heading"' is not assignable to type ...
-          accessibilityRole={Platform.OS === 'web' ? 'heading' : 'header'}
-        >
-          {title}
-        </Text>
+        {typeof title === 'string' ? (
+          <Text
+            {...(isV3 && { variant })}
+            ref={titleRef}
+            style={[
+              {
+                color: titleTextColor,
+                ...(isV3
+                  ? theme.fonts[variant]
+                  : Platform.OS === 'ios'
+                  ? theme.fonts.regular
+                  : theme.fonts.medium),
+              },
+              !isV3 && styles.title,
+              titleStyle,
+            ]}
+            numberOfLines={1}
+            accessible
+            // @ts-ignore Type '"heading"' is not assignable to type ...
+            accessibilityRole={Platform.OS === 'web' ? 'heading' : 'header'}
+          >
+            {title}
+          </Text>
+        ) : (
+          <View>{title}</View>
+        )}
         {!isV3 && subtitle ? (
           <Text
             style={[styles.subtitle, { color: subtitleColor }, subtitleStyle]}

--- a/src/components/__tests__/Appbar/Appbar.test.js
+++ b/src/components/__tests__/Appbar/Appbar.test.js
@@ -14,10 +14,15 @@ import AppbarAction from '../../Appbar/AppbarAction';
 import AppbarBackAction from '../../Appbar/AppbarBackAction';
 import AppbarContent from '../../Appbar/AppbarContent';
 import AppbarHeader from '../../Appbar/AppbarHeader';
-import { getAppbarColor, renderAppbarContent } from '../../Appbar/utils';
+import {
+  getAppbarColor,
+  modeTextVariant,
+  renderAppbarContent,
+} from '../../Appbar/utils';
 import Menu from '../../Menu/Menu';
 import Searchbar from '../../Searchbar';
 import Tooltip from '../../Tooltip/Tooltip';
+import Text from '../../Typography/Text';
 
 jest.mock('react-native-safe-area-context', () => mockSafeAreaContext);
 
@@ -269,6 +274,38 @@ describe('AppbarAction', () => {
 
       expect(appbarActionIcon.props.color).toBe('#ffffff');
     });
+  });
+});
+
+describe('AppbarContent', () => {
+  ['small', 'medium', 'large', 'center-aligned'].forEach((mode) =>
+    it(`should render text component with appropriate variant for ${mode} mode`, () => {
+      const { getByTestId } = render(
+        <Appbar mode={mode}>
+          <Appbar.Content title="Title" />
+        </Appbar>
+      );
+
+      expect(getByTestId('appbar-content-title-text')).toHaveStyle(
+        getTheme().fonts[modeTextVariant[mode]]
+      );
+    })
+  );
+
+  it('should render component passed to title', () => {
+    const { getByText } = render(
+      <Appbar>
+        <Appbar.Content
+          title={
+            <Text testID="title" variant="displaySmall">
+              Title
+            </Text>
+          }
+        />
+      </Appbar>
+    );
+
+    expect(getByText('Title')).toBeDefined();
   });
 });
 

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.js.snap
@@ -692,6 +692,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             ],
           ]
         }
+        testID="appbar-content"
       >
         <Text
           accessibilityRole="header"
@@ -727,6 +728,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
               ],
             ]
           }
+          testID="appbar-content-title-text"
         >
           Examples
         </Text>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

PR introduces adjustments for handling the `title` prop in `Appbar.Content` to wrap **only** the title string within the default `Text` component. Other types passed into `title` are rendered directly in the `View` container.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

#### Related issue

- #3572 

### Test plan

Added unit tests.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
