### PR TITLE
docs: fix copy/paste error

### DIFF
--- a/docs/pages/10.migration-guide-to-5.0.md
+++ b/docs/pages/10.migration-guide-to-5.0.md
@@ -116,7 +116,7 @@ theme: {
 }
 ```
 
-👉 You can find more about color on [Material You website](https://m3.material.io/styles/color/the-color-system/key-colors-tones)
+👉 You can find more about color on the [Material You website](https://m3.material.io/styles/color/the-color-system/key-colors-tones)
 
 ## Typography
 
@@ -166,7 +166,7 @@ Take a look at the suggested replacement diff:
  ```
 
 
-👉 You can find more about color on [Material You website](https://m3.material.io/styles/typography/overview)
+👉 You can find more about typography on the [Material You website](https://m3.material.io/styles/typography/overview)
 
 ### Configure fonts
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

There's a small copy/paste error in the "Typography" section of the Migration guide to Material You 5.0.
That line and the original also read better with an additional "the" added.

### Test plan

N/A
