### PR TITLE
refactor: fix performance of InputLabel

### DIFF
--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -5,10 +5,16 @@ import AnimatedText from '../../Typography/AnimatedText';
 import type { InputLabelProps } from '../types';
 
 const InputLabel = (props: InputLabelProps) => {
-  const { parentState, labelBackground } = props;
   const {
-    label,
+    labeled,
+    wiggle,
     error,
+    focused,
+    opacity,
+    labelLayoutWidth,
+    labelBackground,
+    label,
+    labelError,
     onLayoutAnimatedText,
     hasActiveOutline,
     activeColor,
@@ -23,20 +29,26 @@ const InputLabel = (props: InputLabelProps) => {
     wiggleOffsetX,
     labelScale,
     topPosition,
-    paddingOffset,
+    paddingLeft,
+    paddingRight,
+    backgroundColor,
+    roundness,
     placeholderColor,
     errorColor,
     labelTranslationXOffset,
     maxFontSizeMultiplier,
     testID,
     theme,
-  } = props.labelProps;
+  } = props;
+
+  const paddingOffset =
+    paddingLeft && paddingRight ? { paddingLeft, paddingRight } : {};
 
   const labelTranslationX = {
     transform: [
       {
         // Offset label scale since RN doesn't support transform origin
-        translateX: parentState.labeled.interpolate({
+        translateX: labeled.interpolate({
           inputRange: [0, 1],
           outputRange: [baseLabelTranslateX, labelTranslationXOffset || 0],
         }),
@@ -50,7 +62,7 @@ const InputLabel = (props: InputLabelProps) => {
     lineHeight,
     fontWeight,
     opacity: hasActiveOutline
-      ? parentState.labeled.interpolate({
+      ? labeled.interpolate({
           inputRange: [0, 1],
           outputRange: [1, 0],
         })
@@ -58,19 +70,18 @@ const InputLabel = (props: InputLabelProps) => {
     transform: [
       {
         // Wiggle the label when there's an error
-        translateX:
-          parentState.value && error
-            ? parentState.error.interpolate({
-                inputRange: [0, 0.5, 1],
-                outputRange: [0, wiggleOffsetX, 0],
-              })
-            : 0,
+        translateX: wiggle
+          ? error.interpolate({
+              inputRange: [0, 0.5, 1],
+              outputRange: [0, wiggleOffsetX, 0],
+            })
+          : 0,
       },
       {
         // Move label to top
         translateY:
           baseLabelTranslateY !== 0
-            ? parentState.labeled.interpolate({
+            ? labeled.interpolate({
                 inputRange: [0, 1],
                 outputRange: [baseLabelTranslateY, 0],
               })
@@ -80,23 +91,17 @@ const InputLabel = (props: InputLabelProps) => {
         // Make label smaller
         scale:
           labelScale !== 0
-            ? parentState.labeled.interpolate({
+            ? labeled.interpolate({
                 inputRange: [0, 1],
                 outputRange: [labelScale, 1],
               })
-            : parentState.labeled,
+            : labeled,
       },
     ],
   };
 
-  const textColor = error && errorColor ? errorColor : placeholderColor;
-  // Hide the label in minimized state until we measure it's width
-  const opacity =
-    parentState.value || parentState.focused
-      ? parentState.labelLayout.measured
-        ? 1
-        : 0
-      : 1;
+  const textColor = labelError && errorColor ? errorColor : placeholderColor;
+
   return (
     // Position colored placeholder and gray placeholder on top of each other and crossfade them
     // This gives the effect of animating the color, but allows us to use native driver
@@ -110,10 +115,16 @@ const InputLabel = (props: InputLabelProps) => {
       ]}
     >
       {labelBackground?.({
-        parentState,
+        labeled,
+        labelLayoutWidth,
         labelStyle,
         theme,
-        labelProps: props.labelProps,
+        placeholderStyle,
+        baseLabelTranslateX,
+        topPosition,
+        label,
+        backgroundColor,
+        roundness,
         maxFontSizeMultiplier: maxFontSizeMultiplier,
       })}
       <AnimatedText
@@ -137,7 +148,7 @@ const InputLabel = (props: InputLabelProps) => {
         {label}
       </AnimatedText>
       <AnimatedText
-        variant={parentState.focused ? 'bodyLarge' : 'bodySmall'}
+        variant={focused ? 'bodyLarge' : 'bodySmall'}
         style={[
           placeholderStyle,
           {
@@ -166,4 +177,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default InputLabel;
+export default React.memo(InputLabel);

--- a/src/components/TextInput/Label/LabelBackground.tsx
+++ b/src/components/TextInput/Label/LabelBackground.tsx
@@ -6,20 +6,19 @@ import AnimatedText from '../../Typography/AnimatedText';
 import type { LabelBackgroundProps } from '../types';
 
 const LabelBackground = ({
-  parentState,
-  labelProps: {
-    placeholderStyle,
-    baseLabelTranslateX,
-    topPosition,
-    label,
-    backgroundColor,
-    roundness,
-  },
+  labeled,
+  labelLayoutWidth,
+  placeholderStyle,
+  baseLabelTranslateX,
+  topPosition,
+  label,
+  backgroundColor,
+  roundness,
   labelStyle,
   maxFontSizeMultiplier,
   theme: themeOverrides,
 }: LabelBackgroundProps) => {
-  const opacity = parentState.labeled.interpolate({
+  const opacity = labeled.interpolate({
     inputRange: [0, 0.6],
     outputRange: [1, 0],
   });
@@ -27,14 +26,14 @@ const LabelBackground = ({
   const { isV3 } = useInternalTheme(themeOverrides);
 
   const labelTranslationX = {
-    translateX: parentState.labeled.interpolate({
+    translateX: labeled.interpolate({
       inputRange: [0, 1],
       outputRange: [-baseLabelTranslateX, 0],
     }),
   };
 
   const labelTextScaleY = {
-    scaleY: parentState.labeled.interpolate({
+    scaleY: labeled.interpolate({
       inputRange: [0, 1],
       outputRange: [0.2, 1],
     }),
@@ -44,13 +43,10 @@ const LabelBackground = ({
 
   const labelTextWidth = isV3
     ? {
-        width:
-          parentState.labelLayout.width - placeholderStyle.paddingHorizontal,
+        width: labelLayoutWidth - placeholderStyle.paddingHorizontal,
       }
     : {
-        maxWidth:
-          parentState.labelLayout.width -
-          2 * placeholderStyle.paddingHorizontal,
+        maxWidth: labelLayoutWidth - 2 * placeholderStyle.paddingHorizontal,
       };
 
   const isRounded = roundness > 6;

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -222,6 +222,8 @@ type TextInputHandles = Pick<
  * @extends TextInput props https://reactnative.dev/docs/textinput#props
  */
 
+const DefaultRenderer = (props: RenderProps) => <NativeTextInput {...props} />;
+
 const TextInput = forwardRef<TextInputHandles, Props>(
   (
     {
@@ -232,7 +234,7 @@ const TextInput = forwardRef<TextInputHandles, Props>(
       multiline = false,
       editable = true,
       contentStyle,
-      render = (props: RenderProps) => <NativeTextInput {...props} />,
+      render = DefaultRenderer,
       theme: themeOverrides,
       ...rest
     }: Props,
@@ -380,29 +382,35 @@ const TextInput = forwardRef<TextInputHandles, Props>(
       }
     }, [focused, value, labeled, scale]);
 
-    const onLeftAffixLayoutChange = (event: LayoutChangeEvent) => {
-      const height = roundLayoutSize(event.nativeEvent.layout.height);
-      const width = roundLayoutSize(event.nativeEvent.layout.width);
+    const onLeftAffixLayoutChange = React.useCallback(
+      (event: LayoutChangeEvent) => {
+        const height = roundLayoutSize(event.nativeEvent.layout.height);
+        const width = roundLayoutSize(event.nativeEvent.layout.width);
 
-      if (width !== leftLayout.width || height !== leftLayout.height) {
-        setLeftLayout({
-          width,
-          height,
-        });
-      }
-    };
+        if (width !== leftLayout.width || height !== leftLayout.height) {
+          setLeftLayout({
+            width,
+            height,
+          });
+        }
+      },
+      [leftLayout.height, leftLayout.width]
+    );
 
-    const onRightAffixLayoutChange = (event: LayoutChangeEvent) => {
-      const width = roundLayoutSize(event.nativeEvent.layout.width);
-      const height = roundLayoutSize(event.nativeEvent.layout.height);
+    const onRightAffixLayoutChange = React.useCallback(
+      (event: LayoutChangeEvent) => {
+        const width = roundLayoutSize(event.nativeEvent.layout.width);
+        const height = roundLayoutSize(event.nativeEvent.layout.height);
 
-      if (width !== rightLayout.width || height !== rightLayout.height) {
-        setRightLayout({
-          width,
-          height,
-        });
-      }
-    };
+        if (width !== rightLayout.width || height !== rightLayout.height) {
+          setRightLayout({
+            width,
+            height,
+          });
+        }
+      },
+      [rightLayout.height, rightLayout.width]
+    );
 
     const handleFocus = (args: any) => {
       if (disabled || !editable) {
@@ -435,19 +443,23 @@ const TextInput = forwardRef<TextInputHandles, Props>(
       rest.onChangeText?.(value);
     };
 
-    const handleLayoutAnimatedText = (e: LayoutChangeEvent) => {
-      const width = roundLayoutSize(e.nativeEvent.layout.width);
-      const height = roundLayoutSize(e.nativeEvent.layout.height);
+    const handleLayoutAnimatedText = React.useCallback(
+      (e: LayoutChangeEvent) => {
+        const width = roundLayoutSize(e.nativeEvent.layout.width);
+        const height = roundLayoutSize(e.nativeEvent.layout.height);
 
-      if (width !== labelLayout.width || height !== labelLayout.height) {
-        setLabelLayout({
-          width,
-          height,
-          measured: true,
-        });
-      }
-    };
-    const forceFocus = () => root.current?.focus();
+        if (width !== labelLayout.width || height !== labelLayout.height) {
+          setLabelLayout({
+            width,
+            height,
+            measured: true,
+          });
+        }
+      },
+      [labelLayout.height, labelLayout.width]
+    );
+
+    const forceFocus = React.useCallback(() => root.current?.focus(), []);
 
     const { maxFontSizeMultiplier = 1.5 } = rest;
 

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -252,7 +252,7 @@ const TextInputFlat = ({
     label,
     onLayoutAnimatedText,
     placeholderOpacity,
-    error,
+    labelError: error,
     placeholderStyle: styles.placeholder,
     baseLabelTranslateY,
     baseLabelTranslateX,
@@ -263,12 +263,16 @@ const TextInputFlat = ({
     labelScale,
     wiggleOffsetX: LABEL_WIGGLE_X_OFFSET,
     topPosition,
-    paddingOffset: isAndroid
-      ? {
-          paddingLeft: I18nManager.isRTL ? paddingRight : paddingLeft,
-          paddingRight: I18nManager.isRTL ? paddingLeft : paddingRight,
-        }
-      : { paddingRight, paddingLeft },
+    paddingLeft: isAndroid
+      ? I18nManager.isRTL
+        ? paddingRight
+        : paddingLeft
+      : paddingLeft,
+    paddingRight: isAndroid
+      ? I18nManager.isRTL
+        ? paddingLeft
+        : paddingRight
+      : paddingRight,
     hasActiveOutline,
     activeColor,
     placeholderColor,
@@ -278,7 +282,14 @@ const TextInputFlat = ({
     testID,
     contentStyle,
     theme,
+    opacity:
+      parentState.value || parentState.focused
+        ? parentState.labelLayout.measured
+          ? 1
+          : 0
+        : 1,
   };
+
   const affixTopPosition = {
     [AdornmentSide.Left]: leftAffixTopPosition,
     [AdornmentSide.Right]: rightAffixTopPosition,
@@ -349,7 +360,15 @@ const TextInputFlat = ({
           />
         )}
         {label ? (
-          <InputLabel parentState={parentState} labelProps={labelProps} />
+          <InputLabel
+            labeled={parentState.labeled}
+            error={parentState.error}
+            focused={parentState.focused}
+            wiggle={Boolean(parentState.value && labelProps.labelError)}
+            labelLayoutMeasured={parentState.labelLayout.measured}
+            labelLayoutWidth={parentState.labelLayout.width}
+            {...labelProps}
+          />
         ) : null}
         {render?.({
           testID,

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -189,7 +189,7 @@ const TextInputOutlined = ({
     label,
     onLayoutAnimatedText,
     placeholderOpacity,
-    error,
+    labelError: error,
     placeholderStyle,
     baseLabelTranslateY,
     baseLabelTranslateX,
@@ -211,6 +211,12 @@ const TextInputOutlined = ({
     testID,
     contentStyle,
     theme,
+    opacity:
+      parentState.value || parentState.focused
+        ? parentState.labelLayout.measured
+          ? 1
+          : 0
+        : 1,
   };
 
   const minHeight = (height ||
@@ -314,8 +320,13 @@ const TextInputOutlined = ({
         >
           {label ? (
             <InputLabel
-              parentState={parentState}
-              labelProps={labelProps}
+              labeled={parentState.labeled}
+              error={parentState.error}
+              focused={parentState.focused}
+              wiggle={Boolean(parentState.value && labelProps.labelError)}
+              labelLayoutMeasured={parentState.labelLayout.measured}
+              labelLayoutWidth={parentState.labelLayout.width}
+              {...labelProps}
               labelBackground={LabelBackground}
               maxFontSizeMultiplier={rest.maxFontSizeMultiplier}
             />

--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -70,7 +70,8 @@ export type LabelProps = {
   fontWeight: TextStyle['fontWeight'];
   font: any;
   topPosition: number;
-  paddingOffset?: { paddingLeft: number; paddingRight: number } | null;
+  paddingLeft?: number;
+  paddingRight?: number;
   labelTranslationXOffset?: number;
   placeholderColor: string | null;
   backgroundColor?: ColorValue;
@@ -78,7 +79,7 @@ export type LabelProps = {
   hasActiveOutline?: boolean | null;
   activeColor: string;
   errorColor?: string;
-  error?: boolean | null;
+  labelError?: boolean | null;
   onLayoutAnimatedText: (args: any) => void;
   roundness: number;
   maxFontSizeMultiplier?: number | undefined | null;
@@ -87,16 +88,21 @@ export type LabelProps = {
   theme?: ThemeProp;
 };
 export type InputLabelProps = {
-  parentState: State;
-  labelProps: LabelProps;
+  labeled: Animated.Value;
+  error: Animated.Value;
+  focused: boolean;
+  wiggle: boolean;
+  opacity: number;
+  labelLayoutMeasured: boolean;
+  labelLayoutWidth: number;
   labelBackground?: any;
   maxFontSizeMultiplier?: number | undefined | null;
-};
+} & LabelProps;
 
 export type LabelBackgroundProps = {
-  labelProps: LabelProps;
   labelStyle: any;
-  parentState: State;
+  labeled: Animated.Value;
+  labelLayoutWidth: number;
   maxFontSizeMultiplier?: number | undefined | null;
   theme?: ThemeProp;
-};
+} & LabelProps;


### PR DESCRIPTION
### Summary

Another round of performance improvements over `TextInput`. This time we managed to memoize `InputLabel` so it does not re-render on each key stroke. 

Essentially to do so, I had to inline the `parentState` and `labelProps` objects, so that reconciler has a chance to diff changes in props. Previously both objects would be created on each render.

This work results in slower first render (10% comparing to previous) but faster response on each key stroke (by 25%)

### Test plan

Click through in the example app. No changes to the previous implementation should occur.  
