### PR TITLE
fix: input label positioning regression

### DIFF
--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -38,7 +38,6 @@ const InputLabel = (props: InputLabelProps) => {
     labelTranslationXOffset,
     maxFontSizeMultiplier,
     testID,
-    theme,
   } = props;
 
   const paddingOffset =
@@ -118,7 +117,6 @@ const InputLabel = (props: InputLabelProps) => {
         labeled,
         labelLayoutWidth,
         labelStyle,
-        theme,
         placeholderStyle,
         baseLabelTranslateX,
         topPosition,

--- a/src/components/TextInput/Label/LabelBackground.tsx
+++ b/src/components/TextInput/Label/LabelBackground.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Animated, StyleSheet } from 'react-native';
 
-import { useInternalTheme } from '../../../core/theming';
 import AnimatedText from '../../Typography/AnimatedText';
 import type { LabelBackgroundProps } from '../types';
 
@@ -16,14 +15,11 @@ const LabelBackground = ({
   roundness,
   labelStyle,
   maxFontSizeMultiplier,
-  theme: themeOverrides,
 }: LabelBackgroundProps) => {
   const opacity = labeled.interpolate({
     inputRange: [0, 0.6],
     outputRange: [1, 0],
   });
-
-  const { isV3 } = useInternalTheme(themeOverrides);
 
   const labelTranslationX = {
     translateX: labeled.interpolate({
@@ -40,14 +36,6 @@ const LabelBackground = ({
   };
 
   const labelTextTransform = [...labelStyle.transform, labelTextScaleY];
-
-  const labelTextWidth = isV3
-    ? {
-        width: labelLayoutWidth - placeholderStyle.paddingHorizontal,
-      }
-    : {
-        maxWidth: labelLayoutWidth - 2 * placeholderStyle.paddingHorizontal,
-      };
 
   const isRounded = roundness > 6;
   const roundedEdgeCover = isRounded ? (
@@ -76,14 +64,13 @@ const LabelBackground = ({
         placeholderStyle,
         labelStyle,
         styles.outlinedLabel,
-        isV3 && styles.md3OutlinedLabel,
         {
           top: topPosition + 1,
+          width: labelLayoutWidth - placeholderStyle.paddingHorizontal,
           backgroundColor,
           opacity,
           transform: labelTextTransform,
         },
-        labelTextWidth,
       ]}
       numberOfLines={1}
       maxFontSizeMultiplier={maxFontSizeMultiplier}
@@ -105,11 +92,8 @@ const styles = StyleSheet.create({
   // eslint-disable-next-line react-native/no-color-literals
   outlinedLabel: {
     position: 'absolute',
-    left: 18,
+    left: 8,
     paddingHorizontal: 0,
     color: 'transparent',
-  },
-  md3OutlinedLabel: {
-    left: 8,
   },
 });

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -281,7 +281,6 @@ const TextInputFlat = ({
     maxFontSizeMultiplier: rest.maxFontSizeMultiplier,
     testID,
     contentStyle,
-    theme,
     opacity:
       parentState.value || parentState.focused
         ? parentState.labelLayout.measured

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -210,7 +210,6 @@ const TextInputOutlined = ({
     maxFontSizeMultiplier: rest.maxFontSizeMultiplier,
     testID,
     contentStyle,
-    theme,
     opacity:
       parentState.value || parentState.focused
         ? parentState.labelLayout.measured


### PR DESCRIPTION
### Summary

RNP v5.1.4 introduced regression in positioning of label on outlined TextInput:

![image](https://user-images.githubusercontent.com/7429558/223100108-7ff20032-2fc2-4cd0-a214-bbacc21d6e38.png)

This was caused by https://github.com/callstack/react-native-paper/pull/3642. Reason:

Outlined TextInput uses additional mask to cover bigger round corners:

<img width="233" alt="image" src="https://user-images.githubusercontent.com/7429558/223100655-791e4f4e-c2e0-4821-8435-15de2d2f72b4.png">

Working on performance of this component I decided to apply this mask only on outlined TextInput and only if the roundness is greater than 6pt. What I did not anticipated is that in V2 the this additional mask was used to cover left-most side of the label.

With this additional mask fixed, we can now unify math behind label for both V2 & V3. This should solve the issue.

### Test plan

All outlined inputs were affected. 
