### PR TITLE
Text color change on SegmentedButtons

### DIFF
--- a/src/components/SegmentedButtons/utils.ts
+++ b/src/components/SegmentedButtons/utils.ts
@@ -124,10 +124,14 @@ const getSegmentedButtonBorderWidth = ({
 const getSegmentedButtonTextColor = ({
   theme,
   disabled,
+  checked,
 }: Omit<BaseProps, 'checked'>) => {
   if (theme.isV3) {
     if (disabled) {
       return theme.colors.onSurfaceDisabled;
+    }
+    if (checked) {
+      return theme.colors.onSecondaryContainer;
     }
     return theme.colors.onSurface;
   } else {


### PR DESCRIPTION
The text in SegmentedButtons is set only by the onSurface color property if the theme is V3, but I think it would be nicer if the text color can either be customised by a new properties for the button prop called labelColor & checkedlabelColor  or at least reverses color like in my pull request, thank you.



