### PR TITLE
fix: `AnimatedFAB['style']` type

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@types/react-dom": "^18.0.8",
     "@types/react-native": "^0.70.6",
     "@types/react-native-vector-icons": "^6.4.1",
+    "@types/react-test-renderer": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",
     "all-contributors-cli": "^6.24.0",
@@ -99,8 +100,8 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-vector-icons": "*",
-    "react-native-safe-area-context": "*"
+    "react-native-safe-area-context": "*",
+    "react-native-vector-icons": "*"
   },
   "husky": {
     "hooks": {

--- a/src/components/FAB/AnimatedFAB.tsx
+++ b/src/components/FAB/AnimatedFAB.tsx
@@ -96,7 +96,7 @@ export type Props = $RemoveChildren<typeof Surface> & {
    * Color mappings variant for combinations of container and icon colors.
    */
   variant?: 'primary' | 'secondary' | 'tertiary' | 'surface';
-  style?: StyleProp<ViewStyle>;
+  style?: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
   /**
    * @optional
    */

--- a/src/components/__tests__/AnimatedFAB.test.tsx
+++ b/src/components/__tests__/AnimatedFAB.test.tsx
@@ -1,5 +1,7 @@
+/// <reference types="@testing-library/jest-native" />
+
 import * as React from 'react';
-import { StyleSheet } from 'react-native';
+import { Animated, StyleSheet } from 'react-native';
 
 import { render } from '@testing-library/react-native';
 import renderer from 'react-test-renderer';
@@ -15,7 +17,9 @@ const styles = StyleSheet.create({
 
 it('renders animated fab', () => {
   const tree = renderer
-    .create(<AnimatedFAB onPress={() => {}} icon="plus" />)
+    .create(
+      <AnimatedFAB onPress={() => {}} label="" extended={false} icon="plus" />
+    )
     .toJSON();
 
   expect(tree).toMatchSnapshot();
@@ -55,10 +59,39 @@ it('renders animated fab with only transparent container', () => {
       onPress={() => {}}
       icon="plus"
       testID="animated-fab"
+      extended={false}
       style={styles.background}
     />
   );
   expect(getByTestId('animated-fab-container')).toHaveStyle({
     backgroundColor: 'transparent',
+  });
+});
+
+it('renders animated fab with animated style', () => {
+  const value = new Animated.Value(1);
+  const { getByTestId } = render(
+    <AnimatedFAB
+      label="text"
+      icon="plus"
+      testID="animated-fab"
+      extended={false}
+      style={[{ transform: [{ scale: value }] }]}
+    />
+  );
+  expect(getByTestId('animated-fab-container')).toHaveStyle({
+    transform: [{ scale: 1 }],
+  });
+
+  Animated.timing(value, {
+    toValue: 1.5,
+    useNativeDriver: false,
+    duration: 200,
+  }).start();
+
+  jest.advanceTimersByTime(200);
+
+  expect(getByTestId('animated-fab-container')).toHaveStyle({
+    transform: [{ scale: 1.5 }],
   });
 });

--- a/src/components/__tests__/__snapshots__/AnimatedFAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/AnimatedFAB.test.tsx.snap
@@ -148,6 +148,7 @@ exports[`renders animated fab 1`] = `
             }
           >
             <View
+              accessibilityLabel=""
               accessibilityRole="button"
               accessibilityState={
                 Object {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig",
-  "exclude": ["example"]
+  "exclude": ["example", "**/__tests__/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2896,6 +2896,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@^18.0.0":
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-18.0.0.tgz#7b7f69ca98821ea5501b21ba24ea7b6139da2243"
+  integrity sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*":
   version "18.0.24"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.24.tgz#2f79ed5b27f08d05107aab45c17919754cc44c20"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Related to #3618

`AnimatedFAB['style']` didn't accept `Animated.Value`.
The props are [already an intersection](https://github.com/callstack/react-native-paper/blob/2854b639ffbe140233d08741857708d47195ffb6/src/components/FAB/AnimatedFAB.tsx#L35) of the `Surface` props [which have a correct style type](https://github.com/callstack/react-native-paper/blob/2854b639ffbe140233d08741857708d47195ffb6/src/components/Surface.tsx#L21). ~~The fix was deleting 1 line, deleting the style prop defined in `AnimatedFAB.tsx`: https://github.com/callstack/react-native-paper/commit/3cfdda0c437a55e7c9565773b159e3b9279d9151#diff-975af6e6afe37f64a68ad2557bf0169e45a531c77b0ba2528bbaab8db736db33L99~~
Copied Surface `Props['style']` type due to docs generation [as discussed](#pullrequestreview-1268992712)

### Test plan

Converted `AnimatedFAB.test.js` to TypeScript and wrote a simple test. `yarn typescript` will fail if we revert the changes in `AnimatedFAB.tsx`.
<img width="918" alt="image" src="https://user-images.githubusercontent.com/8790386/214526042-a18e1ae9-8424-4aad-b7f1-a37317774355.png">
