### PR TITLE
fix: adjust label and icon props optionality

### DIFF
--- a/src/components/FAB/AnimatedFAB.tsx
+++ b/src/components/FAB/AnimatedFAB.tsx
@@ -91,7 +91,7 @@ export type Props = $RemoveChildren<typeof Surface> & {
    */
   extended: boolean;
   /**
-   * @supported Available in v3.x with theme version 3
+   * @supported Available in v5.x with theme version 3
    *
    * Color mappings variant for combinations of container and icon colors.
    */

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -23,13 +23,25 @@ type FABSize = 'small' | 'medium' | 'large';
 
 type FABMode = 'flat' | 'elevated';
 
+type IconOrLabel =
+  | {
+      icon: IconSource;
+      label?: string;
+    }
+  | {
+      icon?: IconSource;
+      label: string;
+    };
+
 export type Props = $RemoveChildren<typeof Surface> & {
+  // For `icon` and `label` props their types are duplicated due to the generation of documentation.
+  // Appropriate type for them is `IconOrLabel` contains the both union and intersection types.
   /**
-   * Icon to display for the `FAB`.
+   * Icon to display for the `FAB`. It's optional only if `label` is defined.
    */
-  icon: IconSource;
+  icon?: IconSource;
   /**
-   * Optional label for extended `FAB`.
+   * Optional label for extended `FAB`. It's optional only if `icon` is defined.
    */
   label?: string;
   /**
@@ -117,7 +129,7 @@ export type Props = $RemoveChildren<typeof Surface> & {
   theme?: ThemeProp;
   testID?: string;
   ref?: React.RefObject<View>;
-};
+} & IconOrLabel;
 
 /**
  * A floating action button represents the primary action in an application.


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary


PR adjust types in `FAB` component to make one of `icon` or `label` props optional if one of them is currently defined, however, both mustn't be undefined at the same time.

#### Related issue

- #3594 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

N/A

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
