### PR TITLE
fix: passing flex to the shared and inner layer Surface styles

### DIFF
--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -113,7 +113,7 @@ const Surface = forwardRef<View, Props>(
       children,
       theme: overridenTheme,
       style,
-      testID,
+      testID = 'surface',
       ...props
     }: Props,
     ref
@@ -228,6 +228,7 @@ const Surface = forwardRef<View, Props>(
       bottom,
       start,
       end,
+      flex,
       ...restStyle
     } = (StyleSheet.flatten(style) || {}) as ViewStyle;
 
@@ -241,7 +242,12 @@ const Surface = forwardRef<View, Props>(
       start,
       end,
     };
-    const sharedStyle = [{ backgroundColor }, restStyle];
+
+    const sharedStyle = [{ backgroundColor, flex }, restStyle];
+
+    const innerLayerViewStyles = [{ flex }];
+
+    const outerLayerViewStyles = [absoluteStyles, innerLayerViewStyles];
 
     if (isAnimatedValue(elevation)) {
       const inputRange = [0, 1, 2, 3, 4, 5];
@@ -270,9 +276,13 @@ const Surface = forwardRef<View, Props>(
 
       return (
         <Animated.View
-          style={[getStyleForAnimatedShadowLayer(0), absoluteStyles]}
+          style={[getStyleForAnimatedShadowLayer(0), outerLayerViewStyles]}
+          testID={`${testID}-outer-layer`}
         >
-          <Animated.View style={getStyleForAnimatedShadowLayer(1)}>
+          <Animated.View
+            style={[getStyleForAnimatedShadowLayer(1), innerLayerViewStyles]}
+            testID={`${testID}-inner-layer`}
+          >
             <Animated.View {...props} testID={testID} style={sharedStyle}>
               {children}
             </Animated.View>
@@ -298,9 +308,13 @@ const Surface = forwardRef<View, Props>(
     return (
       <Animated.View
         ref={ref}
-        style={[getStyleForShadowLayer(0), absoluteStyles]}
+        style={[getStyleForShadowLayer(0), outerLayerViewStyles]}
+        testID={`${testID}-outer-layer`}
       >
-        <Animated.View style={getStyleForShadowLayer(1)}>
+        <Animated.View
+          style={[getStyleForShadowLayer(1), innerLayerViewStyles]}
+          testID={`${testID}-inner-layer`}
+        >
           <Animated.View {...props} testID={testID} style={sharedStyle}>
             {children}
           </Animated.View>

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -22,11 +23,13 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
       "top": undefined,
     }
   }
+  testID="surface-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -36,6 +39,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="surface-inner-layer"
   >
     <View
       collapsable={false}
@@ -43,6 +47,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
         Object {
           "alignItems": "center",
           "backgroundColor": "rgba(255, 251, 254, 1)",
+          "flex": undefined,
           "flexDirection": "row",
           "height": 64,
           "paddingBottom": undefined,
@@ -52,6 +57,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
           "paddingTop": undefined,
         }
       }
+      testID="surface"
     >
       <View
         collapsable={false}
@@ -60,6 +66,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
             "alignSelf": undefined,
             "bottom": undefined,
             "end": undefined,
+            "flex": undefined,
             "left": undefined,
             "position": undefined,
             "right": undefined,
@@ -74,11 +81,13 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
             "top": undefined,
           }
         }
+        testID="search-bar-container-outer-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
+              "flex": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 1,
@@ -88,6 +97,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
               "shadowRadius": 1,
             }
           }
+          testID="search-bar-container-inner-layer"
         >
           <View
             collapsable={false}
@@ -96,6 +106,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                 "alignItems": "center",
                 "backgroundColor": "rgb(247, 243, 249)",
                 "borderRadius": 4,
+                "flex": undefined,
                 "flexDirection": "row",
               }
             }
@@ -108,6 +119,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                   "alignSelf": undefined,
                   "bottom": undefined,
                   "end": undefined,
+                  "flex": undefined,
                   "left": undefined,
                   "position": undefined,
                   "right": undefined,
@@ -122,11 +134,13 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                   "top": undefined,
                 }
               }
+              testID="icon-button-container-outer-layer"
             >
               <View
                 collapsable={false}
                 style={
                   Object {
+                    "flex": undefined,
                     "shadowColor": "#000",
                     "shadowOffset": Object {
                       "height": 0,
@@ -136,6 +150,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                     "shadowRadius": 0,
                   }
                 }
+                testID="icon-button-container-inner-layer"
               >
                 <View
                   collapsable={false}
@@ -146,6 +161,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                       "borderRadius": 20,
                       "borderWidth": 0,
                       "elevation": 0,
+                      "flex": undefined,
                       "height": 40,
                       "margin": 6,
                       "overflow": "hidden",
@@ -286,6 +302,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                     "alignSelf": undefined,
                     "bottom": undefined,
                     "end": undefined,
+                    "flex": undefined,
                     "left": undefined,
                     "position": undefined,
                     "right": undefined,
@@ -300,11 +317,13 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                     "top": undefined,
                   }
                 }
+                testID="icon-button-container-outer-layer"
               >
                 <View
                   collapsable={false}
                   style={
                     Object {
+                      "flex": undefined,
                       "shadowColor": "#000",
                       "shadowOffset": Object {
                         "height": 0,
@@ -314,6 +333,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                       "shadowRadius": 0,
                     }
                   }
+                  testID="icon-button-container-inner-layer"
                 >
                   <View
                     collapsable={false}
@@ -324,6 +344,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                         "borderRadius": 20,
                         "borderWidth": 0,
                         "elevation": 0,
+                        "flex": undefined,
                         "height": 40,
                         "margin": 6,
                         "overflow": "hidden",
@@ -440,6 +461,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -454,11 +476,13 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
       "top": undefined,
     }
   }
+  testID="surface-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -468,6 +492,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
         "shadowRadius": 0,
       }
     }
+    testID="surface-inner-layer"
   >
     <View
       collapsable={false}
@@ -475,6 +500,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
         Object {
           "alignItems": "center",
           "backgroundColor": "rgba(255, 251, 254, 1)",
+          "flex": undefined,
           "flexDirection": "row",
           "height": 64,
           "paddingBottom": undefined,
@@ -484,6 +510,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
           "paddingTop": undefined,
         }
       }
+      testID="surface"
     >
       <View
         collapsable={false}
@@ -492,6 +519,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             "alignSelf": undefined,
             "bottom": undefined,
             "end": undefined,
+            "flex": undefined,
             "left": undefined,
             "position": undefined,
             "right": undefined,
@@ -506,11 +534,13 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             "top": undefined,
           }
         }
+        testID="icon-button-container-outer-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
+              "flex": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -520,6 +550,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
               "shadowRadius": 0,
             }
           }
+          testID="icon-button-container-inner-layer"
         >
           <View
             collapsable={false}
@@ -530,6 +561,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
                 "borderRadius": 20,
                 "borderWidth": 0,
                 "elevation": 0,
+                "flex": undefined,
                 "height": 40,
                 "margin": 6,
                 "overflow": "hidden",
@@ -748,6 +780,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             "alignSelf": undefined,
             "bottom": undefined,
             "end": undefined,
+            "flex": undefined,
             "left": undefined,
             "position": undefined,
             "right": undefined,
@@ -762,11 +795,13 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             "top": undefined,
           }
         }
+        testID="icon-button-container-outer-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
+              "flex": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -776,6 +811,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
               "shadowRadius": 0,
             }
           }
+          testID="icon-button-container-inner-layer"
         >
           <View
             collapsable={false}
@@ -786,6 +822,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
                 "borderRadius": 20,
                 "borderWidth": 0,
                 "elevation": 0,
+                "flex": undefined,
                 "height": 40,
                 "margin": 6,
                 "overflow": "hidden",

--- a/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`Card renders an outlined card 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -22,11 +23,13 @@ exports[`Card renders an outlined card 1`] = `
       "top": undefined,
     }
   }
+  testID="card-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -36,6 +39,7 @@ exports[`Card renders an outlined card 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="card-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -44,6 +48,7 @@ exports[`Card renders an outlined card 1`] = `
           "backgroundColor": "rgba(255, 251, 254, 1)",
           "borderRadius": 12,
           "elevation": 1,
+          "flex": undefined,
         }
       }
       testID="card-container"

--- a/src/components/__tests__/Surface.test.js
+++ b/src/components/__tests__/Surface.test.js
@@ -17,7 +17,7 @@ describe('Surface', () => {
 
   describe('on iOS', () => {
     Platform.OS = 'ios';
-    const style = StyleSheet.create({
+    const styles = StyleSheet.create({
       absoluteStyles: {
         bottom: 10,
         end: 20,
@@ -28,40 +28,95 @@ describe('Surface', () => {
         top: 60,
         flex: 1,
       },
+      innerLayerViewStyle: {
+        flex: 1,
+      },
+      restStyle: {
+        padding: 10,
+        flexDirection: 'row',
+        alignContent: 'center',
+      },
     });
 
-    it('should not render absolute position properties on the bottom layer', () => {
-      const testID = 'surface-test-bottom-layer';
+    describe('outer layer', () => {
+      it('should not render rest style', () => {
+        const testID = 'surface-test';
 
-      const { getByTestId } = render(
-        <Surface testID={testID} style={style.absoluteStyles} />
-      );
+        const { getByTestId } = render(
+          <Surface testID={testID} style={styles.restStyle} />
+        );
 
-      expect(getByTestId(testID).props.style).toHaveProperty('flex');
-      expect(getByTestId(testID).props.style).toHaveProperty('backgroundColor');
-      expect(getByTestId(testID).props.style).not.toHaveProperty('bottom');
-      expect(getByTestId(testID).props.style).not.toHaveProperty('end');
-      expect(getByTestId(testID).props.style).not.toHaveProperty('left');
-      expect(getByTestId(testID).props.style).not.toHaveProperty('position');
-      expect(getByTestId(testID).props.style).not.toHaveProperty('right');
-      expect(getByTestId(testID).props.style).not.toHaveProperty('start');
-      expect(getByTestId(testID).props.style).not.toHaveProperty('top');
+        expect(getByTestId(`${testID}-outer-layer`)).not.toHaveStyle(
+          styles.restStyle
+        );
+      });
+
+      it('should render absolute position properties on outer layer', () => {
+        const testID = 'surface-test';
+
+        const { getByTestId } = render(
+          <Surface testID={testID} style={styles.absoluteStyles} />
+        );
+
+        expect(getByTestId(`${testID}-outer-layer`)).toHaveStyle(
+          styles.absoluteStyles
+        );
+      });
+
+      it('should render inner layer styles on outer layer', () => {
+        const testID = 'surface-test';
+
+        const { getByTestId } = render(
+          <Surface testID={testID} style={styles.innerLayerViewStyle} />
+        );
+
+        expect(getByTestId(`${testID}-outer-layer`)).toHaveStyle(
+          styles.innerLayerViewStyle
+        );
+      });
     });
 
-    it('should render absolute position properties on shadow layer 0', () => {
-      const testID = 'surface-test-shadow-layer-0';
+    describe('inner layer', () => {
+      it('should not render absolute position properties on the inner layer', () => {
+        const testID = 'surface-test';
 
-      const { container } = render(
-        <Surface testID={testID} style={style.absoluteStyles} />
-      );
+        const { getByTestId } = render(
+          <Surface testID={testID} style={styles.absoluteStyles} />
+        );
 
-      expect(container.props.style).toHaveProperty('bottom');
-      expect(container.props.style).toHaveProperty('end');
-      expect(container.props.style).toHaveProperty('left');
-      expect(container.props.style).toHaveProperty('position');
-      expect(container.props.style).toHaveProperty('right');
-      expect(container.props.style).toHaveProperty('start');
-      expect(container.props.style).toHaveProperty('top');
+        expect(getByTestId(`${testID}-inner-layer`)).not.toHaveStyle(
+          styles.absoluteStyles
+        );
+      });
+
+      it('should render inner layer styles on the inner layer', () => {
+        const testID = 'surface-test';
+
+        const { getByTestId } = render(
+          <Surface testID={testID} style={styles.innerLayerViewStyle} />
+        );
+
+        expect(getByTestId(`${testID}-inner-layer`)).toHaveStyle(
+          styles.innerLayerViewStyle
+        );
+      });
+    });
+
+    describe('children wrapper', () => {
+      it('should render rest styles', () => {
+        const testID = 'surface-test';
+        const combinedStyles = [
+          styles.backgroundColor,
+          styles.innerLayerViewStyle,
+          styles.restStyle,
+        ];
+
+        const { getByTestId } = render(
+          <Surface testID={testID} style={combinedStyles} />
+        );
+
+        expect(getByTestId(testID)).toHaveStyle(combinedStyles);
+      });
     });
   });
 });

--- a/src/components/__tests__/__snapshots__/AnimatedFAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/AnimatedFAB.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`renders animated fab 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": "absolute",
       "right": undefined,
@@ -22,11 +23,13 @@ exports[`renders animated fab 1`] = `
       "top": undefined,
     }
   }
+  testID="animated-fab-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -36,6 +39,7 @@ exports[`renders animated fab 1`] = `
         "shadowRadius": 3,
       }
     }
+    testID="animated-fab-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -43,6 +47,7 @@ exports[`renders animated fab 1`] = `
         Object {
           "backgroundColor": "transparent",
           "borderRadius": 16,
+          "flex": undefined,
           "opacity": 1,
           "transform": Array [
             Object {
@@ -300,6 +305,7 @@ exports[`renders animated fab with label on the left 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": "absolute",
       "right": undefined,
@@ -314,11 +320,13 @@ exports[`renders animated fab with label on the left 1`] = `
       "top": undefined,
     }
   }
+  testID="animated-fab-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -328,6 +336,7 @@ exports[`renders animated fab with label on the left 1`] = `
         "shadowRadius": 3,
       }
     }
+    testID="animated-fab-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -335,6 +344,7 @@ exports[`renders animated fab with label on the left 1`] = `
         Object {
           "backgroundColor": "transparent",
           "borderRadius": 16,
+          "flex": undefined,
           "opacity": 1,
           "transform": Array [
             Object {
@@ -594,6 +604,7 @@ exports[`renders animated fab with label on the right by default 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": "absolute",
       "right": undefined,
@@ -608,11 +619,13 @@ exports[`renders animated fab with label on the right by default 1`] = `
       "top": undefined,
     }
   }
+  testID="animated-fab-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -622,6 +635,7 @@ exports[`renders animated fab with label on the right by default 1`] = `
         "shadowRadius": 3,
       }
     }
+    testID="animated-fab-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -629,6 +643,7 @@ exports[`renders animated fab with label on the right by default 1`] = `
         Object {
           "backgroundColor": "transparent",
           "borderRadius": 16,
+          "flex": undefined,
           "opacity": 1,
           "transform": Array [
             Object {

--- a/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`render visible banner, with custom theme 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -22,11 +23,13 @@ exports[`render visible banner, with custom theme 1`] = `
       "top": undefined,
     }
   }
+  testID="surface-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -36,14 +39,17 @@ exports[`render visible banner, with custom theme 1`] = `
         "shadowRadius": 1,
       }
     }
+    testID="surface-inner-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
           "backgroundColor": "rgb(247, 243, 249)",
+          "flex": undefined,
         }
       }
+      testID="surface"
     >
       <View
         style={
@@ -130,6 +136,7 @@ exports[`render visible banner, with custom theme 1`] = `
                   "alignSelf": undefined,
                   "bottom": undefined,
                   "end": undefined,
+                  "flex": undefined,
                   "left": undefined,
                   "position": undefined,
                   "right": undefined,
@@ -144,11 +151,13 @@ exports[`render visible banner, with custom theme 1`] = `
                   "top": undefined,
                 }
               }
+              testID="button-container-outer-layer"
             >
               <View
                 collapsable={false}
                 style={
                   Object {
+                    "flex": undefined,
                     "shadowColor": "#000",
                     "shadowOffset": Object {
                       "height": 0,
@@ -158,6 +167,7 @@ exports[`render visible banner, with custom theme 1`] = `
                     "shadowRadius": 0,
                   }
                 }
+                testID="button-container-inner-layer"
               >
                 <View
                   collapsable={false}
@@ -168,6 +178,7 @@ exports[`render visible banner, with custom theme 1`] = `
                       "borderRadius": 20,
                       "borderStyle": "solid",
                       "borderWidth": 0,
+                      "flex": undefined,
                       "margin": 4,
                       "minWidth": "auto",
                     }
@@ -288,6 +299,7 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -302,11 +314,13 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
       "top": undefined,
     }
   }
+  testID="surface-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -316,14 +330,17 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
         "shadowRadius": 1,
       }
     }
+    testID="surface-inner-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
           "backgroundColor": "rgb(247, 243, 249)",
+          "flex": undefined,
         }
       }
+      testID="surface"
     >
       <View
         style={
@@ -430,6 +447,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -444,11 +462,13 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
       "top": undefined,
     }
   }
+  testID="surface-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -458,14 +478,17 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
         "shadowRadius": 1,
       }
     }
+    testID="surface-inner-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
           "backgroundColor": "rgb(247, 243, 249)",
+          "flex": undefined,
         }
       }
+      testID="surface"
     >
       <View
         style={
@@ -574,6 +597,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                   "alignSelf": undefined,
                   "bottom": undefined,
                   "end": undefined,
+                  "flex": undefined,
                   "left": undefined,
                   "position": undefined,
                   "right": undefined,
@@ -588,11 +612,13 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                   "top": undefined,
                 }
               }
+              testID="button-container-outer-layer"
             >
               <View
                 collapsable={false}
                 style={
                   Object {
+                    "flex": undefined,
                     "shadowColor": "#000",
                     "shadowOffset": Object {
                       "height": 0,
@@ -602,6 +628,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                     "shadowRadius": 0,
                   }
                 }
+                testID="button-container-inner-layer"
               >
                 <View
                   collapsable={false}
@@ -612,6 +639,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                       "borderRadius": 20,
                       "borderStyle": "solid",
                       "borderWidth": 0,
+                      "flex": undefined,
                       "margin": 4,
                       "minWidth": "auto",
                     }
@@ -732,6 +760,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -746,11 +775,13 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
       "top": undefined,
     }
   }
+  testID="surface-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -760,14 +791,17 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
         "shadowRadius": 1,
       }
     }
+    testID="surface-inner-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
           "backgroundColor": "rgb(247, 243, 249)",
+          "flex": undefined,
         }
       }
+      testID="surface"
     >
       <View
         style={
@@ -854,6 +888,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   "alignSelf": undefined,
                   "bottom": undefined,
                   "end": undefined,
+                  "flex": undefined,
                   "left": undefined,
                   "position": undefined,
                   "right": undefined,
@@ -868,11 +903,13 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   "top": undefined,
                 }
               }
+              testID="button-container-outer-layer"
             >
               <View
                 collapsable={false}
                 style={
                   Object {
+                    "flex": undefined,
                     "shadowColor": "#000",
                     "shadowOffset": Object {
                       "height": 0,
@@ -882,6 +919,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                     "shadowRadius": 0,
                   }
                 }
+                testID="button-container-inner-layer"
               >
                 <View
                   collapsable={false}
@@ -892,6 +930,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                       "borderRadius": 20,
                       "borderStyle": "solid",
                       "borderWidth": 0,
+                      "flex": undefined,
                       "margin": 4,
                       "minWidth": "auto",
                     }
@@ -1003,6 +1042,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   "alignSelf": undefined,
                   "bottom": undefined,
                   "end": undefined,
+                  "flex": undefined,
                   "left": undefined,
                   "position": undefined,
                   "right": undefined,
@@ -1017,11 +1057,13 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   "top": undefined,
                 }
               }
+              testID="button-container-outer-layer"
             >
               <View
                 collapsable={false}
                 style={
                   Object {
+                    "flex": undefined,
                     "shadowColor": "#000",
                     "shadowOffset": Object {
                       "height": 0,
@@ -1031,6 +1073,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                     "shadowRadius": 0,
                   }
                 }
+                testID="button-container-inner-layer"
               >
                 <View
                   collapsable={false}
@@ -1041,6 +1084,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                       "borderRadius": 20,
                       "borderStyle": "solid",
                       "borderWidth": 0,
+                      "flex": undefined,
                       "margin": 4,
                       "minWidth": "auto",
                     }
@@ -1161,6 +1205,7 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1175,11 +1220,13 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
       "top": undefined,
     }
   }
+  testID="surface-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -1189,14 +1236,17 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
         "shadowRadius": 1,
       }
     }
+    testID="surface-inner-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
           "backgroundColor": "rgb(247, 243, 249)",
+          "flex": undefined,
         }
       }
+      testID="surface"
     >
       <View
         style={
@@ -1313,6 +1363,7 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1327,11 +1378,13 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
       "top": undefined,
     }
   }
+  testID="surface-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -1341,14 +1394,17 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
         "shadowRadius": 1,
       }
     }
+    testID="surface-inner-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
           "backgroundColor": "rgb(247, 243, 249)",
+          "flex": undefined,
         }
       }
+      testID="surface"
     >
       <View
         style={

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
@@ -77,6 +77,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
         "alignSelf": undefined,
         "bottom": 0,
         "end": undefined,
+        "flex": undefined,
         "left": 0,
         "position": undefined,
         "right": 0,
@@ -91,11 +92,13 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
         "top": undefined,
       }
     }
+    testID="bottom-navigation-surface-outer-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
+          "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -105,6 +108,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
           "shadowRadius": 0,
         }
       }
+      testID="bottom-navigation-surface-inner-layer"
     >
       <View
         collapsable={false}
@@ -113,6 +117,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
         style={
           Object {
             "backgroundColor": "transparent",
+            "flex": undefined,
           }
         }
         testID="bottom-navigation-surface"
@@ -825,6 +830,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
         "alignSelf": undefined,
         "bottom": 0,
         "end": undefined,
+        "flex": undefined,
         "left": 0,
         "position": undefined,
         "right": 0,
@@ -839,11 +845,13 @@ exports[`hides labels in shifting bottom navigation 1`] = `
         "top": undefined,
       }
     }
+    testID="bottom-navigation-surface-outer-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
+          "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -853,6 +861,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
           "shadowRadius": 0,
         }
       }
+      testID="bottom-navigation-surface-inner-layer"
     >
       <View
         collapsable={false}
@@ -861,6 +870,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
         style={
           Object {
             "backgroundColor": "transparent",
+            "flex": undefined,
           }
         }
         testID="bottom-navigation-surface"
@@ -1727,6 +1737,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
         "alignSelf": undefined,
         "bottom": 0,
         "end": undefined,
+        "flex": undefined,
         "left": 0,
         "position": undefined,
         "right": 0,
@@ -1741,11 +1752,13 @@ exports[`renders bottom navigation with getLazy 1`] = `
         "top": undefined,
       }
     }
+    testID="bottom-navigation-surface-outer-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
+          "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -1755,6 +1768,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
           "shadowRadius": 0,
         }
       }
+      testID="bottom-navigation-surface-inner-layer"
     >
       <View
         collapsable={false}
@@ -1763,6 +1777,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
         style={
           Object {
             "backgroundColor": "transparent",
+            "flex": undefined,
           }
         }
         testID="bottom-navigation-surface"
@@ -3436,6 +3451,7 @@ exports[`renders bottom navigation with scene animation 1`] = `
         "alignSelf": undefined,
         "bottom": 0,
         "end": undefined,
+        "flex": undefined,
         "left": 0,
         "position": undefined,
         "right": 0,
@@ -3450,11 +3466,13 @@ exports[`renders bottom navigation with scene animation 1`] = `
         "top": undefined,
       }
     }
+    testID="bottom-navigation-surface-outer-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
+          "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -3464,6 +3482,7 @@ exports[`renders bottom navigation with scene animation 1`] = `
           "shadowRadius": 0,
         }
       }
+      testID="bottom-navigation-surface-inner-layer"
     >
       <View
         collapsable={false}
@@ -3472,6 +3491,7 @@ exports[`renders bottom navigation with scene animation 1`] = `
         style={
           Object {
             "backgroundColor": "transparent",
+            "flex": undefined,
           }
         }
         testID="bottom-navigation-surface"
@@ -4927,6 +4947,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
         "alignSelf": undefined,
         "bottom": 0,
         "end": undefined,
+        "flex": undefined,
         "left": 0,
         "position": undefined,
         "right": 0,
@@ -4941,11 +4962,13 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
         "top": undefined,
       }
     }
+    testID="bottom-navigation-surface-outer-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
+          "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -4955,6 +4978,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
           "shadowRadius": 0,
         }
       }
+      testID="bottom-navigation-surface-inner-layer"
     >
       <View
         collapsable={false}
@@ -4963,6 +4987,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
         style={
           Object {
             "backgroundColor": "transparent",
+            "flex": undefined,
           }
         }
         testID="bottom-navigation-surface"
@@ -5615,6 +5640,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
         "alignSelf": undefined,
         "bottom": 0,
         "end": undefined,
+        "flex": undefined,
         "left": 0,
         "position": undefined,
         "right": 0,
@@ -5629,11 +5655,13 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
         "top": undefined,
       }
     }
+    testID="bottom-navigation-surface-outer-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
+          "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -5643,6 +5671,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
           "shadowRadius": 0,
         }
       }
+      testID="bottom-navigation-surface-inner-layer"
     >
       <View
         collapsable={false}
@@ -5651,6 +5680,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
         style={
           Object {
             "backgroundColor": "transparent",
+            "flex": undefined,
           }
         }
         testID="bottom-navigation-surface"
@@ -6606,6 +6636,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
         "alignSelf": undefined,
         "bottom": 0,
         "end": undefined,
+        "flex": undefined,
         "left": 0,
         "position": undefined,
         "right": 0,
@@ -6620,11 +6651,13 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
         "top": undefined,
       }
     }
+    testID="bottom-navigation-surface-outer-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
+          "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -6634,6 +6667,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
           "shadowRadius": 0,
         }
       }
+      testID="bottom-navigation-surface-inner-layer"
     >
       <View
         collapsable={false}
@@ -6642,6 +6676,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
         style={
           Object {
             "backgroundColor": "transparent",
+            "flex": undefined,
           }
         }
         testID="bottom-navigation-surface"
@@ -7699,6 +7734,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
         "alignSelf": undefined,
         "bottom": 0,
         "end": undefined,
+        "flex": undefined,
         "left": 0,
         "position": undefined,
         "right": 0,
@@ -7713,11 +7749,13 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
         "top": undefined,
       }
     }
+    testID="bottom-navigation-surface-outer-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
+          "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -7727,6 +7765,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
           "shadowRadius": 0,
         }
       }
+      testID="bottom-navigation-surface-inner-layer"
     >
       <View
         collapsable={false}
@@ -7735,6 +7774,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
         style={
           Object {
             "backgroundColor": "transparent",
+            "flex": undefined,
           }
         }
         testID="bottom-navigation-surface"
@@ -8670,6 +8710,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
         "alignSelf": undefined,
         "bottom": 0,
         "end": undefined,
+        "flex": undefined,
         "left": 0,
         "position": undefined,
         "right": 0,
@@ -8684,11 +8725,13 @@ exports[`renders non-shifting bottom navigation 1`] = `
         "top": undefined,
       }
     }
+    testID="bottom-navigation-surface-outer-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
+          "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -8698,6 +8741,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
           "shadowRadius": 0,
         }
       }
+      testID="bottom-navigation-surface-inner-layer"
     >
       <View
         collapsable={false}
@@ -8706,6 +8750,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
         style={
           Object {
             "backgroundColor": "transparent",
+            "flex": undefined,
           }
         }
         testID="bottom-navigation-surface"
@@ -9763,6 +9808,7 @@ exports[`renders shifting bottom navigation 1`] = `
         "alignSelf": undefined,
         "bottom": 0,
         "end": undefined,
+        "flex": undefined,
         "left": 0,
         "position": undefined,
         "right": 0,
@@ -9777,11 +9823,13 @@ exports[`renders shifting bottom navigation 1`] = `
         "top": undefined,
       }
     }
+    testID="bottom-navigation-surface-outer-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
+          "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -9791,6 +9839,7 @@ exports[`renders shifting bottom navigation 1`] = `
           "shadowRadius": 0,
         }
       }
+      testID="bottom-navigation-surface-inner-layer"
     >
       <View
         collapsable={false}
@@ -9799,6 +9848,7 @@ exports[`renders shifting bottom navigation 1`] = `
         style={
           Object {
             "backgroundColor": "transparent",
+            "flex": undefined,
           }
         }
         testID="bottom-navigation-surface"

--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`renders button with an accessibility hint 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -22,11 +23,13 @@ exports[`renders button with an accessibility hint 1`] = `
       "top": undefined,
     }
   }
+  testID="button-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -36,6 +39,7 @@ exports[`renders button with an accessibility hint 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="button-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -46,6 +50,7 @@ exports[`renders button with an accessibility hint 1`] = `
           "borderRadius": 20,
           "borderStyle": "solid",
           "borderWidth": 0,
+          "flex": undefined,
           "minWidth": 64,
         }
       }
@@ -158,6 +163,7 @@ exports[`renders button with an accessibility label 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -172,11 +178,13 @@ exports[`renders button with an accessibility label 1`] = `
       "top": undefined,
     }
   }
+  testID="button-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -186,6 +194,7 @@ exports[`renders button with an accessibility label 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="button-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -196,6 +205,7 @@ exports[`renders button with an accessibility label 1`] = `
           "borderRadius": 20,
           "borderStyle": "solid",
           "borderWidth": 0,
+          "flex": undefined,
           "minWidth": 64,
         }
       }
@@ -308,6 +318,7 @@ exports[`renders button with button color 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -322,11 +333,13 @@ exports[`renders button with button color 1`] = `
       "top": undefined,
     }
   }
+  testID="button-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -336,6 +349,7 @@ exports[`renders button with button color 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="button-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -346,6 +360,7 @@ exports[`renders button with button color 1`] = `
           "borderRadius": 20,
           "borderStyle": "solid",
           "borderWidth": 0,
+          "flex": undefined,
           "minWidth": 64,
         }
       }
@@ -457,6 +472,7 @@ exports[`renders button with color 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -471,11 +487,13 @@ exports[`renders button with color 1`] = `
       "top": undefined,
     }
   }
+  testID="button-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -485,6 +503,7 @@ exports[`renders button with color 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="button-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -495,6 +514,7 @@ exports[`renders button with color 1`] = `
           "borderRadius": 20,
           "borderStyle": "solid",
           "borderWidth": 0,
+          "flex": undefined,
           "minWidth": 64,
         }
       }
@@ -606,6 +626,7 @@ exports[`renders button with custom testID 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -620,11 +641,13 @@ exports[`renders button with custom testID 1`] = `
       "top": undefined,
     }
   }
+  testID="custom:testID-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -634,6 +657,7 @@ exports[`renders button with custom testID 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="custom:testID-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -644,6 +668,7 @@ exports[`renders button with custom testID 1`] = `
           "borderRadius": 20,
           "borderStyle": "solid",
           "borderWidth": 0,
+          "flex": undefined,
           "minWidth": 64,
         }
       }
@@ -755,6 +780,7 @@ exports[`renders button with icon 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -769,11 +795,13 @@ exports[`renders button with icon 1`] = `
       "top": undefined,
     }
   }
+  testID="button-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -783,6 +811,7 @@ exports[`renders button with icon 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="button-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -793,6 +822,7 @@ exports[`renders button with icon 1`] = `
           "borderRadius": 20,
           "borderStyle": "solid",
           "borderWidth": 0,
+          "flex": undefined,
           "minWidth": 64,
         }
       }
@@ -960,6 +990,7 @@ exports[`renders button with icon in reverse order 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -974,11 +1005,13 @@ exports[`renders button with icon in reverse order 1`] = `
       "top": undefined,
     }
   }
+  testID="button-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -988,6 +1021,7 @@ exports[`renders button with icon in reverse order 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="button-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -998,6 +1032,7 @@ exports[`renders button with icon in reverse order 1`] = `
           "borderRadius": 20,
           "borderStyle": "solid",
           "borderWidth": 0,
+          "flex": undefined,
           "minWidth": 64,
         }
       }
@@ -1167,6 +1202,7 @@ exports[`renders contained contained with mode 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1181,11 +1217,13 @@ exports[`renders contained contained with mode 1`] = `
       "top": undefined,
     }
   }
+  testID="button-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -1195,6 +1233,7 @@ exports[`renders contained contained with mode 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="button-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -1205,6 +1244,7 @@ exports[`renders contained contained with mode 1`] = `
           "borderRadius": 20,
           "borderStyle": "solid",
           "borderWidth": 0,
+          "flex": undefined,
           "minWidth": 64,
         }
       }
@@ -1317,6 +1357,7 @@ exports[`renders disabled button 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1331,11 +1372,13 @@ exports[`renders disabled button 1`] = `
       "top": undefined,
     }
   }
+  testID="button-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -1345,6 +1388,7 @@ exports[`renders disabled button 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="button-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -1355,6 +1399,7 @@ exports[`renders disabled button 1`] = `
           "borderRadius": 20,
           "borderStyle": "solid",
           "borderWidth": 0,
+          "flex": undefined,
           "minWidth": 64,
         }
       }
@@ -1466,6 +1511,7 @@ exports[`renders loading button 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1480,11 +1526,13 @@ exports[`renders loading button 1`] = `
       "top": undefined,
     }
   }
+  testID="button-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -1494,6 +1542,7 @@ exports[`renders loading button 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="button-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -1504,6 +1553,7 @@ exports[`renders loading button 1`] = `
           "borderRadius": 20,
           "borderStyle": "solid",
           "borderWidth": 0,
+          "flex": undefined,
           "minWidth": 64,
         }
       }
@@ -1823,6 +1873,7 @@ exports[`renders outlined button with mode 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1837,11 +1888,13 @@ exports[`renders outlined button with mode 1`] = `
       "top": undefined,
     }
   }
+  testID="button-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -1851,6 +1904,7 @@ exports[`renders outlined button with mode 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="button-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -1861,6 +1915,7 @@ exports[`renders outlined button with mode 1`] = `
           "borderRadius": 20,
           "borderStyle": "solid",
           "borderWidth": 1,
+          "flex": undefined,
           "minWidth": 64,
         }
       }
@@ -1973,6 +2028,7 @@ exports[`renders text button by default 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1987,11 +2043,13 @@ exports[`renders text button by default 1`] = `
       "top": undefined,
     }
   }
+  testID="button-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -2001,6 +2059,7 @@ exports[`renders text button by default 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="button-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -2011,6 +2070,7 @@ exports[`renders text button by default 1`] = `
           "borderRadius": 20,
           "borderStyle": "solid",
           "borderWidth": 0,
+          "flex": undefined,
           "minWidth": 64,
         }
       }
@@ -2122,6 +2182,7 @@ exports[`renders text button with mode 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -2136,11 +2197,13 @@ exports[`renders text button with mode 1`] = `
       "top": undefined,
     }
   }
+  testID="button-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -2150,6 +2213,7 @@ exports[`renders text button with mode 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="button-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -2160,6 +2224,7 @@ exports[`renders text button with mode 1`] = `
           "borderRadius": 20,
           "borderStyle": "solid",
           "borderWidth": 0,
+          "flex": undefined,
           "minWidth": 64,
         }
       }

--- a/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`renders chip with close button 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -22,11 +23,13 @@ exports[`renders chip with close button 1`] = `
       "top": undefined,
     }
   }
+  testID="chip-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -36,6 +39,7 @@ exports[`renders chip with close button 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="chip-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -46,6 +50,7 @@ exports[`renders chip with close button 1`] = `
           "borderRadius": 8,
           "borderStyle": "solid",
           "borderWidth": 0,
+          "flex": undefined,
           "flexDirection": "column",
         }
       }
@@ -295,6 +300,7 @@ exports[`renders chip with custom close button 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -309,11 +315,13 @@ exports[`renders chip with custom close button 1`] = `
       "top": undefined,
     }
   }
+  testID="chip-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -323,6 +331,7 @@ exports[`renders chip with custom close button 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="chip-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -333,6 +342,7 @@ exports[`renders chip with custom close button 1`] = `
           "borderRadius": 8,
           "borderStyle": "solid",
           "borderWidth": 0,
+          "flex": undefined,
           "flexDirection": "column",
         }
       }
@@ -582,6 +592,7 @@ exports[`renders chip with icon 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -596,11 +607,13 @@ exports[`renders chip with icon 1`] = `
       "top": undefined,
     }
   }
+  testID="chip-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -610,6 +623,7 @@ exports[`renders chip with icon 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="chip-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -620,6 +634,7 @@ exports[`renders chip with icon 1`] = `
           "borderRadius": 8,
           "borderStyle": "solid",
           "borderWidth": 0,
+          "flex": undefined,
           "flexDirection": "column",
         }
       }
@@ -792,6 +807,7 @@ exports[`renders chip with onPress 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -806,11 +822,13 @@ exports[`renders chip with onPress 1`] = `
       "top": undefined,
     }
   }
+  testID="chip-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -820,6 +838,7 @@ exports[`renders chip with onPress 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="chip-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -830,6 +849,7 @@ exports[`renders chip with onPress 1`] = `
           "borderRadius": 8,
           "borderStyle": "solid",
           "borderWidth": 0,
+          "flex": undefined,
           "flexDirection": "column",
         }
       }
@@ -950,6 +970,7 @@ exports[`renders outlined disabled chip 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -964,11 +985,13 @@ exports[`renders outlined disabled chip 1`] = `
       "top": undefined,
     }
   }
+  testID="chip-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -978,6 +1001,7 @@ exports[`renders outlined disabled chip 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="chip-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -988,6 +1012,7 @@ exports[`renders outlined disabled chip 1`] = `
           "borderRadius": 8,
           "borderStyle": "solid",
           "borderWidth": 1,
+          "flex": undefined,
           "flexDirection": "column",
         }
       }
@@ -1108,6 +1133,7 @@ exports[`renders selected chip 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1122,11 +1148,13 @@ exports[`renders selected chip 1`] = `
       "top": undefined,
     }
   }
+  testID="chip-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -1136,6 +1164,7 @@ exports[`renders selected chip 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="chip-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -1146,6 +1175,7 @@ exports[`renders selected chip 1`] = `
           "borderRadius": 8,
           "borderStyle": "solid",
           "borderWidth": 0,
+          "flex": undefined,
           "flexDirection": "column",
         }
       }

--- a/src/components/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.js.snap
@@ -271,6 +271,7 @@ exports[`renders data table pagination 1`] = `
           "alignSelf": undefined,
           "bottom": undefined,
           "end": undefined,
+          "flex": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -285,11 +286,13 @@ exports[`renders data table pagination 1`] = `
           "top": undefined,
         }
       }
+      testID="icon-button-container-outer-layer"
     >
       <View
         collapsable={false}
         style={
           Object {
+            "flex": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -299,6 +302,7 @@ exports[`renders data table pagination 1`] = `
             "shadowRadius": 0,
           }
         }
+        testID="icon-button-container-inner-layer"
       >
         <View
           collapsable={false}
@@ -309,6 +313,7 @@ exports[`renders data table pagination 1`] = `
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
+              "flex": undefined,
               "height": 40,
               "margin": 6,
               "overflow": "hidden",
@@ -415,6 +420,7 @@ exports[`renders data table pagination 1`] = `
           "alignSelf": undefined,
           "bottom": undefined,
           "end": undefined,
+          "flex": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -429,11 +435,13 @@ exports[`renders data table pagination 1`] = `
           "top": undefined,
         }
       }
+      testID="icon-button-container-outer-layer"
     >
       <View
         collapsable={false}
         style={
           Object {
+            "flex": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -443,6 +451,7 @@ exports[`renders data table pagination 1`] = `
             "shadowRadius": 0,
           }
         }
+        testID="icon-button-container-inner-layer"
       >
         <View
           collapsable={false}
@@ -453,6 +462,7 @@ exports[`renders data table pagination 1`] = `
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
+              "flex": undefined,
               "height": 40,
               "margin": 6,
               "overflow": "hidden",
@@ -617,6 +627,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           "alignSelf": undefined,
           "bottom": undefined,
           "end": undefined,
+          "flex": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -631,11 +642,13 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           "top": undefined,
         }
       }
+      testID="icon-button-container-outer-layer"
     >
       <View
         collapsable={false}
         style={
           Object {
+            "flex": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -645,6 +658,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
             "shadowRadius": 0,
           }
         }
+        testID="icon-button-container-inner-layer"
       >
         <View
           collapsable={false}
@@ -655,6 +669,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
+              "flex": undefined,
               "height": 40,
               "margin": 6,
               "overflow": "hidden",
@@ -761,6 +776,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           "alignSelf": undefined,
           "bottom": undefined,
           "end": undefined,
+          "flex": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -775,11 +791,13 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           "top": undefined,
         }
       }
+      testID="icon-button-container-outer-layer"
     >
       <View
         collapsable={false}
         style={
           Object {
+            "flex": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -789,6 +807,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
             "shadowRadius": 0,
           }
         }
+        testID="icon-button-container-inner-layer"
       >
         <View
           collapsable={false}
@@ -799,6 +818,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
+              "flex": undefined,
               "height": 40,
               "margin": 6,
               "overflow": "hidden",
@@ -905,6 +925,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           "alignSelf": undefined,
           "bottom": undefined,
           "end": undefined,
+          "flex": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -919,11 +940,13 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           "top": undefined,
         }
       }
+      testID="icon-button-container-outer-layer"
     >
       <View
         collapsable={false}
         style={
           Object {
+            "flex": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -933,6 +956,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
             "shadowRadius": 0,
           }
         }
+        testID="icon-button-container-inner-layer"
       >
         <View
           collapsable={false}
@@ -943,6 +967,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
+              "flex": undefined,
               "height": 40,
               "margin": 6,
               "overflow": "hidden",
@@ -1049,6 +1074,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           "alignSelf": undefined,
           "bottom": undefined,
           "end": undefined,
+          "flex": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -1063,11 +1089,13 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           "top": undefined,
         }
       }
+      testID="icon-button-container-outer-layer"
     >
       <View
         collapsable={false}
         style={
           Object {
+            "flex": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1077,6 +1105,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
             "shadowRadius": 0,
           }
         }
+        testID="icon-button-container-inner-layer"
       >
         <View
           collapsable={false}
@@ -1087,6 +1116,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
+              "flex": undefined,
               "height": 40,
               "margin": 6,
               "overflow": "hidden",
@@ -1251,6 +1281,7 @@ exports[`renders data table pagination with label 1`] = `
           "alignSelf": undefined,
           "bottom": undefined,
           "end": undefined,
+          "flex": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -1265,11 +1296,13 @@ exports[`renders data table pagination with label 1`] = `
           "top": undefined,
         }
       }
+      testID="icon-button-container-outer-layer"
     >
       <View
         collapsable={false}
         style={
           Object {
+            "flex": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1279,6 +1312,7 @@ exports[`renders data table pagination with label 1`] = `
             "shadowRadius": 0,
           }
         }
+        testID="icon-button-container-inner-layer"
       >
         <View
           collapsable={false}
@@ -1289,6 +1323,7 @@ exports[`renders data table pagination with label 1`] = `
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
+              "flex": undefined,
               "height": 40,
               "margin": 6,
               "overflow": "hidden",
@@ -1395,6 +1430,7 @@ exports[`renders data table pagination with label 1`] = `
           "alignSelf": undefined,
           "bottom": undefined,
           "end": undefined,
+          "flex": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -1409,11 +1445,13 @@ exports[`renders data table pagination with label 1`] = `
           "top": undefined,
         }
       }
+      testID="icon-button-container-outer-layer"
     >
       <View
         collapsable={false}
         style={
           Object {
+            "flex": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1423,6 +1461,7 @@ exports[`renders data table pagination with label 1`] = `
             "shadowRadius": 0,
           }
         }
+        testID="icon-button-container-inner-layer"
       >
         <View
           collapsable={false}
@@ -1433,6 +1472,7 @@ exports[`renders data table pagination with label 1`] = `
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
+              "flex": undefined,
               "height": 40,
               "margin": 6,
               "overflow": "hidden",
@@ -1603,6 +1643,7 @@ exports[`renders data table pagination with options select 1`] = `
             "alignSelf": undefined,
             "bottom": undefined,
             "end": undefined,
+            "flex": undefined,
             "left": undefined,
             "position": undefined,
             "right": undefined,
@@ -1617,11 +1658,13 @@ exports[`renders data table pagination with options select 1`] = `
             "top": undefined,
           }
         }
+        testID="button-container-outer-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
+              "flex": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -1631,6 +1674,7 @@ exports[`renders data table pagination with options select 1`] = `
               "shadowRadius": 0,
             }
           }
+          testID="button-container-inner-layer"
         >
           <View
             collapsable={false}
@@ -1641,6 +1685,7 @@ exports[`renders data table pagination with options select 1`] = `
                 "borderRadius": 20,
                 "borderStyle": "solid",
                 "borderWidth": 1,
+                "flex": undefined,
                 "marginRight": 16,
                 "minWidth": 64,
                 "textAlign": "center",
@@ -1847,6 +1892,7 @@ exports[`renders data table pagination with options select 1`] = `
           "alignSelf": undefined,
           "bottom": undefined,
           "end": undefined,
+          "flex": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -1861,11 +1907,13 @@ exports[`renders data table pagination with options select 1`] = `
           "top": undefined,
         }
       }
+      testID="icon-button-container-outer-layer"
     >
       <View
         collapsable={false}
         style={
           Object {
+            "flex": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1875,6 +1923,7 @@ exports[`renders data table pagination with options select 1`] = `
             "shadowRadius": 0,
           }
         }
+        testID="icon-button-container-inner-layer"
       >
         <View
           collapsable={false}
@@ -1885,6 +1934,7 @@ exports[`renders data table pagination with options select 1`] = `
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
+              "flex": undefined,
               "height": 40,
               "margin": 6,
               "overflow": "hidden",
@@ -1991,6 +2041,7 @@ exports[`renders data table pagination with options select 1`] = `
           "alignSelf": undefined,
           "bottom": undefined,
           "end": undefined,
+          "flex": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -2005,11 +2056,13 @@ exports[`renders data table pagination with options select 1`] = `
           "top": undefined,
         }
       }
+      testID="icon-button-container-outer-layer"
     >
       <View
         collapsable={false}
         style={
           Object {
+            "flex": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -2019,6 +2072,7 @@ exports[`renders data table pagination with options select 1`] = `
             "shadowRadius": 0,
           }
         }
+        testID="icon-button-container-inner-layer"
       >
         <View
           collapsable={false}
@@ -2029,6 +2083,7 @@ exports[`renders data table pagination with options select 1`] = `
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
+              "flex": undefined,
               "height": 40,
               "margin": 6,
               "overflow": "hidden",
@@ -2135,6 +2190,7 @@ exports[`renders data table pagination with options select 1`] = `
           "alignSelf": undefined,
           "bottom": undefined,
           "end": undefined,
+          "flex": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -2149,11 +2205,13 @@ exports[`renders data table pagination with options select 1`] = `
           "top": undefined,
         }
       }
+      testID="icon-button-container-outer-layer"
     >
       <View
         collapsable={false}
         style={
           Object {
+            "flex": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -2163,6 +2221,7 @@ exports[`renders data table pagination with options select 1`] = `
             "shadowRadius": 0,
           }
         }
+        testID="icon-button-container-inner-layer"
       >
         <View
           collapsable={false}
@@ -2173,6 +2232,7 @@ exports[`renders data table pagination with options select 1`] = `
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
+              "flex": undefined,
               "height": 40,
               "margin": 6,
               "overflow": "hidden",
@@ -2279,6 +2339,7 @@ exports[`renders data table pagination with options select 1`] = `
           "alignSelf": undefined,
           "bottom": undefined,
           "end": undefined,
+          "flex": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -2293,11 +2354,13 @@ exports[`renders data table pagination with options select 1`] = `
           "top": undefined,
         }
       }
+      testID="icon-button-container-outer-layer"
     >
       <View
         collapsable={false}
         style={
           Object {
+            "flex": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -2307,6 +2370,7 @@ exports[`renders data table pagination with options select 1`] = `
             "shadowRadius": 0,
           }
         }
+        testID="icon-button-container-inner-layer"
       >
         <View
           collapsable={false}
@@ -2317,6 +2381,7 @@ exports[`renders data table pagination with options select 1`] = `
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
+              "flex": undefined,
               "height": 40,
               "margin": 6,
               "overflow": "hidden",

--- a/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`renders FAB with custom size prop 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -22,11 +23,13 @@ exports[`renders FAB with custom size prop 1`] = `
       "top": undefined,
     }
   }
+  testID="fab-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -36,6 +39,7 @@ exports[`renders FAB with custom size prop 1`] = `
         "shadowRadius": 3,
       }
     }
+    testID="fab-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -44,6 +48,7 @@ exports[`renders FAB with custom size prop 1`] = `
         Object {
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 25,
+          "flex": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -188,6 +193,7 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -202,11 +208,13 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
       "top": undefined,
     }
   }
+  testID="fab-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -216,6 +224,7 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
         "shadowRadius": 3,
       }
     }
+    testID="fab-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -224,6 +233,7 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
         Object {
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 16,
+          "flex": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -368,6 +378,7 @@ exports[`renders default FAB 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -382,11 +393,13 @@ exports[`renders default FAB 1`] = `
       "top": undefined,
     }
   }
+  testID="fab-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -396,6 +409,7 @@ exports[`renders default FAB 1`] = `
         "shadowRadius": 3,
       }
     }
+    testID="fab-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -404,6 +418,7 @@ exports[`renders default FAB 1`] = `
         Object {
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 16,
+          "flex": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -548,6 +563,7 @@ exports[`renders disabled FAB 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -562,11 +578,13 @@ exports[`renders disabled FAB 1`] = `
       "top": undefined,
     }
   }
+  testID="fab-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -576,6 +594,7 @@ exports[`renders disabled FAB 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="fab-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -584,6 +603,7 @@ exports[`renders disabled FAB 1`] = `
         Object {
           "backgroundColor": "rgba(28, 27, 31, 0.12)",
           "borderRadius": 16,
+          "flex": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -728,6 +748,7 @@ exports[`renders extended FAB 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -742,11 +763,13 @@ exports[`renders extended FAB 1`] = `
       "top": undefined,
     }
   }
+  testID="fab-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -756,6 +779,7 @@ exports[`renders extended FAB 1`] = `
         "shadowRadius": 3,
       }
     }
+    testID="fab-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -764,6 +788,7 @@ exports[`renders extended FAB 1`] = `
         Object {
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 16,
+          "flex": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -947,6 +972,7 @@ exports[`renders extended FAB with custom size prop 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -961,11 +987,13 @@ exports[`renders extended FAB with custom size prop 1`] = `
       "top": undefined,
     }
   }
+  testID="fab-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -975,6 +1003,7 @@ exports[`renders extended FAB with custom size prop 1`] = `
         "shadowRadius": 3,
       }
     }
+    testID="fab-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -983,6 +1012,7 @@ exports[`renders extended FAB with custom size prop 1`] = `
         Object {
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 25,
+          "flex": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -1165,6 +1195,7 @@ exports[`renders large FAB 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1179,11 +1210,13 @@ exports[`renders large FAB 1`] = `
       "top": undefined,
     }
   }
+  testID="fab-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -1193,6 +1226,7 @@ exports[`renders large FAB 1`] = `
         "shadowRadius": 3,
       }
     }
+    testID="fab-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -1201,6 +1235,7 @@ exports[`renders large FAB 1`] = `
         Object {
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 28,
+          "flex": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -1345,6 +1380,7 @@ exports[`renders loading FAB 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1359,11 +1395,13 @@ exports[`renders loading FAB 1`] = `
       "top": undefined,
     }
   }
+  testID="fab-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -1373,6 +1411,7 @@ exports[`renders loading FAB 1`] = `
         "shadowRadius": 3,
       }
     }
+    testID="fab-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -1381,6 +1420,7 @@ exports[`renders loading FAB 1`] = `
         Object {
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 16,
+          "flex": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -1650,6 +1690,7 @@ exports[`renders loading FAB with custom size prop 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1664,11 +1705,13 @@ exports[`renders loading FAB with custom size prop 1`] = `
       "top": undefined,
     }
   }
+  testID="fab-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -1678,6 +1721,7 @@ exports[`renders loading FAB with custom size prop 1`] = `
         "shadowRadius": 3,
       }
     }
+    testID="fab-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -1686,6 +1730,7 @@ exports[`renders loading FAB with custom size prop 1`] = `
         Object {
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 25,
+          "flex": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -1955,6 +2000,7 @@ exports[`renders not visible FAB 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -1969,11 +2015,13 @@ exports[`renders not visible FAB 1`] = `
       "top": undefined,
     }
   }
+  testID="fab-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -1983,6 +2031,7 @@ exports[`renders not visible FAB 1`] = `
         "shadowRadius": 3,
       }
     }
+    testID="fab-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -1991,6 +2040,7 @@ exports[`renders not visible FAB 1`] = `
         Object {
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 16,
+          "flex": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -2135,6 +2185,7 @@ exports[`renders small FAB 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -2149,11 +2200,13 @@ exports[`renders small FAB 1`] = `
       "top": undefined,
     }
   }
+  testID="fab-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -2163,6 +2216,7 @@ exports[`renders small FAB 1`] = `
         "shadowRadius": 3,
       }
     }
+    testID="fab-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -2171,6 +2225,7 @@ exports[`renders small FAB 1`] = `
         Object {
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 12,
+          "flex": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -2315,6 +2370,7 @@ exports[`renders visible FAB 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -2329,11 +2385,13 @@ exports[`renders visible FAB 1`] = `
       "top": undefined,
     }
   }
+  testID="fab-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -2343,6 +2401,7 @@ exports[`renders visible FAB 1`] = `
         "shadowRadius": 3,
       }
     }
+    testID="fab-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -2351,6 +2410,7 @@ exports[`renders visible FAB 1`] = `
         Object {
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 16,
+          "flex": undefined,
           "opacity": 0,
           "overflow": "hidden",
           "transform": Array [

--- a/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`renders disabled icon button 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -22,11 +23,13 @@ exports[`renders disabled icon button 1`] = `
       "top": undefined,
     }
   }
+  testID="icon-button-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -36,6 +39,7 @@ exports[`renders disabled icon button 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="icon-button-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -46,6 +50,7 @@ exports[`renders disabled icon button 1`] = `
           "borderRadius": 20,
           "borderWidth": 0,
           "elevation": 0,
+          "flex": undefined,
           "height": 40,
           "margin": 6,
           "overflow": "hidden",
@@ -159,6 +164,7 @@ exports[`renders icon button by default 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -173,11 +179,13 @@ exports[`renders icon button by default 1`] = `
       "top": undefined,
     }
   }
+  testID="icon-button-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -187,6 +195,7 @@ exports[`renders icon button by default 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="icon-button-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -197,6 +206,7 @@ exports[`renders icon button by default 1`] = `
           "borderRadius": 20,
           "borderWidth": 0,
           "elevation": 0,
+          "flex": undefined,
           "height": 40,
           "margin": 6,
           "overflow": "hidden",
@@ -305,6 +315,7 @@ exports[`renders icon button with color 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -319,11 +330,13 @@ exports[`renders icon button with color 1`] = `
       "top": undefined,
     }
   }
+  testID="icon-button-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -333,6 +346,7 @@ exports[`renders icon button with color 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="icon-button-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -343,6 +357,7 @@ exports[`renders icon button with color 1`] = `
           "borderRadius": 20,
           "borderWidth": 0,
           "elevation": 0,
+          "flex": undefined,
           "height": 40,
           "margin": 6,
           "overflow": "hidden",
@@ -451,6 +466,7 @@ exports[`renders icon button with size 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -465,11 +481,13 @@ exports[`renders icon button with size 1`] = `
       "top": undefined,
     }
   }
+  testID="icon-button-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -479,6 +497,7 @@ exports[`renders icon button with size 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="icon-button-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -489,6 +508,7 @@ exports[`renders icon button with size 1`] = `
           "borderRadius": 23,
           "borderWidth": 0,
           "elevation": 0,
+          "flex": undefined,
           "height": 46,
           "margin": 6,
           "overflow": "hidden",
@@ -597,6 +617,7 @@ exports[`renders icon change animated 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -611,11 +632,13 @@ exports[`renders icon change animated 1`] = `
       "top": undefined,
     }
   }
+  testID="icon-button-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -625,6 +648,7 @@ exports[`renders icon change animated 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="icon-button-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -635,6 +659,7 @@ exports[`renders icon change animated 1`] = `
           "borderRadius": 20,
           "borderWidth": 0,
           "elevation": 0,
+          "flex": undefined,
           "height": 40,
           "margin": 6,
           "overflow": "hidden",

--- a/src/components/__tests__/__snapshots__/ListItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.js.snap
@@ -105,6 +105,7 @@ exports[`renders list item with custom description 1`] = `
                 "alignSelf": undefined,
                 "bottom": undefined,
                 "end": undefined,
+                "flex": undefined,
                 "left": undefined,
                 "position": undefined,
                 "right": undefined,
@@ -119,11 +120,13 @@ exports[`renders list item with custom description 1`] = `
                 "top": undefined,
               }
             }
+            testID="chip-container-outer-layer"
           >
             <View
               collapsable={false}
               style={
                 Object {
+                  "flex": undefined,
                   "shadowColor": "#000",
                   "shadowOffset": Object {
                     "height": 0,
@@ -133,6 +136,7 @@ exports[`renders list item with custom description 1`] = `
                   "shadowRadius": 0,
                 }
               }
+              testID="chip-container-inner-layer"
             >
               <View
                 collapsable={false}
@@ -143,6 +147,7 @@ exports[`renders list item with custom description 1`] = `
                     "borderRadius": 8,
                     "borderStyle": "solid",
                     "borderWidth": 0,
+                    "flex": undefined,
                     "flexDirection": "column",
                   }
                 }

--- a/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -21,6 +21,7 @@ Array [
             "alignSelf": undefined,
             "bottom": undefined,
             "end": undefined,
+            "flex": undefined,
             "left": undefined,
             "position": undefined,
             "right": undefined,
@@ -35,11 +36,13 @@ Array [
             "top": undefined,
           }
         }
+        testID="button-container-outer-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
+              "flex": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -49,6 +52,7 @@ Array [
               "shadowRadius": 0,
             }
           }
+          testID="button-container-inner-layer"
         >
           <View
             collapsable={false}
@@ -59,6 +63,7 @@ Array [
                 "borderRadius": 20,
                 "borderStyle": "solid",
                 "borderWidth": 1,
+                "flex": undefined,
                 "minWidth": 64,
               }
             }
@@ -238,6 +243,7 @@ Array [
               "alignSelf": undefined,
               "bottom": undefined,
               "end": undefined,
+              "flex": undefined,
               "left": undefined,
               "position": undefined,
               "right": undefined,
@@ -252,11 +258,13 @@ Array [
               "top": undefined,
             }
           }
+          testID="menu-surface-outer-layer"
         >
           <View
             collapsable={false}
             style={
               Object {
+                "flex": undefined,
                 "shadowColor": "#000",
                 "shadowOffset": Object {
                   "height": 1,
@@ -266,6 +274,7 @@ Array [
                 "shadowRadius": 2,
               }
             }
+            testID="menu-surface-inner-layer"
           >
             <View
               collapsable={false}
@@ -275,6 +284,7 @@ Array [
                   "borderRadius": 4,
                   "borderTopLeftRadius": 0,
                   "borderTopRightRadius": 0,
+                  "flex": undefined,
                   "opacity": 0,
                   "paddingVertical": 8,
                   "transform": Array [
@@ -526,6 +536,7 @@ exports[`renders not visible menu 1`] = `
           "alignSelf": undefined,
           "bottom": undefined,
           "end": undefined,
+          "flex": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -540,11 +551,13 @@ exports[`renders not visible menu 1`] = `
           "top": undefined,
         }
       }
+      testID="button-container-outer-layer"
     >
       <View
         collapsable={false}
         style={
           Object {
+            "flex": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -554,6 +567,7 @@ exports[`renders not visible menu 1`] = `
             "shadowRadius": 0,
           }
         }
+        testID="button-container-inner-layer"
       >
         <View
           collapsable={false}
@@ -564,6 +578,7 @@ exports[`renders not visible menu 1`] = `
               "borderRadius": 20,
               "borderStyle": "solid",
               "borderWidth": 1,
+              "flex": undefined,
               "minWidth": 64,
             }
           }
@@ -691,6 +706,7 @@ Array [
             "alignSelf": undefined,
             "bottom": undefined,
             "end": undefined,
+            "flex": undefined,
             "left": undefined,
             "position": undefined,
             "right": undefined,
@@ -705,11 +721,13 @@ Array [
             "top": undefined,
           }
         }
+        testID="button-container-outer-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
+              "flex": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -719,6 +737,7 @@ Array [
               "shadowRadius": 0,
             }
           }
+          testID="button-container-inner-layer"
         >
           <View
             collapsable={false}
@@ -729,6 +748,7 @@ Array [
                 "borderRadius": 20,
                 "borderStyle": "solid",
                 "borderWidth": 1,
+                "flex": undefined,
                 "minWidth": 64,
               }
             }
@@ -908,6 +928,7 @@ Array [
               "alignSelf": undefined,
               "bottom": undefined,
               "end": undefined,
+              "flex": undefined,
               "left": undefined,
               "position": undefined,
               "right": undefined,
@@ -922,11 +943,13 @@ Array [
               "top": undefined,
             }
           }
+          testID="menu-surface-outer-layer"
         >
           <View
             collapsable={false}
             style={
               Object {
+                "flex": undefined,
                 "shadowColor": "#000",
                 "shadowOffset": Object {
                   "height": 1,
@@ -936,6 +959,7 @@ Array [
                 "shadowRadius": 2,
               }
             }
+            testID="menu-surface-inner-layer"
           >
             <View
               collapsable={false}
@@ -943,6 +967,7 @@ Array [
                 Object {
                   "backgroundColor": "rgb(243, 237, 246)",
                   "borderRadius": 4,
+                  "flex": undefined,
                   "opacity": 0,
                   "paddingVertical": 8,
                   "transform": Array [

--- a/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`activity indicator snapshot test 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -22,11 +23,13 @@ exports[`activity indicator snapshot test 1`] = `
       "top": undefined,
     }
   }
+  testID="search-bar-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -36,6 +39,7 @@ exports[`activity indicator snapshot test 1`] = `
         "shadowRadius": 1,
       }
     }
+    testID="search-bar-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -44,6 +48,7 @@ exports[`activity indicator snapshot test 1`] = `
           "alignItems": "center",
           "backgroundColor": "rgb(247, 243, 249)",
           "borderRadius": 4,
+          "flex": undefined,
           "flexDirection": "row",
         }
       }
@@ -56,6 +61,7 @@ exports[`activity indicator snapshot test 1`] = `
             "alignSelf": undefined,
             "bottom": undefined,
             "end": undefined,
+            "flex": undefined,
             "left": undefined,
             "position": undefined,
             "right": undefined,
@@ -70,11 +76,13 @@ exports[`activity indicator snapshot test 1`] = `
             "top": undefined,
           }
         }
+        testID="icon-button-container-outer-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
+              "flex": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -84,6 +92,7 @@ exports[`activity indicator snapshot test 1`] = `
               "shadowRadius": 0,
             }
           }
+          testID="icon-button-container-inner-layer"
         >
           <View
             collapsable={false}
@@ -94,6 +103,7 @@ exports[`activity indicator snapshot test 1`] = `
                 "borderRadius": 20,
                 "borderWidth": 0,
                 "elevation": 0,
+                "flex": undefined,
                 "height": 40,
                 "margin": 6,
                 "overflow": "hidden",
@@ -434,6 +444,7 @@ exports[`renders with placeholder 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -448,11 +459,13 @@ exports[`renders with placeholder 1`] = `
       "top": undefined,
     }
   }
+  testID="search-bar-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -462,6 +475,7 @@ exports[`renders with placeholder 1`] = `
         "shadowRadius": 1,
       }
     }
+    testID="search-bar-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -470,6 +484,7 @@ exports[`renders with placeholder 1`] = `
           "alignItems": "center",
           "backgroundColor": "rgb(247, 243, 249)",
           "borderRadius": 4,
+          "flex": undefined,
           "flexDirection": "row",
         }
       }
@@ -482,6 +497,7 @@ exports[`renders with placeholder 1`] = `
             "alignSelf": undefined,
             "bottom": undefined,
             "end": undefined,
+            "flex": undefined,
             "left": undefined,
             "position": undefined,
             "right": undefined,
@@ -496,11 +512,13 @@ exports[`renders with placeholder 1`] = `
             "top": undefined,
           }
         }
+        testID="icon-button-container-outer-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
+              "flex": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -510,6 +528,7 @@ exports[`renders with placeholder 1`] = `
               "shadowRadius": 0,
             }
           }
+          testID="icon-button-container-inner-layer"
         >
           <View
             collapsable={false}
@@ -520,6 +539,7 @@ exports[`renders with placeholder 1`] = `
                 "borderRadius": 20,
                 "borderWidth": 0,
                 "elevation": 0,
+                "flex": undefined,
                 "height": 40,
                 "margin": 6,
                 "overflow": "hidden",
@@ -660,6 +680,7 @@ exports[`renders with placeholder 1`] = `
               "alignSelf": undefined,
               "bottom": undefined,
               "end": undefined,
+              "flex": undefined,
               "left": undefined,
               "position": undefined,
               "right": undefined,
@@ -674,11 +695,13 @@ exports[`renders with placeholder 1`] = `
               "top": undefined,
             }
           }
+          testID="icon-button-container-outer-layer"
         >
           <View
             collapsable={false}
             style={
               Object {
+                "flex": undefined,
                 "shadowColor": "#000",
                 "shadowOffset": Object {
                   "height": 0,
@@ -688,6 +711,7 @@ exports[`renders with placeholder 1`] = `
                 "shadowRadius": 0,
               }
             }
+            testID="icon-button-container-inner-layer"
           >
             <View
               collapsable={false}
@@ -698,6 +722,7 @@ exports[`renders with placeholder 1`] = `
                   "borderRadius": 20,
                   "borderWidth": 0,
                   "elevation": 0,
+                  "flex": undefined,
                   "height": 40,
                   "margin": 6,
                   "overflow": "hidden",
@@ -811,6 +836,7 @@ exports[`renders with text 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -825,11 +851,13 @@ exports[`renders with text 1`] = `
       "top": undefined,
     }
   }
+  testID="search-bar-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -839,6 +867,7 @@ exports[`renders with text 1`] = `
         "shadowRadius": 1,
       }
     }
+    testID="search-bar-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -847,6 +876,7 @@ exports[`renders with text 1`] = `
           "alignItems": "center",
           "backgroundColor": "rgb(247, 243, 249)",
           "borderRadius": 4,
+          "flex": undefined,
           "flexDirection": "row",
         }
       }
@@ -859,6 +889,7 @@ exports[`renders with text 1`] = `
             "alignSelf": undefined,
             "bottom": undefined,
             "end": undefined,
+            "flex": undefined,
             "left": undefined,
             "position": undefined,
             "right": undefined,
@@ -873,11 +904,13 @@ exports[`renders with text 1`] = `
             "top": undefined,
           }
         }
+        testID="icon-button-container-outer-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
+              "flex": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -887,6 +920,7 @@ exports[`renders with text 1`] = `
               "shadowRadius": 0,
             }
           }
+          testID="icon-button-container-inner-layer"
         >
           <View
             collapsable={false}
@@ -897,6 +931,7 @@ exports[`renders with text 1`] = `
                 "borderRadius": 20,
                 "borderWidth": 0,
                 "elevation": 0,
+                "flex": undefined,
                 "height": 40,
                 "margin": 6,
                 "overflow": "hidden",
@@ -1037,6 +1072,7 @@ exports[`renders with text 1`] = `
               "alignSelf": undefined,
               "bottom": undefined,
               "end": undefined,
+              "flex": undefined,
               "left": undefined,
               "position": undefined,
               "right": undefined,
@@ -1051,11 +1087,13 @@ exports[`renders with text 1`] = `
               "top": undefined,
             }
           }
+          testID="icon-button-container-outer-layer"
         >
           <View
             collapsable={false}
             style={
               Object {
+                "flex": undefined,
                 "shadowColor": "#000",
                 "shadowOffset": Object {
                   "height": 0,
@@ -1065,6 +1103,7 @@ exports[`renders with text 1`] = `
                 "shadowRadius": 0,
               }
             }
+            testID="icon-button-container-inner-layer"
           >
             <View
               collapsable={false}
@@ -1075,6 +1114,7 @@ exports[`renders with text 1`] = `
                   "borderRadius": 20,
                   "borderWidth": 0,
                   "elevation": 0,
+                  "flex": undefined,
                   "height": 40,
                   "margin": 6,
                   "overflow": "hidden",

--- a/src/components/__tests__/__snapshots__/Snackbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`renders snackbar with Text as a child 1`] = `
         "alignSelf": undefined,
         "bottom": undefined,
         "end": undefined,
+        "flex": undefined,
         "left": undefined,
         "position": undefined,
         "right": undefined,
@@ -41,11 +42,13 @@ exports[`renders snackbar with Text as a child 1`] = `
         "top": undefined,
       }
     }
+    testID="surface-outer-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
+          "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 1,
@@ -55,6 +58,7 @@ exports[`renders snackbar with Text as a child 1`] = `
           "shadowRadius": 2,
         }
       }
+      testID="surface-inner-layer"
     >
       <View
         accessibilityLiveRegion="polite"
@@ -64,6 +68,7 @@ exports[`renders snackbar with Text as a child 1`] = `
           Object {
             "backgroundColor": "rgba(49, 48, 51, 1)",
             "borderRadius": 4,
+            "flex": undefined,
             "flexDirection": "row",
             "justifyContent": "space-between",
             "margin": 8,
@@ -76,6 +81,7 @@ exports[`renders snackbar with Text as a child 1`] = `
             ],
           }
         }
+        testID="surface"
       >
         <View
           style={
@@ -123,6 +129,7 @@ exports[`renders snackbar with View & Text as a child 1`] = `
         "alignSelf": undefined,
         "bottom": undefined,
         "end": undefined,
+        "flex": undefined,
         "left": undefined,
         "position": undefined,
         "right": undefined,
@@ -137,11 +144,13 @@ exports[`renders snackbar with View & Text as a child 1`] = `
         "top": undefined,
       }
     }
+    testID="surface-outer-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
+          "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 1,
@@ -151,6 +160,7 @@ exports[`renders snackbar with View & Text as a child 1`] = `
           "shadowRadius": 2,
         }
       }
+      testID="surface-inner-layer"
     >
       <View
         accessibilityLiveRegion="polite"
@@ -160,6 +170,7 @@ exports[`renders snackbar with View & Text as a child 1`] = `
           Object {
             "backgroundColor": "rgba(49, 48, 51, 1)",
             "borderRadius": 4,
+            "flex": undefined,
             "flexDirection": "row",
             "justifyContent": "space-between",
             "margin": 8,
@@ -172,6 +183,7 @@ exports[`renders snackbar with View & Text as a child 1`] = `
             ],
           }
         }
+        testID="surface"
       >
         <View
           style={
@@ -245,6 +257,7 @@ exports[`renders snackbar with action button 1`] = `
         "alignSelf": undefined,
         "bottom": undefined,
         "end": undefined,
+        "flex": undefined,
         "left": undefined,
         "position": undefined,
         "right": undefined,
@@ -259,11 +272,13 @@ exports[`renders snackbar with action button 1`] = `
         "top": undefined,
       }
     }
+    testID="surface-outer-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
+          "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 1,
@@ -273,6 +288,7 @@ exports[`renders snackbar with action button 1`] = `
           "shadowRadius": 2,
         }
       }
+      testID="surface-inner-layer"
     >
       <View
         accessibilityLiveRegion="polite"
@@ -282,6 +298,7 @@ exports[`renders snackbar with action button 1`] = `
           Object {
             "backgroundColor": "rgba(49, 48, 51, 1)",
             "borderRadius": 4,
+            "flex": undefined,
             "flexDirection": "row",
             "justifyContent": "space-between",
             "margin": 8,
@@ -294,6 +311,7 @@ exports[`renders snackbar with action button 1`] = `
             ],
           }
         }
+        testID="surface"
       >
         <Text
           style={
@@ -349,6 +367,7 @@ exports[`renders snackbar with action button 1`] = `
                 "alignSelf": undefined,
                 "bottom": undefined,
                 "end": undefined,
+                "flex": undefined,
                 "left": undefined,
                 "position": undefined,
                 "right": undefined,
@@ -363,11 +382,13 @@ exports[`renders snackbar with action button 1`] = `
                 "top": undefined,
               }
             }
+            testID="button-container-outer-layer"
           >
             <View
               collapsable={false}
               style={
                 Object {
+                  "flex": undefined,
                   "shadowColor": "#000",
                   "shadowOffset": Object {
                     "height": 0,
@@ -377,6 +398,7 @@ exports[`renders snackbar with action button 1`] = `
                   "shadowRadius": 0,
                 }
               }
+              testID="button-container-inner-layer"
             >
               <View
                 collapsable={false}
@@ -387,6 +409,7 @@ exports[`renders snackbar with action button 1`] = `
                     "borderRadius": 20,
                     "borderStyle": "solid",
                     "borderWidth": 0,
+                    "flex": undefined,
                     "marginLeft": 4,
                     "marginRight": 8,
                     "minWidth": 64,
@@ -522,6 +545,7 @@ exports[`renders snackbar with content 1`] = `
         "alignSelf": undefined,
         "bottom": undefined,
         "end": undefined,
+        "flex": undefined,
         "left": undefined,
         "position": undefined,
         "right": undefined,
@@ -536,11 +560,13 @@ exports[`renders snackbar with content 1`] = `
         "top": undefined,
       }
     }
+    testID="surface-outer-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
+          "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 1,
@@ -550,6 +576,7 @@ exports[`renders snackbar with content 1`] = `
           "shadowRadius": 2,
         }
       }
+      testID="surface-inner-layer"
     >
       <View
         accessibilityLiveRegion="polite"
@@ -559,6 +586,7 @@ exports[`renders snackbar with content 1`] = `
           Object {
             "backgroundColor": "rgba(49, 48, 51, 1)",
             "borderRadius": 4,
+            "flex": undefined,
             "flexDirection": "row",
             "justifyContent": "space-between",
             "margin": 8,
@@ -571,6 +599,7 @@ exports[`renders snackbar with content 1`] = `
             ],
           }
         }
+        testID="surface"
       >
         <Text
           style={

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -1270,6 +1270,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
           "alignSelf": undefined,
           "bottom": undefined,
           "end": undefined,
+          "flex": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -1284,11 +1285,13 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
           "top": undefined,
         }
       }
+      testID="right-icon-adornment-container-outer-layer"
     >
       <View
         collapsable={false}
         style={
           Object {
+            "flex": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1298,6 +1301,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
             "shadowRadius": 0,
           }
         }
+        testID="right-icon-adornment-container-inner-layer"
       >
         <View
           collapsable={false}
@@ -1308,6 +1312,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
+              "flex": undefined,
               "height": 40,
               "margin": 0,
               "overflow": "hidden",
@@ -1627,6 +1632,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
           "alignSelf": undefined,
           "bottom": undefined,
           "end": undefined,
+          "flex": undefined,
           "left": undefined,
           "position": undefined,
           "right": undefined,
@@ -1641,11 +1647,13 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
           "top": undefined,
         }
       }
+      testID="left-icon-adornment-container-outer-layer"
     >
       <View
         collapsable={false}
         style={
           Object {
+            "flex": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1655,6 +1663,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
             "shadowRadius": 0,
           }
         }
+        testID="left-icon-adornment-container-inner-layer"
       >
         <View
           collapsable={false}
@@ -1665,6 +1674,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
+              "flex": undefined,
               "height": 40,
               "margin": 0,
               "overflow": "hidden",

--- a/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`renders disabled toggle button 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -22,11 +23,13 @@ exports[`renders disabled toggle button 1`] = `
       "top": undefined,
     }
   }
+  testID="icon-button-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -36,6 +39,7 @@ exports[`renders disabled toggle button 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="icon-button-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -46,6 +50,7 @@ exports[`renders disabled toggle button 1`] = `
           "borderRadius": 4,
           "borderWidth": 0,
           "elevation": 0,
+          "flex": undefined,
           "height": 42,
           "margin": 0,
           "overflow": "hidden",
@@ -158,6 +163,7 @@ exports[`renders toggle button 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -172,11 +178,13 @@ exports[`renders toggle button 1`] = `
       "top": undefined,
     }
   }
+  testID="icon-button-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -186,6 +194,7 @@ exports[`renders toggle button 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="icon-button-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -196,6 +205,7 @@ exports[`renders toggle button 1`] = `
           "borderRadius": 4,
           "borderWidth": 0,
           "elevation": 0,
+          "flex": undefined,
           "height": 42,
           "margin": 0,
           "overflow": "hidden",
@@ -303,6 +313,7 @@ exports[`renders unchecked toggle button 1`] = `
       "alignSelf": undefined,
       "bottom": undefined,
       "end": undefined,
+      "flex": undefined,
       "left": undefined,
       "position": undefined,
       "right": undefined,
@@ -317,11 +328,13 @@ exports[`renders unchecked toggle button 1`] = `
       "top": undefined,
     }
   }
+  testID="icon-button-container-outer-layer"
 >
   <View
     collapsable={false}
     style={
       Object {
+        "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -331,6 +344,7 @@ exports[`renders unchecked toggle button 1`] = `
         "shadowRadius": 0,
       }
     }
+    testID="icon-button-container-inner-layer"
   >
     <View
       collapsable={false}
@@ -341,6 +355,7 @@ exports[`renders unchecked toggle button 1`] = `
           "borderRadius": 4,
           "borderWidth": 0,
           "elevation": 0,
+          "flex": undefined,
           "height": 42,
           "margin": 0,
           "overflow": "hidden",


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

PR refines styles in the `Surface` views for `iOS` platform, to pass the `flex` into all its layers.

#### Related issue

- #3652 
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Added unit test covering Surface's layer styles.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
