### PR TITLE
chore: show library version in drawer in example app

### DIFF
--- a/example/babel.config.js
+++ b/example/babel.config.js
@@ -13,6 +13,11 @@ module.exports = function (api) {
         {
           extensions: ['.tsx', '.ts', '.js', '.json'],
           alias: {
+            [`${pak.name}/package.json`]: path.join(
+              __dirname,
+              '..',
+              'package.json'
+            ),
             // For development, we want to alias the library to the source
             [pak.name]: path.join(__dirname, '..', pak.source),
           },

--- a/example/src/DrawerItems.tsx
+++ b/example/src/DrawerItems.tsx
@@ -228,6 +228,10 @@ const DrawerItems = ({
               * - available only for MD3
             </Text>
           )}
+          <Text variant="bodySmall" style={styles.annotation}>
+            React Native Paper Version{' '}
+            {require('react-native-paper/package.json').version}
+          </Text>
         </>
       )}
     </DrawerContentScrollView>
@@ -257,6 +261,7 @@ const styles = StyleSheet.create({
   },
   annotation: {
     marginHorizontal: 24,
+    marginVertical: 6,
   },
 });
 


### PR DESCRIPTION

### Summary

|Android|iOS|
|-|-|
|<img width="489" alt="image" src="https://user-images.githubusercontent.com/8790386/216077340-1f4766cc-90d9-48e6-b30e-049735126d6a.png">|<img width="498" alt="image" src="https://user-images.githubusercontent.com/8790386/216077785-96b6b3af-02e1-4e39-b05c-2a31cc8e4c4f.png">|


### Test plan

Version is visible in drawer in example app