### PR TITLE
fix: custom input styling in TextInput (#3648)

### DIFF
--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -537,7 +537,7 @@ const TextInputExample = () => {
             mode="flat"
             style={styles.inputContainerStyle}
             label="Custom style input"
-            placeholder="Input with custom padding"
+            placeholder="Input with custom style"
             value={customStyleText}
             onChangeText={(customStyleText) =>
               inputActionHandler('customStyleText', customStyleText)
@@ -628,6 +628,8 @@ const styles = StyleSheet.create({
   },
   inputContentStyle: {
     paddingLeft: 50,
+    fontWeight: 'bold',
+    fontStyle: 'italic',
   },
   fontSize: {
     fontSize: 32,

--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -29,7 +29,6 @@ const InputLabel = (props: InputLabelProps) => {
     labelTranslationXOffset,
     maxFontSizeMultiplier,
     testID,
-    contentStyle,
     theme,
   } = props.labelProps;
 
@@ -50,10 +49,12 @@ const InputLabel = (props: InputLabelProps) => {
     fontSize,
     lineHeight,
     fontWeight,
-    opacity: parentState.labeled.interpolate({
-      inputRange: [0, 1],
-      outputRange: [hasActiveOutline ? 1 : 0, 0],
-    }),
+    opacity: hasActiveOutline
+      ? parentState.labeled.interpolate({
+          inputRange: [0, 1],
+          outputRange: [1, 0],
+        })
+      : 0,
     transform: [
       {
         // Wiggle the label when there's an error
@@ -148,7 +149,6 @@ const InputLabel = (props: InputLabelProps) => {
             color: textColor,
             opacity: placeholderOpacity,
           },
-          contentStyle,
         ]}
         numberOfLines={1}
         maxFontSizeMultiplier={maxFontSizeMultiplier}

--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -50,12 +50,10 @@ const InputLabel = (props: InputLabelProps) => {
     fontSize,
     lineHeight,
     fontWeight,
-    opacity: hasActiveOutline
-      ? parentState.labeled.interpolate({
-          inputRange: [0, 1],
-          outputRange: [1, 0],
-        })
-      : 0,
+    opacity: parentState.labeled.interpolate({
+      inputRange: [0, 1],
+      outputRange: [hasActiveOutline ? 1 : 0, 0],
+    }),
     transform: [
       {
         // Wiggle the label when there's an error

--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -50,10 +50,12 @@ const InputLabel = (props: InputLabelProps) => {
     fontSize,
     lineHeight,
     fontWeight,
-    opacity: parentState.labeled.interpolate({
-      inputRange: [0, 1],
-      outputRange: [hasActiveOutline ? 1 : 0, 0],
-    }),
+    opacity: hasActiveOutline
+      ? parentState.labeled.interpolate({
+          inputRange: [0, 1],
+          outputRange: [1, 0],
+        })
+      : 0,
     transform: [
       {
         // Wiggle the label when there's an error

--- a/src/components/TextInput/Label/LabelBackground.tsx
+++ b/src/components/TextInput/Label/LabelBackground.tsx
@@ -11,7 +11,6 @@ const LabelBackground = ({
     placeholderStyle,
     baseLabelTranslateX,
     topPosition,
-    hasActiveOutline,
     label,
     backgroundColor,
     roundness,
@@ -20,13 +19,10 @@ const LabelBackground = ({
   maxFontSizeMultiplier,
   theme: themeOverrides,
 }: LabelBackgroundProps) => {
-  const hasFocus = hasActiveOutline || parentState.value;
-  const opacity = hasFocus
-    ? parentState.labeled.interpolate({
-        inputRange: [0, 1],
-        outputRange: [1, 0],
-      })
-    : 0;
+  const opacity = parentState.labeled.interpolate({
+    inputRange: [0, 0.6],
+    outputRange: [1, 0],
+  });
 
   const { isV3 } = useInternalTheme(themeOverrides);
 

--- a/src/components/TextInput/Label/LabelBackground.tsx
+++ b/src/components/TextInput/Label/LabelBackground.tsx
@@ -11,6 +11,7 @@ const LabelBackground = ({
     placeholderStyle,
     baseLabelTranslateX,
     topPosition,
+    hasActiveOutline,
     label,
     backgroundColor,
     roundness,
@@ -19,10 +20,13 @@ const LabelBackground = ({
   maxFontSizeMultiplier,
   theme: themeOverrides,
 }: LabelBackgroundProps) => {
-  const opacity = parentState.labeled.interpolate({
-    inputRange: [0, 0.6],
-    outputRange: [1, 0],
-  });
+  const hasFocus = hasActiveOutline || parentState.value;
+  const opacity = hasFocus
+    ? parentState.labeled.interpolate({
+        inputRange: [0, 1],
+        outputRange: [1, 0],
+      })
+    : 0;
 
   const { isV3 } = useInternalTheme(themeOverrides);
 

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -345,7 +345,6 @@ const TextInput = forwardRef<TextInputHandles, Props>(
         // Root cause:    Placeholder initial value, which has length 0.
         // More context:  The issue was also reproduced in react-native, using its own TextInput.
         // Workaround:    Set an empty space character in the default value.
-
         setPlaceholder(' ');
       }
 

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -744,7 +744,7 @@ exports[`correctly applies paddingLeft from contentStyleProp 1`] = `
             "letterSpacing": 0.15,
             "lineHeight": undefined,
             "opacity": 0,
-            "paddingLeft": 20,
+            "paddingLeft": 16,
             "paddingRight": 16,
             "position": "absolute",
             "textAlign": "left",


### PR DESCRIPTION
### Summary

Based on work started in https://github.com/callstack/react-native-paper/pull/3642 fixes https://github.com/callstack/react-native-paper/issues/3648

Please note that this branch is based of the refactor branch, so if the other goes into `main` first, the target here should be updated to `main` as well.

### Test plan

The app should now behave as presented:

https://user-images.githubusercontent.com/7429558/216358415-f9909a7f-9870-41b3-967c-473f5ad24cd1.mov


