### PR TITLE
fix: correct text color

### DIFF
--- a/src/components/HelperText.tsx
+++ b/src/components/HelperText.tsx
@@ -124,13 +124,13 @@ const HelperText = ({
 
   const { colors, dark } = theme;
 
-  const textColor =
-    type === 'error'
-      ? colors?.error
-      : color(theme.isV3 ? theme.colors.onSurface : theme?.colors?.text)
-          .alpha(dark ? 0.7 : 0.54)
-          .rgb()
-          .string();
+  const infoTextColor = theme.isV3
+    ? theme.colors.onSurfaceVariant
+    : color(theme?.colors?.text)
+        .alpha(dark ? 0.7 : 0.54)
+        .rgb()
+        .string();
+  const textColor = type === 'error' ? colors?.error : infoTextColor;
 
   return (
     <AnimatedText

--- a/src/components/__tests__/HelperText.test.tsx
+++ b/src/components/__tests__/HelperText.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import { render } from '@testing-library/react-native';
+
+import { getTheme } from '../../core/theming';
+import HelperText from '../HelperText';
+
+describe('HelperText', () => {
+  it('should have correct text color for info type', () => {
+    const { getByTestId } = render(
+      <HelperText testID="helper-text" type="info">
+        Info: Maximum length is 100 characters
+      </HelperText>
+    );
+
+    expect(getByTestId('helper-text')).toHaveStyle({
+      color: getTheme().colors.onSurfaceVariant,
+    });
+  });
+
+  it('should have correct text color for error type', () => {
+    const { getByTestId } = render(
+      <HelperText testID="helper-text" type="error">
+        Error: Only letters are allowed
+      </HelperText>
+    );
+
+    expect(getByTestId('helper-text')).toHaveStyle({
+      color: getTheme().colors.error,
+    });
+  });
+});


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/3684

### Summary

Correct text color in `HelperText`


#### Related issue

- #3684 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Added unit test.
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
