### PR TITLE
fix: custom Button styles nested in Card.Actions

### DIFF
--- a/example/src/Examples/CardExample.tsx
+++ b/example/src/Examples/CardExample.tsx
@@ -106,6 +106,20 @@ const CardExample = () => {
         </Card>
         <Card style={styles.card} mode={selectedMode}>
           <Card.Cover
+            source={require('../../assets/images/restaurant-1.jpg')}
+          />
+          <Card.Title title="Custom Button styles" />
+          <Card.Actions>
+            <Button style={styles.button} onPress={() => {}}>
+              Share
+            </Button>
+            <Button style={styles.button} onPress={() => {}}>
+              Explore
+            </Button>
+          </Card.Actions>
+        </Card>
+        <Card style={styles.card} mode={selectedMode}>
+          <Card.Cover
             source={require('../../assets/images/strawberries.jpg')}
           />
           <Card.Title
@@ -200,6 +214,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     paddingVertical: 12,
     paddingHorizontal: 8,
+  },
+  button: {
+    borderRadius: 12,
   },
 });
 

--- a/src/components/Card/CardActions.tsx
+++ b/src/components/Card/CardActions.tsx
@@ -56,7 +56,7 @@ const CardActions = (props: Props) => {
               mode:
                 child.props.mode ||
                 (isV3 && (i === 0 ? 'outlined' : 'contained')),
-              style: isV3 && styles.button,
+              style: [isV3 && styles.button, child.props.style],
             })
           : child;
       })}

--- a/src/components/__tests__/Card/Card.test.tsx
+++ b/src/components/__tests__/Card/Card.test.tsx
@@ -89,6 +89,26 @@ describe('CardActions', () => {
       'contained'
     );
   });
+
+  it('renders button with custom styles', () => {
+    const { getByTestId } = render(
+      <Card>
+        <Card.Actions>
+          <Button
+            testID="card-actions-button"
+            mode="contained"
+            style={styles.customBorderRadius}
+          >
+            Agree
+          </Button>
+        </Card.Actions>
+      </Card>
+    );
+
+    expect(getByTestId('card-actions-button')).toHaveStyle({
+      borderRadius: 32,
+    });
+  });
 });
 
 describe('getCardColors - background color', () => {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: #3633 

### Summary

PR fixes the possibility to pass custom `Button`'s styles when it's wrapped within the `Card.Actions`

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

#### Related issue

- #3633 

### Test plan

Added unit test and additional example in the demo app.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
