### PR TITLE
fix: calls onLayout on input affix

### DIFF
--- a/src/components/TextInput/Adornment/TextInputAffix.tsx
+++ b/src/components/TextInput/Adornment/TextInputAffix.tsx
@@ -118,6 +118,7 @@ const TextInputAffix = ({
   text,
   textStyle: labelStyle,
   theme: themeOverrides,
+  onLayout: onTextLayout,
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
   const { AFFIX_OFFSET } = getConstants(theme.isV3);
@@ -167,6 +168,8 @@ const TextInputAffix = ({
       <Text
         maxFontSizeMultiplier={maxFontSizeMultiplier}
         style={[{ color: textColor }, textStyle, labelStyle]}
+        onLayout={onTextLayout}
+        testID={`${testID}-text`}
       >
         {text}
       </Text>

--- a/src/components/__tests__/TextInput.test.js
+++ b/src/components/__tests__/TextInput.test.js
@@ -289,6 +289,28 @@ it('correctly applies padding offset to input label on Android when LTR', () => 
   });
 });
 
+it('calls onLayout on right-side affix adornment', () => {
+  const onLayoutMock = jest.fn();
+  const nativeEventMock = {
+    nativeEvent: { layout: { height: 100 } },
+  };
+
+  const { getByTestId } = render(
+    <TextInput
+      label="Flat input"
+      placeholder="Type something"
+      value={'Some test value'}
+      right={<TextInput.Affix text={affixTextValue} onLayout={onLayoutMock} />}
+    />
+  );
+  fireEvent(
+    getByTestId('right-affix-adornment-text'),
+    'onLayout',
+    nativeEventMock
+  );
+  expect(onLayoutMock).toHaveBeenCalledWith(nativeEventMock);
+});
+
 ['outlined', 'flat'].forEach((mode) =>
   it(`renders ${mode} input with correct line height`, () => {
     const input = render(

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -1263,6 +1263,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
           },
         ]
       }
+      testID="left-affix-adornment-text"
     >
       /100
     </Text>
@@ -1817,6 +1818,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
           },
         ]
       }
+      testID="right-affix-adornment-text"
     >
       /100
     </Text>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes missing possibility to invoke `onLayout` on `TextInput.Affix` which is mentioned in the documentation.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

#### Related issue

- #3589 

### Test plan

Added unit test.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
