### PR TITLE
feat: allow override of custom theme animation

### DIFF
--- a/src/core/Provider.tsx
+++ b/src/core/Provider.tsx
@@ -86,6 +86,7 @@ const Provider = (props: Props) => {
       ...props.theme,
       version: themeVersion,
       animation: {
+        ...props.theme?.animation,
         scale: reduceMotionEnabled ? 0 : 1,
       },
     };

--- a/src/core/__tests__/Provider.test.js
+++ b/src/core/__tests__/Provider.test.js
@@ -96,6 +96,20 @@ describe('Provider', () => {
     );
   });
 
+  it('handles overriding animation with the custom one', () => {
+    const { getByTestId } = render(
+      createProvider({
+        ...MD3LightTheme,
+        animation: { defaultAnimationDuration: 250 },
+      })
+    );
+
+    expect(getByTestId('provider-child-view').props.theme).toStrictEqual({
+      ...MD3LightTheme,
+      animation: { scale: 1, defaultAnimationDuration: 250 },
+    });
+  });
+
   it('should set AccessibilityInfo listeners, if there is no theme', async () => {
     mockAppearance();
     mockAccessibilityInfo();


### PR DESCRIPTION
### Summary

This pull request wants to allow an override of the animation field of the default theme.
Before it was possible now not anymore.
