### PR TITLE
fix: apply background color to surface outer layers

### DIFF
--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -229,8 +229,26 @@ const Surface = forwardRef<View, Props>(
       start,
       end,
       flex,
+      width,
+      height,
+      transform,
+      opacity,
       ...restStyle
     } = (StyleSheet.flatten(style) || {}) as ViewStyle;
+
+    // Extracts the border radius and margins so that they can be
+    // applied to the outside container and not on the inner one
+    const borderRadiusStyles = Object.fromEntries(
+      Object.entries(restStyle).filter(
+        ([key]) => key.startsWith('border') && key.endsWith('Radius')
+      )
+    );
+    const marginStyles = Object.fromEntries(
+      Object.entries(restStyle).filter(([key]) => key.startsWith('margin'))
+    );
+    const restStyleWithoutMargins = Object.fromEntries(
+      Object.entries(restStyle).filter(([key]) => !key.startsWith('margin'))
+    );
 
     const absoluteStyles = {
       position,
@@ -241,13 +259,36 @@ const Surface = forwardRef<View, Props>(
       left,
       start,
       end,
+      transform,
+      opacity,
     };
 
-    const sharedStyle = [{ backgroundColor, flex }, restStyle];
+    const sharedStyle = [
+      {
+        backgroundColor,
+        flex,
+        width,
+        height,
+        transform,
+        opacity,
+      },
+      restStyleWithoutMargins,
+    ];
 
-    const innerLayerViewStyles = [{ flex }];
+    const innerLayerViewStyles = [
+      {
+        flex,
+        width,
+        height,
+      },
+      borderRadiusStyles,
+    ];
 
-    const outerLayerViewStyles = [absoluteStyles, innerLayerViewStyles];
+    const outerLayerViewStyles = [
+      absoluteStyles,
+      innerLayerViewStyles,
+      marginStyles,
+    ];
 
     if (isAnimatedValue(elevation)) {
       const inputRange = [0, 1, 2, 3, 4, 5];
@@ -271,6 +312,7 @@ const Surface = forwardRef<View, Props>(
             inputRange,
             outputRange: iOSShadowOutputRanges[layer].shadowRadius,
           }),
+          backgroundColor,
         };
       };
 
@@ -302,6 +344,7 @@ const Surface = forwardRef<View, Props>(
           height: iOSShadowOutputRanges[layer].height[elevation],
         },
         shadowRadius: iOSShadowOutputRanges[layer].shadowRadius[elevation],
+        backgroundColor,
       };
     };
 

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
@@ -6,10 +6,13 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": 64,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -21,6 +24,8 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -29,7 +34,9 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
         "flex": undefined,
+        "height": 64,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -37,6 +44,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="surface-inner-layer"
@@ -50,11 +58,14 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
           "flex": undefined,
           "flexDirection": "row",
           "height": 64,
+          "opacity": undefined,
           "paddingBottom": undefined,
           "paddingHorizontal": 4,
           "paddingLeft": undefined,
           "paddingRight": undefined,
           "paddingTop": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="surface"
@@ -64,10 +75,14 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
         style={
           Object {
             "alignSelf": undefined,
+            "backgroundColor": "rgb(247, 243, 249)",
+            "borderRadius": 4,
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
+            "height": undefined,
             "left": undefined,
+            "opacity": undefined,
             "position": undefined,
             "right": undefined,
             "shadowColor": "#000",
@@ -79,6 +94,8 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
             "shadowRadius": 3,
             "start": undefined,
             "top": undefined,
+            "transform": undefined,
+            "width": undefined,
           }
         }
         testID="search-bar-container-outer-layer"
@@ -87,7 +104,10 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
           collapsable={false}
           style={
             Object {
+              "backgroundColor": "rgb(247, 243, 249)",
+              "borderRadius": 4,
               "flex": undefined,
+              "height": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 1,
@@ -95,6 +115,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
               },
               "shadowOpacity": 0.3,
               "shadowRadius": 1,
+              "width": undefined,
             }
           }
           testID="search-bar-container-inner-layer"
@@ -108,6 +129,10 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                 "borderRadius": 4,
                 "flex": undefined,
                 "flexDirection": "row",
+                "height": undefined,
+                "opacity": undefined,
+                "transform": undefined,
+                "width": undefined,
               }
             }
             testID="search-bar-container"
@@ -117,10 +142,15 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
               style={
                 Object {
                   "alignSelf": undefined,
+                  "backgroundColor": "transparent",
+                  "borderRadius": 20,
                   "bottom": undefined,
                   "end": undefined,
                   "flex": undefined,
+                  "height": 40,
                   "left": undefined,
+                  "margin": 6,
+                  "opacity": undefined,
                   "position": undefined,
                   "right": undefined,
                   "shadowColor": "#000",
@@ -132,6 +162,8 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                   "shadowRadius": 0,
                   "start": undefined,
                   "top": undefined,
+                  "transform": undefined,
+                  "width": 40,
                 }
               }
               testID="icon-button-container-outer-layer"
@@ -140,7 +172,10 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                 collapsable={false}
                 style={
                   Object {
+                    "backgroundColor": "transparent",
+                    "borderRadius": 20,
                     "flex": undefined,
+                    "height": 40,
                     "shadowColor": "#000",
                     "shadowOffset": Object {
                       "height": 0,
@@ -148,6 +183,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                     },
                     "shadowOpacity": 0,
                     "shadowRadius": 0,
+                    "width": 40,
                   }
                 }
                 testID="icon-button-container-inner-layer"
@@ -163,8 +199,9 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                       "elevation": 0,
                       "flex": undefined,
                       "height": 40,
-                      "margin": 6,
+                      "opacity": undefined,
                       "overflow": "hidden",
+                      "transform": undefined,
                       "width": 40,
                     }
                   }
@@ -300,10 +337,15 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                 style={
                   Object {
                     "alignSelf": undefined,
+                    "backgroundColor": "transparent",
+                    "borderRadius": 20,
                     "bottom": undefined,
                     "end": undefined,
                     "flex": undefined,
+                    "height": 40,
                     "left": undefined,
+                    "margin": 6,
+                    "opacity": undefined,
                     "position": undefined,
                     "right": undefined,
                     "shadowColor": "#000",
@@ -315,6 +357,8 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                     "shadowRadius": 0,
                     "start": undefined,
                     "top": undefined,
+                    "transform": undefined,
+                    "width": 40,
                   }
                 }
                 testID="icon-button-container-outer-layer"
@@ -323,7 +367,10 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                   collapsable={false}
                   style={
                     Object {
+                      "backgroundColor": "transparent",
+                      "borderRadius": 20,
                       "flex": undefined,
+                      "height": 40,
                       "shadowColor": "#000",
                       "shadowOffset": Object {
                         "height": 0,
@@ -331,6 +378,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                       },
                       "shadowOpacity": 0,
                       "shadowRadius": 0,
+                      "width": 40,
                     }
                   }
                   testID="icon-button-container-inner-layer"
@@ -346,8 +394,9 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                         "elevation": 0,
                         "flex": undefined,
                         "height": 40,
-                        "margin": 6,
+                        "opacity": undefined,
                         "overflow": "hidden",
+                        "transform": undefined,
                         "width": 40,
                       }
                     }
@@ -459,10 +508,13 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": 64,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -474,6 +526,8 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -482,7 +536,9 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
         "flex": undefined,
+        "height": 64,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -490,6 +546,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="surface-inner-layer"
@@ -503,11 +560,14 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
           "flex": undefined,
           "flexDirection": "row",
           "height": 64,
+          "opacity": undefined,
           "paddingBottom": undefined,
           "paddingHorizontal": 4,
           "paddingLeft": undefined,
           "paddingRight": undefined,
           "paddingTop": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="surface"
@@ -517,10 +577,15 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
         style={
           Object {
             "alignSelf": undefined,
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
+            "height": 40,
             "left": undefined,
+            "margin": 6,
+            "opacity": undefined,
             "position": undefined,
             "right": undefined,
             "shadowColor": "#000",
@@ -532,6 +597,8 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             "shadowRadius": 0,
             "start": undefined,
             "top": undefined,
+            "transform": undefined,
+            "width": 40,
           }
         }
         testID="icon-button-container-outer-layer"
@@ -540,7 +607,10 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
           collapsable={false}
           style={
             Object {
+              "backgroundColor": "transparent",
+              "borderRadius": 20,
               "flex": undefined,
+              "height": 40,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -548,6 +618,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
               },
               "shadowOpacity": 0,
               "shadowRadius": 0,
+              "width": 40,
             }
           }
           testID="icon-button-container-inner-layer"
@@ -563,8 +634,9 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
                 "elevation": 0,
                 "flex": undefined,
                 "height": 40,
-                "margin": 6,
+                "opacity": undefined,
                 "overflow": "hidden",
+                "transform": undefined,
                 "width": 40,
               }
             }
@@ -778,10 +850,15 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
         style={
           Object {
             "alignSelf": undefined,
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
+            "height": 40,
             "left": undefined,
+            "margin": 6,
+            "opacity": undefined,
             "position": undefined,
             "right": undefined,
             "shadowColor": "#000",
@@ -793,6 +870,8 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             "shadowRadius": 0,
             "start": undefined,
             "top": undefined,
+            "transform": undefined,
+            "width": 40,
           }
         }
         testID="icon-button-container-outer-layer"
@@ -801,7 +880,10 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
           collapsable={false}
           style={
             Object {
+              "backgroundColor": "transparent",
+              "borderRadius": 20,
               "flex": undefined,
+              "height": 40,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -809,6 +891,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
               },
               "shadowOpacity": 0,
               "shadowRadius": 0,
+              "width": 40,
             }
           }
           testID="icon-button-container-inner-layer"
@@ -824,8 +907,9 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
                 "elevation": 0,
                 "flex": undefined,
                 "height": 40,
-                "margin": 6,
+                "opacity": undefined,
                 "overflow": "hidden",
+                "transform": undefined,
                 "width": 40,
               }
             }

--- a/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
@@ -6,10 +6,14 @@ exports[`Card renders an outlined card 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 12,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -21,6 +25,8 @@ exports[`Card renders an outlined card 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="card-container-outer-layer"
@@ -29,7 +35,10 @@ exports[`Card renders an outlined card 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderRadius": 12,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -37,6 +46,7 @@ exports[`Card renders an outlined card 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="card-container-inner-layer"
@@ -49,6 +59,10 @@ exports[`Card renders an outlined card 1`] = `
           "borderRadius": 12,
           "elevation": 1,
           "flex": undefined,
+          "height": undefined,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="card-container"

--- a/src/components/__tests__/FABGroup.test.tsx
+++ b/src/components/__tests__/FABGroup.test.tsx
@@ -159,7 +159,6 @@ describe('FABActions - labelStyle - containerStyle', () => {
     expect(getByA11yHint('hint')).toHaveStyle({
       padding: 16,
       backgroundColor: '#687456',
-      marginLeft: 16,
     });
   });
 });

--- a/src/components/__tests__/__snapshots__/AnimatedFAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/AnimatedFAB.test.tsx.snap
@@ -6,10 +6,14 @@ exports[`renders animated fab 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(238, 232, 244)",
+      "borderRadius": 16,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": "absolute",
       "right": undefined,
       "shadowColor": "#000",
@@ -21,6 +25,12 @@ exports[`renders animated fab 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="animated-fab-container-outer-layer"
@@ -29,7 +39,10 @@ exports[`renders animated fab 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(238, 232, 244)",
+        "borderRadius": 16,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -37,6 +50,7 @@ exports[`renders animated fab 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 3,
+        "width": undefined,
       }
     }
     testID="animated-fab-container-inner-layer"
@@ -48,12 +62,14 @@ exports[`renders animated fab 1`] = `
           "backgroundColor": "transparent",
           "borderRadius": 16,
           "flex": undefined,
+          "height": undefined,
           "opacity": 1,
           "transform": Array [
             Object {
               "scale": 1,
             },
           ],
+          "width": undefined,
         }
       }
       testID="animated-fab-container"
@@ -303,10 +319,14 @@ exports[`renders animated fab with label on the left 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(238, 232, 244)",
+      "borderRadius": 16,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": "absolute",
       "right": undefined,
       "shadowColor": "#000",
@@ -318,6 +338,12 @@ exports[`renders animated fab with label on the left 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="animated-fab-container-outer-layer"
@@ -326,7 +352,10 @@ exports[`renders animated fab with label on the left 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(238, 232, 244)",
+        "borderRadius": 16,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -334,6 +363,7 @@ exports[`renders animated fab with label on the left 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 3,
+        "width": undefined,
       }
     }
     testID="animated-fab-container-inner-layer"
@@ -345,12 +375,14 @@ exports[`renders animated fab with label on the left 1`] = `
           "backgroundColor": "transparent",
           "borderRadius": 16,
           "flex": undefined,
+          "height": undefined,
           "opacity": 1,
           "transform": Array [
             Object {
               "scale": 1,
             },
           ],
+          "width": undefined,
         }
       }
       testID="animated-fab-container"
@@ -602,10 +634,14 @@ exports[`renders animated fab with label on the right by default 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(238, 232, 244)",
+      "borderRadius": 16,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": "absolute",
       "right": undefined,
       "shadowColor": "#000",
@@ -617,6 +653,12 @@ exports[`renders animated fab with label on the right by default 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="animated-fab-container-outer-layer"
@@ -625,7 +667,10 @@ exports[`renders animated fab with label on the right by default 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(238, 232, 244)",
+        "borderRadius": 16,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -633,6 +678,7 @@ exports[`renders animated fab with label on the right by default 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 3,
+        "width": undefined,
       }
     }
     testID="animated-fab-container-inner-layer"
@@ -644,12 +690,14 @@ exports[`renders animated fab with label on the right by default 1`] = `
           "backgroundColor": "transparent",
           "borderRadius": 16,
           "flex": undefined,
+          "height": undefined,
           "opacity": 1,
           "transform": Array [
             Object {
               "scale": 1,
             },
           ],
+          "width": undefined,
         }
       }
       testID="animated-fab-container"

--- a/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
@@ -6,10 +6,13 @@ exports[`render visible banner, with custom theme 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(247, 243, 249)",
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -21,6 +24,8 @@ exports[`render visible banner, with custom theme 1`] = `
       "shadowRadius": 3,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -29,7 +34,9 @@ exports[`render visible banner, with custom theme 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(247, 243, 249)",
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -37,6 +44,7 @@ exports[`render visible banner, with custom theme 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 1,
+        "width": undefined,
       }
     }
     testID="surface-inner-layer"
@@ -47,6 +55,10 @@ exports[`render visible banner, with custom theme 1`] = `
         Object {
           "backgroundColor": "rgb(247, 243, 249)",
           "flex": undefined,
+          "height": undefined,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="surface"
@@ -134,10 +146,15 @@ exports[`render visible banner, with custom theme 1`] = `
               style={
                 Object {
                   "alignSelf": undefined,
+                  "backgroundColor": "rgba(0, 0, 0, 0)",
+                  "borderRadius": 20,
                   "bottom": undefined,
                   "end": undefined,
                   "flex": undefined,
+                  "height": undefined,
                   "left": undefined,
+                  "margin": 4,
+                  "opacity": undefined,
                   "position": undefined,
                   "right": undefined,
                   "shadowColor": "#000",
@@ -149,6 +166,8 @@ exports[`render visible banner, with custom theme 1`] = `
                   "shadowRadius": 0,
                   "start": undefined,
                   "top": undefined,
+                  "transform": undefined,
+                  "width": undefined,
                 }
               }
               testID="button-container-outer-layer"
@@ -157,7 +176,10 @@ exports[`render visible banner, with custom theme 1`] = `
                 collapsable={false}
                 style={
                   Object {
+                    "backgroundColor": "rgba(0, 0, 0, 0)",
+                    "borderRadius": 20,
                     "flex": undefined,
+                    "height": undefined,
                     "shadowColor": "#000",
                     "shadowOffset": Object {
                       "height": 0,
@@ -165,6 +187,7 @@ exports[`render visible banner, with custom theme 1`] = `
                     },
                     "shadowOpacity": 0,
                     "shadowRadius": 0,
+                    "width": undefined,
                   }
                 }
                 testID="button-container-inner-layer"
@@ -179,8 +202,11 @@ exports[`render visible banner, with custom theme 1`] = `
                       "borderStyle": "solid",
                       "borderWidth": 0,
                       "flex": undefined,
-                      "margin": 4,
+                      "height": undefined,
                       "minWidth": "auto",
+                      "opacity": undefined,
+                      "transform": undefined,
+                      "width": undefined,
                     }
                   }
                   testID="button-container"
@@ -297,10 +323,13 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(247, 243, 249)",
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -312,6 +341,8 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
       "shadowRadius": 3,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -320,7 +351,9 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(247, 243, 249)",
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -328,6 +361,7 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 1,
+        "width": undefined,
       }
     }
     testID="surface-inner-layer"
@@ -338,6 +372,10 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
         Object {
           "backgroundColor": "rgb(247, 243, 249)",
           "flex": undefined,
+          "height": undefined,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="surface"
@@ -445,10 +483,13 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(247, 243, 249)",
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -460,6 +501,8 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
       "shadowRadius": 3,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -468,7 +511,9 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(247, 243, 249)",
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -476,6 +521,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 1,
+        "width": undefined,
       }
     }
     testID="surface-inner-layer"
@@ -486,6 +532,10 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
         Object {
           "backgroundColor": "rgb(247, 243, 249)",
           "flex": undefined,
+          "height": undefined,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="surface"
@@ -595,10 +645,15 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
               style={
                 Object {
                   "alignSelf": undefined,
+                  "backgroundColor": "rgba(0, 0, 0, 0)",
+                  "borderRadius": 20,
                   "bottom": undefined,
                   "end": undefined,
                   "flex": undefined,
+                  "height": undefined,
                   "left": undefined,
+                  "margin": 4,
+                  "opacity": undefined,
                   "position": undefined,
                   "right": undefined,
                   "shadowColor": "#000",
@@ -610,6 +665,8 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                   "shadowRadius": 0,
                   "start": undefined,
                   "top": undefined,
+                  "transform": undefined,
+                  "width": undefined,
                 }
               }
               testID="button-container-outer-layer"
@@ -618,7 +675,10 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                 collapsable={false}
                 style={
                   Object {
+                    "backgroundColor": "rgba(0, 0, 0, 0)",
+                    "borderRadius": 20,
                     "flex": undefined,
+                    "height": undefined,
                     "shadowColor": "#000",
                     "shadowOffset": Object {
                       "height": 0,
@@ -626,6 +686,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                     },
                     "shadowOpacity": 0,
                     "shadowRadius": 0,
+                    "width": undefined,
                   }
                 }
                 testID="button-container-inner-layer"
@@ -640,8 +701,11 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                       "borderStyle": "solid",
                       "borderWidth": 0,
                       "flex": undefined,
-                      "margin": 4,
+                      "height": undefined,
                       "minWidth": "auto",
+                      "opacity": undefined,
+                      "transform": undefined,
+                      "width": undefined,
                     }
                   }
                   testID="button-container"
@@ -758,10 +822,13 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(247, 243, 249)",
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -773,6 +840,8 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
       "shadowRadius": 3,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -781,7 +850,9 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(247, 243, 249)",
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -789,6 +860,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 1,
+        "width": undefined,
       }
     }
     testID="surface-inner-layer"
@@ -799,6 +871,10 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
         Object {
           "backgroundColor": "rgb(247, 243, 249)",
           "flex": undefined,
+          "height": undefined,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="surface"
@@ -886,10 +962,15 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
               style={
                 Object {
                   "alignSelf": undefined,
+                  "backgroundColor": "rgba(0, 0, 0, 0)",
+                  "borderRadius": 20,
                   "bottom": undefined,
                   "end": undefined,
                   "flex": undefined,
+                  "height": undefined,
                   "left": undefined,
+                  "margin": 4,
+                  "opacity": undefined,
                   "position": undefined,
                   "right": undefined,
                   "shadowColor": "#000",
@@ -901,6 +982,8 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   "shadowRadius": 0,
                   "start": undefined,
                   "top": undefined,
+                  "transform": undefined,
+                  "width": undefined,
                 }
               }
               testID="button-container-outer-layer"
@@ -909,7 +992,10 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                 collapsable={false}
                 style={
                   Object {
+                    "backgroundColor": "rgba(0, 0, 0, 0)",
+                    "borderRadius": 20,
                     "flex": undefined,
+                    "height": undefined,
                     "shadowColor": "#000",
                     "shadowOffset": Object {
                       "height": 0,
@@ -917,6 +1003,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                     },
                     "shadowOpacity": 0,
                     "shadowRadius": 0,
+                    "width": undefined,
                   }
                 }
                 testID="button-container-inner-layer"
@@ -931,8 +1018,11 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                       "borderStyle": "solid",
                       "borderWidth": 0,
                       "flex": undefined,
-                      "margin": 4,
+                      "height": undefined,
                       "minWidth": "auto",
+                      "opacity": undefined,
+                      "transform": undefined,
+                      "width": undefined,
                     }
                   }
                   testID="button-container"
@@ -1040,10 +1130,15 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
               style={
                 Object {
                   "alignSelf": undefined,
+                  "backgroundColor": "rgba(0, 0, 0, 0)",
+                  "borderRadius": 20,
                   "bottom": undefined,
                   "end": undefined,
                   "flex": undefined,
+                  "height": undefined,
                   "left": undefined,
+                  "margin": 4,
+                  "opacity": undefined,
                   "position": undefined,
                   "right": undefined,
                   "shadowColor": "#000",
@@ -1055,6 +1150,8 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   "shadowRadius": 0,
                   "start": undefined,
                   "top": undefined,
+                  "transform": undefined,
+                  "width": undefined,
                 }
               }
               testID="button-container-outer-layer"
@@ -1063,7 +1160,10 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                 collapsable={false}
                 style={
                   Object {
+                    "backgroundColor": "rgba(0, 0, 0, 0)",
+                    "borderRadius": 20,
                     "flex": undefined,
+                    "height": undefined,
                     "shadowColor": "#000",
                     "shadowOffset": Object {
                       "height": 0,
@@ -1071,6 +1171,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                     },
                     "shadowOpacity": 0,
                     "shadowRadius": 0,
+                    "width": undefined,
                   }
                 }
                 testID="button-container-inner-layer"
@@ -1085,8 +1186,11 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                       "borderStyle": "solid",
                       "borderWidth": 0,
                       "flex": undefined,
-                      "margin": 4,
+                      "height": undefined,
                       "minWidth": "auto",
+                      "opacity": undefined,
+                      "transform": undefined,
+                      "width": undefined,
                     }
                   }
                   testID="button-container"
@@ -1203,10 +1307,13 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(247, 243, 249)",
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1218,6 +1325,8 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
       "shadowRadius": 3,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -1226,7 +1335,9 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(247, 243, 249)",
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -1234,6 +1345,7 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 1,
+        "width": undefined,
       }
     }
     testID="surface-inner-layer"
@@ -1244,6 +1356,10 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
         Object {
           "backgroundColor": "rgb(247, 243, 249)",
           "flex": undefined,
+          "height": undefined,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="surface"
@@ -1361,10 +1477,13 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(247, 243, 249)",
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1376,6 +1495,8 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
       "shadowRadius": 3,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -1384,7 +1505,9 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(247, 243, 249)",
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -1392,6 +1515,7 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 1,
+        "width": undefined,
       }
     }
     testID="surface-inner-layer"
@@ -1402,6 +1526,10 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
         Object {
           "backgroundColor": "rgb(247, 243, 249)",
           "flex": undefined,
+          "height": undefined,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="surface"

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
@@ -75,10 +75,13 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "transparent",
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": 0,
+        "opacity": undefined,
         "position": undefined,
         "right": 0,
         "shadowColor": "#000",
@@ -90,6 +93,8 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
         "shadowRadius": 0,
         "start": undefined,
         "top": undefined,
+        "transform": undefined,
+        "width": undefined,
       }
     }
     testID="bottom-navigation-surface-outer-layer"
@@ -98,7 +103,9 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
       collapsable={false}
       style={
         Object {
+          "backgroundColor": "transparent",
           "flex": undefined,
+          "height": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -106,6 +113,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "width": undefined,
         }
       }
       testID="bottom-navigation-surface-inner-layer"
@@ -118,6 +126,10 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
           Object {
             "backgroundColor": "transparent",
             "flex": undefined,
+            "height": undefined,
+            "opacity": undefined,
+            "transform": undefined,
+            "width": undefined,
           }
         }
         testID="bottom-navigation-surface"
@@ -828,10 +840,13 @@ exports[`hides labels in shifting bottom navigation 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "transparent",
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": 0,
+        "opacity": undefined,
         "position": undefined,
         "right": 0,
         "shadowColor": "#000",
@@ -843,6 +858,8 @@ exports[`hides labels in shifting bottom navigation 1`] = `
         "shadowRadius": 0,
         "start": undefined,
         "top": undefined,
+        "transform": undefined,
+        "width": undefined,
       }
     }
     testID="bottom-navigation-surface-outer-layer"
@@ -851,7 +868,9 @@ exports[`hides labels in shifting bottom navigation 1`] = `
       collapsable={false}
       style={
         Object {
+          "backgroundColor": "transparent",
           "flex": undefined,
+          "height": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -859,6 +878,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "width": undefined,
         }
       }
       testID="bottom-navigation-surface-inner-layer"
@@ -871,6 +891,10 @@ exports[`hides labels in shifting bottom navigation 1`] = `
           Object {
             "backgroundColor": "transparent",
             "flex": undefined,
+            "height": undefined,
+            "opacity": undefined,
+            "transform": undefined,
+            "width": undefined,
           }
         }
         testID="bottom-navigation-surface"
@@ -1735,10 +1759,13 @@ exports[`renders bottom navigation with getLazy 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "transparent",
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": 0,
+        "opacity": undefined,
         "position": undefined,
         "right": 0,
         "shadowColor": "#000",
@@ -1750,6 +1777,8 @@ exports[`renders bottom navigation with getLazy 1`] = `
         "shadowRadius": 0,
         "start": undefined,
         "top": undefined,
+        "transform": undefined,
+        "width": undefined,
       }
     }
     testID="bottom-navigation-surface-outer-layer"
@@ -1758,7 +1787,9 @@ exports[`renders bottom navigation with getLazy 1`] = `
       collapsable={false}
       style={
         Object {
+          "backgroundColor": "transparent",
           "flex": undefined,
+          "height": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -1766,6 +1797,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "width": undefined,
         }
       }
       testID="bottom-navigation-surface-inner-layer"
@@ -1778,6 +1810,10 @@ exports[`renders bottom navigation with getLazy 1`] = `
           Object {
             "backgroundColor": "transparent",
             "flex": undefined,
+            "height": undefined,
+            "opacity": undefined,
+            "transform": undefined,
+            "width": undefined,
           }
         }
         testID="bottom-navigation-surface"
@@ -3449,10 +3485,13 @@ exports[`renders bottom navigation with scene animation 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "transparent",
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": 0,
+        "opacity": undefined,
         "position": undefined,
         "right": 0,
         "shadowColor": "#000",
@@ -3464,6 +3503,8 @@ exports[`renders bottom navigation with scene animation 1`] = `
         "shadowRadius": 0,
         "start": undefined,
         "top": undefined,
+        "transform": undefined,
+        "width": undefined,
       }
     }
     testID="bottom-navigation-surface-outer-layer"
@@ -3472,7 +3513,9 @@ exports[`renders bottom navigation with scene animation 1`] = `
       collapsable={false}
       style={
         Object {
+          "backgroundColor": "transparent",
           "flex": undefined,
+          "height": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -3480,6 +3523,7 @@ exports[`renders bottom navigation with scene animation 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "width": undefined,
         }
       }
       testID="bottom-navigation-surface-inner-layer"
@@ -3492,6 +3536,10 @@ exports[`renders bottom navigation with scene animation 1`] = `
           Object {
             "backgroundColor": "transparent",
             "flex": undefined,
+            "height": undefined,
+            "opacity": undefined,
+            "transform": undefined,
+            "width": undefined,
           }
         }
         testID="bottom-navigation-surface"
@@ -4945,10 +4993,13 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "transparent",
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": 0,
+        "opacity": undefined,
         "position": undefined,
         "right": 0,
         "shadowColor": "#000",
@@ -4960,6 +5011,8 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
         "shadowRadius": 0,
         "start": undefined,
         "top": undefined,
+        "transform": undefined,
+        "width": undefined,
       }
     }
     testID="bottom-navigation-surface-outer-layer"
@@ -4968,7 +5021,9 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
       collapsable={false}
       style={
         Object {
+          "backgroundColor": "transparent",
           "flex": undefined,
+          "height": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -4976,6 +5031,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "width": undefined,
         }
       }
       testID="bottom-navigation-surface-inner-layer"
@@ -4988,6 +5044,10 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
           Object {
             "backgroundColor": "transparent",
             "flex": undefined,
+            "height": undefined,
+            "opacity": undefined,
+            "transform": undefined,
+            "width": undefined,
           }
         }
         testID="bottom-navigation-surface"
@@ -5638,10 +5698,13 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "transparent",
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": 0,
+        "opacity": undefined,
         "position": undefined,
         "right": 0,
         "shadowColor": "#000",
@@ -5653,6 +5716,8 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
         "shadowRadius": 0,
         "start": undefined,
         "top": undefined,
+        "transform": undefined,
+        "width": undefined,
       }
     }
     testID="bottom-navigation-surface-outer-layer"
@@ -5661,7 +5726,9 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
       collapsable={false}
       style={
         Object {
+          "backgroundColor": "transparent",
           "flex": undefined,
+          "height": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -5669,6 +5736,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "width": undefined,
         }
       }
       testID="bottom-navigation-surface-inner-layer"
@@ -5681,6 +5749,10 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
           Object {
             "backgroundColor": "transparent",
             "flex": undefined,
+            "height": undefined,
+            "opacity": undefined,
+            "transform": undefined,
+            "width": undefined,
           }
         }
         testID="bottom-navigation-surface"
@@ -6634,10 +6706,13 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "transparent",
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": 0,
+        "opacity": undefined,
         "position": undefined,
         "right": 0,
         "shadowColor": "#000",
@@ -6649,6 +6724,8 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
         "shadowRadius": 0,
         "start": undefined,
         "top": undefined,
+        "transform": undefined,
+        "width": undefined,
       }
     }
     testID="bottom-navigation-surface-outer-layer"
@@ -6657,7 +6734,9 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
       collapsable={false}
       style={
         Object {
+          "backgroundColor": "transparent",
           "flex": undefined,
+          "height": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -6665,6 +6744,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "width": undefined,
         }
       }
       testID="bottom-navigation-surface-inner-layer"
@@ -6677,6 +6757,10 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
           Object {
             "backgroundColor": "transparent",
             "flex": undefined,
+            "height": undefined,
+            "opacity": undefined,
+            "transform": undefined,
+            "width": undefined,
           }
         }
         testID="bottom-navigation-surface"
@@ -7732,10 +7816,13 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "transparent",
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": 0,
+        "opacity": undefined,
         "position": undefined,
         "right": 0,
         "shadowColor": "#000",
@@ -7747,6 +7834,8 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
         "shadowRadius": 0,
         "start": undefined,
         "top": undefined,
+        "transform": undefined,
+        "width": undefined,
       }
     }
     testID="bottom-navigation-surface-outer-layer"
@@ -7755,7 +7844,9 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
       collapsable={false}
       style={
         Object {
+          "backgroundColor": "transparent",
           "flex": undefined,
+          "height": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -7763,6 +7854,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "width": undefined,
         }
       }
       testID="bottom-navigation-surface-inner-layer"
@@ -7775,6 +7867,10 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
           Object {
             "backgroundColor": "transparent",
             "flex": undefined,
+            "height": undefined,
+            "opacity": undefined,
+            "transform": undefined,
+            "width": undefined,
           }
         }
         testID="bottom-navigation-surface"
@@ -8708,10 +8804,13 @@ exports[`renders non-shifting bottom navigation 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "transparent",
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": 0,
+        "opacity": undefined,
         "position": undefined,
         "right": 0,
         "shadowColor": "#000",
@@ -8723,6 +8822,8 @@ exports[`renders non-shifting bottom navigation 1`] = `
         "shadowRadius": 0,
         "start": undefined,
         "top": undefined,
+        "transform": undefined,
+        "width": undefined,
       }
     }
     testID="bottom-navigation-surface-outer-layer"
@@ -8731,7 +8832,9 @@ exports[`renders non-shifting bottom navigation 1`] = `
       collapsable={false}
       style={
         Object {
+          "backgroundColor": "transparent",
           "flex": undefined,
+          "height": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -8739,6 +8842,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "width": undefined,
         }
       }
       testID="bottom-navigation-surface-inner-layer"
@@ -8751,6 +8855,10 @@ exports[`renders non-shifting bottom navigation 1`] = `
           Object {
             "backgroundColor": "transparent",
             "flex": undefined,
+            "height": undefined,
+            "opacity": undefined,
+            "transform": undefined,
+            "width": undefined,
           }
         }
         testID="bottom-navigation-surface"
@@ -9806,10 +9914,13 @@ exports[`renders shifting bottom navigation 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "transparent",
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": 0,
+        "opacity": undefined,
         "position": undefined,
         "right": 0,
         "shadowColor": "#000",
@@ -9821,6 +9932,8 @@ exports[`renders shifting bottom navigation 1`] = `
         "shadowRadius": 0,
         "start": undefined,
         "top": undefined,
+        "transform": undefined,
+        "width": undefined,
       }
     }
     testID="bottom-navigation-surface-outer-layer"
@@ -9829,7 +9942,9 @@ exports[`renders shifting bottom navigation 1`] = `
       collapsable={false}
       style={
         Object {
+          "backgroundColor": "transparent",
           "flex": undefined,
+          "height": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -9837,6 +9952,7 @@ exports[`renders shifting bottom navigation 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
+          "width": undefined,
         }
       }
       testID="bottom-navigation-surface-inner-layer"
@@ -9849,6 +9965,10 @@ exports[`renders shifting bottom navigation 1`] = `
           Object {
             "backgroundColor": "transparent",
             "flex": undefined,
+            "height": undefined,
+            "opacity": undefined,
+            "transform": undefined,
+            "width": undefined,
           }
         }
         testID="bottom-navigation-surface"

--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -6,10 +6,14 @@ exports[`renders button with an accessibility hint 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(0, 0, 0, 0)",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -21,6 +25,8 @@ exports[`renders button with an accessibility hint 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -29,7 +35,10 @@ exports[`renders button with an accessibility hint 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderRadius": 20,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -37,6 +46,7 @@ exports[`renders button with an accessibility hint 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="button-container-inner-layer"
@@ -51,7 +61,11 @@ exports[`renders button with an accessibility hint 1`] = `
           "borderStyle": "solid",
           "borderWidth": 0,
           "flex": undefined,
+          "height": undefined,
           "minWidth": 64,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="button-container"
@@ -161,10 +175,14 @@ exports[`renders button with an accessibility label 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(0, 0, 0, 0)",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -176,6 +194,8 @@ exports[`renders button with an accessibility label 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -184,7 +204,10 @@ exports[`renders button with an accessibility label 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderRadius": 20,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -192,6 +215,7 @@ exports[`renders button with an accessibility label 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="button-container-inner-layer"
@@ -206,7 +230,11 @@ exports[`renders button with an accessibility label 1`] = `
           "borderStyle": "solid",
           "borderWidth": 0,
           "flex": undefined,
+          "height": undefined,
           "minWidth": 64,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="button-container"
@@ -316,10 +344,14 @@ exports[`renders button with button color 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(0, 0, 0, 0)",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -331,6 +363,8 @@ exports[`renders button with button color 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -339,7 +373,10 @@ exports[`renders button with button color 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderRadius": 20,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -347,6 +384,7 @@ exports[`renders button with button color 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="button-container-inner-layer"
@@ -361,7 +399,11 @@ exports[`renders button with button color 1`] = `
           "borderStyle": "solid",
           "borderWidth": 0,
           "flex": undefined,
+          "height": undefined,
           "minWidth": 64,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="button-container"
@@ -470,10 +512,14 @@ exports[`renders button with color 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(0, 0, 0, 0)",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -485,6 +531,8 @@ exports[`renders button with color 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -493,7 +541,10 @@ exports[`renders button with color 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderRadius": 20,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -501,6 +552,7 @@ exports[`renders button with color 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="button-container-inner-layer"
@@ -515,7 +567,11 @@ exports[`renders button with color 1`] = `
           "borderStyle": "solid",
           "borderWidth": 0,
           "flex": undefined,
+          "height": undefined,
           "minWidth": 64,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="button-container"
@@ -624,10 +680,14 @@ exports[`renders button with custom testID 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(0, 0, 0, 0)",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -639,6 +699,8 @@ exports[`renders button with custom testID 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="custom:testID-container-outer-layer"
@@ -647,7 +709,10 @@ exports[`renders button with custom testID 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderRadius": 20,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -655,6 +720,7 @@ exports[`renders button with custom testID 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="custom:testID-container-inner-layer"
@@ -669,7 +735,11 @@ exports[`renders button with custom testID 1`] = `
           "borderStyle": "solid",
           "borderWidth": 0,
           "flex": undefined,
+          "height": undefined,
           "minWidth": 64,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="custom:testID-container"
@@ -778,10 +848,14 @@ exports[`renders button with icon 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(0, 0, 0, 0)",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -793,6 +867,8 @@ exports[`renders button with icon 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -801,7 +877,10 @@ exports[`renders button with icon 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderRadius": 20,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -809,6 +888,7 @@ exports[`renders button with icon 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="button-container-inner-layer"
@@ -823,7 +903,11 @@ exports[`renders button with icon 1`] = `
           "borderStyle": "solid",
           "borderWidth": 0,
           "flex": undefined,
+          "height": undefined,
           "minWidth": 64,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="button-container"
@@ -988,10 +1072,14 @@ exports[`renders button with icon in reverse order 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(0, 0, 0, 0)",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1003,6 +1091,8 @@ exports[`renders button with icon in reverse order 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -1011,7 +1101,10 @@ exports[`renders button with icon in reverse order 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderRadius": 20,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -1019,6 +1112,7 @@ exports[`renders button with icon in reverse order 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="button-container-inner-layer"
@@ -1033,7 +1127,11 @@ exports[`renders button with icon in reverse order 1`] = `
           "borderStyle": "solid",
           "borderWidth": 0,
           "flex": undefined,
+          "height": undefined,
           "minWidth": 64,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="button-container"
@@ -1200,10 +1298,14 @@ exports[`renders contained contained with mode 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(0, 0, 0, 0)",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1215,6 +1317,8 @@ exports[`renders contained contained with mode 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -1223,7 +1327,10 @@ exports[`renders contained contained with mode 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderRadius": 20,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -1231,6 +1338,7 @@ exports[`renders contained contained with mode 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="button-container-inner-layer"
@@ -1245,7 +1353,11 @@ exports[`renders contained contained with mode 1`] = `
           "borderStyle": "solid",
           "borderWidth": 0,
           "flex": undefined,
+          "height": undefined,
           "minWidth": 64,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="button-container"
@@ -1355,10 +1467,14 @@ exports[`renders disabled button 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(0, 0, 0, 0)",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1370,6 +1486,8 @@ exports[`renders disabled button 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -1378,7 +1496,10 @@ exports[`renders disabled button 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderRadius": 20,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -1386,6 +1507,7 @@ exports[`renders disabled button 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="button-container-inner-layer"
@@ -1400,7 +1522,11 @@ exports[`renders disabled button 1`] = `
           "borderStyle": "solid",
           "borderWidth": 0,
           "flex": undefined,
+          "height": undefined,
           "minWidth": 64,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="button-container"
@@ -1509,10 +1635,14 @@ exports[`renders loading button 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(0, 0, 0, 0)",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1524,6 +1654,8 @@ exports[`renders loading button 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -1532,7 +1664,10 @@ exports[`renders loading button 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderRadius": 20,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -1540,6 +1675,7 @@ exports[`renders loading button 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="button-container-inner-layer"
@@ -1554,7 +1690,11 @@ exports[`renders loading button 1`] = `
           "borderStyle": "solid",
           "borderWidth": 0,
           "flex": undefined,
+          "height": undefined,
           "minWidth": 64,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="button-container"
@@ -1871,10 +2011,14 @@ exports[`renders outlined button with mode 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(0, 0, 0, 0)",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1886,6 +2030,8 @@ exports[`renders outlined button with mode 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -1894,7 +2040,10 @@ exports[`renders outlined button with mode 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderRadius": 20,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -1902,6 +2051,7 @@ exports[`renders outlined button with mode 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="button-container-inner-layer"
@@ -1916,7 +2066,11 @@ exports[`renders outlined button with mode 1`] = `
           "borderStyle": "solid",
           "borderWidth": 1,
           "flex": undefined,
+          "height": undefined,
           "minWidth": 64,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="button-container"
@@ -2026,10 +2180,14 @@ exports[`renders text button by default 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(0, 0, 0, 0)",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -2041,6 +2199,8 @@ exports[`renders text button by default 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -2049,7 +2209,10 @@ exports[`renders text button by default 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderRadius": 20,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -2057,6 +2220,7 @@ exports[`renders text button by default 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="button-container-inner-layer"
@@ -2071,7 +2235,11 @@ exports[`renders text button by default 1`] = `
           "borderStyle": "solid",
           "borderWidth": 0,
           "flex": undefined,
+          "height": undefined,
           "minWidth": 64,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="button-container"
@@ -2180,10 +2348,14 @@ exports[`renders text button with mode 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(0, 0, 0, 0)",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -2195,6 +2367,8 @@ exports[`renders text button with mode 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -2203,7 +2377,10 @@ exports[`renders text button with mode 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderRadius": 20,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -2211,6 +2388,7 @@ exports[`renders text button with mode 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="button-container-inner-layer"
@@ -2225,7 +2403,11 @@ exports[`renders text button with mode 1`] = `
           "borderStyle": "solid",
           "borderWidth": 0,
           "flex": undefined,
+          "height": undefined,
           "minWidth": 64,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="button-container"

--- a/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -6,10 +6,14 @@ exports[`renders chip with close button 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(0, 0, 0, 0)",
+      "borderRadius": 8,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -21,6 +25,8 @@ exports[`renders chip with close button 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="chip-container-outer-layer"
@@ -29,7 +35,10 @@ exports[`renders chip with close button 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderRadius": 8,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -37,6 +46,7 @@ exports[`renders chip with close button 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="chip-container-inner-layer"
@@ -52,6 +62,10 @@ exports[`renders chip with close button 1`] = `
           "borderWidth": 0,
           "flex": undefined,
           "flexDirection": "column",
+          "height": undefined,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="chip-container"
@@ -298,10 +312,14 @@ exports[`renders chip with custom close button 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(0, 0, 0, 0)",
+      "borderRadius": 8,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -313,6 +331,8 @@ exports[`renders chip with custom close button 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="chip-container-outer-layer"
@@ -321,7 +341,10 @@ exports[`renders chip with custom close button 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderRadius": 8,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -329,6 +352,7 @@ exports[`renders chip with custom close button 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="chip-container-inner-layer"
@@ -344,6 +368,10 @@ exports[`renders chip with custom close button 1`] = `
           "borderWidth": 0,
           "flex": undefined,
           "flexDirection": "column",
+          "height": undefined,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="chip-container"
@@ -590,10 +618,14 @@ exports[`renders chip with icon 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(0, 0, 0, 0)",
+      "borderRadius": 8,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -605,6 +637,8 @@ exports[`renders chip with icon 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="chip-container-outer-layer"
@@ -613,7 +647,10 @@ exports[`renders chip with icon 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderRadius": 8,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -621,6 +658,7 @@ exports[`renders chip with icon 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="chip-container-inner-layer"
@@ -636,6 +674,10 @@ exports[`renders chip with icon 1`] = `
           "borderWidth": 0,
           "flex": undefined,
           "flexDirection": "column",
+          "height": undefined,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="chip-container"
@@ -805,10 +847,14 @@ exports[`renders chip with onPress 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(0, 0, 0, 0)",
+      "borderRadius": 8,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -820,6 +866,8 @@ exports[`renders chip with onPress 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="chip-container-outer-layer"
@@ -828,7 +876,10 @@ exports[`renders chip with onPress 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderRadius": 8,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -836,6 +887,7 @@ exports[`renders chip with onPress 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="chip-container-inner-layer"
@@ -851,6 +903,10 @@ exports[`renders chip with onPress 1`] = `
           "borderWidth": 0,
           "flex": undefined,
           "flexDirection": "column",
+          "height": undefined,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="chip-container"
@@ -968,10 +1024,14 @@ exports[`renders outlined disabled chip 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(0, 0, 0, 0)",
+      "borderRadius": 8,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -983,6 +1043,8 @@ exports[`renders outlined disabled chip 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="chip-container-outer-layer"
@@ -991,7 +1053,10 @@ exports[`renders outlined disabled chip 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderRadius": 8,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -999,6 +1064,7 @@ exports[`renders outlined disabled chip 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="chip-container-inner-layer"
@@ -1014,6 +1080,10 @@ exports[`renders outlined disabled chip 1`] = `
           "borderWidth": 1,
           "flex": undefined,
           "flexDirection": "column",
+          "height": undefined,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="chip-container"
@@ -1131,10 +1201,14 @@ exports[`renders selected chip 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(0, 0, 0, 0)",
+      "borderRadius": 8,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1146,6 +1220,8 @@ exports[`renders selected chip 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="chip-container-outer-layer"
@@ -1154,7 +1230,10 @@ exports[`renders selected chip 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(0, 0, 0, 0)",
+        "borderRadius": 8,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -1162,6 +1241,7 @@ exports[`renders selected chip 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="chip-container-inner-layer"
@@ -1177,6 +1257,10 @@ exports[`renders selected chip 1`] = `
           "borderWidth": 0,
           "flex": undefined,
           "flexDirection": "column",
+          "height": undefined,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="chip-container"

--- a/src/components/__tests__/__snapshots__/DataTable.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.js.snap
@@ -269,10 +269,15 @@ exports[`renders data table pagination 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -284,6 +289,8 @@ exports[`renders data table pagination 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -292,7 +299,10 @@ exports[`renders data table pagination 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "flex": undefined,
+            "height": 40,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -300,6 +310,7 @@ exports[`renders data table pagination 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "width": 40,
           }
         }
         testID="icon-button-container-inner-layer"
@@ -315,8 +326,9 @@ exports[`renders data table pagination 1`] = `
               "elevation": 0,
               "flex": undefined,
               "height": 40,
-              "margin": 6,
+              "opacity": undefined,
               "overflow": "hidden",
+              "transform": undefined,
               "width": 40,
             }
           }
@@ -418,10 +430,15 @@ exports[`renders data table pagination 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -433,6 +450,8 @@ exports[`renders data table pagination 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -441,7 +460,10 @@ exports[`renders data table pagination 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "flex": undefined,
+            "height": 40,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -449,6 +471,7 @@ exports[`renders data table pagination 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "width": 40,
           }
         }
         testID="icon-button-container-inner-layer"
@@ -464,8 +487,9 @@ exports[`renders data table pagination 1`] = `
               "elevation": 0,
               "flex": undefined,
               "height": 40,
-              "margin": 6,
+              "opacity": undefined,
               "overflow": "hidden",
+              "transform": undefined,
               "width": 40,
             }
           }
@@ -625,10 +649,15 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -640,6 +669,8 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -648,7 +679,10 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "flex": undefined,
+            "height": 40,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -656,6 +690,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "width": 40,
           }
         }
         testID="icon-button-container-inner-layer"
@@ -671,8 +706,9 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
               "elevation": 0,
               "flex": undefined,
               "height": 40,
-              "margin": 6,
+              "opacity": undefined,
               "overflow": "hidden",
+              "transform": undefined,
               "width": 40,
             }
           }
@@ -774,10 +810,15 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -789,6 +830,8 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -797,7 +840,10 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "flex": undefined,
+            "height": 40,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -805,6 +851,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "width": 40,
           }
         }
         testID="icon-button-container-inner-layer"
@@ -820,8 +867,9 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
               "elevation": 0,
               "flex": undefined,
               "height": 40,
-              "margin": 6,
+              "opacity": undefined,
               "overflow": "hidden",
+              "transform": undefined,
               "width": 40,
             }
           }
@@ -923,10 +971,15 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -938,6 +991,8 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -946,7 +1001,10 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "flex": undefined,
+            "height": 40,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -954,6 +1012,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "width": 40,
           }
         }
         testID="icon-button-container-inner-layer"
@@ -969,8 +1028,9 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
               "elevation": 0,
               "flex": undefined,
               "height": 40,
-              "margin": 6,
+              "opacity": undefined,
               "overflow": "hidden",
+              "transform": undefined,
               "width": 40,
             }
           }
@@ -1072,10 +1132,15 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -1087,6 +1152,8 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -1095,7 +1162,10 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "flex": undefined,
+            "height": 40,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1103,6 +1173,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "width": 40,
           }
         }
         testID="icon-button-container-inner-layer"
@@ -1118,8 +1189,9 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
               "elevation": 0,
               "flex": undefined,
               "height": 40,
-              "margin": 6,
+              "opacity": undefined,
               "overflow": "hidden",
+              "transform": undefined,
               "width": 40,
             }
           }
@@ -1279,10 +1351,15 @@ exports[`renders data table pagination with label 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -1294,6 +1371,8 @@ exports[`renders data table pagination with label 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -1302,7 +1381,10 @@ exports[`renders data table pagination with label 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "flex": undefined,
+            "height": 40,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1310,6 +1392,7 @@ exports[`renders data table pagination with label 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "width": 40,
           }
         }
         testID="icon-button-container-inner-layer"
@@ -1325,8 +1408,9 @@ exports[`renders data table pagination with label 1`] = `
               "elevation": 0,
               "flex": undefined,
               "height": 40,
-              "margin": 6,
+              "opacity": undefined,
               "overflow": "hidden",
+              "transform": undefined,
               "width": 40,
             }
           }
@@ -1428,10 +1512,15 @@ exports[`renders data table pagination with label 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -1443,6 +1532,8 @@ exports[`renders data table pagination with label 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -1451,7 +1542,10 @@ exports[`renders data table pagination with label 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "flex": undefined,
+            "height": 40,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1459,6 +1553,7 @@ exports[`renders data table pagination with label 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "width": 40,
           }
         }
         testID="icon-button-container-inner-layer"
@@ -1474,8 +1569,9 @@ exports[`renders data table pagination with label 1`] = `
               "elevation": 0,
               "flex": undefined,
               "height": 40,
-              "margin": 6,
+              "opacity": undefined,
               "overflow": "hidden",
+              "transform": undefined,
               "width": 40,
             }
           }
@@ -1641,10 +1737,15 @@ exports[`renders data table pagination with options select 1`] = `
         style={
           Object {
             "alignSelf": undefined,
+            "backgroundColor": "rgba(0, 0, 0, 0)",
+            "borderRadius": 20,
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
+            "height": undefined,
             "left": undefined,
+            "marginRight": 16,
+            "opacity": undefined,
             "position": undefined,
             "right": undefined,
             "shadowColor": "#000",
@@ -1656,6 +1757,8 @@ exports[`renders data table pagination with options select 1`] = `
             "shadowRadius": 0,
             "start": undefined,
             "top": undefined,
+            "transform": undefined,
+            "width": undefined,
           }
         }
         testID="button-container-outer-layer"
@@ -1664,7 +1767,10 @@ exports[`renders data table pagination with options select 1`] = `
           collapsable={false}
           style={
             Object {
+              "backgroundColor": "rgba(0, 0, 0, 0)",
+              "borderRadius": 20,
               "flex": undefined,
+              "height": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -1672,6 +1778,7 @@ exports[`renders data table pagination with options select 1`] = `
               },
               "shadowOpacity": 0,
               "shadowRadius": 0,
+              "width": undefined,
             }
           }
           testID="button-container-inner-layer"
@@ -1686,9 +1793,12 @@ exports[`renders data table pagination with options select 1`] = `
                 "borderStyle": "solid",
                 "borderWidth": 1,
                 "flex": undefined,
-                "marginRight": 16,
+                "height": undefined,
                 "minWidth": 64,
+                "opacity": undefined,
                 "textAlign": "center",
+                "transform": undefined,
+                "width": undefined,
               }
             }
             testID="button-container"
@@ -1890,10 +2000,15 @@ exports[`renders data table pagination with options select 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -1905,6 +2020,8 @@ exports[`renders data table pagination with options select 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -1913,7 +2030,10 @@ exports[`renders data table pagination with options select 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "flex": undefined,
+            "height": 40,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1921,6 +2041,7 @@ exports[`renders data table pagination with options select 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "width": 40,
           }
         }
         testID="icon-button-container-inner-layer"
@@ -1936,8 +2057,9 @@ exports[`renders data table pagination with options select 1`] = `
               "elevation": 0,
               "flex": undefined,
               "height": 40,
-              "margin": 6,
+              "opacity": undefined,
               "overflow": "hidden",
+              "transform": undefined,
               "width": 40,
             }
           }
@@ -2039,10 +2161,15 @@ exports[`renders data table pagination with options select 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -2054,6 +2181,8 @@ exports[`renders data table pagination with options select 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -2062,7 +2191,10 @@ exports[`renders data table pagination with options select 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "flex": undefined,
+            "height": 40,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -2070,6 +2202,7 @@ exports[`renders data table pagination with options select 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "width": 40,
           }
         }
         testID="icon-button-container-inner-layer"
@@ -2085,8 +2218,9 @@ exports[`renders data table pagination with options select 1`] = `
               "elevation": 0,
               "flex": undefined,
               "height": 40,
-              "margin": 6,
+              "opacity": undefined,
               "overflow": "hidden",
+              "transform": undefined,
               "width": 40,
             }
           }
@@ -2188,10 +2322,15 @@ exports[`renders data table pagination with options select 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -2203,6 +2342,8 @@ exports[`renders data table pagination with options select 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -2211,7 +2352,10 @@ exports[`renders data table pagination with options select 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "flex": undefined,
+            "height": 40,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -2219,6 +2363,7 @@ exports[`renders data table pagination with options select 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "width": 40,
           }
         }
         testID="icon-button-container-inner-layer"
@@ -2234,8 +2379,9 @@ exports[`renders data table pagination with options select 1`] = `
               "elevation": 0,
               "flex": undefined,
               "height": 40,
-              "margin": 6,
+              "opacity": undefined,
               "overflow": "hidden",
+              "transform": undefined,
               "width": 40,
             }
           }
@@ -2337,10 +2483,15 @@ exports[`renders data table pagination with options select 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -2352,6 +2503,8 @@ exports[`renders data table pagination with options select 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -2360,7 +2513,10 @@ exports[`renders data table pagination with options select 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "flex": undefined,
+            "height": 40,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -2368,6 +2524,7 @@ exports[`renders data table pagination with options select 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "width": 40,
           }
         }
         testID="icon-button-container-inner-layer"
@@ -2383,8 +2540,9 @@ exports[`renders data table pagination with options select 1`] = `
               "elevation": 0,
               "flex": undefined,
               "height": 40,
-              "margin": 6,
+              "opacity": undefined,
               "overflow": "hidden",
+              "transform": undefined,
               "width": 40,
             }
           }

--- a/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
@@ -6,10 +6,14 @@ exports[`renders FAB with custom size prop 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(238, 232, 244)",
+      "borderRadius": 25,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -21,6 +25,12 @@ exports[`renders FAB with custom size prop 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -29,7 +39,10 @@ exports[`renders FAB with custom size prop 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(238, 232, 244)",
+        "borderRadius": 25,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -37,6 +50,7 @@ exports[`renders FAB with custom size prop 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 3,
+        "width": undefined,
       }
     }
     testID="fab-container-inner-layer"
@@ -49,6 +63,7 @@ exports[`renders FAB with custom size prop 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 25,
           "flex": undefined,
+          "height": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -56,6 +71,7 @@ exports[`renders FAB with custom size prop 1`] = `
               "scale": 1,
             },
           ],
+          "width": undefined,
         }
       }
       testID="fab-container"
@@ -191,10 +207,14 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(238, 232, 244)",
+      "borderRadius": 16,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -206,6 +226,12 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -214,7 +240,10 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(238, 232, 244)",
+        "borderRadius": 16,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -222,6 +251,7 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 3,
+        "width": undefined,
       }
     }
     testID="fab-container-inner-layer"
@@ -234,6 +264,7 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 16,
           "flex": undefined,
+          "height": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -241,6 +272,7 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
               "scale": 1,
             },
           ],
+          "width": undefined,
         }
       }
       testID="fab-container"
@@ -376,10 +408,14 @@ exports[`renders default FAB 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(238, 232, 244)",
+      "borderRadius": 16,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -391,6 +427,12 @@ exports[`renders default FAB 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -399,7 +441,10 @@ exports[`renders default FAB 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(238, 232, 244)",
+        "borderRadius": 16,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -407,6 +452,7 @@ exports[`renders default FAB 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 3,
+        "width": undefined,
       }
     }
     testID="fab-container-inner-layer"
@@ -419,6 +465,7 @@ exports[`renders default FAB 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 16,
           "flex": undefined,
+          "height": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -426,6 +473,7 @@ exports[`renders default FAB 1`] = `
               "scale": 1,
             },
           ],
+          "width": undefined,
         }
       }
       testID="fab-container"
@@ -561,10 +609,14 @@ exports[`renders disabled FAB 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 16,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -576,6 +628,12 @@ exports[`renders disabled FAB 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -584,7 +642,10 @@ exports[`renders disabled FAB 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderRadius": 16,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -592,6 +653,7 @@ exports[`renders disabled FAB 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": undefined,
       }
     }
     testID="fab-container-inner-layer"
@@ -604,6 +666,7 @@ exports[`renders disabled FAB 1`] = `
           "backgroundColor": "rgba(28, 27, 31, 0.12)",
           "borderRadius": 16,
           "flex": undefined,
+          "height": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -611,6 +674,7 @@ exports[`renders disabled FAB 1`] = `
               "scale": 1,
             },
           ],
+          "width": undefined,
         }
       }
       testID="fab-container"
@@ -746,10 +810,14 @@ exports[`renders extended FAB 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(238, 232, 244)",
+      "borderRadius": 16,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -761,6 +829,12 @@ exports[`renders extended FAB 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -769,7 +843,10 @@ exports[`renders extended FAB 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(238, 232, 244)",
+        "borderRadius": 16,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -777,6 +854,7 @@ exports[`renders extended FAB 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 3,
+        "width": undefined,
       }
     }
     testID="fab-container-inner-layer"
@@ -789,6 +867,7 @@ exports[`renders extended FAB 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 16,
           "flex": undefined,
+          "height": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -796,6 +875,7 @@ exports[`renders extended FAB 1`] = `
               "scale": 1,
             },
           ],
+          "width": undefined,
         }
       }
       testID="fab-container"
@@ -970,10 +1050,14 @@ exports[`renders extended FAB with custom size prop 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(238, 232, 244)",
+      "borderRadius": 25,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -985,6 +1069,12 @@ exports[`renders extended FAB with custom size prop 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -993,7 +1083,10 @@ exports[`renders extended FAB with custom size prop 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(238, 232, 244)",
+        "borderRadius": 25,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -1001,6 +1094,7 @@ exports[`renders extended FAB with custom size prop 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 3,
+        "width": undefined,
       }
     }
     testID="fab-container-inner-layer"
@@ -1013,6 +1107,7 @@ exports[`renders extended FAB with custom size prop 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 25,
           "flex": undefined,
+          "height": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -1020,6 +1115,7 @@ exports[`renders extended FAB with custom size prop 1`] = `
               "scale": 1,
             },
           ],
+          "width": undefined,
         }
       }
       testID="fab-container"
@@ -1193,10 +1289,14 @@ exports[`renders large FAB 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(238, 232, 244)",
+      "borderRadius": 28,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1208,6 +1308,12 @@ exports[`renders large FAB 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -1216,7 +1322,10 @@ exports[`renders large FAB 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(238, 232, 244)",
+        "borderRadius": 28,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -1224,6 +1333,7 @@ exports[`renders large FAB 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 3,
+        "width": undefined,
       }
     }
     testID="fab-container-inner-layer"
@@ -1236,6 +1346,7 @@ exports[`renders large FAB 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 28,
           "flex": undefined,
+          "height": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -1243,6 +1354,7 @@ exports[`renders large FAB 1`] = `
               "scale": 1,
             },
           ],
+          "width": undefined,
         }
       }
       testID="fab-container"
@@ -1378,10 +1490,14 @@ exports[`renders loading FAB 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(238, 232, 244)",
+      "borderRadius": 16,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1393,6 +1509,12 @@ exports[`renders loading FAB 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -1401,7 +1523,10 @@ exports[`renders loading FAB 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(238, 232, 244)",
+        "borderRadius": 16,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -1409,6 +1534,7 @@ exports[`renders loading FAB 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 3,
+        "width": undefined,
       }
     }
     testID="fab-container-inner-layer"
@@ -1421,6 +1547,7 @@ exports[`renders loading FAB 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 16,
           "flex": undefined,
+          "height": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -1428,6 +1555,7 @@ exports[`renders loading FAB 1`] = `
               "scale": 1,
             },
           ],
+          "width": undefined,
         }
       }
       testID="fab-container"
@@ -1688,10 +1816,14 @@ exports[`renders loading FAB with custom size prop 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(238, 232, 244)",
+      "borderRadius": 25,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1703,6 +1835,12 @@ exports[`renders loading FAB with custom size prop 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -1711,7 +1849,10 @@ exports[`renders loading FAB with custom size prop 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(238, 232, 244)",
+        "borderRadius": 25,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -1719,6 +1860,7 @@ exports[`renders loading FAB with custom size prop 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 3,
+        "width": undefined,
       }
     }
     testID="fab-container-inner-layer"
@@ -1731,6 +1873,7 @@ exports[`renders loading FAB with custom size prop 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 25,
           "flex": undefined,
+          "height": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -1738,6 +1881,7 @@ exports[`renders loading FAB with custom size prop 1`] = `
               "scale": 1,
             },
           ],
+          "width": undefined,
         }
       }
       testID="fab-container"
@@ -1998,10 +2142,14 @@ exports[`renders not visible FAB 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(238, 232, 244)",
+      "borderRadius": 16,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -2013,6 +2161,12 @@ exports[`renders not visible FAB 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -2021,7 +2175,10 @@ exports[`renders not visible FAB 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(238, 232, 244)",
+        "borderRadius": 16,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -2029,6 +2186,7 @@ exports[`renders not visible FAB 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 3,
+        "width": undefined,
       }
     }
     testID="fab-container-inner-layer"
@@ -2041,6 +2199,7 @@ exports[`renders not visible FAB 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 16,
           "flex": undefined,
+          "height": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -2048,6 +2207,7 @@ exports[`renders not visible FAB 1`] = `
               "scale": 1,
             },
           ],
+          "width": undefined,
         }
       }
       testID="fab-container"
@@ -2183,10 +2343,14 @@ exports[`renders small FAB 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(238, 232, 244)",
+      "borderRadius": 12,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -2198,6 +2362,12 @@ exports[`renders small FAB 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -2206,7 +2376,10 @@ exports[`renders small FAB 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(238, 232, 244)",
+        "borderRadius": 12,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -2214,6 +2387,7 @@ exports[`renders small FAB 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 3,
+        "width": undefined,
       }
     }
     testID="fab-container-inner-layer"
@@ -2226,6 +2400,7 @@ exports[`renders small FAB 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 12,
           "flex": undefined,
+          "height": undefined,
           "opacity": 1,
           "overflow": "hidden",
           "transform": Array [
@@ -2233,6 +2408,7 @@ exports[`renders small FAB 1`] = `
               "scale": 1,
             },
           ],
+          "width": undefined,
         }
       }
       testID="fab-container"
@@ -2368,10 +2544,14 @@ exports[`renders visible FAB 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(238, 232, 244)",
+      "borderRadius": 16,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 0,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -2383,6 +2563,12 @@ exports[`renders visible FAB 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 0,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -2391,7 +2577,10 @@ exports[`renders visible FAB 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(238, 232, 244)",
+        "borderRadius": 16,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -2399,6 +2588,7 @@ exports[`renders visible FAB 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 3,
+        "width": undefined,
       }
     }
     testID="fab-container-inner-layer"
@@ -2411,6 +2601,7 @@ exports[`renders visible FAB 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 16,
           "flex": undefined,
+          "height": undefined,
           "opacity": 0,
           "overflow": "hidden",
           "transform": Array [
@@ -2418,6 +2609,7 @@ exports[`renders visible FAB 1`] = `
               "scale": 0,
             },
           ],
+          "width": undefined,
         }
       }
       testID="fab-container"

--- a/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
@@ -6,10 +6,15 @@ exports[`renders disabled icon button 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": 40,
       "left": undefined,
+      "margin": 6,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -21,6 +26,8 @@ exports[`renders disabled icon button 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": 40,
     }
   }
   testID="icon-button-container-outer-layer"
@@ -29,7 +36,10 @@ exports[`renders disabled icon button 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderRadius": 20,
         "flex": undefined,
+        "height": 40,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -37,6 +47,7 @@ exports[`renders disabled icon button 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": 40,
       }
     }
     testID="icon-button-container-inner-layer"
@@ -52,8 +63,9 @@ exports[`renders disabled icon button 1`] = `
           "elevation": 0,
           "flex": undefined,
           "height": 40,
-          "margin": 6,
+          "opacity": undefined,
           "overflow": "hidden",
+          "transform": undefined,
           "width": 40,
         }
       }
@@ -162,10 +174,15 @@ exports[`renders icon button by default 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": 40,
       "left": undefined,
+      "margin": 6,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -177,6 +194,8 @@ exports[`renders icon button by default 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": 40,
     }
   }
   testID="icon-button-container-outer-layer"
@@ -185,7 +204,10 @@ exports[`renders icon button by default 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderRadius": 20,
         "flex": undefined,
+        "height": 40,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -193,6 +215,7 @@ exports[`renders icon button by default 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": 40,
       }
     }
     testID="icon-button-container-inner-layer"
@@ -208,8 +231,9 @@ exports[`renders icon button by default 1`] = `
           "elevation": 0,
           "flex": undefined,
           "height": 40,
-          "margin": 6,
+          "opacity": undefined,
           "overflow": "hidden",
+          "transform": undefined,
           "width": 40,
         }
       }
@@ -313,10 +337,15 @@ exports[`renders icon button with color 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": 40,
       "left": undefined,
+      "margin": 6,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -328,6 +357,8 @@ exports[`renders icon button with color 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": 40,
     }
   }
   testID="icon-button-container-outer-layer"
@@ -336,7 +367,10 @@ exports[`renders icon button with color 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderRadius": 20,
         "flex": undefined,
+        "height": 40,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -344,6 +378,7 @@ exports[`renders icon button with color 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": 40,
       }
     }
     testID="icon-button-container-inner-layer"
@@ -359,8 +394,9 @@ exports[`renders icon button with color 1`] = `
           "elevation": 0,
           "flex": undefined,
           "height": 40,
-          "margin": 6,
+          "opacity": undefined,
           "overflow": "hidden",
+          "transform": undefined,
           "width": 40,
         }
       }
@@ -464,10 +500,15 @@ exports[`renders icon button with size 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 23,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": 46,
       "left": undefined,
+      "margin": 6,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -479,6 +520,8 @@ exports[`renders icon button with size 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": 46,
     }
   }
   testID="icon-button-container-outer-layer"
@@ -487,7 +530,10 @@ exports[`renders icon button with size 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderRadius": 23,
         "flex": undefined,
+        "height": 46,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -495,6 +541,7 @@ exports[`renders icon button with size 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": 46,
       }
     }
     testID="icon-button-container-inner-layer"
@@ -510,8 +557,9 @@ exports[`renders icon button with size 1`] = `
           "elevation": 0,
           "flex": undefined,
           "height": 46,
-          "margin": 6,
+          "opacity": undefined,
           "overflow": "hidden",
+          "transform": undefined,
           "width": 46,
         }
       }
@@ -615,10 +663,15 @@ exports[`renders icon change animated 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": 40,
       "left": undefined,
+      "margin": 6,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -630,6 +683,8 @@ exports[`renders icon change animated 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": 40,
     }
   }
   testID="icon-button-container-outer-layer"
@@ -638,7 +693,10 @@ exports[`renders icon change animated 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderRadius": 20,
         "flex": undefined,
+        "height": 40,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -646,6 +704,7 @@ exports[`renders icon change animated 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": 40,
       }
     }
     testID="icon-button-container-inner-layer"
@@ -661,8 +720,9 @@ exports[`renders icon change animated 1`] = `
           "elevation": 0,
           "flex": undefined,
           "height": 40,
-          "margin": 6,
+          "opacity": undefined,
           "overflow": "hidden",
+          "transform": undefined,
           "width": 40,
         }
       }

--- a/src/components/__tests__/__snapshots__/ListItem.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.js.snap
@@ -103,10 +103,14 @@ exports[`renders list item with custom description 1`] = `
             style={
               Object {
                 "alignSelf": undefined,
+                "backgroundColor": "rgba(0, 0, 0, 0)",
+                "borderRadius": 8,
                 "bottom": undefined,
                 "end": undefined,
                 "flex": undefined,
+                "height": undefined,
                 "left": undefined,
+                "opacity": undefined,
                 "position": undefined,
                 "right": undefined,
                 "shadowColor": "#000",
@@ -118,6 +122,8 @@ exports[`renders list item with custom description 1`] = `
                 "shadowRadius": 0,
                 "start": undefined,
                 "top": undefined,
+                "transform": undefined,
+                "width": undefined,
               }
             }
             testID="chip-container-outer-layer"
@@ -126,7 +132,10 @@ exports[`renders list item with custom description 1`] = `
               collapsable={false}
               style={
                 Object {
+                  "backgroundColor": "rgba(0, 0, 0, 0)",
+                  "borderRadius": 8,
                   "flex": undefined,
+                  "height": undefined,
                   "shadowColor": "#000",
                   "shadowOffset": Object {
                     "height": 0,
@@ -134,6 +143,7 @@ exports[`renders list item with custom description 1`] = `
                   },
                   "shadowOpacity": 0,
                   "shadowRadius": 0,
+                  "width": undefined,
                 }
               }
               testID="chip-container-inner-layer"
@@ -149,6 +159,10 @@ exports[`renders list item with custom description 1`] = `
                     "borderWidth": 0,
                     "flex": undefined,
                     "flexDirection": "column",
+                    "height": undefined,
+                    "opacity": undefined,
+                    "transform": undefined,
+                    "width": undefined,
                   }
                 }
                 testID="chip-container"

--- a/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -19,10 +19,14 @@ Array [
         style={
           Object {
             "alignSelf": undefined,
+            "backgroundColor": "rgba(0, 0, 0, 0)",
+            "borderRadius": 20,
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
+            "height": undefined,
             "left": undefined,
+            "opacity": undefined,
             "position": undefined,
             "right": undefined,
             "shadowColor": "#000",
@@ -34,6 +38,8 @@ Array [
             "shadowRadius": 0,
             "start": undefined,
             "top": undefined,
+            "transform": undefined,
+            "width": undefined,
           }
         }
         testID="button-container-outer-layer"
@@ -42,7 +48,10 @@ Array [
           collapsable={false}
           style={
             Object {
+              "backgroundColor": "rgba(0, 0, 0, 0)",
+              "borderRadius": 20,
               "flex": undefined,
+              "height": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -50,6 +59,7 @@ Array [
               },
               "shadowOpacity": 0,
               "shadowRadius": 0,
+              "width": undefined,
             }
           }
           testID="button-container-inner-layer"
@@ -64,7 +74,11 @@ Array [
                 "borderStyle": "solid",
                 "borderWidth": 1,
                 "flex": undefined,
+                "height": undefined,
                 "minWidth": 64,
+                "opacity": undefined,
+                "transform": undefined,
+                "width": undefined,
               }
             }
             testID="button-container"
@@ -241,10 +255,16 @@ Array [
           style={
             Object {
               "alignSelf": undefined,
+              "backgroundColor": "rgb(243, 237, 246)",
+              "borderRadius": 4,
+              "borderTopLeftRadius": 0,
+              "borderTopRightRadius": 0,
               "bottom": undefined,
               "end": undefined,
               "flex": undefined,
+              "height": undefined,
               "left": undefined,
+              "opacity": 0,
               "position": undefined,
               "right": undefined,
               "shadowColor": "#000",
@@ -256,6 +276,15 @@ Array [
               "shadowRadius": 6,
               "start": undefined,
               "top": undefined,
+              "transform": Array [
+                Object {
+                  "scaleX": 0,
+                },
+                Object {
+                  "scaleY": 0,
+                },
+              ],
+              "width": undefined,
             }
           }
           testID="menu-surface-outer-layer"
@@ -264,7 +293,12 @@ Array [
             collapsable={false}
             style={
               Object {
+                "backgroundColor": "rgb(243, 237, 246)",
+                "borderRadius": 4,
+                "borderTopLeftRadius": 0,
+                "borderTopRightRadius": 0,
                 "flex": undefined,
+                "height": undefined,
                 "shadowColor": "#000",
                 "shadowOffset": Object {
                   "height": 1,
@@ -272,6 +306,7 @@ Array [
                 },
                 "shadowOpacity": 0.3,
                 "shadowRadius": 2,
+                "width": undefined,
               }
             }
             testID="menu-surface-inner-layer"
@@ -285,6 +320,7 @@ Array [
                   "borderTopLeftRadius": 0,
                   "borderTopRightRadius": 0,
                   "flex": undefined,
+                  "height": undefined,
                   "opacity": 0,
                   "paddingVertical": 8,
                   "transform": Array [
@@ -295,6 +331,7 @@ Array [
                       "scaleY": 0,
                     },
                   ],
+                  "width": undefined,
                 }
               }
               testID="menu-surface"
@@ -534,10 +571,14 @@ exports[`renders not visible menu 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "rgba(0, 0, 0, 0)",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": undefined,
           "left": undefined,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -549,6 +590,8 @@ exports[`renders not visible menu 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="button-container-outer-layer"
@@ -557,7 +600,10 @@ exports[`renders not visible menu 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "rgba(0, 0, 0, 0)",
+            "borderRadius": 20,
             "flex": undefined,
+            "height": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -565,6 +611,7 @@ exports[`renders not visible menu 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "width": undefined,
           }
         }
         testID="button-container-inner-layer"
@@ -579,7 +626,11 @@ exports[`renders not visible menu 1`] = `
               "borderStyle": "solid",
               "borderWidth": 1,
               "flex": undefined,
+              "height": undefined,
               "minWidth": 64,
+              "opacity": undefined,
+              "transform": undefined,
+              "width": undefined,
             }
           }
           testID="button-container"
@@ -704,10 +755,14 @@ Array [
         style={
           Object {
             "alignSelf": undefined,
+            "backgroundColor": "rgba(0, 0, 0, 0)",
+            "borderRadius": 20,
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
+            "height": undefined,
             "left": undefined,
+            "opacity": undefined,
             "position": undefined,
             "right": undefined,
             "shadowColor": "#000",
@@ -719,6 +774,8 @@ Array [
             "shadowRadius": 0,
             "start": undefined,
             "top": undefined,
+            "transform": undefined,
+            "width": undefined,
           }
         }
         testID="button-container-outer-layer"
@@ -727,7 +784,10 @@ Array [
           collapsable={false}
           style={
             Object {
+              "backgroundColor": "rgba(0, 0, 0, 0)",
+              "borderRadius": 20,
               "flex": undefined,
+              "height": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -735,6 +795,7 @@ Array [
               },
               "shadowOpacity": 0,
               "shadowRadius": 0,
+              "width": undefined,
             }
           }
           testID="button-container-inner-layer"
@@ -749,7 +810,11 @@ Array [
                 "borderStyle": "solid",
                 "borderWidth": 1,
                 "flex": undefined,
+                "height": undefined,
                 "minWidth": 64,
+                "opacity": undefined,
+                "transform": undefined,
+                "width": undefined,
               }
             }
             testID="button-container"
@@ -926,10 +991,14 @@ Array [
           style={
             Object {
               "alignSelf": undefined,
+              "backgroundColor": "rgb(243, 237, 246)",
+              "borderRadius": 4,
               "bottom": undefined,
               "end": undefined,
               "flex": undefined,
+              "height": undefined,
               "left": undefined,
+              "opacity": 0,
               "position": undefined,
               "right": undefined,
               "shadowColor": "#000",
@@ -941,6 +1010,15 @@ Array [
               "shadowRadius": 6,
               "start": undefined,
               "top": undefined,
+              "transform": Array [
+                Object {
+                  "scaleX": 0,
+                },
+                Object {
+                  "scaleY": 0,
+                },
+              ],
+              "width": undefined,
             }
           }
           testID="menu-surface-outer-layer"
@@ -949,7 +1027,10 @@ Array [
             collapsable={false}
             style={
               Object {
+                "backgroundColor": "rgb(243, 237, 246)",
+                "borderRadius": 4,
                 "flex": undefined,
+                "height": undefined,
                 "shadowColor": "#000",
                 "shadowOffset": Object {
                   "height": 1,
@@ -957,6 +1038,7 @@ Array [
                 },
                 "shadowOpacity": 0.3,
                 "shadowRadius": 2,
+                "width": undefined,
               }
             }
             testID="menu-surface-inner-layer"
@@ -968,6 +1050,7 @@ Array [
                   "backgroundColor": "rgb(243, 237, 246)",
                   "borderRadius": 4,
                   "flex": undefined,
+                  "height": undefined,
                   "opacity": 0,
                   "paddingVertical": 8,
                   "transform": Array [
@@ -978,6 +1061,7 @@ Array [
                       "scaleY": 0,
                     },
                   ],
+                  "width": undefined,
                 }
               }
               testID="menu-surface"

--- a/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
@@ -6,10 +6,14 @@ exports[`activity indicator snapshot test 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(247, 243, 249)",
+      "borderRadius": 4,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -21,6 +25,8 @@ exports[`activity indicator snapshot test 1`] = `
       "shadowRadius": 3,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="search-bar-container-outer-layer"
@@ -29,7 +35,10 @@ exports[`activity indicator snapshot test 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(247, 243, 249)",
+        "borderRadius": 4,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -37,6 +46,7 @@ exports[`activity indicator snapshot test 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 1,
+        "width": undefined,
       }
     }
     testID="search-bar-container-inner-layer"
@@ -50,6 +60,10 @@ exports[`activity indicator snapshot test 1`] = `
           "borderRadius": 4,
           "flex": undefined,
           "flexDirection": "row",
+          "height": undefined,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="search-bar-container"
@@ -59,10 +73,15 @@ exports[`activity indicator snapshot test 1`] = `
         style={
           Object {
             "alignSelf": undefined,
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
+            "height": 40,
             "left": undefined,
+            "margin": 6,
+            "opacity": undefined,
             "position": undefined,
             "right": undefined,
             "shadowColor": "#000",
@@ -74,6 +93,8 @@ exports[`activity indicator snapshot test 1`] = `
             "shadowRadius": 0,
             "start": undefined,
             "top": undefined,
+            "transform": undefined,
+            "width": 40,
           }
         }
         testID="icon-button-container-outer-layer"
@@ -82,7 +103,10 @@ exports[`activity indicator snapshot test 1`] = `
           collapsable={false}
           style={
             Object {
+              "backgroundColor": "transparent",
+              "borderRadius": 20,
               "flex": undefined,
+              "height": 40,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -90,6 +114,7 @@ exports[`activity indicator snapshot test 1`] = `
               },
               "shadowOpacity": 0,
               "shadowRadius": 0,
+              "width": 40,
             }
           }
           testID="icon-button-container-inner-layer"
@@ -105,8 +130,9 @@ exports[`activity indicator snapshot test 1`] = `
                 "elevation": 0,
                 "flex": undefined,
                 "height": 40,
-                "margin": 6,
+                "opacity": undefined,
                 "overflow": "hidden",
+                "transform": undefined,
                 "width": 40,
               }
             }
@@ -442,10 +468,14 @@ exports[`renders with placeholder 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(247, 243, 249)",
+      "borderRadius": 4,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -457,6 +487,8 @@ exports[`renders with placeholder 1`] = `
       "shadowRadius": 3,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="search-bar-container-outer-layer"
@@ -465,7 +497,10 @@ exports[`renders with placeholder 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(247, 243, 249)",
+        "borderRadius": 4,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -473,6 +508,7 @@ exports[`renders with placeholder 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 1,
+        "width": undefined,
       }
     }
     testID="search-bar-container-inner-layer"
@@ -486,6 +522,10 @@ exports[`renders with placeholder 1`] = `
           "borderRadius": 4,
           "flex": undefined,
           "flexDirection": "row",
+          "height": undefined,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="search-bar-container"
@@ -495,10 +535,15 @@ exports[`renders with placeholder 1`] = `
         style={
           Object {
             "alignSelf": undefined,
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
+            "height": 40,
             "left": undefined,
+            "margin": 6,
+            "opacity": undefined,
             "position": undefined,
             "right": undefined,
             "shadowColor": "#000",
@@ -510,6 +555,8 @@ exports[`renders with placeholder 1`] = `
             "shadowRadius": 0,
             "start": undefined,
             "top": undefined,
+            "transform": undefined,
+            "width": 40,
           }
         }
         testID="icon-button-container-outer-layer"
@@ -518,7 +565,10 @@ exports[`renders with placeholder 1`] = `
           collapsable={false}
           style={
             Object {
+              "backgroundColor": "transparent",
+              "borderRadius": 20,
               "flex": undefined,
+              "height": 40,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -526,6 +576,7 @@ exports[`renders with placeholder 1`] = `
               },
               "shadowOpacity": 0,
               "shadowRadius": 0,
+              "width": 40,
             }
           }
           testID="icon-button-container-inner-layer"
@@ -541,8 +592,9 @@ exports[`renders with placeholder 1`] = `
                 "elevation": 0,
                 "flex": undefined,
                 "height": 40,
-                "margin": 6,
+                "opacity": undefined,
                 "overflow": "hidden",
+                "transform": undefined,
                 "width": 40,
               }
             }
@@ -678,10 +730,15 @@ exports[`renders with placeholder 1`] = `
           style={
             Object {
               "alignSelf": undefined,
+              "backgroundColor": "transparent",
+              "borderRadius": 20,
               "bottom": undefined,
               "end": undefined,
               "flex": undefined,
+              "height": 40,
               "left": undefined,
+              "margin": 6,
+              "opacity": undefined,
               "position": undefined,
               "right": undefined,
               "shadowColor": "#000",
@@ -693,6 +750,8 @@ exports[`renders with placeholder 1`] = `
               "shadowRadius": 0,
               "start": undefined,
               "top": undefined,
+              "transform": undefined,
+              "width": 40,
             }
           }
           testID="icon-button-container-outer-layer"
@@ -701,7 +760,10 @@ exports[`renders with placeholder 1`] = `
             collapsable={false}
             style={
               Object {
+                "backgroundColor": "transparent",
+                "borderRadius": 20,
                 "flex": undefined,
+                "height": 40,
                 "shadowColor": "#000",
                 "shadowOffset": Object {
                   "height": 0,
@@ -709,6 +771,7 @@ exports[`renders with placeholder 1`] = `
                 },
                 "shadowOpacity": 0,
                 "shadowRadius": 0,
+                "width": 40,
               }
             }
             testID="icon-button-container-inner-layer"
@@ -724,8 +787,9 @@ exports[`renders with placeholder 1`] = `
                   "elevation": 0,
                   "flex": undefined,
                   "height": 40,
-                  "margin": 6,
+                  "opacity": undefined,
                   "overflow": "hidden",
+                  "transform": undefined,
                   "width": 40,
                 }
               }
@@ -834,10 +898,14 @@ exports[`renders with text 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(247, 243, 249)",
+      "borderRadius": 4,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -849,6 +917,8 @@ exports[`renders with text 1`] = `
       "shadowRadius": 3,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="search-bar-container-outer-layer"
@@ -857,7 +927,10 @@ exports[`renders with text 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(247, 243, 249)",
+        "borderRadius": 4,
         "flex": undefined,
+        "height": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 1,
@@ -865,6 +938,7 @@ exports[`renders with text 1`] = `
         },
         "shadowOpacity": 0.3,
         "shadowRadius": 1,
+        "width": undefined,
       }
     }
     testID="search-bar-container-inner-layer"
@@ -878,6 +952,10 @@ exports[`renders with text 1`] = `
           "borderRadius": 4,
           "flex": undefined,
           "flexDirection": "row",
+          "height": undefined,
+          "opacity": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="search-bar-container"
@@ -887,10 +965,15 @@ exports[`renders with text 1`] = `
         style={
           Object {
             "alignSelf": undefined,
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
+            "height": 40,
             "left": undefined,
+            "margin": 6,
+            "opacity": undefined,
             "position": undefined,
             "right": undefined,
             "shadowColor": "#000",
@@ -902,6 +985,8 @@ exports[`renders with text 1`] = `
             "shadowRadius": 0,
             "start": undefined,
             "top": undefined,
+            "transform": undefined,
+            "width": 40,
           }
         }
         testID="icon-button-container-outer-layer"
@@ -910,7 +995,10 @@ exports[`renders with text 1`] = `
           collapsable={false}
           style={
             Object {
+              "backgroundColor": "transparent",
+              "borderRadius": 20,
               "flex": undefined,
+              "height": 40,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -918,6 +1006,7 @@ exports[`renders with text 1`] = `
               },
               "shadowOpacity": 0,
               "shadowRadius": 0,
+              "width": 40,
             }
           }
           testID="icon-button-container-inner-layer"
@@ -933,8 +1022,9 @@ exports[`renders with text 1`] = `
                 "elevation": 0,
                 "flex": undefined,
                 "height": 40,
-                "margin": 6,
+                "opacity": undefined,
                 "overflow": "hidden",
+                "transform": undefined,
                 "width": 40,
               }
             }
@@ -1070,10 +1160,15 @@ exports[`renders with text 1`] = `
           style={
             Object {
               "alignSelf": undefined,
+              "backgroundColor": "transparent",
+              "borderRadius": 20,
               "bottom": undefined,
               "end": undefined,
               "flex": undefined,
+              "height": 40,
               "left": undefined,
+              "margin": 6,
+              "opacity": undefined,
               "position": undefined,
               "right": undefined,
               "shadowColor": "#000",
@@ -1085,6 +1180,8 @@ exports[`renders with text 1`] = `
               "shadowRadius": 0,
               "start": undefined,
               "top": undefined,
+              "transform": undefined,
+              "width": 40,
             }
           }
           testID="icon-button-container-outer-layer"
@@ -1093,7 +1190,10 @@ exports[`renders with text 1`] = `
             collapsable={false}
             style={
               Object {
+                "backgroundColor": "transparent",
+                "borderRadius": 20,
                 "flex": undefined,
+                "height": 40,
                 "shadowColor": "#000",
                 "shadowOffset": Object {
                   "height": 0,
@@ -1101,6 +1201,7 @@ exports[`renders with text 1`] = `
                 },
                 "shadowOpacity": 0,
                 "shadowRadius": 0,
+                "width": 40,
               }
             }
             testID="icon-button-container-inner-layer"
@@ -1116,8 +1217,9 @@ exports[`renders with text 1`] = `
                   "elevation": 0,
                   "flex": undefined,
                   "height": 40,
-                  "margin": 6,
+                  "opacity": undefined,
                   "overflow": "hidden",
+                  "transform": undefined,
                   "width": 40,
                 }
               }

--- a/src/components/__tests__/__snapshots__/Snackbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.tsx.snap
@@ -25,10 +25,15 @@ exports[`renders snackbar with Text as a child 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "rgb(243, 237, 246)",
+        "borderRadius": 4,
         "bottom": undefined,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": undefined,
+        "margin": 8,
+        "opacity": 1,
         "position": undefined,
         "right": undefined,
         "shadowColor": "#000",
@@ -40,6 +45,12 @@ exports[`renders snackbar with Text as a child 1`] = `
         "shadowRadius": 6,
         "start": undefined,
         "top": undefined,
+        "transform": Array [
+          Object {
+            "scale": 1,
+          },
+        ],
+        "width": undefined,
       }
     }
     testID="surface-outer-layer"
@@ -48,7 +59,10 @@ exports[`renders snackbar with Text as a child 1`] = `
       collapsable={false}
       style={
         Object {
+          "backgroundColor": "rgb(243, 237, 246)",
+          "borderRadius": 4,
           "flex": undefined,
+          "height": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 1,
@@ -56,6 +70,7 @@ exports[`renders snackbar with Text as a child 1`] = `
           },
           "shadowOpacity": 0.3,
           "shadowRadius": 2,
+          "width": undefined,
         }
       }
       testID="surface-inner-layer"
@@ -70,8 +85,8 @@ exports[`renders snackbar with Text as a child 1`] = `
             "borderRadius": 4,
             "flex": undefined,
             "flexDirection": "row",
+            "height": undefined,
             "justifyContent": "space-between",
-            "margin": 8,
             "minHeight": 48,
             "opacity": 1,
             "transform": Array [
@@ -79,6 +94,7 @@ exports[`renders snackbar with Text as a child 1`] = `
                 "scale": 1,
               },
             ],
+            "width": undefined,
           }
         }
         testID="surface"
@@ -127,10 +143,15 @@ exports[`renders snackbar with View & Text as a child 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "rgb(243, 237, 246)",
+        "borderRadius": 4,
         "bottom": undefined,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": undefined,
+        "margin": 8,
+        "opacity": 1,
         "position": undefined,
         "right": undefined,
         "shadowColor": "#000",
@@ -142,6 +163,12 @@ exports[`renders snackbar with View & Text as a child 1`] = `
         "shadowRadius": 6,
         "start": undefined,
         "top": undefined,
+        "transform": Array [
+          Object {
+            "scale": 1,
+          },
+        ],
+        "width": undefined,
       }
     }
     testID="surface-outer-layer"
@@ -150,7 +177,10 @@ exports[`renders snackbar with View & Text as a child 1`] = `
       collapsable={false}
       style={
         Object {
+          "backgroundColor": "rgb(243, 237, 246)",
+          "borderRadius": 4,
           "flex": undefined,
+          "height": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 1,
@@ -158,6 +188,7 @@ exports[`renders snackbar with View & Text as a child 1`] = `
           },
           "shadowOpacity": 0.3,
           "shadowRadius": 2,
+          "width": undefined,
         }
       }
       testID="surface-inner-layer"
@@ -172,8 +203,8 @@ exports[`renders snackbar with View & Text as a child 1`] = `
             "borderRadius": 4,
             "flex": undefined,
             "flexDirection": "row",
+            "height": undefined,
             "justifyContent": "space-between",
-            "margin": 8,
             "minHeight": 48,
             "opacity": 1,
             "transform": Array [
@@ -181,6 +212,7 @@ exports[`renders snackbar with View & Text as a child 1`] = `
                 "scale": 1,
               },
             ],
+            "width": undefined,
           }
         }
         testID="surface"
@@ -255,10 +287,15 @@ exports[`renders snackbar with action button 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "rgb(243, 237, 246)",
+        "borderRadius": 4,
         "bottom": undefined,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": undefined,
+        "margin": 8,
+        "opacity": 1,
         "position": undefined,
         "right": undefined,
         "shadowColor": "#000",
@@ -270,6 +307,12 @@ exports[`renders snackbar with action button 1`] = `
         "shadowRadius": 6,
         "start": undefined,
         "top": undefined,
+        "transform": Array [
+          Object {
+            "scale": 1,
+          },
+        ],
+        "width": undefined,
       }
     }
     testID="surface-outer-layer"
@@ -278,7 +321,10 @@ exports[`renders snackbar with action button 1`] = `
       collapsable={false}
       style={
         Object {
+          "backgroundColor": "rgb(243, 237, 246)",
+          "borderRadius": 4,
           "flex": undefined,
+          "height": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 1,
@@ -286,6 +332,7 @@ exports[`renders snackbar with action button 1`] = `
           },
           "shadowOpacity": 0.3,
           "shadowRadius": 2,
+          "width": undefined,
         }
       }
       testID="surface-inner-layer"
@@ -300,8 +347,8 @@ exports[`renders snackbar with action button 1`] = `
             "borderRadius": 4,
             "flex": undefined,
             "flexDirection": "row",
+            "height": undefined,
             "justifyContent": "space-between",
-            "margin": 8,
             "minHeight": 48,
             "opacity": 1,
             "transform": Array [
@@ -309,6 +356,7 @@ exports[`renders snackbar with action button 1`] = `
                 "scale": 1,
               },
             ],
+            "width": undefined,
           }
         }
         testID="surface"
@@ -365,10 +413,16 @@ exports[`renders snackbar with action button 1`] = `
             style={
               Object {
                 "alignSelf": undefined,
+                "backgroundColor": "rgba(0, 0, 0, 0)",
+                "borderRadius": 20,
                 "bottom": undefined,
                 "end": undefined,
                 "flex": undefined,
+                "height": undefined,
                 "left": undefined,
+                "marginLeft": 4,
+                "marginRight": 8,
+                "opacity": undefined,
                 "position": undefined,
                 "right": undefined,
                 "shadowColor": "#000",
@@ -380,6 +434,8 @@ exports[`renders snackbar with action button 1`] = `
                 "shadowRadius": 0,
                 "start": undefined,
                 "top": undefined,
+                "transform": undefined,
+                "width": undefined,
               }
             }
             testID="button-container-outer-layer"
@@ -388,7 +444,10 @@ exports[`renders snackbar with action button 1`] = `
               collapsable={false}
               style={
                 Object {
+                  "backgroundColor": "rgba(0, 0, 0, 0)",
+                  "borderRadius": 20,
                   "flex": undefined,
+                  "height": undefined,
                   "shadowColor": "#000",
                   "shadowOffset": Object {
                     "height": 0,
@@ -396,6 +455,7 @@ exports[`renders snackbar with action button 1`] = `
                   },
                   "shadowOpacity": 0,
                   "shadowRadius": 0,
+                  "width": undefined,
                 }
               }
               testID="button-container-inner-layer"
@@ -410,9 +470,11 @@ exports[`renders snackbar with action button 1`] = `
                     "borderStyle": "solid",
                     "borderWidth": 0,
                     "flex": undefined,
-                    "marginLeft": 4,
-                    "marginRight": 8,
+                    "height": undefined,
                     "minWidth": 64,
+                    "opacity": undefined,
+                    "transform": undefined,
+                    "width": undefined,
                   }
                 }
                 testID="button-container"
@@ -543,10 +605,15 @@ exports[`renders snackbar with content 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "rgb(243, 237, 246)",
+        "borderRadius": 4,
         "bottom": undefined,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": undefined,
+        "margin": 8,
+        "opacity": 1,
         "position": undefined,
         "right": undefined,
         "shadowColor": "#000",
@@ -558,6 +625,12 @@ exports[`renders snackbar with content 1`] = `
         "shadowRadius": 6,
         "start": undefined,
         "top": undefined,
+        "transform": Array [
+          Object {
+            "scale": 1,
+          },
+        ],
+        "width": undefined,
       }
     }
     testID="surface-outer-layer"
@@ -566,7 +639,10 @@ exports[`renders snackbar with content 1`] = `
       collapsable={false}
       style={
         Object {
+          "backgroundColor": "rgb(243, 237, 246)",
+          "borderRadius": 4,
           "flex": undefined,
+          "height": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 1,
@@ -574,6 +650,7 @@ exports[`renders snackbar with content 1`] = `
           },
           "shadowOpacity": 0.3,
           "shadowRadius": 2,
+          "width": undefined,
         }
       }
       testID="surface-inner-layer"
@@ -588,8 +665,8 @@ exports[`renders snackbar with content 1`] = `
             "borderRadius": 4,
             "flex": undefined,
             "flexDirection": "row",
+            "height": undefined,
             "justifyContent": "space-between",
-            "margin": 8,
             "minHeight": 48,
             "opacity": 1,
             "transform": Array [
@@ -597,6 +674,7 @@ exports[`renders snackbar with content 1`] = `
                 "scale": 1,
               },
             ],
+            "width": undefined,
           }
         }
         testID="surface"

--- a/src/components/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.js.snap
@@ -1268,10 +1268,15 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 0,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -1283,6 +1288,8 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="right-icon-adornment-container-outer-layer"
@@ -1291,7 +1298,10 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "flex": undefined,
+            "height": 40,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1299,6 +1309,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "width": 40,
           }
         }
         testID="right-icon-adornment-container-inner-layer"
@@ -1314,8 +1325,9 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
               "elevation": 0,
               "flex": undefined,
               "height": 40,
-              "margin": 0,
+              "opacity": undefined,
               "overflow": "hidden",
+              "transform": undefined,
               "width": 40,
             }
           }
@@ -1630,10 +1642,15 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 0,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -1645,6 +1662,8 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="left-icon-adornment-container-outer-layer"
@@ -1653,7 +1672,10 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "flex": undefined,
+            "height": 40,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1661,6 +1683,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
+            "width": 40,
           }
         }
         testID="left-icon-adornment-container-inner-layer"
@@ -1676,8 +1699,9 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
               "elevation": 0,
               "flex": undefined,
               "height": 40,
-              "margin": 0,
+              "opacity": undefined,
               "overflow": "hidden",
+              "transform": undefined,
               "width": 40,
             }
           }

--- a/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -6,10 +6,15 @@ exports[`renders disabled toggle button 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 4,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": 42,
       "left": undefined,
+      "margin": 0,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -21,6 +26,8 @@ exports[`renders disabled toggle button 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": 42,
     }
   }
   testID="icon-button-container-outer-layer"
@@ -29,7 +36,10 @@ exports[`renders disabled toggle button 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderRadius": 4,
         "flex": undefined,
+        "height": 42,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -37,6 +47,7 @@ exports[`renders disabled toggle button 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": 42,
       }
     }
     testID="icon-button-container-inner-layer"
@@ -52,8 +63,9 @@ exports[`renders disabled toggle button 1`] = `
           "elevation": 0,
           "flex": undefined,
           "height": 42,
-          "margin": 0,
+          "opacity": undefined,
           "overflow": "hidden",
+          "transform": undefined,
           "width": 42,
         }
       }
@@ -161,10 +173,15 @@ exports[`renders toggle button 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 4,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": 42,
       "left": undefined,
+      "margin": 0,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -176,6 +193,8 @@ exports[`renders toggle button 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": 42,
     }
   }
   testID="icon-button-container-outer-layer"
@@ -184,7 +203,10 @@ exports[`renders toggle button 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderRadius": 4,
         "flex": undefined,
+        "height": 42,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -192,6 +214,7 @@ exports[`renders toggle button 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": 42,
       }
     }
     testID="icon-button-container-inner-layer"
@@ -207,8 +230,9 @@ exports[`renders toggle button 1`] = `
           "elevation": 0,
           "flex": undefined,
           "height": 42,
-          "margin": 0,
+          "opacity": undefined,
           "overflow": "hidden",
+          "transform": undefined,
           "width": 42,
         }
       }
@@ -311,10 +335,15 @@ exports[`renders unchecked toggle button 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 4,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": 42,
       "left": undefined,
+      "margin": 0,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -326,6 +355,8 @@ exports[`renders unchecked toggle button 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": 42,
     }
   }
   testID="icon-button-container-outer-layer"
@@ -334,7 +365,10 @@ exports[`renders unchecked toggle button 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderRadius": 4,
         "flex": undefined,
+        "height": 42,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -342,6 +376,7 @@ exports[`renders unchecked toggle button 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
+        "width": 42,
       }
     }
     testID="icon-button-container-inner-layer"
@@ -357,8 +392,9 @@ exports[`renders unchecked toggle button 1`] = `
           "elevation": 0,
           "flex": undefined,
           "height": 42,
-          "margin": 0,
+          "opacity": undefined,
           "overflow": "hidden",
+          "transform": undefined,
           "width": 42,
         }
       }


### PR DESCRIPTION
### Summary

Fixes https://github.com/callstack/react-native-paper/issues/3593.

As mentioned in the issue, using version 0.71.0 of RN causes causes warnings to be shown in the console when using the `Surface` component. This has to do with the fact that the component is defining a shadow without a view having a background color, which causes performance issues - see reasoning [here](https://github.com/facebook/react-native/commit/e4c53c28aea7e067e48f5c8c0100c7cafc031b06).

The fix was applying the background color to the outer and inner layer, which meant that it was necessary to modifying the structure of Surface to match the given width, height, margins (and remove them from the inner view) and border radius.

### Test plan

The changes made can be tested in the iOS example app. It should not be possible to see any changes, since it's expected that the behaviour and UI remains the same.