### PR TITLE
docs: fix get started button

### DIFF
--- a/docs/src/components/GetStartedButtons.tsx
+++ b/docs/src/components/GetStartedButtons.tsx
@@ -32,7 +32,7 @@ const noop = () => {};
 const GetStartedButton = () => {
   return (
     <View style={styles.container}>
-      <Link to="docs/guides/getting-started" style={noTextDecoration}>
+      <Link to="/docs/guides/getting-started" style={noTextDecoration}>
         <Button mode="contained" style={styles.button} onPress={noop}>
           Get started
         </Button>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Get started button in docs doesn't work

For Docusaurus to prepend `baseUrl` the href needs to start with `/`: https://github.com/facebook/docusaurus/blob/50b1dc7db33f570f15942f8414be84f5d471282f/packages/docusaurus/src/client/exports/Link.tsx#L28


<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Get started button in docs works
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
