### PR TITLE
fix: correct label color for v2

### DIFF
--- a/src/components/BottomNavigation/utils.ts
+++ b/src/components/BottomNavigation/utils.ts
@@ -59,11 +59,10 @@ export const getLabelColor = ({
     return tintColor;
   }
 
-  if (focused) {
-    return theme.colors.onSurface;
-  }
-
   if (theme.isV3) {
+    if (focused) {
+      return theme.colors.onSurface;
+    }
     return theme.colors.onSurfaceVariant;
   }
 

--- a/src/components/__tests__/BottomNavigation.test.tsx
+++ b/src/components/__tests__/BottomNavigation.test.tsx
@@ -518,6 +518,7 @@ describe('getLabelColor', () => {
     ${undefined} | ${true}  | ${'#fff'}    | ${true}  | ${MD3Colors.neutral10}
     ${undefined} | ${false} | ${'#fff'}    | ${true}  | ${MD3Colors.neutralVariant30}
     ${undefined} | ${false} | ${'#fff'}    | ${false} | ${'#fff'}
+    ${undefined} | ${true}  | ${'#fff'}    | ${false} | ${'#fff'}
   `(
     'returns $expected when tintColor: $tintColor, focused: $focused useV3: $useV3',
     ({ tintColor, focused, defaultColor, useV3, expected }) => {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Corrects label color for `BottomNavigation` for `v2`.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Added a unit test case.

before | after
--- | ---
<img width="525" alt="Zrzut ekranu 2023-02-27 o 16 24 06" src="https://user-images.githubusercontent.com/22746080/221605111-08fc34e4-9422-4ab7-8e4b-612f4c87b316.png"> | <img width="525" alt="Zrzut ekranu 2023-02-27 o 16 17 34" src="https://user-images.githubusercontent.com/22746080/221604930-296e8529-538b-4325-a3a6-b1326440ec7a.png">


<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
