### PR TITLE
fix: changed accessibility label based on onPress callback

### DIFF
--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -130,7 +130,7 @@ const AppbarContent = ({
 
   return (
     <TouchableWithoutFeedback
-      accessibilityRole="button"
+      accessibilityRole={onPress ? 'button' : 'text'}
       onPress={onPress}
       disabled={!onPress}
     >

--- a/src/components/__tests__/Appbar/Appbar.test.tsx
+++ b/src/components/__tests__/Appbar/Appbar.test.tsx
@@ -210,6 +210,29 @@ describe('renderAppbarContent', () => {
       expect.arrayContaining([expect.objectContaining(v2Spacing)])
     );
   });
+
+  it('Is recognized as a header when no onPress callback has been pressed', () => {
+    const { getByRole } = render(
+      <mockSafeAreaContext.SafeAreaProvider>
+        <Appbar.Header>
+          <Appbar.Content title="Accessible test" />
+        </Appbar.Header>
+      </mockSafeAreaContext.SafeAreaProvider>
+    );
+
+    expect(getByRole('text')).toBeTruthy();
+  });
+  it('Is recognized as a button when onPress callback has been pressed', () => {
+    const { getByRole } = render(
+      <mockSafeAreaContext.SafeAreaProvider>
+        <Appbar.Header>
+          <Appbar.Content title="Accessible test" onPress={() => {}} />
+        </Appbar.Header>
+      </mockSafeAreaContext.SafeAreaProvider>
+    );
+
+    expect(getByRole('button')).toBeTruthy();
+  });
 });
 
 describe('AppbarAction', () => {

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
@@ -700,7 +700,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
         </View>
       </View>
       <View
-        accessibilityRole="button"
+        accessibilityRole="text"
         accessibilityState={
           Object {
             "disabled": true,


### PR DESCRIPTION
### Summary
Resolves problem for accessibility label when Appbar.Content has no OnPress action
detailed info: https://github.com/callstack/react-native-paper/issues/3704


### Test plan

- Start the app
- Open Xcode, then go to the Xcode menu -> Open Developer Tool -> Accessibility Inspector
- Select the heading

|   case | expected result  |
|---|---|
|  **when Appbar.Content hasn't onPress callback: content is recognized as a text** |  ![image](https://user-images.githubusercontent.com/7682108/222532538-bce91603-7df1-42cb-a9d3-3454d13a8575.png) |
|  **when Appbar.Content has onPress callback:  component is recognized as a button** |   ![image](https://user-images.githubusercontent.com/7682108/222532749-91edf103-7ded-4d37-93b0-fdebbc0e5725.png)
|






