### PR TITLE
docs: screen flash on initial docs load

### DIFF
--- a/docs/src/components/BannerExample.tsx
+++ b/docs/src/components/BannerExample.tsx
@@ -139,7 +139,30 @@ const BannerExample = () => {
   );
 };
 
-const WithProvider = () => {
+const Shimmer = () => {
+  /* Docusaurus won't call StyleSheet.create() server-side */
+  /* eslint-disable react-native/no-inline-styles, react-native/no-color-literals */
+
+  return (
+    <View
+      style={{
+        display: 'flex',
+        minHeight: 500,
+        borderWidth: 1,
+        borderColor: 'rgba(125, 82, 96, 0.4)',
+        borderStyle: 'solid',
+        borderRadius: 40,
+        alignContent: 'center',
+        justifyContent: 'center',
+        padding: 30,
+        marginTop: 36,
+        marginBottom: 32,
+      }}
+    />
+  );
+};
+
+const ThemedBannerExample = () => {
   const isDarkTheme = useColorMode().colorMode === 'dark';
   return (
     <Provider theme={isDarkTheme ? DarkTheme : DefaultTheme}>
@@ -150,8 +173,8 @@ const WithProvider = () => {
 
 export default function ClientSideBannerExample() {
   return (
-    <BrowserOnly fallback={<ProgressBar indeterminate />}>
-      {() => <WithProvider />}
+    <BrowserOnly fallback={<Shimmer />}>
+      {() => <ThemedBannerExample />}
     </BrowserOnly>
   );
 }

--- a/docs/src/components/BannerExample.tsx
+++ b/docs/src/components/BannerExample.tsx
@@ -139,15 +139,19 @@ const BannerExample = () => {
   );
 };
 
-export default function WithProvider() {
+const WithProvider = () => {
   const isDarkTheme = useColorMode().colorMode === 'dark';
   return (
+    <Provider theme={isDarkTheme ? DarkTheme : DefaultTheme}>
+      <BannerExample />
+    </Provider>
+  );
+};
+
+export default function ClientSideBannerExample() {
+  return (
     <BrowserOnly fallback={<ProgressBar indeterminate />}>
-      {() => (
-        <Provider theme={isDarkTheme ? DarkTheme : DefaultTheme}>
-          <BannerExample />
-        </Provider>
-      )}
+      {() => <WithProvider />}
     </BrowserOnly>
   );
 }

--- a/docs/src/components/GetStartedButtons.tsx
+++ b/docs/src/components/GetStartedButtons.tsx
@@ -51,7 +51,45 @@ const GetStartedButton = () => {
   );
 };
 
-const WithProvider = () => {
+const Shimmer = () => {
+  /* Docusaurus won't call StyleSheet.create() server-side */
+  /* eslint-disable react-native/no-inline-styles, react-native/no-color-literals */
+
+  return (
+    <View
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'center',
+        paddingBottom: 18,
+      }}
+    >
+      <View
+        style={{
+          width: 121,
+          marginRight: 16,
+          borderWidth: 1,
+          borderColor: 'rgba(125, 82, 96, 0.4)',
+          borderStyle: 'solid',
+          borderRadius: 40,
+          height: 40,
+        }}
+      />
+      <View
+        style={{
+          width: 132,
+          borderWidth: 1,
+          borderColor: 'rgba(125, 82, 96, 0.4)',
+          borderStyle: 'solid',
+          borderRadius: 40,
+          height: 40,
+        }}
+      />
+    </View>
+  );
+};
+
+const ThemedGetStarted = () => {
   const isDarkTheme = useColorMode().colorMode === 'dark';
   return (
     <Provider theme={isDarkTheme ? DarkTheme : DefaultTheme}>
@@ -61,5 +99,9 @@ const WithProvider = () => {
 };
 
 export default function ClientSideGetStarted() {
-  return <BrowserOnly>{() => <WithProvider />}</BrowserOnly>;
+  return (
+    <BrowserOnly fallback={<Shimmer />}>
+      {() => <ThemedGetStarted />}
+    </BrowserOnly>
+  );
 }

--- a/docs/src/components/GetStartedButtons.tsx
+++ b/docs/src/components/GetStartedButtons.tsx
@@ -51,15 +51,15 @@ const GetStartedButton = () => {
   );
 };
 
-export default function WithProvider() {
+const WithProvider = () => {
   const isDarkTheme = useColorMode().colorMode === 'dark';
   return (
-    <BrowserOnly>
-      {() => (
-        <Provider theme={isDarkTheme ? DarkTheme : DefaultTheme}>
-          <GetStartedButton />
-        </Provider>
-      )}
-    </BrowserOnly>
+    <Provider theme={isDarkTheme ? DarkTheme : DefaultTheme}>
+      <GetStartedButton />
+    </Provider>
   );
+};
+
+export default function ClientSideGetStarted() {
+  return <BrowserOnly>{() => <WithProvider />}</BrowserOnly>;
 }

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -12,7 +12,7 @@ Paper is a collection of customizable and production-ready components for React 
 
 Or check the demo app on [iOS](https://apps.apple.com/app/react-native-paper/id1548934513) or [Android](https://play.google.com/store/apps/details?id=com.callstack.reactnativepaperexample).
 
-<BannerExample />
+ <BannerExample />
 
 <div class="gallery gallery-light">
   <img src="./gallery/button.png" />

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -12,7 +12,7 @@ Paper is a collection of customizable and production-ready components for React 
 
 Or check the demo app on [iOS](https://apps.apple.com/app/react-native-paper/id1548934513) or [Android](https://play.google.com/store/apps/details?id=com.callstack.reactnativepaperexample).
 
- <BannerExample />
+<BannerExample />
 
 <div class="gallery gallery-light">
   <img src="./gallery/button.png" />


### PR DESCRIPTION
### Summary

When opening the new docs, the screen flashes for a brief moment. This is caused by Docusaurus rendering full-screen loader via `react-loadable` (https://github.com/jamiebuilds/react-loadable#avoiding-flash-of-loading-component)

I guess the way to fix it is to defer using `useColorMode` hook until page is fully hydrated.

### Test plan

Go to https://callstack.github.io/react-native-paper/index.html and use Analyze page lode via Chrome's Lighthouse.
