### PR TITLE
refactor: Fix exhaustive deps linting errors

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -149,6 +149,18 @@ const Banner = ({
     measured: false,
   });
 
+  const showCallback = React.useRef<Props['onShowAnimationFinished']>(
+    onShowAnimationFinished
+  );
+  const hideCallback = React.useRef<Props['onHideAnimationFinished']>(
+    onHideAnimationFinished
+  );
+
+  React.useEffect(() => {
+    showCallback.current = onShowAnimationFinished;
+    hideCallback.current = onHideAnimationFinished;
+  });
+
   const { scale } = theme.animation;
 
   React.useEffect(() => {
@@ -158,14 +170,14 @@ const Banner = ({
         duration: 250 * scale,
         toValue: 1,
         useNativeDriver: false,
-      }).start(onShowAnimationFinished);
+      }).start(showCallback.current);
     } else {
       // hide
       Animated.timing(position, {
         duration: 200 * scale,
         toValue: 0,
         useNativeDriver: false,
-      }).start(onHideAnimationFinished);
+      }).start(hideCallback.current);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible, position, scale]);

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Animated, StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 
+import useEventCallback from 'use-event-callback';
+
 import { useInternalTheme } from '../core/theming';
 import type { $RemoveChildren, ThemeProp } from '../types';
 import Button from './Button/Button';
@@ -149,17 +151,8 @@ const Banner = ({
     measured: false,
   });
 
-  const showCallback = React.useRef<Props['onShowAnimationFinished']>(
-    onShowAnimationFinished
-  );
-  const hideCallback = React.useRef<Props['onHideAnimationFinished']>(
-    onHideAnimationFinished
-  );
-
-  React.useEffect(() => {
-    showCallback.current = onShowAnimationFinished;
-    hideCallback.current = onHideAnimationFinished;
-  });
+  const showCallback = useEventCallback(onShowAnimationFinished);
+  const hideCallback = useEventCallback(onHideAnimationFinished);
 
   const { scale } = theme.animation;
 
@@ -170,14 +163,14 @@ const Banner = ({
         duration: 250 * scale,
         toValue: 1,
         useNativeDriver: false,
-      }).start(showCallback.current);
+      }).start(showCallback);
     } else {
       // hide
       Animated.timing(position, {
         duration: 200 * scale,
         toValue: 0,
         useNativeDriver: false,
-      }).start(hideCallback.current);
+      }).start(hideCallback);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible, position, scale]);

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -83,6 +83,8 @@ const ProgressBar = ({
     new Animated.Value(0)
   );
   const { current: fade } = React.useRef<Animated.Value>(new Animated.Value(0));
+  const passedAnimatedValue =
+    React.useRef<Props['animatedValue']>(animatedValue);
   const [width, setWidth] = React.useState<number>(0);
   const [prevWidth, setPrevWidth] = React.useState<number>(0);
 
@@ -90,6 +92,10 @@ const ProgressBar = ({
     React.useRef<Animated.CompositeAnimation | null>(null);
 
   const { scale } = theme.animation;
+
+  React.useEffect(() => {
+    passedAnimatedValue.current = animatedValue;
+  });
 
   const startAnimation = React.useCallback(() => {
     // Show progress bar
@@ -100,7 +106,17 @@ const ProgressBar = ({
       isInteraction: false,
     }).start();
 
-    if (animatedValue && animatedValue >= 0) {
+    /**
+     * We shouldn't add @param animatedValue to the
+     * deps array, to avoid the unnecessary loop.
+     * We can only check if the prop is passed initially,
+     * and we do early return.
+     */
+    const externalAnimation =
+      typeof passedAnimatedValue.current !== 'undefined' &&
+      passedAnimatedValue.current >= 0;
+
+    if (externalAnimation) {
       return;
     }
 
@@ -128,13 +144,6 @@ const ProgressBar = ({
         isInteraction: false,
       }).start();
     }
-    /**
-     * We shouldn't add @param animatedValue to the
-     * deps array, to avoid the unnecessary loop.
-     * We can only check if the prop is passed initially,
-     * and we do early return.
-     */
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fade, scale, indeterminate, timer, progress]);
 
   const stopAnimation = React.useCallback(() => {

--- a/src/components/__tests__/Banner.test.js
+++ b/src/components/__tests__/Banner.test.js
@@ -137,7 +137,7 @@ describe('animations', () => {
 
   describe('when component is rendered hidden', () => {
     // This behaviour is probably a bug. Needs triage before next version.
-    it('should fire onHideAnimationFinished on mount', () => {
+    it('will fire onHideAnimationFinished on mount', () => {
       renderer.create(
         <Banner
           onShowAnimationFinished={showCallback}
@@ -186,7 +186,7 @@ describe('animations', () => {
 
   describe('when component is rendered visible', () => {
     // This behaviour is probably a bug. Needs triage before next version.
-    it('should fire onShowAnimationFinished on mount', () => {
+    it('will fire onShowAnimationFinished on mount', () => {
       renderer.create(
         <Banner
           onShowAnimationFinished={showCallback}

--- a/src/components/__tests__/Banner.test.js
+++ b/src/components/__tests__/Banner.test.js
@@ -116,3 +116,208 @@ it('render visible banner, with custom theme', () => {
 
   expect(tree).toMatchSnapshot();
 });
+
+describe('animations', () => {
+  let showCallback, hideCallback;
+
+  beforeEach(() => {
+    showCallback = jest.fn();
+    hideCallback = jest.fn();
+  });
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+    showCallback = undefined;
+    hideCallback = undefined;
+  });
+
+  describe('when component is rendered hidden', () => {
+    // This behaviour is probably a bug. Needs triage before next version.
+    it('should fire onHideAnimationFinished on mount', () => {
+      renderer.create(
+        <Banner
+          onShowAnimationFinished={showCallback}
+          onHideAnimationFinished={hideCallback}
+        >
+          Text
+        </Banner>
+      );
+
+      expect(showCallback).not.toHaveBeenCalled();
+      expect(hideCallback).not.toHaveBeenCalled();
+
+      jest.runAllTimers();
+      expect(showCallback).not.toHaveBeenCalled();
+      expect(hideCallback).toHaveBeenCalled();
+    });
+
+    it('should fire onShowAnimationFinished upon opening', () => {
+      const tree = renderer.create(
+        <Banner
+          onShowAnimationFinished={showCallback}
+          onHideAnimationFinished={hideCallback}
+        >
+          Text
+        </Banner>
+      );
+
+      jest.runAllTimers();
+      expect(showCallback).toHaveBeenCalledTimes(0);
+      expect(hideCallback).toHaveBeenCalledTimes(1);
+
+      tree.update(
+        <Banner
+          onShowAnimationFinished={showCallback}
+          onHideAnimationFinished={hideCallback}
+          visible
+        >
+          Text
+        </Banner>
+      );
+      jest.runAllTimers();
+      expect(showCallback).toHaveBeenCalledTimes(1);
+      expect(hideCallback).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when component is rendered visible', () => {
+    // This behaviour is probably a bug. Needs triage before next version.
+    it('should fire onShowAnimationFinished on mount', () => {
+      renderer.create(
+        <Banner
+          onShowAnimationFinished={showCallback}
+          onHideAnimationFinished={hideCallback}
+          visible
+        >
+          Text
+        </Banner>
+      );
+
+      expect(showCallback).not.toHaveBeenCalled();
+      expect(hideCallback).not.toHaveBeenCalled();
+
+      jest.runAllTimers();
+      expect(showCallback).toHaveBeenCalled();
+      expect(hideCallback).not.toHaveBeenCalled();
+    });
+
+    it('should fire onHideAnimationFinished upon closing', () => {
+      const tree = renderer.create(
+        <Banner
+          onShowAnimationFinished={showCallback}
+          onHideAnimationFinished={hideCallback}
+          visible
+        >
+          Text
+        </Banner>
+      );
+
+      jest.runAllTimers();
+      expect(showCallback).toHaveBeenCalledTimes(1);
+      expect(hideCallback).toHaveBeenCalledTimes(0);
+
+      tree.update(
+        <Banner
+          onShowAnimationFinished={showCallback}
+          onHideAnimationFinished={hideCallback}
+        >
+          Text
+        </Banner>
+      );
+      jest.runAllTimers();
+      expect(showCallback).toHaveBeenCalledTimes(1);
+      expect(hideCallback).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when the callbacks change while the component is mounted', () => {
+    it('should not cause another open/close animation', () => {
+      const tree = renderer.create(
+        <Banner
+          onShowAnimationFinished={showCallback}
+          onHideAnimationFinished={hideCallback}
+          visible
+        >
+          Text
+        </Banner>
+      );
+
+      jest.runAllTimers();
+      expect(showCallback).toHaveBeenCalledTimes(1);
+      expect(hideCallback).toHaveBeenCalledTimes(0);
+
+      const nextShowCallback = jest.fn();
+      const nextHideCallback = jest.fn();
+
+      tree.update(
+        <Banner
+          onShowAnimationFinished={nextShowCallback}
+          onHideAnimationFinished={nextHideCallback}
+          visible
+        >
+          Text
+        </Banner>
+      );
+
+      jest.runAllTimers();
+      expect(showCallback).toHaveBeenCalledTimes(1);
+      expect(hideCallback).toHaveBeenCalledTimes(0);
+      expect(nextShowCallback).toHaveBeenCalledTimes(0);
+      expect(nextHideCallback).toHaveBeenCalledTimes(0);
+    });
+
+    it('should use the new callbacks upon opening/closing', () => {
+      const tree = renderer.create(
+        <Banner
+          onShowAnimationFinished={showCallback}
+          onHideAnimationFinished={hideCallback}
+          visible
+        >
+          Text
+        </Banner>
+      );
+
+      jest.runAllTimers();
+      expect(showCallback).toHaveBeenCalledTimes(1);
+      expect(hideCallback).toHaveBeenCalledTimes(0);
+
+      const nextShowCallback = jest.fn();
+      const nextHideCallback = jest.fn();
+
+      tree.update(
+        <Banner
+          onShowAnimationFinished={nextShowCallback}
+          onHideAnimationFinished={nextHideCallback}
+          visible
+        >
+          Text
+        </Banner>
+      );
+
+      jest.runAllTimers();
+      expect(showCallback).toHaveBeenCalledTimes(1);
+      expect(hideCallback).toHaveBeenCalledTimes(0);
+      expect(nextShowCallback).toHaveBeenCalledTimes(0);
+      expect(nextHideCallback).toHaveBeenCalledTimes(0);
+
+      tree.update(
+        <Banner
+          onShowAnimationFinished={nextShowCallback}
+          onHideAnimationFinished={nextHideCallback}
+        >
+          Text
+        </Banner>
+      );
+
+      jest.runAllTimers();
+      expect(showCallback).toHaveBeenCalledTimes(1);
+      expect(hideCallback).toHaveBeenCalledTimes(0);
+      expect(nextShowCallback).toHaveBeenCalledTimes(0);
+      expect(nextHideCallback).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/__tests__/Modal.test.js
+++ b/src/components/__tests__/Modal.test.js
@@ -1,38 +1,504 @@
 import * as React from 'react';
+import { Text, BackHandler } from 'react-native';
 
-import { render } from '@testing-library/react-native';
+import { act, fireEvent, render } from '@testing-library/react-native';
 
+import { MD3LightTheme } from '../../styles/themes';
 import Modal from '../Modal';
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ bottom: 44, left: 0, right: 0, top: 37 }),
 }));
 
-describe('Modal', () => {
-  it('should render custom backdrop color', () => {
-    const { getByTestId } = render(
-      <Modal
-        visible={true}
-        testID="modal"
-        theme={{
-          colors: {
-            backdrop: 'transparent',
-          },
-        }}
-      />
-    );
+jest.mock('react-native/Libraries/Utilities/BackHandler', () =>
+  // eslint-disable-next-line jest/no-mocks-import
+  require('react-native/Libraries/Utilities/__mocks__/BackHandler')
+);
 
-    expect(getByTestId('modal-backdrop')).toHaveStyle({
-      backgroundColor: 'transparent',
+describe('Modal', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => setTimeout(callback, 1));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+    window.requestAnimationFrame.mockRestore();
+  });
+
+  describe('by default', () => {
+    it('should render passed children', () => {
+      const { getByTestId } = render(
+        <Modal visible={true} testID="modal">
+          <Text>Children</Text>
+        </Modal>
+      );
+
+      expect(getByTestId('modal')).toHaveTextContent('Children');
+    });
+
+    it("should render a backdrop in default theme's color", () => {
+      const { getByTestId } = render(<Modal visible={true} testID="modal" />);
+
+      expect(getByTestId('modal-backdrop')).toHaveStyle({
+        backgroundColor: MD3LightTheme.colors.backdrop,
+      });
+    });
+
+    it('should render a custom backdrop color if specified', () => {
+      const { getByTestId } = render(
+        <Modal
+          visible={true}
+          testID="modal"
+          theme={{
+            colors: {
+              backdrop: 'transparent',
+            },
+          }}
+        />
+      );
+
+      expect(getByTestId('modal-backdrop')).toHaveStyle({
+        backgroundColor: 'transparent',
+      });
+    });
+
+    it('should receive appropriate top and bottom insets', () => {
+      const { getByTestId } = render(<Modal visible={true} testID="modal" />);
+
+      expect(getByTestId('modal-wrapper')).toHaveStyle({
+        marginTop: 37,
+        marginBottom: 44,
+      });
+    });
+  });
+  describe('when open', () => {
+    describe('if closed via touching backdrop', () => {
+      it('will run the animation but not fade out', async () => {
+        const { getByTestId } = render(
+          <Modal testID="modal" visible onDismiss={() => {}} />
+        );
+
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 1,
+        });
+
+        act(() => {
+          fireEvent.press(getByTestId('modal-backdrop'));
+        });
+
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 1,
+        });
+
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        expect(getByTestId('modal-backdrop')).toHaveStyle({
+          opacity: 1,
+        });
+
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 1,
+        });
+      });
+
+      it('should invoke the onDismiss function after the animation', () => {
+        const onDismiss = jest.fn();
+        const { getByTestId } = render(
+          <Modal testID="modal" visible onDismiss={onDismiss} />
+        );
+
+        expect(onDismiss).not.toHaveBeenCalled();
+
+        act(() => {
+          fireEvent.press(getByTestId('modal-backdrop'));
+        });
+
+        expect(onDismiss).not.toHaveBeenCalled();
+
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('if closed via Android back button', () => {
+      it('will run the animation but not fade out', async () => {
+        const { getByTestId } = render(
+          <Modal testID="modal" visible onDismiss={() => {}} />
+        );
+
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 1,
+        });
+
+        act(() => {
+          BackHandler.mockPressBack();
+        });
+
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 1,
+        });
+
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        expect(getByTestId('modal-backdrop')).toHaveStyle({
+          opacity: 1,
+        });
+
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 1,
+        });
+      });
+
+      it('should invoke the onDismiss function after the animation', () => {
+        const onDismiss = jest.fn();
+
+        render(<Modal testID="modal" visible onDismiss={onDismiss} />);
+
+        expect(onDismiss).not.toHaveBeenCalled();
+
+        act(() => {
+          BackHandler.mockPressBack();
+        });
+
+        expect(onDismiss).not.toHaveBeenCalled();
+
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+      });
     });
   });
 
-  it('should receive appropriate top and bottom insets', () => {
-    const { getByTestId } = render(<Modal visible={true} testID="modal" />);
+  describe('when open as non-dismissible modal', () => {
+    describe('if closed via touching backdrop', () => {
+      it('will run the animation but not fade out', async () => {
+        const { getByTestId } = render(
+          <Modal
+            testID="modal"
+            visible
+            onDismiss={() => {}}
+            dismissable={false}
+          />
+        );
 
-    expect(getByTestId('modal-wrapper')).toHaveStyle({
-      marginTop: 37,
-      marginBottom: 44,
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 1,
+        });
+
+        act(() => {
+          fireEvent.press(getByTestId('modal-backdrop'));
+        });
+
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 1,
+        });
+
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        expect(getByTestId('modal-backdrop')).toHaveStyle({
+          opacity: 1,
+        });
+
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 1,
+        });
+      });
+
+      it('should not invoke onDismiss', () => {
+        const onDismiss = jest.fn();
+        const { getByTestId } = render(
+          <Modal
+            testID="modal"
+            visible
+            onDismiss={onDismiss}
+            dismissable={false}
+          />
+        );
+
+        expect(onDismiss).not.toHaveBeenCalled();
+
+        act(() => {
+          fireEvent.press(getByTestId('modal-backdrop'));
+        });
+
+        expect(onDismiss).not.toHaveBeenCalled();
+
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        expect(onDismiss).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('if closed via Android back button', () => {
+      it('will run the animation but not fade out', async () => {
+        const { getByTestId } = render(
+          <Modal
+            testID="modal"
+            visible
+            onDismiss={() => {}}
+            dismissable={false}
+          />
+        );
+
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 1,
+        });
+
+        act(() => {
+          BackHandler.mockPressBack();
+        });
+
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 1,
+        });
+
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        expect(getByTestId('modal-backdrop')).toHaveStyle({
+          opacity: 1,
+        });
+
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 1,
+        });
+      });
+
+      it('should not invoke onDismiss', () => {
+        const onDismiss = jest.fn();
+
+        render(
+          <Modal
+            testID="modal"
+            visible
+            onDismiss={onDismiss}
+            dismissable={false}
+          />
+        );
+
+        expect(onDismiss).not.toHaveBeenCalled();
+
+        act(() => {
+          BackHandler.mockPressBack();
+        });
+
+        expect(onDismiss).not.toHaveBeenCalled();
+
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        expect(onDismiss).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when visible prop changes', () => {
+    describe('from false to true (closed to open)', () => {
+      it('should run fade-in animation on opening', () => {
+        const { queryByTestId, getByTestId, rerender } = render(
+          <Modal testID="modal" />
+        );
+
+        expect(queryByTestId('modal')).toBe(null);
+
+        rerender(<Modal testID="modal" visible />);
+
+        expect(getByTestId('modal-backdrop')).toHaveStyle({
+          opacity: 0,
+        });
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 0,
+        });
+
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        expect(getByTestId('modal-backdrop')).toHaveStyle({
+          opacity: 1,
+        });
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 1,
+        });
+      });
+    });
+
+    describe('from true to false (open to closed)', () => {
+      it('should run fade-out animation on closing', async () => {
+        const { queryByTestId, getByTestId, rerender } = render(
+          <Modal testID="modal" visible />
+        );
+
+        expect(getByTestId('modal-backdrop')).toHaveStyle({
+          opacity: 1,
+        });
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 1,
+        });
+
+        rerender(<Modal testID="modal" visible={false} />);
+
+        expect(getByTestId('modal-backdrop')).toHaveStyle({
+          opacity: 1,
+        });
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 1,
+        });
+
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        expect(queryByTestId('modal')).toBe(null);
+      });
+
+      it('should not invoke onDismiss', async () => {
+        const onDismiss = jest.fn();
+
+        const { rerender } = render(
+          <Modal testID="modal" visible onDismiss={onDismiss} />
+        );
+
+        expect(onDismiss).not.toHaveBeenCalled();
+
+        rerender(
+          <Modal testID="modal" visible={false} onDismiss={onDismiss} />
+        );
+
+        expect(onDismiss).not.toHaveBeenCalled();
+
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        expect(onDismiss).not.toHaveBeenCalled();
+      });
+
+      it('should close even if the dialog is not dismissible', async () => {
+        const { queryByTestId, getByTestId, rerender } = render(
+          <Modal testID="modal" visible dismissable={false} />
+        );
+
+        expect(getByTestId('modal-backdrop')).toHaveStyle({
+          opacity: 1,
+        });
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 1,
+        });
+
+        rerender(<Modal testID="modal" visible={false} dismissable={false} />);
+
+        expect(getByTestId('modal-backdrop')).toHaveStyle({
+          opacity: 1,
+        });
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 1,
+        });
+
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        expect(queryByTestId('modal')).toBe(null);
+      });
+    });
+  });
+
+  describe('when visible prop changes again during the open/close animation', () => {
+    describe('while closing, back to true (visible)', () => {
+      it('should keep the modal open', () => {
+        const { getByTestId, rerender } = render(
+          <Modal testID="modal" visible />
+        );
+
+        expect(getByTestId('modal-backdrop')).toHaveStyle({
+          opacity: 1,
+        });
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 1,
+        });
+
+        rerender(<Modal testID="modal" visible={false} />);
+
+        expect(getByTestId('modal-backdrop')).toHaveStyle({
+          opacity: 1,
+        });
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 1,
+        });
+
+        act(() => {
+          // Not a real seconds, this depends on how frequently
+          // requestAnimationFrame is called
+          jest.advanceTimersToNextTimer(1000);
+        });
+
+        rerender(<Modal testID="modal" visible />);
+
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        expect(getByTestId('modal-backdrop')).toHaveStyle({
+          opacity: 1,
+        });
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 1,
+        });
+      });
+    });
+
+    describe('while opening, back to false (hidden)', () => {
+      it('should keep the modal closed', () => {
+        const { queryByTestId, getByTestId, rerender } = render(
+          <Modal testID="modal" visible={false} />
+        );
+
+        expect(queryByTestId('modal-backdrop')).toBe(null);
+
+        rerender(<Modal testID="modal" visible />);
+
+        expect(getByTestId('modal-backdrop')).toHaveStyle({
+          opacity: 0,
+        });
+        expect(getByTestId('modal-surface')).toHaveStyle({
+          opacity: 0,
+        });
+
+        act(() => {
+          // Not a real seconds, this depends on how frequently
+          // requestAnimationFrame is called
+          jest.advanceTimersToNextTimer(1000);
+        });
+
+        expect(queryByTestId('modal-backdrop')).not.toBe(null);
+
+        rerender(<Modal testID="modal" visible={false} />);
+
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        expect(queryByTestId('modal-backdrop')).toBe(null);
+      });
     });
   });
 });

--- a/src/components/__tests__/ProgressBar.test.js
+++ b/src/components/__tests__/ProgressBar.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Animated } from 'react-native';
 
-import { render } from '@testing-library/react-native';
+import { render, waitFor } from '@testing-library/react-native';
 
 import ProgressBar from '../ProgressBar.tsx';
 
@@ -13,7 +13,7 @@ const layoutEvent = {
   },
 };
 
-const a11Role = 'progressbar';
+const a11yRole = 'progressbar';
 
 class ClassProgressBar extends React.Component {
   constructor(props) {
@@ -27,41 +27,39 @@ class ClassProgressBar extends React.Component {
 
 const AnimatedProgressBar = Animated.createAnimatedComponent(ClassProgressBar);
 
-it('renders progress bar with animated value', () => {
+it('renders progress bar with animated value', async () => {
   const tree = render(<AnimatedProgressBar animatedValue={0.2} />);
-
-  const props = tree.getByRole(a11Role).props;
-  props.onLayout(layoutEvent);
+  await waitFor(() => tree.getByRole(a11yRole).props.onLayout(layoutEvent));
 
   tree.update(<AnimatedProgressBar animatedValue={0.4} />);
 
   expect(tree.container.props['animatedValue']).toBe(0.4);
 });
 
-it('renders progress bar with specific progress', () => {
+it('renders progress bar with specific progress', async () => {
   const tree = render(<ProgressBar progress={0.2} />);
-  tree.getByRole(a11Role).props.onLayout(layoutEvent);
+  await waitFor(() => tree.getByRole(a11yRole).props.onLayout(layoutEvent));
 
   expect(tree.toJSON()).toMatchSnapshot();
 });
 
-it('renders hidden progress bar', () => {
+it('renders hidden progress bar', async () => {
   const tree = render(<ProgressBar progress={0.2} visible={false} />);
-  tree.getByRole(a11Role).props.onLayout(layoutEvent);
+  await waitFor(() => tree.getByRole(a11yRole).props.onLayout(layoutEvent));
 
   expect(tree.toJSON()).toMatchSnapshot();
 });
 
-it('renders colored progress bar', () => {
+it('renders colored progress bar', async () => {
   const tree = render(<ProgressBar progress={0.2} color="red" />);
-  tree.getByRole(a11Role).props.onLayout(layoutEvent);
+  await waitFor(() => tree.getByRole(a11yRole).props.onLayout(layoutEvent));
 
   expect(tree.toJSON()).toMatchSnapshot();
 });
 
-it('renders indeterminate progress bar', () => {
+it('renders indeterminate progress bar', async () => {
   const tree = render(<ProgressBar indeterminate />);
-  tree.getByRole(a11Role).props.onLayout(layoutEvent);
+  await waitFor(() => tree.getByRole(a11yRole).props.onLayout(layoutEvent));
 
   expect(tree.toJSON()).toMatchSnapshot();
 });


### PR DESCRIPTION
### Summary

As an addition to https://github.com/callstack/react-native-paper/pull/3583 this PR fixes suppressed `exhaustive deps` errors in:  ProgressBar, Banner, Modal


### Test plan

There should be no functional changes at all after this refactor. Added unit tests to check for regression where applicable.

### Notes

After https://github.com/callstack/react-native-paper/pull/3583 gets merged there will be some conflicts which I'll happily resolve.
