### PR TITLE
fix: allow for custom variants in `Text` (with factory)

### DIFF
--- a/docs/docs/guides/04-fonts.md
+++ b/docs/docs/guides/04-fonts.md
@@ -393,7 +393,6 @@ Platform.select({
 
 #### Using `configureFonts` helper
 
-<div style={{display: 'none'}}>
 * If there is a need to create a custom font variant, prepare its config object including required all fonts properties. After that, defined `fontConfig` has to be passed under the <b>`variant`</b> name as `config` into the params object:
 
 ```js
@@ -428,7 +427,16 @@ export default function Main() {
   );
 }
 ```
-</div>
+
+If you're using TypeScript you will need to create a custom `Text` component which accepts your custom variants:
+
+```typescript
+import { customText } from 'react-native-paper'
+
+// Use this instead of importing `Text` from `react-native-paper`
+export const Text = customText<'customVariant'>()
+```
+
 
 * In order to override one of the available `variant`'s font properties, pass the modified `fontConfig` under specific <b>`variant`</b> name as `config` into the params object:
 

--- a/example/src/Examples/TextExample.tsx
+++ b/example/src/Examples/TextExample.tsx
@@ -1,20 +1,46 @@
 import * as React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 
 import {
   Caption,
+  configureFonts,
   Headline,
+  MD3LightTheme,
   Paragraph,
+  Provider,
   Subheading,
-  Text,
+  customText,
   Title,
 } from 'react-native-paper';
 
 import { useExampleTheme } from '..';
 import ScreenWrapper from '../ScreenWrapper';
 
+const Text = customText<'customVariant'>();
+
 const TextExample = () => {
   const { isV3 } = useExampleTheme();
+
+  const fontConfig = {
+    customVariant: {
+      fontFamily: Platform.select({
+        ios: 'Noteworthy',
+        default: 'serif',
+      }),
+      fontWeight: '400',
+      letterSpacing: Platform.select({
+        ios: 7,
+        default: 4.6,
+      }),
+      lineHeight: 54,
+      fontSize: 40,
+    },
+  } as const;
+
+  const theme = {
+    ...MD3LightTheme,
+    fonts: configureFonts({ config: fontConfig }),
+  };
   return (
     <ScreenWrapper>
       <View style={styles.container}>
@@ -79,6 +105,12 @@ const TextExample = () => {
             <Text style={styles.text} variant="bodySmall">
               Body Small
             </Text>
+
+            <Provider theme={theme}>
+              <Text style={styles.text} variant="customVariant">
+                Custom Variant
+              </Text>
+            </Provider>
           </>
         )}
       </View>

--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -15,7 +15,7 @@ import color from 'color';
 import { useInternalTheme } from '../../core/theming';
 import { white } from '../../styles/themes/v2/colors';
 import type { $RemoveChildren, MD3TypescaleKey, ThemeProp } from '../../types';
-import Text from '../Typography/Text';
+import Text, { TextRef } from '../Typography/Text';
 import { modeTextVariant } from './utils';
 
 type TitleString = {
@@ -39,7 +39,7 @@ export type Props = $RemoveChildren<typeof View> & {
   /**
    * Reference for the title.
    */
-  titleRef?: React.RefObject<Text>;
+  titleRef?: React.RefObject<TextRef>;
   /**
    * @deprecated Deprecated in v5.x
    * Text for the subtitle.

--- a/src/components/Typography/AnimatedText.tsx
+++ b/src/components/Typography/AnimatedText.tsx
@@ -56,9 +56,9 @@ function AnimatedText({
       <Animated.Text
         {...rest}
         style={[
-          { ...font, color: theme.colors.onSurface },
+          font,
           styles.text,
-          { writingDirection },
+          { writingDirection, color: theme.colors.onSurface },
           style,
         ]}
       />

--- a/src/components/Typography/AnimatedText.tsx
+++ b/src/components/Typography/AnimatedText.tsx
@@ -2,9 +2,10 @@ import * as React from 'react';
 import { Animated, I18nManager, StyleSheet, TextStyle } from 'react-native';
 
 import { useInternalTheme } from '../../core/theming';
-import { Font, ThemeProp, MD3TypescaleKey } from '../../types';
+import type { ThemeProp } from '../../types';
+import type { VariantProp } from './types';
 
-type Props = React.ComponentPropsWithRef<typeof Animated.Text> & {
+type Props<T> = React.ComponentPropsWithRef<typeof Animated.Text> & {
   /**
    * Variant defines appropriate text styles for type role and its size.
    * Available variants:
@@ -19,7 +20,7 @@ type Props = React.ComponentPropsWithRef<typeof Animated.Text> & {
    *
    *  Body: `bodyLarge`, `bodyMedium`, `bodySmall`
    */
-  variant?: keyof typeof MD3TypescaleKey;
+  variant?: VariantProp<T>;
   style?: TextStyle;
   /**
    * @optional
@@ -37,44 +38,29 @@ function AnimatedText({
   theme: themeOverrides,
   variant,
   ...rest
-}: Props) {
+}: Props<never>) {
   const theme = useInternalTheme(themeOverrides);
   const writingDirection = I18nManager.getConstants().isRTL ? 'rtl' : 'ltr';
 
   if (theme.isV3 && variant) {
-    const stylesByVariant = Object.keys(MD3TypescaleKey).reduce(
-      (acc, key) => {
-        const { fontSize, fontWeight, lineHeight, letterSpacing, fontFamily } =
-          theme.fonts[key as keyof typeof MD3TypescaleKey];
-
-        return {
-          ...acc,
-          [key]: {
-            fontFamily,
-            fontSize,
-            fontWeight,
-            lineHeight: lineHeight,
-            letterSpacing,
-            color: theme.colors.onSurface,
-          },
-        };
-      },
-      {} as {
-        [key in MD3TypescaleKey]: {
-          fontSize: number;
-          fontWeight: Font['fontWeight'];
-          lineHeight: number;
-          letterSpacing: number;
-        };
-      }
-    );
-
-    const styleForVariant = stylesByVariant[variant];
+    const font = theme.fonts[variant];
+    if (typeof font !== 'object') {
+      throw new Error(
+        `Variant ${variant} was not provided properly. Valid variants are ${Object.keys(
+          theme.fonts
+        ).join(', ')}.`
+      );
+    }
 
     return (
       <Animated.Text
         {...rest}
-        style={[styleForVariant, styles.text, { writingDirection }, style]}
+        style={[
+          { ...font, color: theme.colors.onSurface },
+          styles.text,
+          { writingDirection },
+          style,
+        ]}
       />
     );
   } else {
@@ -104,5 +90,8 @@ const styles = StyleSheet.create({
     textAlign: 'left',
   },
 });
+
+export const customAnimatedText = <T,>() =>
+  AnimatedText as (props: Props<T>) => JSX.Element;
 
 export default AnimatedText;

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -109,12 +109,9 @@ const Text = (
       <NativeText
         ref={root}
         style={[
-          {
-            ...font,
-            color: theme.colors.onSurface,
-          },
+          font,
           styles.text,
-          { writingDirection },
+          { writingDirection, color: theme.colors.onSurface },
           style,
         ]}
         {...rest}

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -8,10 +8,11 @@ import {
 } from 'react-native';
 
 import { useInternalTheme } from '../../core/theming';
-import { Font, MD3TypescaleKey, ThemeProp } from '../../types';
+import type { ThemeProp } from '../../types';
 import { forwardRef } from '../../utils/forwardRef';
+import type { VariantProp } from './types';
 
-export type Props = React.ComponentProps<typeof NativeText> & {
+export type Props<T> = React.ComponentProps<typeof NativeText> & {
   /**
    * @supported Available in v5.x with theme version 3
    *
@@ -28,11 +29,15 @@ export type Props = React.ComponentProps<typeof NativeText> & {
    *
    *  Body: `bodyLarge`, `bodyMedium`, `bodySmall`
    */
-  variant?: keyof typeof MD3TypescaleKey;
+  variant?: VariantProp<T>;
   children: React.ReactNode;
   theme?: ThemeProp;
   style?: StyleProp<TextStyle>;
 };
+
+export type TextRef = React.ForwardedRef<{
+  setNativeProps(args: Object): void;
+}>;
 
 // @component-group Typography
 
@@ -77,10 +82,9 @@ export type Props = React.ComponentProps<typeof NativeText> & {
  *
  * @extends Text props https://reactnative.dev/docs/text#props
  */
-
-const Text: React.ForwardRefRenderFunction<{}, Props> = (
-  { style, variant, theme: initialTheme, ...rest }: Props,
-  ref
+const Text = (
+  { style, variant, theme: initialTheme, ...rest }: Props<string>,
+  ref: TextRef
 ) => {
   const root = React.useRef<NativeText | null>(null);
   // FIXME: destructure it in TS 4.6+
@@ -92,39 +96,27 @@ const Text: React.ForwardRefRenderFunction<{}, Props> = (
   }));
 
   if (theme.isV3 && variant) {
-    const stylesByVariant = Object.keys(MD3TypescaleKey).reduce(
-      (acc, key) => {
-        const { fontSize, fontWeight, lineHeight, letterSpacing, fontFamily } =
-          theme.fonts[key as keyof typeof MD3TypescaleKey];
-
-        return {
-          ...acc,
-          [key]: {
-            fontFamily,
-            fontSize,
-            fontWeight,
-            lineHeight,
-            letterSpacing,
-            color: theme.colors.onSurface,
-          },
-        };
-      },
-      {} as {
-        [key in MD3TypescaleKey]: {
-          fontSize: number;
-          fontWeight: Font['fontWeight'];
-          lineHeight: number;
-          letterSpacing: number;
-        };
-      }
-    );
-
-    const styleForVariant = stylesByVariant[variant];
+    const font = theme.fonts[variant];
+    if (typeof font !== 'object') {
+      throw new Error(
+        `Variant ${variant} was not provided properly. Valid variants are ${Object.keys(
+          theme.fonts
+        ).join(', ')}.`
+      );
+    }
 
     return (
       <NativeText
         ref={root}
-        style={[styleForVariant, styles.text, { writingDirection }, style]}
+        style={[
+          {
+            ...font,
+            color: theme.colors.onSurface,
+          },
+          styles.text,
+          { writingDirection },
+          style,
+        ]}
         {...rest}
       />
     );
@@ -150,4 +142,12 @@ const styles = StyleSheet.create({
   },
 });
 
-export default forwardRef(Text);
+type TextComponent<T> = (
+  props: Props<T> & { ref?: React.RefObject<TextRef> }
+) => JSX.Element;
+
+const Component = forwardRef(Text) as TextComponent<never>;
+
+export const customText = <T,>() => Component as unknown as TextComponent<T>;
+
+export default Component;

--- a/src/components/Typography/types.tsx
+++ b/src/components/Typography/types.tsx
@@ -1,0 +1,5 @@
+import type { MD3TypescaleKey } from '../../types';
+
+export type VariantProp<T> =
+  | (T extends string ? (string extends T ? never : T) : never)
+  | keyof typeof MD3TypescaleKey;

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
@@ -741,7 +741,6 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
           style={
             Array [
               Object {
-                "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontSize": 22,
                 "fontWeight": "400",
@@ -752,6 +751,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
                 "textAlign": "left",
               },
               Object {
+                "color": "rgba(28, 27, 31, 1)",
                 "writingDirection": "ltr",
               },
               Array [

--- a/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.tsx.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.tsx.snap
@@ -129,7 +129,6 @@ exports[`can render leading checkbox control 1`] = `
       style={
         Array [
           Object {
-            "color": "rgba(28, 27, 31, 1)",
             "fontFamily": "System",
             "fontSize": 16,
             "fontWeight": "400",
@@ -140,6 +139,7 @@ exports[`can render leading checkbox control 1`] = `
             "textAlign": "left",
           },
           Object {
+            "color": "rgba(28, 27, 31, 1)",
             "writingDirection": "ltr",
           },
           Array [
@@ -213,7 +213,6 @@ exports[`can render the Android checkbox on different platforms 1`] = `
       style={
         Array [
           Object {
-            "color": "rgba(28, 27, 31, 1)",
             "fontFamily": "System",
             "fontSize": 16,
             "fontWeight": "400",
@@ -224,6 +223,7 @@ exports[`can render the Android checkbox on different platforms 1`] = `
             "textAlign": "left",
           },
           Object {
+            "color": "rgba(28, 27, 31, 1)",
             "writingDirection": "ltr",
           },
           Array [
@@ -412,7 +412,6 @@ exports[`can render the iOS checkbox on different platforms 1`] = `
       style={
         Array [
           Object {
-            "color": "rgba(28, 27, 31, 1)",
             "fontFamily": "System",
             "fontSize": 16,
             "fontWeight": "400",
@@ -423,6 +422,7 @@ exports[`can render the iOS checkbox on different platforms 1`] = `
             "textAlign": "left",
           },
           Object {
+            "color": "rgba(28, 27, 31, 1)",
             "writingDirection": "ltr",
           },
           Array [
@@ -575,7 +575,6 @@ exports[`renders unchecked 1`] = `
       style={
         Array [
           Object {
-            "color": "rgba(28, 27, 31, 1)",
             "fontFamily": "System",
             "fontSize": 16,
             "fontWeight": "400",
@@ -586,6 +585,7 @@ exports[`renders unchecked 1`] = `
             "textAlign": "left",
           },
           Object {
+            "color": "rgba(28, 27, 31, 1)",
             "writingDirection": "ltr",
           },
           Array [

--- a/src/components/__tests__/RadioButton/__snapshots__/RadioButtonItem.test.tsx.snap
+++ b/src/components/__tests__/RadioButton/__snapshots__/RadioButtonItem.test.tsx.snap
@@ -128,7 +128,6 @@ exports[`can render leading radio button control 1`] = `
       style={
         Array [
           Object {
-            "color": "rgba(28, 27, 31, 1)",
             "fontFamily": "System",
             "fontSize": 16,
             "fontWeight": "400",
@@ -139,6 +138,7 @@ exports[`can render leading radio button control 1`] = `
             "textAlign": "left",
           },
           Object {
+            "color": "rgba(28, 27, 31, 1)",
             "writingDirection": "ltr",
           },
           Array [
@@ -211,7 +211,6 @@ exports[`can render the Android radio button on different platforms 1`] = `
       style={
         Array [
           Object {
-            "color": "rgba(28, 27, 31, 1)",
             "fontFamily": "System",
             "fontSize": 16,
             "fontWeight": "400",
@@ -222,6 +221,7 @@ exports[`can render the Android radio button on different platforms 1`] = `
             "textAlign": "left",
           },
           Object {
+            "color": "rgba(28, 27, 31, 1)",
             "writingDirection": "ltr",
           },
           Array [
@@ -341,7 +341,6 @@ exports[`can render the iOS radio button on different platforms 1`] = `
       style={
         Array [
           Object {
-            "color": "rgba(28, 27, 31, 1)",
             "fontFamily": "System",
             "fontSize": 16,
             "fontWeight": "400",
@@ -352,6 +351,7 @@ exports[`can render the iOS radio button on different platforms 1`] = `
             "textAlign": "left",
           },
           Object {
+            "color": "rgba(28, 27, 31, 1)",
             "writingDirection": "ltr",
           },
           Array [
@@ -503,7 +503,6 @@ exports[`renders unchecked 1`] = `
       style={
         Array [
           Object {
-            "color": "rgba(28, 27, 31, 1)",
             "fontFamily": "System",
             "fontSize": 16,
             "fontWeight": "400",
@@ -514,6 +513,7 @@ exports[`renders unchecked 1`] = `
             "textAlign": "left",
           },
           Object {
+            "color": "rgba(28, 27, 31, 1)",
             "writingDirection": "ltr",
           },
           Array [

--- a/src/components/__tests__/Typography/Text.test.tsx
+++ b/src/components/__tests__/Typography/Text.test.tsx
@@ -3,8 +3,11 @@ import * as React from 'react';
 import { render } from '@testing-library/react-native';
 import renderer from 'react-test-renderer';
 
+import Provider from '../../../core/Provider';
+import configureFonts from '../../../styles/fonts';
+import { MD3LightTheme } from '../../../styles/themes';
 import { tokens } from '../../../styles/themes/v3/tokens';
-import Text from '../../Typography/Text';
+import Text, { customText } from '../../Typography/Text';
 
 const content = 'Something rendered as a child content';
 
@@ -48,4 +51,42 @@ it('renders v3 Text component without variant with default fontWeight and fontFa
     fontFamily: brandRegular,
     fontWeight: weightRegular,
   });
+});
+
+it('renders v3 Text component with custom variant correctly', () => {
+  const fontConfig = {
+    customVariant: {
+      fontFamily: 'Montserrat-Regular',
+      fontWeight: '400',
+      letterSpacing: 0.51,
+      lineHeight: 54.1,
+      fontSize: 41,
+    },
+  } as const;
+
+  const theme = {
+    ...MD3LightTheme,
+    fonts: configureFonts({ config: fontConfig }),
+  };
+  const Text = customText<'customVariant'>();
+  const { getByTestId } = render(
+    <Provider theme={theme}>
+      <Text testID="text-with-custom-variant" variant="customVariant">
+        {content}
+      </Text>
+    </Provider>
+  );
+
+  expect(getByTestId('text-with-custom-variant').props.style).toMatchSnapshot();
+});
+
+it('throws when custom variant not provided', () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  const Text = customText<'myCustomVariant'>();
+  expect(() =>
+    render(<Text variant="myCustomVariant">{content}</Text>)
+  ).toThrow(/myCustomVariant was not provided/);
+
+  jest.clearAllMocks();
 });

--- a/src/components/__tests__/Typography/__snapshots__/Text.test.tsx.snap
+++ b/src/components/__tests__/Typography/__snapshots__/Text.test.tsx.snap
@@ -349,3 +349,23 @@ Array [
   </Text>,
 ]
 `;
+
+exports[`renders v3 Text component with custom variant correctly 1`] = `
+Array [
+  Object {
+    "color": "rgba(28, 27, 31, 1)",
+    "fontFamily": "Montserrat-Regular",
+    "fontSize": 41,
+    "fontWeight": "400",
+    "letterSpacing": 0.51,
+    "lineHeight": 54.1,
+  },
+  Object {
+    "textAlign": "left",
+  },
+  Object {
+    "writingDirection": "ltr",
+  },
+  undefined,
+]
+`;

--- a/src/components/__tests__/Typography/__snapshots__/Text.test.tsx.snap
+++ b/src/components/__tests__/Typography/__snapshots__/Text.test.tsx.snap
@@ -6,7 +6,6 @@ Array [
     style={
       Array [
         Object {
-          "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontSize": 57,
           "fontWeight": "400",
@@ -17,6 +16,7 @@ Array [
           "textAlign": "left",
         },
         Object {
+          "color": "rgba(28, 27, 31, 1)",
           "writingDirection": "ltr",
         },
         undefined,
@@ -29,7 +29,6 @@ Array [
     style={
       Array [
         Object {
-          "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontSize": 45,
           "fontWeight": "400",
@@ -40,6 +39,7 @@ Array [
           "textAlign": "left",
         },
         Object {
+          "color": "rgba(28, 27, 31, 1)",
           "writingDirection": "ltr",
         },
         undefined,
@@ -52,7 +52,6 @@ Array [
     style={
       Array [
         Object {
-          "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontSize": 36,
           "fontWeight": "400",
@@ -63,6 +62,7 @@ Array [
           "textAlign": "left",
         },
         Object {
+          "color": "rgba(28, 27, 31, 1)",
           "writingDirection": "ltr",
         },
         undefined,
@@ -75,7 +75,6 @@ Array [
     style={
       Array [
         Object {
-          "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontSize": 32,
           "fontWeight": "400",
@@ -86,6 +85,7 @@ Array [
           "textAlign": "left",
         },
         Object {
+          "color": "rgba(28, 27, 31, 1)",
           "writingDirection": "ltr",
         },
         undefined,
@@ -98,7 +98,6 @@ Array [
     style={
       Array [
         Object {
-          "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontSize": 28,
           "fontWeight": "400",
@@ -109,6 +108,7 @@ Array [
           "textAlign": "left",
         },
         Object {
+          "color": "rgba(28, 27, 31, 1)",
           "writingDirection": "ltr",
         },
         undefined,
@@ -121,7 +121,6 @@ Array [
     style={
       Array [
         Object {
-          "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontSize": 24,
           "fontWeight": "400",
@@ -132,6 +131,7 @@ Array [
           "textAlign": "left",
         },
         Object {
+          "color": "rgba(28, 27, 31, 1)",
           "writingDirection": "ltr",
         },
         undefined,
@@ -144,7 +144,6 @@ Array [
     style={
       Array [
         Object {
-          "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontSize": 22,
           "fontWeight": "400",
@@ -155,6 +154,7 @@ Array [
           "textAlign": "left",
         },
         Object {
+          "color": "rgba(28, 27, 31, 1)",
           "writingDirection": "ltr",
         },
         undefined,
@@ -167,7 +167,6 @@ Array [
     style={
       Array [
         Object {
-          "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontSize": 16,
           "fontWeight": "500",
@@ -178,6 +177,7 @@ Array [
           "textAlign": "left",
         },
         Object {
+          "color": "rgba(28, 27, 31, 1)",
           "writingDirection": "ltr",
         },
         undefined,
@@ -190,7 +190,6 @@ Array [
     style={
       Array [
         Object {
-          "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontSize": 14,
           "fontWeight": "500",
@@ -201,6 +200,7 @@ Array [
           "textAlign": "left",
         },
         Object {
+          "color": "rgba(28, 27, 31, 1)",
           "writingDirection": "ltr",
         },
         undefined,
@@ -213,7 +213,6 @@ Array [
     style={
       Array [
         Object {
-          "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontSize": 16,
           "fontWeight": "400",
@@ -224,6 +223,7 @@ Array [
           "textAlign": "left",
         },
         Object {
+          "color": "rgba(28, 27, 31, 1)",
           "writingDirection": "ltr",
         },
         undefined,
@@ -236,7 +236,6 @@ Array [
     style={
       Array [
         Object {
-          "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontSize": 14,
           "fontWeight": "400",
@@ -247,6 +246,7 @@ Array [
           "textAlign": "left",
         },
         Object {
+          "color": "rgba(28, 27, 31, 1)",
           "writingDirection": "ltr",
         },
         undefined,
@@ -259,7 +259,6 @@ Array [
     style={
       Array [
         Object {
-          "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontSize": 12,
           "fontWeight": "400",
@@ -270,6 +269,7 @@ Array [
           "textAlign": "left",
         },
         Object {
+          "color": "rgba(28, 27, 31, 1)",
           "writingDirection": "ltr",
         },
         undefined,
@@ -282,7 +282,6 @@ Array [
     style={
       Array [
         Object {
-          "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontSize": 14,
           "fontWeight": "500",
@@ -293,6 +292,7 @@ Array [
           "textAlign": "left",
         },
         Object {
+          "color": "rgba(28, 27, 31, 1)",
           "writingDirection": "ltr",
         },
         undefined,
@@ -305,7 +305,6 @@ Array [
     style={
       Array [
         Object {
-          "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontSize": 12,
           "fontWeight": "500",
@@ -316,6 +315,7 @@ Array [
           "textAlign": "left",
         },
         Object {
+          "color": "rgba(28, 27, 31, 1)",
           "writingDirection": "ltr",
         },
         undefined,
@@ -328,7 +328,6 @@ Array [
     style={
       Array [
         Object {
-          "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontSize": 11,
           "fontWeight": "500",
@@ -339,6 +338,7 @@ Array [
           "textAlign": "left",
         },
         Object {
+          "color": "rgba(28, 27, 31, 1)",
           "writingDirection": "ltr",
         },
         undefined,
@@ -353,7 +353,6 @@ Array [
 exports[`renders v3 Text component with custom variant correctly 1`] = `
 Array [
   Object {
-    "color": "rgba(28, 27, 31, 1)",
     "fontFamily": "Montserrat-Regular",
     "fontSize": 41,
     "fontWeight": "400",
@@ -364,6 +363,7 @@ Array [
     "textAlign": "left",
   },
   Object {
+    "color": "rgba(28, 27, 31, 1)",
     "writingDirection": "ltr",
   },
   undefined,

--- a/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
@@ -235,7 +235,6 @@ exports[`render visible banner, with custom theme 1`] = `
                         style={
                           Array [
                             Object {
-                              "color": "rgba(28, 27, 31, 1)",
                               "fontFamily": "System",
                               "fontSize": 14,
                               "fontWeight": "500",
@@ -246,6 +245,7 @@ exports[`render visible banner, with custom theme 1`] = `
                               "textAlign": "left",
                             },
                             Object {
+                              "color": "rgba(28, 27, 31, 1)",
                               "writingDirection": "ltr",
                             },
                             Array [
@@ -696,7 +696,6 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                         style={
                           Array [
                             Object {
-                              "color": "rgba(28, 27, 31, 1)",
                               "fontFamily": "System",
                               "fontSize": 14,
                               "fontWeight": "500",
@@ -707,6 +706,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                               "textAlign": "left",
                             },
                             Object {
+                              "color": "rgba(28, 27, 31, 1)",
                               "writingDirection": "ltr",
                             },
                             Array [
@@ -987,7 +987,6 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                         style={
                           Array [
                             Object {
-                              "color": "rgba(28, 27, 31, 1)",
                               "fontFamily": "System",
                               "fontSize": 14,
                               "fontWeight": "500",
@@ -998,6 +997,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                               "textAlign": "left",
                             },
                             Object {
+                              "color": "rgba(28, 27, 31, 1)",
                               "writingDirection": "ltr",
                             },
                             Array [
@@ -1141,7 +1141,6 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                         style={
                           Array [
                             Object {
-                              "color": "rgba(28, 27, 31, 1)",
                               "fontFamily": "System",
                               "fontSize": 14,
                               "fontWeight": "500",
@@ -1152,6 +1151,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                               "textAlign": "left",
                             },
                             Object {
+                              "color": "rgba(28, 27, 31, 1)",
                               "writingDirection": "ltr",
                             },
                             Array [

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
@@ -2042,7 +2042,6 @@ exports[`renders bottom navigation with getLazy 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -2053,6 +2052,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -2096,7 +2096,6 @@ exports[`renders bottom navigation with getLazy 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -2107,6 +2106,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -2350,7 +2350,6 @@ exports[`renders bottom navigation with getLazy 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -2361,6 +2360,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -2404,7 +2404,6 @@ exports[`renders bottom navigation with getLazy 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -2415,6 +2414,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -2658,7 +2658,6 @@ exports[`renders bottom navigation with getLazy 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -2669,6 +2668,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -2712,7 +2712,6 @@ exports[`renders bottom navigation with getLazy 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -2723,6 +2722,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -2966,7 +2966,6 @@ exports[`renders bottom navigation with getLazy 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -2977,6 +2976,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -3020,7 +3020,6 @@ exports[`renders bottom navigation with getLazy 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -3031,6 +3030,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -3274,7 +3274,6 @@ exports[`renders bottom navigation with getLazy 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -3285,6 +3284,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -3328,7 +3328,6 @@ exports[`renders bottom navigation with getLazy 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -3339,6 +3338,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -3784,7 +3784,6 @@ exports[`renders bottom navigation with scene animation 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -3795,6 +3794,7 @@ exports[`renders bottom navigation with scene animation 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -4044,7 +4044,6 @@ exports[`renders bottom navigation with scene animation 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -4055,6 +4054,7 @@ exports[`renders bottom navigation with scene animation 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -4304,7 +4304,6 @@ exports[`renders bottom navigation with scene animation 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -4315,6 +4314,7 @@ exports[`renders bottom navigation with scene animation 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -4564,7 +4564,6 @@ exports[`renders bottom navigation with scene animation 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -4575,6 +4574,7 @@ exports[`renders bottom navigation with scene animation 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -4824,7 +4824,6 @@ exports[`renders bottom navigation with scene animation 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -4835,6 +4834,7 @@ exports[`renders bottom navigation with scene animation 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -6941,7 +6941,6 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -6952,6 +6951,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -6995,7 +6995,6 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -7006,6 +7005,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -7249,7 +7249,6 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -7260,6 +7259,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -7303,7 +7303,6 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -7314,6 +7313,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -7557,7 +7557,6 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -7568,6 +7567,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -7611,7 +7611,6 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -7622,6 +7621,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -8067,7 +8067,6 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -8078,6 +8077,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -8327,7 +8327,6 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -8338,6 +8337,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -8587,7 +8587,6 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -8598,6 +8597,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -9015,7 +9015,6 @@ exports[`renders non-shifting bottom navigation 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -9026,6 +9025,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -9069,7 +9069,6 @@ exports[`renders non-shifting bottom navigation 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -9080,6 +9079,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -9323,7 +9323,6 @@ exports[`renders non-shifting bottom navigation 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -9334,6 +9333,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -9377,7 +9377,6 @@ exports[`renders non-shifting bottom navigation 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -9388,6 +9387,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -9631,7 +9631,6 @@ exports[`renders non-shifting bottom navigation 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -9642,6 +9641,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -9685,7 +9685,6 @@ exports[`renders non-shifting bottom navigation 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -9696,6 +9695,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -10141,7 +10141,6 @@ exports[`renders shifting bottom navigation 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -10152,6 +10151,7 @@ exports[`renders shifting bottom navigation 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -10401,7 +10401,6 @@ exports[`renders shifting bottom navigation 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -10412,6 +10411,7 @@ exports[`renders shifting bottom navigation 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -10661,7 +10661,6 @@ exports[`renders shifting bottom navigation 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -10672,6 +10671,7 @@ exports[`renders shifting bottom navigation 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -10921,7 +10921,6 @@ exports[`renders shifting bottom navigation 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -10932,6 +10931,7 @@ exports[`renders shifting bottom navigation 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -11181,7 +11181,6 @@ exports[`renders shifting bottom navigation 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
@@ -11192,6 +11191,7 @@ exports[`renders shifting bottom navigation 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [

--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -107,7 +107,6 @@ exports[`renders button with an accessibility hint 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -118,6 +117,7 @@ exports[`renders button with an accessibility hint 1`] = `
                   "textAlign": "left",
                 },
                 Object {
+                  "color": "rgba(28, 27, 31, 1)",
                   "writingDirection": "ltr",
                 },
                 Array [
@@ -262,7 +262,6 @@ exports[`renders button with an accessibility label 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -273,6 +272,7 @@ exports[`renders button with an accessibility label 1`] = `
                   "textAlign": "left",
                 },
                 Object {
+                  "color": "rgba(28, 27, 31, 1)",
                   "writingDirection": "ltr",
                 },
                 Array [
@@ -416,7 +416,6 @@ exports[`renders button with button color 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -427,6 +426,7 @@ exports[`renders button with button color 1`] = `
                   "textAlign": "left",
                 },
                 Object {
+                  "color": "rgba(28, 27, 31, 1)",
                   "writingDirection": "ltr",
                 },
                 Array [
@@ -570,7 +570,6 @@ exports[`renders button with color 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -581,6 +580,7 @@ exports[`renders button with color 1`] = `
                   "textAlign": "left",
                 },
                 Object {
+                  "color": "rgba(28, 27, 31, 1)",
                   "writingDirection": "ltr",
                 },
                 Array [
@@ -724,7 +724,6 @@ exports[`renders button with custom testID 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -735,6 +734,7 @@ exports[`renders button with custom testID 1`] = `
                   "textAlign": "left",
                 },
                 Object {
+                  "color": "rgba(28, 27, 31, 1)",
                   "writingDirection": "ltr",
                 },
                 Array [
@@ -934,7 +934,6 @@ exports[`renders button with icon 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -945,6 +944,7 @@ exports[`renders button with icon 1`] = `
                   "textAlign": "left",
                 },
                 Object {
+                  "color": "rgba(28, 27, 31, 1)",
                   "writingDirection": "ltr",
                 },
                 Array [
@@ -1146,7 +1146,6 @@ exports[`renders button with icon in reverse order 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -1157,6 +1156,7 @@ exports[`renders button with icon in reverse order 1`] = `
                   "textAlign": "left",
                 },
                 Object {
+                  "color": "rgba(28, 27, 31, 1)",
                   "writingDirection": "ltr",
                 },
                 Array [
@@ -1300,7 +1300,6 @@ exports[`renders contained contained with mode 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -1311,6 +1310,7 @@ exports[`renders contained contained with mode 1`] = `
                   "textAlign": "left",
                 },
                 Object {
+                  "color": "rgba(28, 27, 31, 1)",
                   "writingDirection": "ltr",
                 },
                 Array [
@@ -1455,7 +1455,6 @@ exports[`renders disabled button 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -1466,6 +1465,7 @@ exports[`renders disabled button 1`] = `
                   "textAlign": "left",
                 },
                 Object {
+                  "color": "rgba(28, 27, 31, 1)",
                   "writingDirection": "ltr",
                 },
                 Array [
@@ -1817,7 +1817,6 @@ exports[`renders loading button 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -1828,6 +1827,7 @@ exports[`renders loading button 1`] = `
                   "textAlign": "left",
                 },
                 Object {
+                  "color": "rgba(28, 27, 31, 1)",
                   "writingDirection": "ltr",
                 },
                 Array [
@@ -1971,7 +1971,6 @@ exports[`renders outlined button with mode 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -1982,6 +1981,7 @@ exports[`renders outlined button with mode 1`] = `
                   "textAlign": "left",
                 },
                 Object {
+                  "color": "rgba(28, 27, 31, 1)",
                   "writingDirection": "ltr",
                 },
                 Array [
@@ -2126,7 +2126,6 @@ exports[`renders text button by default 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -2137,6 +2136,7 @@ exports[`renders text button by default 1`] = `
                   "textAlign": "left",
                 },
                 Object {
+                  "color": "rgba(28, 27, 31, 1)",
                   "writingDirection": "ltr",
                 },
                 Array [
@@ -2280,7 +2280,6 @@ exports[`renders text button with mode 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -2291,6 +2290,7 @@ exports[`renders text button with mode 1`] = `
                   "textAlign": "left",
                 },
                 Object {
+                  "color": "rgba(28, 27, 31, 1)",
                   "writingDirection": "ltr",
                 },
                 Array [

--- a/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -171,7 +171,6 @@ exports[`renders chip with close button 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -182,6 +181,7 @@ exports[`renders chip with close button 1`] = `
                   "textAlign": "left",
                 },
                 Object {
+                  "color": "rgba(28, 27, 31, 1)",
                   "writingDirection": "ltr",
                 },
                 Array [
@@ -463,7 +463,6 @@ exports[`renders chip with custom close button 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -474,6 +473,7 @@ exports[`renders chip with custom close button 1`] = `
                   "textAlign": "left",
                 },
                 Object {
+                  "color": "rgba(28, 27, 31, 1)",
                   "writingDirection": "ltr",
                 },
                 Array [
@@ -755,7 +755,6 @@ exports[`renders chip with icon 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -766,6 +765,7 @@ exports[`renders chip with icon 1`] = `
                   "textAlign": "left",
                 },
                 Object {
+                  "color": "rgba(28, 27, 31, 1)",
                   "writingDirection": "ltr",
                 },
                 Array [
@@ -918,7 +918,6 @@ exports[`renders chip with onPress 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -929,6 +928,7 @@ exports[`renders chip with onPress 1`] = `
                   "textAlign": "left",
                 },
                 Object {
+                  "color": "rgba(28, 27, 31, 1)",
                   "writingDirection": "ltr",
                 },
                 Array [
@@ -1081,7 +1081,6 @@ exports[`renders outlined disabled chip 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -1092,6 +1091,7 @@ exports[`renders outlined disabled chip 1`] = `
                   "textAlign": "left",
                 },
                 Object {
+                  "color": "rgba(28, 27, 31, 1)",
                   "writingDirection": "ltr",
                 },
                 Array [
@@ -1296,7 +1296,6 @@ exports[`renders selected chip 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -1307,6 +1306,7 @@ exports[`renders selected chip 1`] = `
                   "textAlign": "left",
                 },
                 Object {
+                  "color": "rgba(28, 27, 31, 1)",
                   "writingDirection": "ltr",
                 },
                 Array [

--- a/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -1798,7 +1798,6 @@ exports[`renders data table pagination with options select 1`] = `
                   style={
                     Array [
                       Object {
-                        "color": "rgba(28, 27, 31, 1)",
                         "fontFamily": "System",
                         "fontSize": 14,
                         "fontWeight": "500",
@@ -1809,6 +1808,7 @@ exports[`renders data table pagination with options select 1`] = `
                         "textAlign": "left",
                       },
                       Object {
+                        "color": "rgba(28, 27, 31, 1)",
                         "writingDirection": "ltr",
                       },
                       Array [

--- a/src/components/__tests__/__snapshots__/DrawerItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DrawerItem.test.tsx.snap
@@ -116,7 +116,6 @@ exports[`renders DrawerItem with icon 1`] = `
           style={
             Array [
               Object {
-                "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontSize": 14,
                 "fontWeight": "500",
@@ -127,6 +126,7 @@ exports[`renders DrawerItem with icon 1`] = `
                 "textAlign": "left",
               },
               Object {
+                "color": "rgba(28, 27, 31, 1)",
                 "writingDirection": "ltr",
               },
               Array [
@@ -270,7 +270,6 @@ exports[`renders active DrawerItem 1`] = `
           style={
             Array [
               Object {
-                "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontSize": 14,
                 "fontWeight": "500",
@@ -281,6 +280,7 @@ exports[`renders active DrawerItem 1`] = `
                 "textAlign": "left",
               },
               Object {
+                "color": "rgba(28, 27, 31, 1)",
                 "writingDirection": "ltr",
               },
               Array [
@@ -388,7 +388,6 @@ exports[`renders basic DrawerItem 1`] = `
           style={
             Array [
               Object {
-                "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontSize": 14,
                 "fontWeight": "500",
@@ -399,6 +398,7 @@ exports[`renders basic DrawerItem 1`] = `
                 "textAlign": "left",
               },
               Object {
+                "color": "rgba(28, 27, 31, 1)",
                 "writingDirection": "ltr",
               },
               Array [

--- a/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
@@ -924,7 +924,6 @@ exports[`renders extended FAB 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -935,6 +934,7 @@ exports[`renders extended FAB 1`] = `
                   "textAlign": "left",
                 },
                 Object {
+                  "color": "rgba(28, 27, 31, 1)",
                   "writingDirection": "ltr",
                 },
                 Array [
@@ -1147,7 +1147,6 @@ exports[`renders extended FAB with custom size prop 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(28, 27, 31, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -1158,6 +1157,7 @@ exports[`renders extended FAB with custom size prop 1`] = `
                   "textAlign": "left",
                 },
                 Object {
+                  "color": "rgba(28, 27, 31, 1)",
                   "writingDirection": "ltr",
                 },
                 Array [

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -268,7 +268,6 @@ exports[`renders list item with custom description 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 14,
                             "fontWeight": "500",
@@ -279,6 +278,7 @@ exports[`renders list item with custom description 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [

--- a/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
@@ -181,7 +181,6 @@ exports[`renders list section with custom title style 1`] = `
     style={
       Array [
         Object {
-          "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontSize": 14,
           "fontWeight": "400",
@@ -192,6 +191,7 @@ exports[`renders list section with custom title style 1`] = `
           "textAlign": "left",
         },
         Object {
+          "color": "rgba(28, 27, 31, 1)",
           "writingDirection": "ltr",
         },
         Array [
@@ -682,7 +682,6 @@ exports[`renders list section with subheader 1`] = `
     style={
       Array [
         Object {
-          "color": "rgba(28, 27, 31, 1)",
           "fontFamily": "System",
           "fontSize": 14,
           "fontWeight": "400",
@@ -693,6 +692,7 @@ exports[`renders list section with subheader 1`] = `
           "textAlign": "left",
         },
         Object {
+          "color": "rgba(28, 27, 31, 1)",
           "writingDirection": "ltr",
         },
         Array [

--- a/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -119,7 +119,6 @@ Array [
                   style={
                     Array [
                       Object {
-                        "color": "rgba(28, 27, 31, 1)",
                         "fontFamily": "System",
                         "fontSize": 14,
                         "fontWeight": "500",
@@ -130,6 +129,7 @@ Array [
                         "textAlign": "left",
                       },
                       Object {
+                        "color": "rgba(28, 27, 31, 1)",
                         "writingDirection": "ltr",
                       },
                       Array [
@@ -370,7 +370,6 @@ Array [
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 16,
                             "fontWeight": "400",
@@ -381,6 +380,7 @@ Array [
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -474,7 +474,6 @@ Array [
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 16,
                             "fontWeight": "400",
@@ -485,6 +484,7 @@ Array [
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -634,7 +634,6 @@ exports[`renders not visible menu 1`] = `
                 style={
                   Array [
                     Object {
-                      "color": "rgba(28, 27, 31, 1)",
                       "fontFamily": "System",
                       "fontSize": 14,
                       "fontWeight": "500",
@@ -645,6 +644,7 @@ exports[`renders not visible menu 1`] = `
                       "textAlign": "left",
                     },
                     Object {
+                      "color": "rgba(28, 27, 31, 1)",
                       "writingDirection": "ltr",
                     },
                     Array [
@@ -804,7 +804,6 @@ Array [
                   style={
                     Array [
                       Object {
-                        "color": "rgba(28, 27, 31, 1)",
                         "fontFamily": "System",
                         "fontSize": 14,
                         "fontWeight": "500",
@@ -815,6 +814,7 @@ Array [
                         "textAlign": "left",
                       },
                       Object {
+                        "color": "rgba(28, 27, 31, 1)",
                         "writingDirection": "ltr",
                       },
                       Array [
@@ -1053,7 +1053,6 @@ Array [
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 16,
                             "fontWeight": "400",
@@ -1064,6 +1063,7 @@ Array [
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -1157,7 +1157,6 @@ Array [
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 16,
                             "fontWeight": "400",
@@ -1168,6 +1167,7 @@ Array [
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [

--- a/src/components/__tests__/__snapshots__/MenuItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/MenuItem.test.tsx.snap
@@ -121,7 +121,6 @@ Array [
           style={
             Array [
               Object {
-                "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontSize": 16,
                 "fontWeight": "400",
@@ -132,6 +131,7 @@ Array [
                 "textAlign": "left",
               },
               Object {
+                "color": "rgba(28, 27, 31, 1)",
                 "writingDirection": "ltr",
               },
               Array [
@@ -273,7 +273,6 @@ Array [
           style={
             Array [
               Object {
-                "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontSize": 16,
                 "fontWeight": "400",
@@ -284,6 +283,7 @@ Array [
                 "textAlign": "left",
               },
               Object {
+                "color": "rgba(28, 27, 31, 1)",
                 "writingDirection": "ltr",
               },
               Array [
@@ -425,7 +425,6 @@ Array [
           style={
             Array [
               Object {
-                "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontSize": 16,
                 "fontWeight": "400",
@@ -436,6 +435,7 @@ Array [
                 "textAlign": "left",
               },
               Object {
+                "color": "rgba(28, 27, 31, 1)",
                 "writingDirection": "ltr",
               },
               Array [
@@ -577,7 +577,6 @@ Array [
           style={
             Array [
               Object {
-                "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontSize": 16,
                 "fontWeight": "400",
@@ -588,6 +587,7 @@ Array [
                 "textAlign": "left",
               },
               Object {
+                "color": "rgba(28, 27, 31, 1)",
                 "writingDirection": "ltr",
               },
               Array [
@@ -681,7 +681,6 @@ Array [
           style={
             Array [
               Object {
-                "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontSize": 16,
                 "fontWeight": "400",
@@ -692,6 +691,7 @@ Array [
                 "textAlign": "left",
               },
               Object {
+                "color": "rgba(28, 27, 31, 1)",
                 "writingDirection": "ltr",
               },
               Array [

--- a/src/components/__tests__/__snapshots__/SegmentedButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/SegmentedButton.test.tsx.snap
@@ -145,7 +145,6 @@ exports[`renders checked segmented button with selected check 1`] = `
           style={
             Array [
               Object {
-                "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontSize": 14,
                 "fontWeight": "500",
@@ -156,6 +155,7 @@ exports[`renders checked segmented button with selected check 1`] = `
                 "textAlign": "left",
               },
               Object {
+                "color": "rgba(28, 27, 31, 1)",
                 "writingDirection": "ltr",
               },
               Array [
@@ -256,7 +256,6 @@ exports[`renders checked segmented button with selected check 1`] = `
           style={
             Array [
               Object {
-                "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontSize": 14,
                 "fontWeight": "500",
@@ -267,6 +266,7 @@ exports[`renders checked segmented button with selected check 1`] = `
                 "textAlign": "left",
               },
               Object {
+                "color": "rgba(28, 27, 31, 1)",
                 "writingDirection": "ltr",
               },
               Array [
@@ -385,7 +385,6 @@ exports[`renders disabled segmented button 1`] = `
           style={
             Array [
               Object {
-                "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontSize": 14,
                 "fontWeight": "500",
@@ -396,6 +395,7 @@ exports[`renders disabled segmented button 1`] = `
                 "textAlign": "left",
               },
               Object {
+                "color": "rgba(28, 27, 31, 1)",
                 "writingDirection": "ltr",
               },
               Array [
@@ -496,7 +496,6 @@ exports[`renders disabled segmented button 1`] = `
           style={
             Array [
               Object {
-                "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontSize": 14,
                 "fontWeight": "500",
@@ -507,6 +506,7 @@ exports[`renders disabled segmented button 1`] = `
                 "textAlign": "left",
               },
               Object {
+                "color": "rgba(28, 27, 31, 1)",
                 "writingDirection": "ltr",
               },
               Array [
@@ -623,7 +623,6 @@ exports[`renders segmented button 1`] = `
           style={
             Array [
               Object {
-                "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontSize": 14,
                 "fontWeight": "500",
@@ -634,6 +633,7 @@ exports[`renders segmented button 1`] = `
                 "textAlign": "left",
               },
               Object {
+                "color": "rgba(28, 27, 31, 1)",
                 "writingDirection": "ltr",
               },
               Array [
@@ -734,7 +734,6 @@ exports[`renders segmented button 1`] = `
           style={
             Array [
               Object {
-                "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontSize": 14,
                 "fontWeight": "500",
@@ -745,6 +744,7 @@ exports[`renders segmented button 1`] = `
                 "textAlign": "left",
               },
               Object {
+                "color": "rgba(28, 27, 31, 1)",
                 "writingDirection": "ltr",
               },
               Array [

--- a/src/components/__tests__/__snapshots__/Snackbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.tsx.snap
@@ -317,7 +317,6 @@ exports[`renders snackbar with action button 1`] = `
           style={
             Array [
               Object {
-                "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontSize": 14,
                 "fontWeight": "400",
@@ -328,6 +327,7 @@ exports[`renders snackbar with action button 1`] = `
                 "textAlign": "left",
               },
               Object {
+                "color": "rgba(28, 27, 31, 1)",
                 "writingDirection": "ltr",
               },
               Array [
@@ -467,7 +467,6 @@ exports[`renders snackbar with action button 1`] = `
                       style={
                         Array [
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 14,
                             "fontWeight": "500",
@@ -478,6 +477,7 @@ exports[`renders snackbar with action button 1`] = `
                             "textAlign": "left",
                           },
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "writingDirection": "ltr",
                           },
                           Array [
@@ -605,7 +605,6 @@ exports[`renders snackbar with content 1`] = `
           style={
             Array [
               Object {
-                "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontSize": 14,
                 "fontWeight": "400",
@@ -616,6 +615,7 @@ exports[`renders snackbar with content 1`] = `
                 "textAlign": "left",
               },
               Object {
+                "color": "rgba(28, 27, 31, 1)",
                 "writingDirection": "ltr",
               },
               Array [

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -63,7 +63,7 @@ export {
   Subheading,
   Title,
 } from './components/Typography/v2';
-export { default as Text } from './components/Typography/Text';
+export { default as Text, customText } from './components/Typography/Text';
 
 // Types
 export type { Props as ActivityIndicatorProps } from './components/ActivityIndicator';
@@ -149,4 +149,10 @@ export type { Props as SegmentedButtonsProps } from './components/SegmentedButto
 export type { Props as ListImageProps } from './components/List/ListImage';
 export type { Props as TooltipProps } from './components/Tooltip/Tooltip';
 
-export type { MD2Theme, MD3Theme, ThemeBase, MD3Elevation } from './types';
+export type {
+  MD2Theme,
+  MD3Theme,
+  ThemeBase,
+  MD3Elevation,
+  MD3TypescaleKey,
+} from './types';


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes #3658
Closes #3659

- Updated docs
- Updated example
- Added tests

|iOS|Android|
|-|-|
|<img width="548" alt="image" src="https://user-images.githubusercontent.com/8790386/217033819-facdee97-c7f9-4574-8940-88d3b1b7a326.png">|<img width="526" alt="image" src="https://user-images.githubusercontent.com/8790386/217033801-0ed32380-b08e-4866-b6e1-aac0788a39b1.png">|

### Test plan

CI passes. Example works as expected.