### PR TITLE
fix: BannerExample component theme in production

### DIFF
--- a/docs/.eslintrc
+++ b/docs/.eslintrc
@@ -6,6 +6,10 @@
   },
 
   "rules": {
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "import/no-unresolved": [
+      2,
+      {"ignore": ["^@docusaurus"]}
+    ]
   }
 }

--- a/docs/src/components/BannerExample.tsx
+++ b/docs/src/components/BannerExample.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
 
+import BrowserOnly from '@docusaurus/BrowserOnly';
 import { useColorMode } from '@docusaurus/theme-common';
 import {
   Avatar,
@@ -141,8 +142,12 @@ const BannerExample = () => {
 export default function WithProvider() {
   const isDarkTheme = useColorMode().colorMode === 'dark';
   return (
-    <Provider theme={isDarkTheme ? DarkTheme : DefaultTheme}>
-      <BannerExample />
-    </Provider>
+    <BrowserOnly>
+      {() => (
+        <Provider theme={isDarkTheme ? DarkTheme : DefaultTheme}>
+          <BannerExample />
+        </Provider>
+      )}
+    </BrowserOnly>
   );
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

#### What is the issue?

The Banner Example component always "light" till manually toggle the mode

#### Why

React Native Paper isn't optimized for Server-Side-Rendering, so it's always rendered in the light mode on the server.

#### The solution

Render example only on the browser (Client-Side)

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
