### PR TITLE
TextInput: add `cursorColor` to RenderProps types

### DIFF
--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -20,6 +20,7 @@ export type RenderProps = {
   placeholderTextColor?: ColorValue;
   editable?: boolean;
   selectionColor?: string;
+  cursorColor?: string;
   onFocus?: (args: any) => void;
   onBlur?: (args: any) => void;
   underlineColorAndroid?: string;


### PR DESCRIPTION
### Summary

This PR adds support for the recently introduced `cursorColor` feature https://reactnative.dev/docs/0.70/textinput#cursorcolor-android

Fixes #3611 