### PR TITLE
feat: add content style prop to the Card

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -67,7 +67,11 @@ export type Props = React.ComponentProps<typeof Surface> & {
    * Changes Card shadow and background on iOS and Android.
    */
   elevation?: 0 | 1 | 2 | 3 | 4 | 5 | Animated.Value;
-  style?: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
+  /**
+   * Style of card's inner content.
+   */
+  contentStyle?: StyleProp<ViewStyle>;
+  style?: StyleProp<ViewStyle>;
   /**
    * @optional
    */
@@ -133,6 +137,7 @@ const Card = ({
   mode: cardMode = 'elevated',
   children,
   style,
+  contentStyle,
   theme: themeOverrides,
   testID = 'card',
   accessible,
@@ -275,7 +280,10 @@ const Card = ({
         testID={testID}
         accessible={accessible}
       >
-        <View style={styles.innerContainer}>
+        <View
+          style={[styles.innerContainer, contentStyle]}
+          testID={`${testID}-inner-container`}
+        >
           {React.Children.map(children, (child, index) =>
             React.isValidElement(child)
               ? React.cloneElement(child as React.ReactElement<any>, {

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -280,10 +280,7 @@ const Card = ({
         testID={testID}
         accessible={accessible}
       >
-        <View
-          style={[styles.innerContainer, contentStyle]}
-          testID={`${testID}-inner-container`}
-        >
+        <View style={[styles.innerContainer, contentStyle]}>
           {React.Children.map(children, (child, index) =>
             React.isValidElement(child)
               ? React.cloneElement(child as React.ReactElement<any>, {

--- a/src/components/__tests__/Card/Card.test.tsx
+++ b/src/components/__tests__/Card/Card.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Animated, StyleSheet } from 'react-native';
+import { Animated, StyleSheet, Text } from 'react-native';
 
 import { render } from '@testing-library/react-native';
 import color from 'color';
@@ -15,6 +15,9 @@ import { getCardColors, getCardCoverStyle } from '../../Card/utils';
 const styles = StyleSheet.create({
   customBorderRadius: {
     borderRadius: 32,
+  },
+  contentStyle: {
+    flexDirection: 'column-reverse',
   },
 });
 
@@ -72,6 +75,16 @@ describe('Card', () => {
     expect(getByLabelText('card')).toHaveStyle({
       backgroundColor: '#0000FF',
     });
+  });
+
+  it('renders with a content style', () => {
+    const { getByTestId } = render(
+      <Card contentStyle={styles.contentStyle}>
+        <Text>Content</Text>
+      </Card>
+    );
+
+    expect(getByTestId('card')).toHaveStyle(styles.contentStyle);
   });
 });
 

--- a/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
@@ -83,9 +83,12 @@ exports[`Card renders an outlined card 1`] = `
         onResponderTerminationRequest={[Function]}
         onStartShouldSetResponder={[Function]}
         style={
-          Object {
-            "flexShrink": 1,
-          }
+          Array [
+            Object {
+              "flexShrink": 1,
+            },
+            undefined,
+          ]
         }
         testID="card"
       />


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

PR introduce new prop called `contentStyle` to allow override the view styles which is wrapping `Card`'s content.

#### Related issue

- #3646 
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

New prop covered by unit test.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
