### PR TITLE
fix: android elevation issue

### DIFF
--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -602,6 +602,7 @@ const BottomNavigation = ({
     }
 
     if (index !== navigationState.index) {
+      prevNavigationState.current = navigationState;
       onIndexChange(index);
     }
   };
@@ -612,6 +613,7 @@ const BottomNavigation = ({
         (route) => route.key === key
       );
 
+      prevNavigationState.current = navigationState;
       onIndexChange(index);
     },
     [navigationState.routes, onIndexChange]
@@ -690,6 +692,12 @@ const BottomNavigation = ({
           }
 
           const focused = navigationState.index === index;
+          const previouslyFocused =
+            prevNavigationState.current?.index === index;
+          const countAlphaOffscreen =
+            sceneAnimationEnabled && (focused || previouslyFocused);
+          const renderToHardwareTextureAndroid =
+            sceneAnimationEnabled && focused;
 
           const opacity = sceneAnimationEnabled
             ? tabsPositionAnims[index].interpolate({
@@ -739,9 +747,9 @@ const BottomNavigation = ({
             >
               <Animated.View
                 {...(Platform.OS === 'android' && {
-                  needsOffscreenAlphaCompositing: sceneAnimationEnabled,
+                  needsOffscreenAlphaCompositing: countAlphaOffscreen,
                 })}
-                renderToHardwareTextureAndroid={sceneAnimationEnabled}
+                renderToHardwareTextureAndroid={renderToHardwareTextureAndroid}
                 style={[
                   styles.content,
                   {


### PR DESCRIPTION
### Summary

In regards to https://github.com/callstack/react-native-paper/issues/3467 this seems to fix the issue. 

This seems to be an issue on how `renderToHardwareTextureAndroid` handles off-screen components. For some reason, upon navigation, we try to animate all previously visited screens - even the ones not visible at all. That's where the bug happens. We can mitigate it by allowing `renderToHardwareTextureAndroid` only on the focused screen.

Not sure if that's the proper way to address the issue so I'll be grateful for any feedback.

### Test plan

The owner provided a repo to reproduce the issue: https://github.com/iM-GeeKy/shadows-bug
