### PR TITLE
refactor: iOS `Surface` major refactoring

### DIFF
--- a/example/src/Examples/SurfaceExample.tsx
+++ b/example/src/Examples/SurfaceExample.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
-import { MD3Elevation, Surface, Text } from 'react-native-paper';
+import { MD3Elevation, Surface, Text, MD3Colors } from 'react-native-paper';
 
 import { useExampleTheme } from '..';
 import { isWeb } from '../../utils';
@@ -31,6 +31,23 @@ const SurfaceExample = () => {
           </Text>
         </Surface>
       ))}
+
+      <View style={styles.horizontalSurfacesContainer}>
+        <Surface style={styles.horizontalSurface}>
+          <Text style={styles.centerText}>Left</Text>
+        </Surface>
+        <Surface style={styles.horizontalSurface}>
+          <Text style={styles.centerText}>Right</Text>
+        </Surface>
+      </View>
+      <View style={styles.verticalSurfacesContainer}>
+        <Surface style={styles.verticalSurface}>
+          <Text style={styles.centerText}>Top</Text>
+        </Surface>
+        <Surface style={styles.verticalSurface}>
+          <Text style={styles.centerText}>Bottom</Text>
+        </Surface>
+      </View>
     </ScreenWrapper>
   );
 };
@@ -60,6 +77,37 @@ const styles = StyleSheet.create({
     width: 200,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+
+  horizontalSurfacesContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    width: '100%',
+    marginBottom: 20,
+    borderColor: MD3Colors.tertiary50,
+    padding: 10,
+    borderWidth: 1,
+  },
+  horizontalSurface: {
+    width: '48%',
+  },
+
+  verticalSurfacesContainer: {
+    height: 400,
+    justifyContent: 'space-between',
+    width: '100%',
+    marginBottom: 100,
+    borderColor: MD3Colors.tertiary50,
+    padding: 10,
+    borderWidth: 1,
+  },
+  verticalSurface: {
+    height: '48%',
+    justifyContent: 'center',
+  },
+
+  centerText: {
+    textAlign: 'center',
   },
 });
 

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -266,7 +266,6 @@ const FAB = forwardRef<View, Props>(
               },
             ],
           },
-          styles.container,
           !isV3 && styles.elevated,
           !isV3 && disabled && styles.disabled,
           style,
@@ -286,6 +285,7 @@ const FAB = forwardRef<View, Props>(
           accessibilityRole="button"
           accessibilityState={newAccessibilityState}
           testID={testID}
+          style={{ borderRadius }}
         >
           <View
             style={[styles.content, label ? extendedStyle : fabStyle]}
@@ -329,9 +329,6 @@ const FAB = forwardRef<View, Props>(
 const styles = StyleSheet.create({
   elevated: {
     elevation: 6,
-  },
-  container: {
-    overflow: 'hidden',
   },
   content: {
     flexDirection: 'row',

--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {
   Animated,
   Platform,
+  ShadowStyleIOS,
   StyleProp,
   StyleSheet,
   View,
@@ -14,6 +15,8 @@ import shadow from '../styles/shadow';
 import type { ThemeProp, MD3Elevation } from '../types';
 import { forwardRef } from '../utils/forwardRef';
 import { splitStyles } from '../utils/splitStyles';
+
+type Elevation = 0 | 1 | 2 | 3 | 4 | 5 | Animated.Value;
 
 export type Props = React.ComponentPropsWithRef<typeof View> & {
   /**
@@ -29,7 +32,7 @@ export type Props = React.ComponentPropsWithRef<typeof View> & {
    * Note: In version 2 the `elevation` prop was accepted via `style` prop i.e. `style={{ elevation: 4 }}`.
    * It's no longer supported with theme version 3 and you should use `elevation` property instead.
    */
-  elevation?: 0 | 1 | 2 | 3 | 4 | 5 | Animated.Value;
+  elevation?: Elevation;
   /**
    * @optional
    */
@@ -64,6 +67,138 @@ const MD2Surface = forwardRef<View, Props>(
     );
   }
 );
+
+const shadowColor = '#000';
+const iOSShadowOutputRanges = [
+  {
+    shadowOpacity: 0.15,
+    height: [0, 1, 2, 4, 6, 8],
+    shadowRadius: [0, 3, 6, 8, 10, 12],
+  },
+  {
+    shadowOpacity: 0.3,
+    height: [0, 1, 1, 1, 2, 4],
+    shadowRadius: [0, 1, 2, 3, 3, 4],
+  },
+];
+const inputRange = [0, 1, 2, 3, 4, 5];
+function getStyleForShadowLayer(
+  elevation: Elevation,
+  layer: 0 | 1
+): Animated.WithAnimatedValue<ShadowStyleIOS> {
+  if (isAnimatedValue(elevation)) {
+    return {
+      shadowColor,
+      shadowOpacity: elevation.interpolate({
+        inputRange: [0, 1],
+        outputRange: [0, iOSShadowOutputRanges[layer].shadowOpacity],
+        extrapolate: 'clamp',
+      }),
+      shadowOffset: {
+        width: 0,
+        height: elevation.interpolate({
+          inputRange,
+          outputRange: iOSShadowOutputRanges[layer].height,
+        }),
+      },
+      shadowRadius: elevation.interpolate({
+        inputRange,
+        outputRange: iOSShadowOutputRanges[layer].shadowRadius,
+      }),
+    };
+  }
+
+  return {
+    shadowColor,
+    shadowOpacity: elevation ? iOSShadowOutputRanges[layer].shadowOpacity : 0,
+    shadowOffset: {
+      width: 0,
+      height: iOSShadowOutputRanges[layer].height[elevation],
+    },
+    shadowRadius: iOSShadowOutputRanges[layer].shadowRadius[elevation],
+  };
+}
+
+const SurfaceIOS = forwardRef<
+  View,
+  Omit<Props, 'elevation'> & {
+    elevation: Elevation;
+    backgroundColor?: string | Animated.AnimatedInterpolation<string | number>;
+  }
+>(({ elevation, style, backgroundColor, testID, children, ...props }, ref) => {
+  const [outerLayerViewStyles, innerLayerViewStyles] = React.useMemo(() => {
+    const {
+      position,
+      alignSelf,
+      top,
+      left,
+      right,
+      bottom,
+      start,
+      end,
+      flex,
+      backgroundColor: backgroundColorStyle,
+      width,
+      height,
+      transform,
+      opacity,
+      ...restStyle
+    } = (StyleSheet.flatten(style) || {}) as ViewStyle;
+
+    const [filteredStyles, marginStyles] = splitStyles(restStyle, (style) =>
+      style.startsWith('margin')
+    );
+
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      filteredStyles.overflow === 'hidden' &&
+      elevation !== 0
+    ) {
+      console.warn(
+        'When setting overflow to hidden on Surface the shadow will not be displayed correctly. Wrap the content of your component in a separate View with the overflow style.'
+      );
+    }
+
+    const outerLayerViewStyles = {
+      ...getStyleForShadowLayer(elevation, 0),
+      ...marginStyles,
+      position,
+      alignSelf,
+      top,
+      right,
+      bottom,
+      left,
+      start,
+      end,
+      flex,
+      width,
+      height,
+      transform,
+      opacity,
+    };
+
+    const innerLayerViewStyles = {
+      ...getStyleForShadowLayer(elevation, 1),
+      ...filteredStyles,
+      flex: height ? 1 : undefined,
+      backgroundColor: backgroundColorStyle || backgroundColor,
+    };
+
+    return [outerLayerViewStyles, innerLayerViewStyles];
+  }, [style, elevation, backgroundColor]);
+
+  return (
+    <Animated.View
+      ref={ref}
+      style={outerLayerViewStyles}
+      testID={`${testID}-outer-layer`}
+    >
+      <Animated.View {...props} style={innerLayerViewStyles} testID={testID}>
+        {children}
+      </Animated.View>
+    </Animated.View>
+  );
+});
 
 /**
  * Surface is a basic container that can give depth to an element with elevation shadow.
@@ -205,146 +340,16 @@ const Surface = forwardRef<View, Props>(
       );
     }
 
-    const iOSShadowOutputRanges = [
-      {
-        shadowOpacity: 0.15,
-        height: [0, 1, 2, 4, 6, 8],
-        shadowRadius: [0, 3, 6, 8, 10, 12],
-      },
-      {
-        shadowOpacity: 0.3,
-        height: [0, 1, 1, 1, 2, 4],
-        shadowRadius: [0, 1, 2, 3, 3, 4],
-      },
-    ];
-
-    const shadowColor = '#000';
-
-    const {
-      position,
-      alignSelf,
-      top,
-      left,
-      right,
-      bottom,
-      start,
-      end,
-      flex,
-      backgroundColor: backgroundColorStyle,
-      width,
-      height,
-      transform,
-      opacity,
-      ...restStyle
-    } = (StyleSheet.flatten(style) || {}) as ViewStyle;
-
-    const [filteredStyle, marginStyle] = splitStyles(restStyle, (style) =>
-      style.startsWith('margin')
-    );
-
-    if (
-      process.env.NODE_ENV !== 'production' &&
-      filteredStyle.overflow === 'hidden' &&
-      elevation !== 0
-    ) {
-      console.warn(
-        'When setting overflow to hidden on Surface the shadow will not be displayed correctly. Wrap the content of your component in a separate View with the overflow style.'
-      );
-    }
-
-    const innerLayerViewStyles = [
-      filteredStyle,
-      {
-        flex: height ? 1 : undefined,
-        backgroundColor: backgroundColorStyle || backgroundColor,
-      },
-    ];
-
-    const outerLayerViewStyles = {
-      position,
-      alignSelf,
-      top,
-      right,
-      bottom,
-      left,
-      start,
-      end,
-      flex,
-      width,
-      height,
-      transform,
-      opacity,
-      ...marginStyle,
-    };
-
-    if (isAnimatedValue(elevation)) {
-      const inputRange = [0, 1, 2, 3, 4, 5];
-
-      const getStyleForAnimatedShadowLayer = (layer: 0 | 1) => {
-        return {
-          shadowColor,
-          shadowOpacity: elevation.interpolate({
-            inputRange: [0, 1],
-            outputRange: [0, iOSShadowOutputRanges[layer].shadowOpacity],
-            extrapolate: 'clamp',
-          }),
-          shadowOffset: {
-            width: 0,
-            height: elevation.interpolate({
-              inputRange,
-              outputRange: iOSShadowOutputRanges[layer].height,
-            }),
-          },
-          shadowRadius: elevation.interpolate({
-            inputRange,
-            outputRange: iOSShadowOutputRanges[layer].shadowRadius,
-          }),
-        };
-      };
-
-      return (
-        <Animated.View
-          style={[getStyleForAnimatedShadowLayer(0), outerLayerViewStyles]}
-          testID={`${testID}-outer-layer`}
-        >
-          <Animated.View
-            style={[getStyleForAnimatedShadowLayer(1), innerLayerViewStyles]}
-            testID={testID}
-          >
-            {children}
-          </Animated.View>
-        </Animated.View>
-      );
-    }
-
-    const getStyleForShadowLayer = (layer: 0 | 1) => {
-      return {
-        shadowColor,
-        shadowOpacity: elevation
-          ? iOSShadowOutputRanges[layer].shadowOpacity
-          : 0,
-        shadowOffset: {
-          width: 0,
-          height: iOSShadowOutputRanges[layer].height[elevation],
-        },
-        shadowRadius: iOSShadowOutputRanges[layer].shadowRadius[elevation],
-      };
-    };
-
     return (
-      <Animated.View
-        ref={ref}
-        style={[getStyleForShadowLayer(0), outerLayerViewStyles]}
-        testID={`${testID}-outer-layer`}
+      <SurfaceIOS
+        {...props}
+        elevation={elevation}
+        backgroundColor={backgroundColor}
+        style={style}
+        testID={testID}
       >
-        <Animated.View
-          {...props}
-          style={[getStyleForShadowLayer(1), innerLayerViewStyles]}
-          testID={testID}
-        >
-          {children}
-        </Animated.View>
-      </Animated.View>
+        {children}
+      </SurfaceIOS>
     );
   }
 );

--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -145,8 +145,10 @@ const SurfaceIOS = forwardRef<
       ...restStyle
     } = (StyleSheet.flatten(style) || {}) as ViewStyle;
 
-    const [filteredStyles, marginStyles] = splitStyles(restStyle, (style) =>
-      style.startsWith('margin')
+    const [filteredStyles, marginStyles, borderRadiusStyles] = splitStyles(
+      restStyle,
+      (style) => style.startsWith('margin'),
+      (style) => style.startsWith('border') && style.endsWith('Radius')
     );
 
     if (
@@ -159,9 +161,12 @@ const SurfaceIOS = forwardRef<
       );
     }
 
+    const bgColor = backgroundColorStyle || backgroundColor;
+
     const outerLayerViewStyles = {
       ...getStyleForShadowLayer(elevation, 0),
       ...marginStyles,
+      ...borderRadiusStyles,
       position,
       alignSelf,
       top,
@@ -175,13 +180,15 @@ const SurfaceIOS = forwardRef<
       height,
       transform,
       opacity,
+      backgroundColor: bgColor,
     };
 
     const innerLayerViewStyles = {
       ...getStyleForShadowLayer(elevation, 1),
       ...filteredStyles,
+      ...borderRadiusStyles,
       flex: height ? 1 : undefined,
-      backgroundColor: backgroundColorStyle || backgroundColor,
+      backgroundColor: bgColor,
     };
 
     return [outerLayerViewStyles, innerLayerViewStyles];

--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -238,21 +238,26 @@ const Surface = forwardRef<View, Props>(
       ...restStyle
     } = (StyleSheet.flatten(style) || {}) as ViewStyle;
 
-    const [filteredStyle, borderRadiusStyle, marginStyle] = splitStyles(
-      restStyle,
-      (style) => style.startsWith('border') && style.endsWith('Radius'),
-      (style) => style.startsWith('margin')
+    const [filteredStyle, marginStyle] = splitStyles(restStyle, (style) =>
+      style.startsWith('margin')
     );
 
-    const sharedStyles = {
-      flex: height ? 1 : undefined,
-    };
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      filteredStyle.overflow === 'hidden' &&
+      elevation !== 0
+    ) {
+      console.warn(
+        'When setting overflow to hidden on Surface the shadow will not be displayed correctly. Wrap the content of your component in a separate View with the overflow style.'
+      );
+    }
 
     const innerLayerViewStyles = [
       filteredStyle,
-      sharedStyles,
-      borderRadiusStyle,
-      { backgroundColor: backgroundColorStyle || backgroundColor },
+      {
+        flex: height ? 1 : undefined,
+        backgroundColor: backgroundColorStyle || backgroundColor,
+      },
     ];
 
     const outerLayerViewStyles = {
@@ -303,16 +308,10 @@ const Surface = forwardRef<View, Props>(
           testID={`${testID}-outer-layer`}
         >
           <Animated.View
-            style={[getStyleForAnimatedShadowLayer(1), sharedStyles]}
-            testID={`${testID}-middle-layer`}
+            style={[getStyleForAnimatedShadowLayer(1), innerLayerViewStyles]}
+            testID={testID}
           >
-            <Animated.View
-              {...props}
-              testID={testID}
-              style={innerLayerViewStyles}
-            >
-              {children}
-            </Animated.View>
+            {children}
           </Animated.View>
         </Animated.View>
       );
@@ -339,16 +338,11 @@ const Surface = forwardRef<View, Props>(
         testID={`${testID}-outer-layer`}
       >
         <Animated.View
-          style={[getStyleForShadowLayer(1), sharedStyles]}
-          testID={`${testID}-middle-layer`}
+          {...props}
+          style={[getStyleForShadowLayer(1), innerLayerViewStyles]}
+          testID={testID}
         >
-          <Animated.View
-            {...props}
-            testID={testID}
-            style={innerLayerViewStyles}
-          >
-            {children}
-          </Animated.View>
+          {children}
         </Animated.View>
       </Animated.View>
     );

--- a/src/components/__tests__/AnimatedFAB.test.tsx
+++ b/src/components/__tests__/AnimatedFAB.test.tsx
@@ -79,7 +79,7 @@ it('animated value changes correctly', () => {
       style={[{ transform: [{ scale: value }] }]}
     />
   );
-  expect(getByTestId('animated-fab-container')).toHaveStyle({
+  expect(getByTestId('animated-fab-container-outer-layer')).toHaveStyle({
     transform: [{ scale: 1 }],
   });
 
@@ -91,7 +91,7 @@ it('animated value changes correctly', () => {
 
   jest.advanceTimersByTime(200);
 
-  expect(getByTestId('animated-fab-container')).toHaveStyle({
+  expect(getByTestId('animated-fab-container-outer-layer')).toHaveStyle({
     transform: [{ scale: 1.5 }],
   });
 });

--- a/src/components/__tests__/Appbar/Appbar.test.tsx
+++ b/src/components/__tests__/Appbar/Appbar.test.tsx
@@ -384,7 +384,7 @@ describe('animated value changes correctly', () => {
         <Appbar.Action icon="menu" />
       </Appbar>
     );
-    expect(getByTestId('appbar')).toHaveStyle({
+    expect(getByTestId('appbar-outer-layer')).toHaveStyle({
       transform: [{ scale: 1 }],
     });
 
@@ -396,7 +396,7 @@ describe('animated value changes correctly', () => {
 
     jest.advanceTimersByTime(200);
 
-    expect(getByTestId('appbar')).toHaveStyle({
+    expect(getByTestId('appbar-outer-layer')).toHaveStyle({
       transform: [{ scale: 1.5 }],
     });
   });
@@ -412,7 +412,7 @@ describe('animated value changes correctly', () => {
         />
       </Appbar>
     );
-    expect(getByTestId('appbar-action-container')).toHaveStyle({
+    expect(getByTestId('appbar-action-container-outer-layer')).toHaveStyle({
       transform: [{ scale: 1 }],
     });
 
@@ -424,7 +424,7 @@ describe('animated value changes correctly', () => {
 
     jest.advanceTimersByTime(200);
 
-    expect(getByTestId('appbar-action-container')).toHaveStyle({
+    expect(getByTestId('appbar-action-container-outer-layer')).toHaveStyle({
       transform: [{ scale: 1.5 }],
     });
   });
@@ -439,9 +439,11 @@ describe('animated value changes correctly', () => {
         />
       </Appbar>
     );
-    expect(getByTestId('appbar-back-action-container')).toHaveStyle({
-      transform: [{ scale: 1 }],
-    });
+    expect(getByTestId('appbar-back-action-container-outer-layer')).toHaveStyle(
+      {
+        transform: [{ scale: 1 }],
+      }
+    );
 
     Animated.timing(value, {
       toValue: 1.5,
@@ -451,9 +453,11 @@ describe('animated value changes correctly', () => {
 
     jest.advanceTimersByTime(200);
 
-    expect(getByTestId('appbar-back-action-container')).toHaveStyle({
-      transform: [{ scale: 1.5 }],
-    });
+    expect(getByTestId('appbar-back-action-container-outer-layer')).toHaveStyle(
+      {
+        transform: [{ scale: 1.5 }],
+      }
+    );
   });
 
   it('header animated value changes correctly', () => {
@@ -468,7 +472,7 @@ describe('animated value changes correctly', () => {
         </Appbar.Header>
       </mockSafeAreaContext.SafeAreaProvider>
     );
-    expect(getByTestId('appbar-header')).toHaveStyle({
+    expect(getByTestId('appbar-header-outer-layer')).toHaveStyle({
       transform: [{ scale: 1 }],
     });
 
@@ -480,7 +484,7 @@ describe('animated value changes correctly', () => {
 
     jest.advanceTimersByTime(200);
 
-    expect(getByTestId('appbar-header')).toHaveStyle({
+    expect(getByTestId('appbar-header-outer-layer')).toHaveStyle({
       transform: [{ scale: 1.5 }],
     });
   });

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
@@ -9,7 +9,9 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": 64,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -21,6 +23,8 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -29,7 +33,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
     collapsable={false}
     style={
       Object {
-        "flex": undefined,
+        "flex": 1,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -39,7 +43,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="surface-inner-layer"
+    testID="surface-middle-layer"
   >
     <View
       collapsable={false}
@@ -47,9 +51,8 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
         Object {
           "alignItems": "center",
           "backgroundColor": "rgba(255, 251, 254, 1)",
-          "flex": undefined,
+          "flex": 1,
           "flexDirection": "row",
-          "height": 64,
           "paddingBottom": undefined,
           "paddingHorizontal": 4,
           "paddingLeft": undefined,
@@ -67,7 +70,9 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
+            "height": undefined,
             "left": undefined,
+            "opacity": undefined,
             "position": undefined,
             "right": undefined,
             "shadowColor": "#000",
@@ -79,6 +84,8 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
             "shadowRadius": 0,
             "start": undefined,
             "top": undefined,
+            "transform": undefined,
+            "width": undefined,
           }
         }
         testID="search-bar-container-outer-layer"
@@ -97,7 +104,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
               "shadowRadius": 0,
             }
           }
-          testID="search-bar-container-inner-layer"
+          testID="search-bar-container-middle-layer"
         >
           <View
             collapsable={false}
@@ -120,7 +127,10 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                   "bottom": undefined,
                   "end": undefined,
                   "flex": undefined,
+                  "height": 40,
                   "left": undefined,
+                  "margin": 6,
+                  "opacity": undefined,
                   "position": undefined,
                   "right": undefined,
                   "shadowColor": "#000",
@@ -132,6 +142,8 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                   "shadowRadius": 0,
                   "start": undefined,
                   "top": undefined,
+                  "transform": undefined,
+                  "width": 40,
                 }
               }
               testID="icon-button-container-outer-layer"
@@ -140,7 +152,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                 collapsable={false}
                 style={
                   Object {
-                    "flex": undefined,
+                    "flex": 1,
                     "shadowColor": "#000",
                     "shadowOffset": Object {
                       "height": 0,
@@ -150,22 +162,19 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                     "shadowRadius": 0,
                   }
                 }
-                testID="icon-button-container-inner-layer"
+                testID="icon-button-container-middle-layer"
               >
                 <View
                   collapsable={false}
                   style={
                     Object {
-                      "backgroundColor": undefined,
+                      "backgroundColor": "transparent",
                       "borderColor": "rgba(121, 116, 126, 1)",
                       "borderRadius": 20,
                       "borderWidth": 0,
                       "elevation": 0,
-                      "flex": undefined,
-                      "height": 40,
-                      "margin": 6,
+                      "flex": 1,
                       "overflow": "hidden",
-                      "width": 40,
                     }
                   }
                   testID="icon-button-container"
@@ -319,7 +328,10 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                     "bottom": undefined,
                     "end": undefined,
                     "flex": undefined,
+                    "height": 40,
                     "left": undefined,
+                    "margin": 6,
+                    "opacity": undefined,
                     "position": undefined,
                     "right": undefined,
                     "shadowColor": "#000",
@@ -331,6 +343,8 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                     "shadowRadius": 0,
                     "start": undefined,
                     "top": undefined,
+                    "transform": undefined,
+                    "width": 40,
                   }
                 }
                 testID="icon-button-container-outer-layer"
@@ -339,7 +353,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "flex": undefined,
+                      "flex": 1,
                       "shadowColor": "#000",
                       "shadowOffset": Object {
                         "height": 0,
@@ -349,22 +363,19 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                       "shadowRadius": 0,
                     }
                   }
-                  testID="icon-button-container-inner-layer"
+                  testID="icon-button-container-middle-layer"
                 >
                   <View
                     collapsable={false}
                     style={
                       Object {
-                        "backgroundColor": undefined,
+                        "backgroundColor": "transparent",
                         "borderColor": "rgba(121, 116, 126, 1)",
                         "borderRadius": 20,
                         "borderWidth": 0,
                         "elevation": 0,
-                        "flex": undefined,
-                        "height": 40,
-                        "margin": 6,
+                        "flex": 1,
                         "overflow": "hidden",
-                        "width": 40,
                       }
                     }
                     testID="icon-button-container"
@@ -478,7 +489,9 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": 64,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -490,6 +503,8 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -498,7 +513,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
     collapsable={false}
     style={
       Object {
-        "flex": undefined,
+        "flex": 1,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -508,7 +523,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
         "shadowRadius": 0,
       }
     }
-    testID="surface-inner-layer"
+    testID="surface-middle-layer"
   >
     <View
       collapsable={false}
@@ -516,9 +531,8 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
         Object {
           "alignItems": "center",
           "backgroundColor": "rgba(255, 251, 254, 1)",
-          "flex": undefined,
+          "flex": 1,
           "flexDirection": "row",
-          "height": 64,
           "paddingBottom": undefined,
           "paddingHorizontal": 4,
           "paddingLeft": undefined,
@@ -536,7 +550,10 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
+            "height": 40,
             "left": undefined,
+            "margin": 6,
+            "opacity": undefined,
             "position": undefined,
             "right": undefined,
             "shadowColor": "#000",
@@ -548,6 +565,8 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             "shadowRadius": 0,
             "start": undefined,
             "top": undefined,
+            "transform": undefined,
+            "width": 40,
           }
         }
         testID="icon-button-container-outer-layer"
@@ -556,7 +575,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
           collapsable={false}
           style={
             Object {
-              "flex": undefined,
+              "flex": 1,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -566,22 +585,19 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
               "shadowRadius": 0,
             }
           }
-          testID="icon-button-container-inner-layer"
+          testID="icon-button-container-middle-layer"
         >
           <View
             collapsable={false}
             style={
               Object {
-                "backgroundColor": undefined,
+                "backgroundColor": "transparent",
                 "borderColor": "rgba(121, 116, 126, 1)",
                 "borderRadius": 20,
                 "borderWidth": 0,
                 "elevation": 0,
-                "flex": undefined,
-                "height": 40,
-                "margin": 6,
+                "flex": 1,
                 "overflow": "hidden",
-                "width": 40,
               }
             }
             testID="icon-button-container"
@@ -797,7 +813,10 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
+            "height": 40,
             "left": undefined,
+            "margin": 6,
+            "opacity": undefined,
             "position": undefined,
             "right": undefined,
             "shadowColor": "#000",
@@ -809,6 +828,8 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             "shadowRadius": 0,
             "start": undefined,
             "top": undefined,
+            "transform": undefined,
+            "width": 40,
           }
         }
         testID="icon-button-container-outer-layer"
@@ -817,7 +838,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
           collapsable={false}
           style={
             Object {
-              "flex": undefined,
+              "flex": 1,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -827,22 +848,19 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
               "shadowRadius": 0,
             }
           }
-          testID="icon-button-container-inner-layer"
+          testID="icon-button-container-middle-layer"
         >
           <View
             collapsable={false}
             style={
               Object {
-                "backgroundColor": undefined,
+                "backgroundColor": "transparent",
                 "borderColor": "rgba(121, 116, 126, 1)",
                 "borderRadius": 20,
                 "borderWidth": 0,
                 "elevation": 0,
-                "flex": undefined,
-                "height": 40,
-                "margin": 6,
+                "flex": 1,
                 "overflow": "hidden",
-                "width": 40,
               }
             }
             testID="icon-button-container"

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
@@ -33,7 +33,15 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
     collapsable={false}
     style={
       Object {
+        "alignItems": "center",
+        "backgroundColor": "rgba(255, 251, 254, 1)",
         "flex": 1,
+        "flexDirection": "row",
+        "paddingBottom": undefined,
+        "paddingHorizontal": 4,
+        "paddingLeft": undefined,
+        "paddingRight": undefined,
+        "paddingTop": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -43,38 +51,45 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="surface-middle-layer"
+    testID="surface"
   >
     <View
       collapsable={false}
       style={
         Object {
-          "alignItems": "center",
-          "backgroundColor": "rgba(255, 251, 254, 1)",
-          "flex": 1,
-          "flexDirection": "row",
-          "paddingBottom": undefined,
-          "paddingHorizontal": 4,
-          "paddingLeft": undefined,
-          "paddingRight": undefined,
-          "paddingTop": undefined,
+          "alignSelf": undefined,
+          "bottom": undefined,
+          "end": undefined,
+          "flex": undefined,
+          "height": undefined,
+          "left": undefined,
+          "opacity": undefined,
+          "position": undefined,
+          "right": undefined,
+          "shadowColor": "#000",
+          "shadowOffset": Object {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+          "start": undefined,
+          "top": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
-      testID="surface"
+      testID="search-bar-container-outer-layer"
     >
       <View
         collapsable={false}
         style={
           Object {
-            "alignSelf": undefined,
-            "bottom": undefined,
-            "end": undefined,
+            "alignItems": "center",
+            "backgroundColor": "rgb(238, 232, 244)",
+            "borderRadius": 28,
             "flex": undefined,
-            "height": undefined,
-            "left": undefined,
-            "opacity": undefined,
-            "position": undefined,
-            "right": undefined,
+            "flexDirection": "row",
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -82,19 +97,24 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
-            "start": undefined,
-            "top": undefined,
-            "transform": undefined,
-            "width": undefined,
           }
         }
-        testID="search-bar-container-outer-layer"
+        testID="search-bar-container"
       >
         <View
           collapsable={false}
           style={
             Object {
+              "alignSelf": undefined,
+              "bottom": undefined,
+              "end": undefined,
               "flex": undefined,
+              "height": 40,
+              "left": undefined,
+              "margin": 6,
+              "opacity": undefined,
+              "position": undefined,
+              "right": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -102,37 +122,216 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
               },
               "shadowOpacity": 0,
               "shadowRadius": 0,
+              "start": undefined,
+              "top": undefined,
+              "transform": undefined,
+              "width": 40,
             }
           }
-          testID="search-bar-container-middle-layer"
+          testID="icon-button-container-outer-layer"
         >
           <View
             collapsable={false}
             style={
               Object {
-                "alignItems": "center",
-                "backgroundColor": "rgb(238, 232, 244)",
-                "borderRadius": 28,
-                "flex": undefined,
-                "flexDirection": "row",
+                "backgroundColor": "transparent",
+                "borderColor": "rgba(121, 116, 126, 1)",
+                "borderRadius": 20,
+                "borderWidth": 0,
+                "elevation": 0,
+                "flex": 1,
+                "overflow": "hidden",
+                "shadowColor": "#000",
+                "shadowOffset": Object {
+                  "height": 0,
+                  "width": 0,
+                },
+                "shadowOpacity": 0,
+                "shadowRadius": 0,
               }
             }
-            testID="search-bar-container"
+            testID="icon-button-container"
+          >
+            <View
+              accessibilityComponentType="button"
+              accessibilityLabel="search"
+              accessibilityRole="button"
+              accessibilityState={
+                Object {
+                  "disabled": true,
+                }
+              }
+              accessibilityTraits="button"
+              accessible={true}
+              centered={true}
+              collapsable={false}
+              focusable={true}
+              hitSlop={
+                Object {
+                  "bottom": 6,
+                  "left": 6,
+                  "right": 6,
+                  "top": 6,
+                }
+              }
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Array [
+                  Object {
+                    "overflow": "hidden",
+                  },
+                  false,
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    },
+                    Object {
+                      "borderRadius": 20,
+                    },
+                  ],
+                ]
+              }
+              testID="icon-button"
+            >
+              <Text
+                accessibilityElementsHidden={true}
+                allowFontScaling={false}
+                importantForAccessibility="no-hide-descendants"
+                pointerEvents="none"
+                selectable={false}
+                style={
+                  Array [
+                    Object {
+                      "color": "rgba(73, 69, 79, 1)",
+                      "fontSize": 24,
+                    },
+                    Array [
+                      Object {
+                        "lineHeight": 24,
+                        "transform": Array [
+                          Object {
+                            "scaleX": 1,
+                          },
+                        ],
+                      },
+                      Object {
+                        "backgroundColor": "transparent",
+                      },
+                    ],
+                    Object {
+                      "fontFamily": "Material Design Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                󰍉
+              </Text>
+            </View>
+          </View>
+        </View>
+        <TextInput
+          accessibilityRole="search"
+          keyboardAppearance="light"
+          placeholder="Search"
+          placeholderTextColor="rgba(28, 27, 31, 1)"
+          returnKeyType="search"
+          selectionColor="rgba(103, 80, 164, 1)"
+          style={
+            Array [
+              Object {
+                "alignSelf": "stretch",
+                "flex": 1,
+                "fontSize": 18,
+                "minWidth": 0,
+                "paddingLeft": 8,
+                "textAlign": "left",
+              },
+              Object {
+                "color": "rgba(73, 69, 79, 1)",
+                "fontFamily": "System",
+                "fontSize": 16,
+                "fontWeight": "400",
+                "letterSpacing": 0.15,
+                "lineHeight": 0,
+              },
+              Object {
+                "minHeight": 56,
+                "paddingLeft": 0,
+              },
+              undefined,
+            ]
+          }
+          testID="search-bar"
+          underlineColorAndroid="transparent"
+          value=""
+        />
+        <View
+          pointerEvents="none"
+          style={
+            Array [
+              Object {
+                "marginLeft": 16,
+                "position": "absolute",
+                "right": 0,
+              },
+              false,
+            ]
+          }
+          testID="search-bar-icon-wrapper"
+        >
+          <View
+            collapsable={false}
+            style={
+              Object {
+                "alignSelf": undefined,
+                "bottom": undefined,
+                "end": undefined,
+                "flex": undefined,
+                "height": 40,
+                "left": undefined,
+                "margin": 6,
+                "opacity": undefined,
+                "position": undefined,
+                "right": undefined,
+                "shadowColor": "#000",
+                "shadowOffset": Object {
+                  "height": 0,
+                  "width": 0,
+                },
+                "shadowOpacity": 0,
+                "shadowRadius": 0,
+                "start": undefined,
+                "top": undefined,
+                "transform": undefined,
+                "width": 40,
+              }
+            }
+            testID="icon-button-container-outer-layer"
           >
             <View
               collapsable={false}
               style={
                 Object {
-                  "alignSelf": undefined,
-                  "bottom": undefined,
-                  "end": undefined,
-                  "flex": undefined,
-                  "height": 40,
-                  "left": undefined,
-                  "margin": 6,
-                  "opacity": undefined,
-                  "position": undefined,
-                  "right": undefined,
+                  "backgroundColor": "transparent",
+                  "borderColor": "rgba(121, 116, 126, 1)",
+                  "borderRadius": 20,
+                  "borderWidth": 0,
+                  "elevation": 0,
+                  "flex": 1,
+                  "overflow": "hidden",
                   "shadowColor": "#000",
                   "shadowOffset": Object {
                     "height": 0,
@@ -140,336 +339,97 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                   },
                   "shadowOpacity": 0,
                   "shadowRadius": 0,
-                  "start": undefined,
-                  "top": undefined,
-                  "transform": undefined,
-                  "width": 40,
                 }
               }
-              testID="icon-button-container-outer-layer"
+              testID="icon-button-container"
             >
               <View
-                collapsable={false}
-                style={
+                accessibilityComponentType="button"
+                accessibilityLabel="clear"
+                accessibilityRole="button"
+                accessibilityState={
                   Object {
-                    "flex": 1,
-                    "shadowColor": "#000",
-                    "shadowOffset": Object {
-                      "height": 0,
-                      "width": 0,
-                    },
-                    "shadowOpacity": 0,
-                    "shadowRadius": 0,
+                    "disabled": false,
                   }
                 }
-                testID="icon-button-container-middle-layer"
-              >
-                <View
-                  collapsable={false}
-                  style={
-                    Object {
-                      "backgroundColor": "transparent",
-                      "borderColor": "rgba(121, 116, 126, 1)",
-                      "borderRadius": 20,
-                      "borderWidth": 0,
-                      "elevation": 0,
-                      "flex": 1,
-                      "overflow": "hidden",
-                    }
+                accessibilityTraits="button"
+                accessible={true}
+                centered={true}
+                collapsable={false}
+                focusable={true}
+                hitSlop={
+                  Object {
+                    "bottom": 6,
+                    "left": 6,
+                    "right": 6,
+                    "top": 6,
                   }
-                  testID="icon-button-container"
-                >
-                  <View
-                    accessibilityComponentType="button"
-                    accessibilityLabel="search"
-                    accessibilityRole="button"
-                    accessibilityState={
+                }
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Array [
+                    Object {
+                      "overflow": "hidden",
+                    },
+                    false,
+                    Array [
                       Object {
-                        "disabled": true,
-                      }
-                    }
-                    accessibilityTraits="button"
-                    accessible={true}
-                    centered={true}
-                    collapsable={false}
-                    focusable={true}
-                    hitSlop={
+                        "alignItems": "center",
+                        "flexGrow": 1,
+                        "justifyContent": "center",
+                      },
                       Object {
-                        "bottom": 6,
-                        "left": 6,
-                        "right": 6,
-                        "top": 6,
-                      }
-                    }
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onResponderGrant={[Function]}
-                    onResponderMove={[Function]}
-                    onResponderRelease={[Function]}
-                    onResponderTerminate={[Function]}
-                    onResponderTerminationRequest={[Function]}
-                    onStartShouldSetResponder={[Function]}
-                    style={
+                        "borderRadius": 20,
+                      },
+                    ],
+                  ]
+                }
+                testID="icon-button"
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  allowFontScaling={false}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    Array [
+                      Object {
+                        "color": "rgba(255, 255, 255, 0)",
+                        "fontSize": 24,
+                      },
                       Array [
                         Object {
-                          "overflow": "hidden",
+                          "lineHeight": 24,
+                          "transform": Array [
+                            Object {
+                              "scaleX": 1,
+                            },
+                          ],
                         },
-                        false,
-                        Array [
-                          Object {
-                            "alignItems": "center",
-                            "flexGrow": 1,
-                            "justifyContent": "center",
-                          },
-                          Object {
-                            "borderRadius": 20,
-                          },
-                        ],
-                      ]
-                    }
-                    testID="icon-button"
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰍉
-                    </Text>
-                  </View>
-                </View>
-              </View>
-            </View>
-            <TextInput
-              accessibilityRole="search"
-              keyboardAppearance="light"
-              placeholder="Search"
-              placeholderTextColor="rgba(28, 27, 31, 1)"
-              returnKeyType="search"
-              selectionColor="rgba(103, 80, 164, 1)"
-              style={
-                Array [
-                  Object {
-                    "alignSelf": "stretch",
-                    "flex": 1,
-                    "fontSize": 18,
-                    "minWidth": 0,
-                    "paddingLeft": 8,
-                    "textAlign": "left",
-                  },
-                  Object {
-                    "color": "rgba(73, 69, 79, 1)",
-                    "fontFamily": "System",
-                    "fontSize": 16,
-                    "fontWeight": "400",
-                    "letterSpacing": 0.15,
-                    "lineHeight": 0,
-                  },
-                  Object {
-                    "minHeight": 56,
-                    "paddingLeft": 0,
-                  },
-                  undefined,
-                ]
-              }
-              testID="search-bar"
-              underlineColorAndroid="transparent"
-              value=""
-            />
-            <View
-              pointerEvents="none"
-              style={
-                Array [
-                  Object {
-                    "marginLeft": 16,
-                    "position": "absolute",
-                    "right": 0,
-                  },
-                  false,
-                ]
-              }
-              testID="search-bar-icon-wrapper"
-            >
-              <View
-                collapsable={false}
-                style={
-                  Object {
-                    "alignSelf": undefined,
-                    "bottom": undefined,
-                    "end": undefined,
-                    "flex": undefined,
-                    "height": 40,
-                    "left": undefined,
-                    "margin": 6,
-                    "opacity": undefined,
-                    "position": undefined,
-                    "right": undefined,
-                    "shadowColor": "#000",
-                    "shadowOffset": Object {
-                      "height": 0,
-                      "width": 0,
-                    },
-                    "shadowOpacity": 0,
-                    "shadowRadius": 0,
-                    "start": undefined,
-                    "top": undefined,
-                    "transform": undefined,
-                    "width": 40,
-                  }
-                }
-                testID="icon-button-container-outer-layer"
-              >
-                <View
-                  collapsable={false}
-                  style={
-                    Object {
-                      "flex": 1,
-                      "shadowColor": "#000",
-                      "shadowOffset": Object {
-                        "height": 0,
-                        "width": 0,
-                      },
-                      "shadowOpacity": 0,
-                      "shadowRadius": 0,
-                    }
-                  }
-                  testID="icon-button-container-middle-layer"
-                >
-                  <View
-                    collapsable={false}
-                    style={
+                        Object {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
                       Object {
-                        "backgroundColor": "transparent",
-                        "borderColor": "rgba(121, 116, 126, 1)",
-                        "borderRadius": 20,
-                        "borderWidth": 0,
-                        "elevation": 0,
-                        "flex": 1,
-                        "overflow": "hidden",
-                      }
-                    }
-                    testID="icon-button-container"
-                  >
-                    <View
-                      accessibilityComponentType="button"
-                      accessibilityLabel="clear"
-                      accessibilityRole="button"
-                      accessibilityState={
-                        Object {
-                          "disabled": false,
-                        }
-                      }
-                      accessibilityTraits="button"
-                      accessible={true}
-                      centered={true}
-                      collapsable={false}
-                      focusable={true}
-                      hitSlop={
-                        Object {
-                          "bottom": 6,
-                          "left": 6,
-                          "right": 6,
-                          "top": 6,
-                        }
-                      }
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
-                      style={
-                        Array [
-                          Object {
-                            "overflow": "hidden",
-                          },
-                          false,
-                          Array [
-                            Object {
-                              "alignItems": "center",
-                              "flexGrow": 1,
-                              "justifyContent": "center",
-                            },
-                            Object {
-                              "borderRadius": 20,
-                            },
-                          ],
-                        ]
-                      }
-                      testID="icon-button"
-                    >
-                      <Text
-                        accessibilityElementsHidden={true}
-                        allowFontScaling={false}
-                        importantForAccessibility="no-hide-descendants"
-                        pointerEvents="none"
-                        selectable={false}
-                        style={
-                          Array [
-                            Object {
-                              "color": "rgba(255, 255, 255, 0)",
-                              "fontSize": 24,
-                            },
-                            Array [
-                              Object {
-                                "lineHeight": 24,
-                                "transform": Array [
-                                  Object {
-                                    "scaleX": 1,
-                                  },
-                                ],
-                              },
-                              Object {
-                                "backgroundColor": "transparent",
-                              },
-                            ],
-                            Object {
-                              "fontFamily": "Material Design Icons",
-                              "fontStyle": "normal",
-                              "fontWeight": "normal",
-                            },
-                            Object {},
-                          ]
-                        }
-                      >
-                        󰅖
-                      </Text>
-                    </View>
-                  </View>
-                </View>
+                        "fontFamily": "Material Design Icons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  󰅖
+                </Text>
               </View>
             </View>
           </View>
@@ -513,7 +473,15 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
     collapsable={false}
     style={
       Object {
+        "alignItems": "center",
+        "backgroundColor": "rgba(255, 251, 254, 1)",
         "flex": 1,
+        "flexDirection": "row",
+        "paddingBottom": undefined,
+        "paddingHorizontal": 4,
+        "paddingLeft": undefined,
+        "paddingRight": undefined,
+        "paddingTop": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -523,39 +491,48 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
         "shadowRadius": 0,
       }
     }
-    testID="surface-middle-layer"
+    testID="surface"
   >
     <View
       collapsable={false}
       style={
         Object {
-          "alignItems": "center",
-          "backgroundColor": "rgba(255, 251, 254, 1)",
-          "flex": 1,
-          "flexDirection": "row",
-          "paddingBottom": undefined,
-          "paddingHorizontal": 4,
-          "paddingLeft": undefined,
-          "paddingRight": undefined,
-          "paddingTop": undefined,
+          "alignSelf": undefined,
+          "bottom": undefined,
+          "end": undefined,
+          "flex": undefined,
+          "height": 40,
+          "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
+          "position": undefined,
+          "right": undefined,
+          "shadowColor": "#000",
+          "shadowOffset": Object {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+          "start": undefined,
+          "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
-      testID="surface"
+      testID="icon-button-container-outer-layer"
     >
       <View
         collapsable={false}
         style={
           Object {
-            "alignSelf": undefined,
-            "bottom": undefined,
-            "end": undefined,
-            "flex": undefined,
-            "height": 40,
-            "left": undefined,
-            "margin": 6,
-            "opacity": undefined,
-            "position": undefined,
-            "right": undefined,
+            "backgroundColor": "transparent",
+            "borderColor": "rgba(121, 116, 126, 1)",
+            "borderRadius": 20,
+            "borderWidth": 0,
+            "elevation": 0,
+            "flex": 1,
+            "overflow": "hidden",
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -563,95 +540,92 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
-            "start": undefined,
-            "top": undefined,
-            "transform": undefined,
-            "width": 40,
           }
         }
-        testID="icon-button-container-outer-layer"
+        testID="icon-button-container"
       >
         <View
-          collapsable={false}
-          style={
+          accessibilityComponentType="button"
+          accessibilityLabel="Back"
+          accessibilityRole="button"
+          accessibilityState={
             Object {
-              "flex": 1,
-              "shadowColor": "#000",
-              "shadowOffset": Object {
-                "height": 0,
-                "width": 0,
-              },
-              "shadowOpacity": 0,
-              "shadowRadius": 0,
+              "disabled": false,
             }
           }
-          testID="icon-button-container-middle-layer"
+          accessibilityTraits="button"
+          accessible={true}
+          centered={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 6,
+              "left": 6,
+              "right": 6,
+              "top": 6,
+            }
+          }
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              false,
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                Object {
+                  "borderRadius": 20,
+                },
+              ],
+            ]
+          }
+          testID="icon-button"
         >
           <View
-            collapsable={false}
             style={
-              Object {
-                "backgroundColor": "transparent",
-                "borderColor": "rgba(121, 116, 126, 1)",
-                "borderRadius": 20,
-                "borderWidth": 0,
-                "elevation": 0,
-                "flex": 1,
-                "overflow": "hidden",
-              }
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "justifyContent": "center",
+                },
+                Object {
+                  "height": 24,
+                  "width": 24,
+                },
+              ]
             }
-            testID="icon-button-container"
           >
             <View
-              accessibilityComponentType="button"
-              accessibilityLabel="Back"
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "disabled": false,
-                }
-              }
-              accessibilityTraits="button"
-              accessible={true}
-              centered={true}
               collapsable={false}
-              focusable={true}
-              hitSlop={
-                Object {
-                  "bottom": 6,
-                  "left": 6,
-                  "right": 6,
-                  "top": 6,
-                }
-              }
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
-                Array [
-                  Object {
-                    "overflow": "hidden",
-                  },
-                  false,
-                  Array [
+                Object {
+                  "bottom": 0,
+                  "left": 0,
+                  "opacity": 1,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "transform": Array [
                     Object {
-                      "alignItems": "center",
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    },
-                    Object {
-                      "borderRadius": 20,
+                      "rotate": "0deg",
                     },
                   ],
-                ]
+                }
               }
-              testID="icon-button"
             >
               <View
                 style={
@@ -662,163 +636,156 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
                     },
                     Object {
                       "height": 24,
+                      "transform": Array [
+                        Object {
+                          "scaleX": 1,
+                        },
+                      ],
                       "width": 24,
                     },
                   ]
                 }
               >
-                <View
-                  collapsable={false}
-                  style={
+                <Image
+                  accessibilityIgnoresInvertColors={true}
+                  source={
                     Object {
-                      "bottom": 0,
-                      "left": 0,
-                      "opacity": 1,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                      "transform": Array [
-                        Object {
-                          "rotate": "0deg",
-                        },
-                      ],
+                      "testUri": "../../../src/assets/back-chevron.png",
                     }
                   }
-                >
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "alignItems": "center",
-                          "justifyContent": "center",
-                        },
-                        Object {
-                          "height": 24,
-                          "transform": Array [
-                            Object {
-                              "scaleX": 1,
-                            },
-                          ],
-                          "width": 24,
-                        },
-                      ]
-                    }
-                  >
-                    <Image
-                      accessibilityIgnoresInvertColors={true}
-                      source={
-                        Object {
-                          "testUri": "../../../src/assets/back-chevron.png",
-                        }
-                      }
-                      style={
-                        Array [
-                          Object {
-                            "resizeMode": "contain",
-                          },
-                          Object {
-                            "height": 21,
-                            "tintColor": "rgba(28, 27, 31, 1)",
-                            "width": 21,
-                          },
-                        ]
-                      }
-                    />
-                  </View>
-                </View>
+                  style={
+                    Array [
+                      Object {
+                        "resizeMode": "contain",
+                      },
+                      Object {
+                        "height": 21,
+                        "tintColor": "rgba(28, 27, 31, 1)",
+                        "width": 21,
+                      },
+                    ]
+                  }
+                />
               </View>
             </View>
           </View>
         </View>
       </View>
-      <View
-        accessibilityRole="text"
-        accessibilityState={
-          Object {
-            "disabled": true,
-          }
+    </View>
+    <View
+      accessibilityRole="text"
+      accessibilityState={
+        Object {
+          "disabled": true,
         }
+      }
+      accessible={true}
+      focusable={false}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      pointerEvents="box-none"
+      style={
+        Array [
+          Object {
+            "flex": 1,
+            "paddingHorizontal": 12,
+          },
+          Object {
+            "paddingHorizontal": 0,
+          },
+          Array [
+            false,
+            false,
+            undefined,
+          ],
+        ]
+      }
+      testID="appbar-content"
+    >
+      <Text
+        accessibilityRole="header"
         accessible={true}
-        focusable={false}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        pointerEvents="box-none"
+        numberOfLines={1}
         style={
           Array [
             Object {
-              "flex": 1,
-              "paddingHorizontal": 12,
+              "fontFamily": "System",
+              "fontSize": 22,
+              "fontWeight": "400",
+              "letterSpacing": 0,
+              "lineHeight": 28,
             },
             Object {
-              "paddingHorizontal": 0,
+              "textAlign": "left",
+            },
+            Object {
+              "color": "rgba(28, 27, 31, 1)",
+              "writingDirection": "ltr",
             },
             Array [
-              false,
-              false,
-              undefined,
-            ],
-          ]
-        }
-        testID="appbar-content"
-      >
-        <Text
-          accessibilityRole="header"
-          accessible={true}
-          numberOfLines={1}
-          style={
-            Array [
               Object {
+                "color": "rgba(28, 27, 31, 1)",
                 "fontFamily": "System",
                 "fontSize": 22,
                 "fontWeight": "400",
                 "letterSpacing": 0,
                 "lineHeight": 28,
               },
-              Object {
-                "textAlign": "left",
-              },
-              Object {
-                "color": "rgba(28, 27, 31, 1)",
-                "writingDirection": "ltr",
-              },
-              Array [
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "fontFamily": "System",
-                  "fontSize": 22,
-                  "fontWeight": "400",
-                  "letterSpacing": 0,
-                  "lineHeight": 28,
-                },
-                false,
-                undefined,
-              ],
-            ]
-          }
-          testID="appbar-content-title-text"
-        >
-          Examples
-        </Text>
-      </View>
+              false,
+              undefined,
+            ],
+          ]
+        }
+        testID="appbar-content-title-text"
+      >
+        Examples
+      </Text>
+    </View>
+    <View
+      collapsable={false}
+      style={
+        Object {
+          "alignSelf": undefined,
+          "bottom": undefined,
+          "end": undefined,
+          "flex": undefined,
+          "height": 40,
+          "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
+          "position": undefined,
+          "right": undefined,
+          "shadowColor": "#000",
+          "shadowOffset": Object {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+          "start": undefined,
+          "top": undefined,
+          "transform": undefined,
+          "width": 40,
+        }
+      }
+      testID="icon-button-container-outer-layer"
+    >
       <View
         collapsable={false}
         style={
           Object {
-            "alignSelf": undefined,
-            "bottom": undefined,
-            "end": undefined,
-            "flex": undefined,
-            "height": 40,
-            "left": undefined,
-            "margin": 6,
-            "opacity": undefined,
-            "position": undefined,
-            "right": undefined,
+            "backgroundColor": "transparent",
+            "borderColor": "rgba(121, 116, 126, 1)",
+            "borderRadius": 20,
+            "borderWidth": 0,
+            "elevation": 0,
+            "flex": 1,
+            "overflow": "hidden",
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -826,165 +793,128 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
-            "start": undefined,
-            "top": undefined,
-            "transform": undefined,
-            "width": 40,
           }
         }
-        testID="icon-button-container-outer-layer"
+        testID="icon-button-container"
       >
         <View
-          collapsable={false}
-          style={
+          accessibilityComponentType="button"
+          accessibilityRole="button"
+          accessibilityState={
             Object {
-              "flex": 1,
-              "shadowColor": "#000",
-              "shadowOffset": Object {
-                "height": 0,
-                "width": 0,
-              },
-              "shadowOpacity": 0,
-              "shadowRadius": 0,
+              "disabled": false,
             }
           }
-          testID="icon-button-container-middle-layer"
+          accessibilityTraits="button"
+          accessible={true}
+          centered={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 6,
+              "left": 6,
+              "right": 6,
+              "top": 6,
+            }
+          }
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              false,
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                Object {
+                  "borderRadius": 20,
+                },
+              ],
+            ]
+          }
+          testID="icon-button"
         >
           <View
-            collapsable={false}
             style={
-              Object {
-                "backgroundColor": "transparent",
-                "borderColor": "rgba(121, 116, 126, 1)",
-                "borderRadius": 20,
-                "borderWidth": 0,
-                "elevation": 0,
-                "flex": 1,
-                "overflow": "hidden",
-              }
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "justifyContent": "center",
+                },
+                Object {
+                  "height": 24,
+                  "width": 24,
+                },
+              ]
             }
-            testID="icon-button-container"
           >
             <View
-              accessibilityComponentType="button"
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "disabled": false,
-                }
-              }
-              accessibilityTraits="button"
-              accessible={true}
-              centered={true}
               collapsable={false}
-              focusable={true}
-              hitSlop={
-                Object {
-                  "bottom": 6,
-                  "left": 6,
-                  "right": 6,
-                  "top": 6,
-                }
-              }
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
-                Array [
-                  Object {
-                    "overflow": "hidden",
-                  },
-                  false,
-                  Array [
+                Object {
+                  "bottom": 0,
+                  "left": 0,
+                  "opacity": 1,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "transform": Array [
                     Object {
-                      "alignItems": "center",
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    },
-                    Object {
-                      "borderRadius": 20,
+                      "rotate": "0deg",
                     },
                   ],
-                ]
+                }
               }
-              testID="icon-button"
             >
-              <View
+              <Text
+                accessibilityElementsHidden={true}
+                allowFontScaling={false}
+                importantForAccessibility="no-hide-descendants"
+                pointerEvents="none"
+                selectable={false}
                 style={
                   Array [
                     Object {
-                      "alignItems": "center",
-                      "justifyContent": "center",
+                      "color": "rgba(73, 69, 79, 1)",
+                      "fontSize": 24,
                     },
+                    Array [
+                      Object {
+                        "lineHeight": 24,
+                        "transform": Array [
+                          Object {
+                            "scaleX": 1,
+                          },
+                        ],
+                      },
+                      Object {
+                        "backgroundColor": "transparent",
+                      },
+                    ],
                     Object {
-                      "height": 24,
-                      "width": 24,
+                      "fontFamily": "Material Design Icons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
                     },
+                    Object {},
                   ]
                 }
               >
-                <View
-                  collapsable={false}
-                  style={
-                    Object {
-                      "bottom": 0,
-                      "left": 0,
-                      "opacity": 1,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                      "transform": Array [
-                        Object {
-                          "rotate": "0deg",
-                        },
-                      ],
-                    }
-                  }
-                >
-                  <Text
-                    accessibilityElementsHidden={true}
-                    allowFontScaling={false}
-                    importantForAccessibility="no-hide-descendants"
-                    pointerEvents="none"
-                    selectable={false}
-                    style={
-                      Array [
-                        Object {
-                          "color": "rgba(73, 69, 79, 1)",
-                          "fontSize": 24,
-                        },
-                        Array [
-                          Object {
-                            "lineHeight": 24,
-                            "transform": Array [
-                              Object {
-                                "scaleX": 1,
-                              },
-                            ],
-                          },
-                          Object {
-                            "backgroundColor": "transparent",
-                          },
-                        ],
-                        Object {
-                          "fontFamily": "Material Design Icons",
-                          "fontStyle": "normal",
-                          "fontWeight": "normal",
-                        },
-                        Object {},
-                      ]
-                    }
-                  >
-                    󰍜
-                  </Text>
-                </View>
-              </View>
+                󰍜
+              </Text>
             </View>
           </View>
         </View>

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(255, 251, 254, 1)",
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -58,6 +59,8 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "rgb(238, 232, 244)",
+          "borderRadius": 28,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
@@ -106,6 +109,8 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
           style={
             Object {
               "alignSelf": undefined,
+              "backgroundColor": "transparent",
+              "borderRadius": 20,
               "bottom": undefined,
               "end": undefined,
               "flex": undefined,
@@ -297,6 +302,8 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
             style={
               Object {
                 "alignSelf": undefined,
+                "backgroundColor": "transparent",
+                "borderRadius": 20,
                 "bottom": undefined,
                 "end": undefined,
                 "flex": undefined,
@@ -446,6 +453,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(255, 251, 254, 1)",
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -498,6 +506,8 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
@@ -751,6 +761,8 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,

--- a/src/components/__tests__/Banner.test.tsx
+++ b/src/components/__tests__/Banner.test.tsx
@@ -338,7 +338,7 @@ describe('animations', () => {
         Banner
       </Banner>
     );
-    expect(getByTestId('banner')).toHaveStyle({
+    expect(getByTestId('banner-outer-layer')).toHaveStyle({
       transform: [{ scale: 1 }],
     });
 
@@ -350,7 +350,7 @@ describe('animations', () => {
 
     jest.runAllTimers();
 
-    expect(getByTestId('banner')).toHaveStyle({
+    expect(getByTestId('banner-outer-layer')).toHaveStyle({
       transform: [{ scale: 1.5 }],
     });
   });

--- a/src/components/__tests__/BottomNavigation.test.tsx
+++ b/src/components/__tests__/BottomNavigation.test.tsx
@@ -553,7 +553,7 @@ it('barStyle animated value changes correctly', () => {
       barStyle={[{ transform: [{ scale: value }] }]}
     />
   );
-  expect(getByTestId('bottom-navigation-bar')).toHaveStyle({
+  expect(getByTestId('bottom-navigation-bar-outer-layer')).toHaveStyle({
     transform: [{ scale: 1 }],
   });
 
@@ -565,7 +565,7 @@ it('barStyle animated value changes correctly', () => {
 
   jest.advanceTimersByTime(200);
 
-  expect(getByTestId('bottom-navigation-bar')).toHaveStyle({
+  expect(getByTestId('bottom-navigation-bar-outer-layer')).toHaveStyle({
     transform: [{ scale: 1.5 }],
   });
 });

--- a/src/components/__tests__/Button.test.tsx
+++ b/src/components/__tests__/Button.test.tsx
@@ -851,7 +851,7 @@ it('animated value changes correctly', () => {
       Compact button
     </Button>
   );
-  expect(getByTestId('button-container')).toHaveStyle({
+  expect(getByTestId('button-container-outer-layer')).toHaveStyle({
     transform: [{ scale: 1 }],
   });
 
@@ -863,7 +863,7 @@ it('animated value changes correctly', () => {
 
   jest.advanceTimersByTime(200);
 
-  expect(getByTestId('button-container')).toHaveStyle({
+  expect(getByTestId('button-container-outer-layer')).toHaveStyle({
     transform: [{ scale: 1.5 }],
   });
 });

--- a/src/components/__tests__/Card/Card.test.tsx
+++ b/src/components/__tests__/Card/Card.test.tsx
@@ -253,7 +253,7 @@ it('animated value changes correctly', () => {
       {null}
     </Card>
   );
-  expect(getByTestId('card-container')).toHaveStyle({
+  expect(getByTestId('card-container-outer-layer')).toHaveStyle({
     transform: [{ scale: 1 }],
   });
 
@@ -265,7 +265,7 @@ it('animated value changes correctly', () => {
 
   jest.advanceTimersByTime(200);
 
-  expect(getByTestId('card-container')).toHaveStyle({
+  expect(getByTestId('card-container-outer-layer')).toHaveStyle({
     transform: [{ scale: 1.5 }],
   });
 });

--- a/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
@@ -9,7 +9,9 @@ exports[`Card renders an outlined card 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -21,6 +23,8 @@ exports[`Card renders an outlined card 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="card-container-outer-layer"
@@ -39,7 +43,7 @@ exports[`Card renders an outlined card 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="card-container-inner-layer"
+    testID="card-container-middle-layer"
   >
     <View
       collapsable={false}

--- a/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
@@ -33,6 +33,9 @@ exports[`Card renders an outlined card 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(255, 251, 254, 1)",
+        "borderRadius": 12,
+        "elevation": 1,
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -43,65 +46,52 @@ exports[`Card renders an outlined card 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="card-container-middle-layer"
+    testID="card-container"
   >
     <View
-      collapsable={false}
+      pointerEvents="none"
       style={
+        Array [
+          Object {
+            "borderColor": "rgba(121, 116, 126, 1)",
+            "borderRadius": 12,
+          },
+          Object {
+            "borderWidth": 1,
+            "height": "100%",
+            "position": "absolute",
+            "width": "100%",
+            "zIndex": 2,
+          },
+        ]
+      }
+      testID="card-outline"
+    />
+    <View
+      accessibilityState={
         Object {
-          "backgroundColor": "rgba(255, 251, 254, 1)",
-          "borderRadius": 12,
-          "elevation": 1,
-          "flex": undefined,
+          "disabled": true,
         }
       }
-      testID="card-container"
-    >
-      <View
-        pointerEvents="none"
-        style={
-          Array [
-            Object {
-              "borderColor": "rgba(121, 116, 126, 1)",
-              "borderRadius": 12,
-            },
-            Object {
-              "borderWidth": 1,
-              "height": "100%",
-              "position": "absolute",
-              "width": "100%",
-              "zIndex": 2,
-            },
-          ]
-        }
-        testID="card-outline"
-      />
-      <View
-        accessibilityState={
+      accessible={true}
+      focusable={false}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
           Object {
-            "disabled": true,
-          }
-        }
-        accessible={true}
-        focusable={false}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Array [
-            Object {
-              "flexShrink": 1,
-            },
-            undefined,
-          ]
-        }
-        testID="card"
-      />
-    </View>
+            "flexShrink": 1,
+          },
+          undefined,
+        ]
+      }
+      testID="card"
+    />
   </View>
 </View>
 `;

--- a/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
@@ -6,6 +6,8 @@ exports[`Card renders an outlined card 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(255, 251, 254, 1)",
+      "borderRadius": 12,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,

--- a/src/components/__tests__/Chip.test.tsx
+++ b/src/components/__tests__/Chip.test.tsx
@@ -756,7 +756,7 @@ it('animated value changes correctly', () => {
       Example Chip
     </Chip>
   );
-  expect(getByTestId('chip-container')).toHaveStyle({
+  expect(getByTestId('chip-container-outer-layer')).toHaveStyle({
     transform: [{ scale: 1 }],
   });
 
@@ -768,7 +768,7 @@ it('animated value changes correctly', () => {
 
   jest.advanceTimersByTime(200);
 
-  expect(getByTestId('chip-container')).toHaveStyle({
+  expect(getByTestId('chip-container-outer-layer')).toHaveStyle({
     transform: [{ scale: 1.5 }],
   });
 });

--- a/src/components/__tests__/FAB.test.tsx
+++ b/src/components/__tests__/FAB.test.tsx
@@ -411,7 +411,7 @@ it('animated value changes correctly', () => {
       style={[{ transform: [{ scale: value }] }]}
     />
   );
-  expect(getByTestId('fab-container')).toHaveStyle({
+  expect(getByTestId('fab-container-outer-layer')).toHaveStyle({
     transform: [{ scale: 1 }],
   });
 
@@ -423,7 +423,7 @@ it('animated value changes correctly', () => {
 
   jest.advanceTimersByTime(200);
 
-  expect(getByTestId('fab-container')).toHaveStyle({
+  expect(getByTestId('fab-container-outer-layer')).toHaveStyle({
     transform: [{ scale: 1.5 }],
   });
 });

--- a/src/components/__tests__/FABGroup.test.tsx
+++ b/src/components/__tests__/FABGroup.test.tsx
@@ -159,7 +159,6 @@ describe('FABActions - labelStyle - containerStyle', () => {
     expect(getByA11yHint('hint')).toHaveStyle({
       padding: 16,
       backgroundColor: '#687456',
-      marginLeft: 16,
     });
   });
 });
@@ -205,7 +204,7 @@ it('animated value changes correctly', () => {
       ]}
     />
   );
-  expect(getByTestId('my-fab-container')).toHaveStyle({
+  expect(getByTestId('my-fab-container-outer-layer')).toHaveStyle({
     transform: [{ scale: 1 }],
   });
 
@@ -217,7 +216,7 @@ it('animated value changes correctly', () => {
 
   jest.advanceTimersByTime(200);
 
-  expect(getByTestId('my-fab-container')).toHaveStyle({
+  expect(getByTestId('my-fab-container-outer-layer')).toHaveStyle({
     transform: [{ scale: 1.5 }],
   });
 });

--- a/src/components/__tests__/IconButton.test.tsx
+++ b/src/components/__tests__/IconButton.test.tsx
@@ -349,7 +349,7 @@ it('action animated value changes correctly', () => {
       testID="icon-button"
     />
   );
-  expect(getByTestId('icon-button-container')).toHaveStyle({
+  expect(getByTestId('icon-button-container-outer-layer')).toHaveStyle({
     transform: [{ scale: 1 }],
   });
 
@@ -361,7 +361,7 @@ it('action animated value changes correctly', () => {
 
   jest.advanceTimersByTime(200);
 
-  expect(getByTestId('icon-button-container')).toHaveStyle({
+  expect(getByTestId('icon-button-container-outer-layer')).toHaveStyle({
     transform: [{ scale: 1.5 }],
   });
 });

--- a/src/components/__tests__/Menu.test.tsx
+++ b/src/components/__tests__/Menu.test.tsx
@@ -184,7 +184,7 @@ it('animated value changes correctly', () => {
       </Menu>
     </Portal.Host>
   );
-  expect(getByTestId('menu-surface')).toHaveStyle({
+  expect(getByTestId('menu-surface-outer-layer')).toHaveStyle({
     transform: [{ scale: 1 }],
   });
 
@@ -196,7 +196,7 @@ it('animated value changes correctly', () => {
 
   jest.advanceTimersByTime(200);
 
-  expect(getByTestId('menu-surface')).toHaveStyle({
+  expect(getByTestId('menu-surface-outer-layer')).toHaveStyle({
     transform: [{ scale: 1.5 }],
   });
 });

--- a/src/components/__tests__/Modal.test.tsx
+++ b/src/components/__tests__/Modal.test.tsx
@@ -106,7 +106,7 @@ describe('Modal', () => {
           </Modal>
         );
 
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 1,
         });
 
@@ -114,7 +114,7 @@ describe('Modal', () => {
           fireEvent.press(getByTestId('modal-backdrop'));
         });
 
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 1,
         });
 
@@ -126,7 +126,7 @@ describe('Modal', () => {
           opacity: 1,
         });
 
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 1,
         });
       });
@@ -163,7 +163,7 @@ describe('Modal', () => {
           </Modal>
         );
 
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 1,
         });
 
@@ -171,7 +171,7 @@ describe('Modal', () => {
           BackHandler.mockPressBack();
         });
 
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 1,
         });
 
@@ -183,7 +183,7 @@ describe('Modal', () => {
           opacity: 1,
         });
 
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 1,
         });
       });
@@ -228,7 +228,7 @@ describe('Modal', () => {
           </Modal>
         );
 
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 1,
         });
 
@@ -236,7 +236,7 @@ describe('Modal', () => {
           fireEvent.press(getByTestId('modal-backdrop'));
         });
 
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 1,
         });
 
@@ -248,7 +248,7 @@ describe('Modal', () => {
           opacity: 1,
         });
 
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 1,
         });
       });
@@ -295,7 +295,7 @@ describe('Modal', () => {
           </Modal>
         );
 
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 1,
         });
 
@@ -303,7 +303,7 @@ describe('Modal', () => {
           BackHandler.mockPressBack();
         });
 
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 1,
         });
 
@@ -315,7 +315,7 @@ describe('Modal', () => {
           opacity: 1,
         });
 
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 1,
         });
       });
@@ -371,7 +371,7 @@ describe('Modal', () => {
         expect(getByTestId('modal-backdrop')).toHaveStyle({
           opacity: 0,
         });
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 0,
         });
 
@@ -382,7 +382,7 @@ describe('Modal', () => {
         expect(getByTestId('modal-backdrop')).toHaveStyle({
           opacity: 1,
         });
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 1,
         });
       });
@@ -399,7 +399,7 @@ describe('Modal', () => {
         expect(getByTestId('modal-backdrop')).toHaveStyle({
           opacity: 1,
         });
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 1,
         });
 
@@ -412,7 +412,7 @@ describe('Modal', () => {
         expect(getByTestId('modal-backdrop')).toHaveStyle({
           opacity: 1,
         });
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 1,
         });
 
@@ -459,7 +459,7 @@ describe('Modal', () => {
         expect(getByTestId('modal-backdrop')).toHaveStyle({
           opacity: 1,
         });
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 1,
         });
 
@@ -472,7 +472,7 @@ describe('Modal', () => {
         expect(getByTestId('modal-backdrop')).toHaveStyle({
           opacity: 1,
         });
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 1,
         });
 
@@ -497,7 +497,7 @@ describe('Modal', () => {
         expect(getByTestId('modal-backdrop')).toHaveStyle({
           opacity: 1,
         });
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 1,
         });
 
@@ -510,7 +510,7 @@ describe('Modal', () => {
         expect(getByTestId('modal-backdrop')).toHaveStyle({
           opacity: 1,
         });
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 1,
         });
 
@@ -533,7 +533,7 @@ describe('Modal', () => {
         expect(getByTestId('modal-backdrop')).toHaveStyle({
           opacity: 1,
         });
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 1,
         });
       });
@@ -558,7 +558,7 @@ describe('Modal', () => {
         expect(getByTestId('modal-backdrop')).toHaveStyle({
           opacity: 0,
         });
-        expect(getByTestId('modal-surface')).toHaveStyle({
+        expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
           opacity: 0,
         });
 
@@ -596,7 +596,7 @@ describe('Modal', () => {
         {null}
       </Modal>
     );
-    expect(getByTestId('modal-surface')).toHaveStyle({
+    expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
       transform: [{ scale: 1 }],
     });
 
@@ -608,7 +608,7 @@ describe('Modal', () => {
 
     jest.runAllTimers();
 
-    expect(getByTestId('modal-surface')).toHaveStyle({
+    expect(getByTestId('modal-surface-outer-layer')).toHaveStyle({
       transform: [{ scale: 1.5 }],
     });
   });

--- a/src/components/__tests__/Searchbar.test.tsx
+++ b/src/components/__tests__/Searchbar.test.tsx
@@ -78,7 +78,7 @@ it('animated value changes correctly', () => {
       style={[{ transform: [{ scale: value }] }]}
     />
   );
-  expect(getByTestId('search-bar-container')).toHaveStyle({
+  expect(getByTestId('search-bar-container-outer-layer')).toHaveStyle({
     transform: [{ scale: 1 }],
   });
 
@@ -90,7 +90,7 @@ it('animated value changes correctly', () => {
 
   jest.advanceTimersByTime(200);
 
-  expect(getByTestId('search-bar-container')).toHaveStyle({
+  expect(getByTestId('search-bar-container-outer-layer')).toHaveStyle({
     transform: [{ scale: 1.5 }],
   });
 });

--- a/src/components/__tests__/Snackbar.test.tsx
+++ b/src/components/__tests__/Snackbar.test.tsx
@@ -128,7 +128,7 @@ it('animated value changes correctly', () => {
       Snackbar content
     </Snackbar>
   );
-  expect(getByTestId('snack-bar')).toHaveStyle({
+  expect(getByTestId('snack-bar-outer-layer')).toHaveStyle({
     transform: [{ scale: 1 }],
   });
 
@@ -140,7 +140,7 @@ it('animated value changes correctly', () => {
 
   jest.advanceTimersByTime(200);
 
-  expect(getByTestId('snack-bar')).toHaveStyle({
+  expect(getByTestId('snack-bar-outer-layer')).toHaveStyle({
     transform: [{ scale: 1.5 }],
   });
 });

--- a/src/components/__tests__/Surface.test.tsx
+++ b/src/components/__tests__/Surface.test.tsx
@@ -71,21 +71,25 @@ describe('Surface', () => {
       );
 
       expect(getByTestId('surface-test-outer-layer')).toHaveStyle(style);
-      expect(getByTestId('surface-test-middle-layer')).not.toHaveStyle(style);
       expect(getByTestId('surface-test')).not.toHaveStyle(style);
     });
 
     it.each`
-      property               | value
-      ${'padding'}           | ${12}
-      ${'paddingLeft'}       | ${12.1}
-      ${'paddingRight'}      | ${12.2}
-      ${'paddingTop'}        | ${12.3}
-      ${'paddingBottom'}     | ${12.4}
-      ${'paddingHorizontal'} | ${12.5}
-      ${'paddingVertical'}   | ${12.6}
-      ${'borderWidth'}       | ${2}
-      ${'borderColor'}       | ${'black'}
+      property                     | value
+      ${'padding'}                 | ${12}
+      ${'paddingLeft'}             | ${12.1}
+      ${'paddingRight'}            | ${12.2}
+      ${'paddingTop'}              | ${12.3}
+      ${'paddingBottom'}           | ${12.4}
+      ${'paddingHorizontal'}       | ${12.5}
+      ${'paddingVertical'}         | ${12.6}
+      ${'borderWidth'}             | ${2}
+      ${'borderColor'}             | ${'black'}
+      ${'borderRadius'}            | ${3}
+      ${'borderTopLeftRadius'}     | ${1}
+      ${'borderTopRightRadius'}    | ${2}
+      ${'borderBottomLeftRadius'}  | ${3}
+      ${'borderBottomRightRadius'} | ${4}
     `('applies $property to inner layer only', ({ property, value }) => {
       const style = { [property]: value };
 
@@ -96,28 +100,6 @@ describe('Surface', () => {
       );
 
       expect(getByTestId('surface-test-outer-layer')).not.toHaveStyle(style);
-      expect(getByTestId('surface-test-middle-layer')).not.toHaveStyle(style);
-      expect(getByTestId('surface-test')).toHaveStyle(style);
-    });
-
-    it.each`
-      property                     | value
-      ${'borderRadius'}            | ${3}
-      ${'borderTopLeftRadius'}     | ${1}
-      ${'borderTopRightRadius'}    | ${2}
-      ${'borderBottomLeftRadius'}  | ${3}
-      ${'borderBottomRightRadius'} | ${4}
-    `('applies $property to inner layer', ({ property, value }) => {
-      const style = { [property]: value };
-
-      const { getByTestId } = render(
-        <Surface testID="surface-test" style={style}>
-          {null}
-        </Surface>
-      );
-
-      expect(getByTestId('surface-test-outer-layer')).not.toHaveStyle(style);
-      expect(getByTestId('surface-test-middle-layer')).not.toHaveStyle(style);
       expect(getByTestId('surface-test')).toHaveStyle(style);
     });
 
@@ -179,7 +161,6 @@ describe('Surface', () => {
 
         const style = { backgroundColor };
         expect(getByTestId('surface-test-outer-layer')).not.toHaveStyle(style);
-        expect(getByTestId('surface-test-middle-layer')).not.toHaveStyle(style);
         expect(getByTestId('surface-test')).toHaveStyle(style);
       });
 

--- a/src/components/__tests__/Surface.test.tsx
+++ b/src/components/__tests__/Surface.test.tsx
@@ -28,10 +28,9 @@ describe('Surface', () => {
         right: 40,
         start: 50,
         top: 60,
-        flex: 1,
       },
       innerLayerViewStyle: {
-        flex: 1,
+        padding: 13,
       },
       restStyle: {
         padding: 10,
@@ -69,23 +68,7 @@ describe('Surface', () => {
         );
       });
 
-      it('should render inner layer styles on outer layer', () => {
-        const testID = 'surface-test';
-
-        const { getByTestId } = render(
-          <Surface testID={testID} style={styles.innerLayerViewStyle}>
-            {null}
-          </Surface>
-        );
-
-        expect(getByTestId(`${testID}-outer-layer`)).toHaveStyle(
-          styles.innerLayerViewStyle
-        );
-      });
-    });
-
-    describe('inner layer', () => {
-      it('should not render absolute position properties on the inner layer', () => {
+      it('should render absolute position properties on the outer layer', () => {
         const testID = 'surface-test';
 
         const { getByTestId } = render(
@@ -94,9 +77,28 @@ describe('Surface', () => {
           </Surface>
         );
 
-        expect(getByTestId(`${testID}-inner-layer`)).not.toHaveStyle(
+        expect(getByTestId(`${testID}-outer-layer`)).toHaveStyle(
           styles.absoluteStyles
         );
+      });
+    });
+
+    describe('inner layer', () => {
+      it('applies backgroundColor to inner layer only', () => {
+        const backgroundColor = 'rgb(1,2,3)';
+        const { getByTestId } = render(
+          <Surface
+            testID="surface-test"
+            theme={{ colors: { elevation: { level1: backgroundColor } } }}
+          >
+            {null}
+          </Surface>
+        );
+
+        const style = { backgroundColor };
+        expect(getByTestId('surface-test-outer-layer')).not.toHaveStyle(style);
+        expect(getByTestId('surface-test-middle-layer')).not.toHaveStyle(style);
+        expect(getByTestId('surface-test')).toHaveStyle(style);
       });
 
       it('should render inner layer styles on the inner layer', () => {
@@ -108,9 +110,7 @@ describe('Surface', () => {
           </Surface>
         );
 
-        expect(getByTestId(`${testID}-inner-layer`)).toHaveStyle(
-          styles.innerLayerViewStyle
-        );
+        expect(getByTestId(testID)).toHaveStyle(styles.innerLayerViewStyle);
       });
     });
 

--- a/src/components/__tests__/Surface.test.tsx
+++ b/src/components/__tests__/Surface.test.tsx
@@ -39,6 +39,88 @@ describe('Surface', () => {
       },
     });
 
+    it.each`
+      property              | value
+      ${'opacity'}          | ${0.7}
+      ${'transform'}        | ${[{ scale: 1.02 }]}
+      ${'width'}            | ${'42%'}
+      ${'height'}           | ${'32.5%'}
+      ${'margin'}           | ${13}
+      ${'marginLeft'}       | ${13.1}
+      ${'marginRight'}      | ${13.2}
+      ${'marginTop'}        | ${13.3}
+      ${'marginBottom'}     | ${13.4}
+      ${'marginHorizontal'} | ${13.5}
+      ${'marginVertical'}   | ${13.6}
+      ${'position'}         | ${'absolute'}
+      ${'alignSelf'}        | ${'flex-start'}
+      ${'top'}              | ${1.1}
+      ${'right'}            | ${1.2}
+      ${'bottom'}           | ${1.3}
+      ${'left'}             | ${1.4}
+      ${'start'}            | ${1.5}
+      ${'end'}              | ${1.6}
+      ${'flex'}             | ${6}
+    `('applies $property to outer layer only', ({ property, value }) => {
+      const style = { [property]: value };
+
+      const { getByTestId } = render(
+        <Surface testID="surface-test" style={style}>
+          {null}
+        </Surface>
+      );
+
+      expect(getByTestId('surface-test-outer-layer')).toHaveStyle(style);
+      expect(getByTestId('surface-test-middle-layer')).not.toHaveStyle(style);
+      expect(getByTestId('surface-test')).not.toHaveStyle(style);
+    });
+
+    it.each`
+      property               | value
+      ${'padding'}           | ${12}
+      ${'paddingLeft'}       | ${12.1}
+      ${'paddingRight'}      | ${12.2}
+      ${'paddingTop'}        | ${12.3}
+      ${'paddingBottom'}     | ${12.4}
+      ${'paddingHorizontal'} | ${12.5}
+      ${'paddingVertical'}   | ${12.6}
+      ${'borderWidth'}       | ${2}
+      ${'borderColor'}       | ${'black'}
+    `('applies $property to inner layer only', ({ property, value }) => {
+      const style = { [property]: value };
+
+      const { getByTestId } = render(
+        <Surface testID="surface-test" style={style}>
+          {null}
+        </Surface>
+      );
+
+      expect(getByTestId('surface-test-outer-layer')).not.toHaveStyle(style);
+      expect(getByTestId('surface-test-middle-layer')).not.toHaveStyle(style);
+      expect(getByTestId('surface-test')).toHaveStyle(style);
+    });
+
+    it.each`
+      property                     | value
+      ${'borderRadius'}            | ${3}
+      ${'borderTopLeftRadius'}     | ${1}
+      ${'borderTopRightRadius'}    | ${2}
+      ${'borderBottomLeftRadius'}  | ${3}
+      ${'borderBottomRightRadius'} | ${4}
+    `('applies $property to inner layer', ({ property, value }) => {
+      const style = { [property]: value };
+
+      const { getByTestId } = render(
+        <Surface testID="surface-test" style={style}>
+          {null}
+        </Surface>
+      );
+
+      expect(getByTestId('surface-test-outer-layer')).not.toHaveStyle(style);
+      expect(getByTestId('surface-test-middle-layer')).not.toHaveStyle(style);
+      expect(getByTestId('surface-test')).toHaveStyle(style);
+    });
+
     describe('outer layer', () => {
       it('should not render rest style', () => {
         const testID = 'surface-test';

--- a/src/components/__tests__/Surface.test.tsx
+++ b/src/components/__tests__/Surface.test.tsx
@@ -75,21 +75,16 @@ describe('Surface', () => {
     });
 
     it.each`
-      property                     | value
-      ${'padding'}                 | ${12}
-      ${'paddingLeft'}             | ${12.1}
-      ${'paddingRight'}            | ${12.2}
-      ${'paddingTop'}              | ${12.3}
-      ${'paddingBottom'}           | ${12.4}
-      ${'paddingHorizontal'}       | ${12.5}
-      ${'paddingVertical'}         | ${12.6}
-      ${'borderWidth'}             | ${2}
-      ${'borderColor'}             | ${'black'}
-      ${'borderRadius'}            | ${3}
-      ${'borderTopLeftRadius'}     | ${1}
-      ${'borderTopRightRadius'}    | ${2}
-      ${'borderBottomLeftRadius'}  | ${3}
-      ${'borderBottomRightRadius'} | ${4}
+      property               | value
+      ${'padding'}           | ${12}
+      ${'paddingLeft'}       | ${12.1}
+      ${'paddingRight'}      | ${12.2}
+      ${'paddingTop'}        | ${12.3}
+      ${'paddingBottom'}     | ${12.4}
+      ${'paddingHorizontal'} | ${12.5}
+      ${'paddingVertical'}   | ${12.6}
+      ${'borderWidth'}       | ${2}
+      ${'borderColor'}       | ${'black'}
     `('applies $property to inner layer only', ({ property, value }) => {
       const style = { [property]: value };
 
@@ -100,6 +95,27 @@ describe('Surface', () => {
       );
 
       expect(getByTestId('surface-test-outer-layer')).not.toHaveStyle(style);
+      expect(getByTestId('surface-test')).toHaveStyle(style);
+    });
+
+    it.each`
+      property                     | value
+      ${'borderRadius'}            | ${3}
+      ${'borderTopLeftRadius'}     | ${1}
+      ${'borderTopRightRadius'}    | ${2}
+      ${'borderBottomLeftRadius'}  | ${3}
+      ${'borderBottomRightRadius'} | ${4}
+      ${'backgroundColor'}         | ${'rgb(4, 5, 6)'}
+    `('applies $property to every layer', ({ property, value }) => {
+      const style = { [property]: value };
+
+      const { getByTestId } = render(
+        <Surface testID="surface-test" style={style}>
+          {null}
+        </Surface>
+      );
+
+      expect(getByTestId('surface-test-outer-layer')).toHaveStyle(style);
       expect(getByTestId('surface-test')).toHaveStyle(style);
     });
 
@@ -148,22 +164,6 @@ describe('Surface', () => {
     });
 
     describe('inner layer', () => {
-      it('applies backgroundColor to inner layer only', () => {
-        const backgroundColor = 'rgb(1,2,3)';
-        const { getByTestId } = render(
-          <Surface
-            testID="surface-test"
-            theme={{ colors: { elevation: { level1: backgroundColor } } }}
-          >
-            {null}
-          </Surface>
-        );
-
-        const style = { backgroundColor };
-        expect(getByTestId('surface-test-outer-layer')).not.toHaveStyle(style);
-        expect(getByTestId('surface-test')).toHaveStyle(style);
-      });
-
       it('should render inner layer styles on the inner layer', () => {
         const testID = 'surface-test';
 
@@ -175,6 +175,22 @@ describe('Surface', () => {
 
         expect(getByTestId(testID)).toHaveStyle(styles.innerLayerViewStyle);
       });
+    });
+
+    it('applies backgroundColor to every layer', () => {
+      const backgroundColor = 'rgb(1, 2, 3)';
+      const { getByTestId } = render(
+        <Surface
+          testID="surface-test"
+          theme={{ colors: { elevation: { level1: backgroundColor } } }}
+        >
+          {null}
+        </Surface>
+      );
+
+      const style = { backgroundColor };
+      expect(getByTestId('surface-test-outer-layer')).toHaveStyle(style);
+      expect(getByTestId('surface-test')).toHaveStyle(style);
     });
 
     describe('children wrapper', () => {

--- a/src/components/__tests__/ToggleButton.test.tsx
+++ b/src/components/__tests__/ToggleButton.test.tsx
@@ -85,7 +85,7 @@ it('animated value changes correctly', () => {
       style={[{ transform: [{ scale: value }] }]}
     />
   );
-  expect(getByTestId('toggle-button-container')).toHaveStyle({
+  expect(getByTestId('toggle-button-container-outer-layer')).toHaveStyle({
     transform: [{ scale: 1 }],
   });
 
@@ -97,7 +97,7 @@ it('animated value changes correctly', () => {
 
   jest.advanceTimersByTime(200);
 
-  expect(getByTestId('toggle-button-container')).toHaveStyle({
+  expect(getByTestId('toggle-button-container-outer-layer')).toHaveStyle({
     transform: [{ scale: 1.5 }],
   });
 });

--- a/src/components/__tests__/__snapshots__/AnimatedFAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/AnimatedFAB.test.tsx.snap
@@ -9,7 +9,9 @@ exports[`renders animated fab 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": "absolute",
       "right": undefined,
       "shadowColor": "#000",
@@ -21,6 +23,12 @@ exports[`renders animated fab 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="animated-fab-container-outer-layer"
@@ -39,7 +47,7 @@ exports[`renders animated fab 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="animated-fab-container-inner-layer"
+    testID="animated-fab-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -48,12 +56,6 @@ exports[`renders animated fab 1`] = `
           "backgroundColor": "transparent",
           "borderRadius": 16,
           "flex": undefined,
-          "opacity": 1,
-          "transform": Array [
-            Object {
-              "scale": 1,
-            },
-          ],
         }
       }
       testID="animated-fab-container"
@@ -306,7 +308,9 @@ exports[`renders animated fab with label on the left 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": "absolute",
       "right": undefined,
       "shadowColor": "#000",
@@ -318,6 +322,12 @@ exports[`renders animated fab with label on the left 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="animated-fab-container-outer-layer"
@@ -336,7 +346,7 @@ exports[`renders animated fab with label on the left 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="animated-fab-container-inner-layer"
+    testID="animated-fab-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -345,12 +355,6 @@ exports[`renders animated fab with label on the left 1`] = `
           "backgroundColor": "transparent",
           "borderRadius": 16,
           "flex": undefined,
-          "opacity": 1,
-          "transform": Array [
-            Object {
-              "scale": 1,
-            },
-          ],
         }
       }
       testID="animated-fab-container"
@@ -605,7 +609,9 @@ exports[`renders animated fab with label on the right by default 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": "absolute",
       "right": undefined,
       "shadowColor": "#000",
@@ -617,6 +623,12 @@ exports[`renders animated fab with label on the right by default 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="animated-fab-container-outer-layer"
@@ -635,7 +647,7 @@ exports[`renders animated fab with label on the right by default 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="animated-fab-container-inner-layer"
+    testID="animated-fab-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -644,12 +656,6 @@ exports[`renders animated fab with label on the right by default 1`] = `
           "backgroundColor": "transparent",
           "borderRadius": 16,
           "flex": undefined,
-          "opacity": 1,
-          "transform": Array [
-            Object {
-              "scale": 1,
-            },
-          ],
         }
       }
       testID="animated-fab-container"

--- a/src/components/__tests__/__snapshots__/AnimatedFAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/AnimatedFAB.test.tsx.snap
@@ -37,6 +37,8 @@ exports[`renders animated fab 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderRadius": 16,
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -47,253 +49,241 @@ exports[`renders animated fab 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="animated-fab-container-middle-layer"
+    testID="animated-fab-container"
   >
     <View
       collapsable={false}
       style={
         Object {
-          "backgroundColor": "transparent",
           "borderRadius": 16,
-          "flex": undefined,
+          "height": 56,
         }
       }
-      testID="animated-fab-container"
     >
       <View
-        collapsable={false}
         style={
-          Object {
-            "borderRadius": 16,
-            "height": 56,
-          }
+          Array [
+            Object {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "elevation": 0,
+            },
+          ]
         }
       >
         <View
-          style={
-            Array [
-              Object {
-                "bottom": 0,
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              },
-              Object {
-                "elevation": 0,
-              },
-            ]
-          }
-        >
-          <View
-            collapsable={false}
-            pointerEvents="none"
-            style={
-              Object {
-                "borderRadius": 16,
-                "bottom": 0,
-                "elevation": 6,
-                "left": 0,
-                "opacity": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-                "width": 72,
-              }
-            }
-          />
-          <View
-            collapsable={false}
-            pointerEvents="none"
-            style={
-              Object {
-                "borderRadius": 16,
-                "bottom": 0,
-                "elevation": 6,
-                "left": 0,
-                "opacity": 1,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-                "transform": Array [
-                  Object {
-                    "translateX": 16,
-                  },
-                ],
-                "width": 56,
-              }
-            }
-          />
-        </View>
-        <View
           collapsable={false}
-          pointerEvents="box-none"
+          pointerEvents="none"
           style={
             Object {
               "borderRadius": 16,
-              "flexDirection": "row",
-              "overflow": "hidden",
+              "bottom": 0,
+              "elevation": 6,
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": 72,
+            }
+          }
+        />
+        <View
+          collapsable={false}
+          pointerEvents="none"
+          style={
+            Object {
+              "borderRadius": 16,
+              "bottom": 0,
+              "elevation": 6,
+              "left": 0,
+              "opacity": 1,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "transform": Array [
+                Object {
+                  "translateX": 16,
+                },
+              ],
+              "width": 56,
+            }
+          }
+        />
+      </View>
+      <View
+        collapsable={false}
+        pointerEvents="box-none"
+        style={
+          Object {
+            "borderRadius": 16,
+            "flexDirection": "row",
+            "overflow": "hidden",
+          }
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            Object {
+              "backgroundColor": "rgba(234, 221, 255, 1)",
+              "borderRadius": 16,
+              "height": 56,
+              "left": 16,
+              "right": undefined,
+              "transform": Array [
+                Object {
+                  "translateX": 0,
+                },
+              ],
+              "width": 72,
             }
           }
         >
           <View
-            collapsable={false}
-            style={
+            accessibilityLabel=""
+            accessibilityRole="button"
+            accessibilityState={
               Object {
-                "backgroundColor": "rgba(234, 221, 255, 1)",
-                "borderRadius": 16,
-                "height": 56,
-                "left": 16,
-                "right": undefined,
-                "transform": Array [
-                  Object {
-                    "translateX": 0,
-                  },
-                ],
-                "width": 72,
+                "disabled": false,
               }
             }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                false,
+                Object {
+                  "borderRadius": 16,
+                },
+              ]
+            }
+            testID="animated-fab"
           >
             <View
-              accessibilityLabel=""
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "disabled": false,
-                }
-              }
-              accessible={true}
-              collapsable={false}
-              focusable={true}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Array [
                   Object {
-                    "overflow": "hidden",
+                    "height": 56,
                   },
-                  false,
                   Object {
                     "borderRadius": 16,
+                    "width": 72,
                   },
                 ]
               }
-              testID="animated-fab"
-            >
-              <View
-                style={
-                  Array [
-                    Object {
-                      "height": 56,
-                    },
-                    Object {
-                      "borderRadius": 16,
-                      "width": 72,
-                    },
-                  ]
-                }
-              />
-            </View>
+            />
           </View>
         </View>
       </View>
-      <View
-        collapsable={false}
-        pointerEvents="none"
-        style={
-          Object {
-            "alignItems": "center",
-            "height": 56,
-            "justifyContent": "center",
-            "left": 16,
-            "position": "absolute",
-            "right": undefined,
-            "transform": Array [
-              Object {
-                "translateX": 0,
-              },
-            ],
-            "width": 56,
-          }
+    </View>
+    <View
+      collapsable={false}
+      pointerEvents="none"
+      style={
+        Object {
+          "alignItems": "center",
+          "height": 56,
+          "justifyContent": "center",
+          "left": 16,
+          "position": "absolute",
+          "right": undefined,
+          "transform": Array [
+            Object {
+              "translateX": 0,
+            },
+          ],
+          "width": 56,
         }
-      >
-        <Text
-          accessibilityElementsHidden={true}
-          allowFontScaling={false}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "rgba(33, 0, 93, 1)",
-                "fontSize": 24,
-              },
-              Array [
-                Object {
-                  "lineHeight": 24,
-                  "transform": Array [
-                    Object {
-                      "scaleX": 1,
-                    },
-                  ],
-                },
-                Object {
-                  "backgroundColor": "transparent",
-                },
-              ],
-              Object {
-                "fontFamily": "Material Design Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          󰐕
-        </Text>
-      </View>
-      <View
+      }
+    >
+      <Text
+        accessibilityElementsHidden={true}
+        allowFontScaling={false}
+        importantForAccessibility="no-hide-descendants"
         pointerEvents="none"
-      >
-        <Text
-          collapsable={false}
-          ellipsizeMode="tail"
-          numberOfLines={1}
-          onTextLayout={[Function]}
-          style={
+        selectable={false}
+        style={
+          Array [
             Object {
               "color": "rgba(33, 0, 93, 1)",
-              "fontFamily": "System",
-              "fontSize": 14,
-              "fontWeight": "500",
-              "letterSpacing": 0.1,
-              "lineHeight": 20,
-              "minWidth": 0,
-              "opacity": 0,
-              "position": "absolute",
-              "right": 16,
-              "textAlign": "left",
-              "top": -28,
-              "transform": Array [
-                Object {
-                  "translateX": 56,
-                },
-              ],
-              "writingDirection": "ltr",
-            }
+              "fontSize": 24,
+            },
+            Array [
+              Object {
+                "lineHeight": 24,
+                "transform": Array [
+                  Object {
+                    "scaleX": 1,
+                  },
+                ],
+              },
+              Object {
+                "backgroundColor": "transparent",
+              },
+            ],
+            Object {
+              "fontFamily": "Material Design Icons",
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {},
+          ]
+        }
+      >
+        󰐕
+      </Text>
+    </View>
+    <View
+      pointerEvents="none"
+    >
+      <Text
+        collapsable={false}
+        ellipsizeMode="tail"
+        numberOfLines={1}
+        onTextLayout={[Function]}
+        style={
+          Object {
+            "color": "rgba(33, 0, 93, 1)",
+            "fontFamily": "System",
+            "fontSize": 14,
+            "fontWeight": "500",
+            "letterSpacing": 0.1,
+            "lineHeight": 20,
+            "minWidth": 0,
+            "opacity": 0,
+            "position": "absolute",
+            "right": 16,
+            "textAlign": "left",
+            "top": -28,
+            "transform": Array [
+              Object {
+                "translateX": 56,
+              },
+            ],
+            "writingDirection": "ltr",
           }
-          testID="animated-fab-text"
-        />
-      </View>
+        }
+        testID="animated-fab-text"
+      />
     </View>
   </View>
 </View>
@@ -336,6 +326,8 @@ exports[`renders animated fab with label on the left 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderRadius": 16,
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -346,255 +338,243 @@ exports[`renders animated fab with label on the left 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="animated-fab-container-middle-layer"
+    testID="animated-fab-container"
   >
     <View
       collapsable={false}
       style={
         Object {
-          "backgroundColor": "transparent",
           "borderRadius": 16,
-          "flex": undefined,
+          "height": 56,
         }
       }
-      testID="animated-fab-container"
     >
       <View
-        collapsable={false}
         style={
-          Object {
-            "borderRadius": 16,
-            "height": 56,
-          }
+          Array [
+            Object {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "elevation": 0,
+            },
+          ]
         }
       >
         <View
-          style={
-            Array [
-              Object {
-                "bottom": 0,
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              },
-              Object {
-                "elevation": 0,
-              },
-            ]
-          }
-        >
-          <View
-            collapsable={false}
-            pointerEvents="none"
-            style={
-              Object {
-                "borderRadius": 16,
-                "bottom": 0,
-                "elevation": 6,
-                "left": 0,
-                "opacity": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-                "width": 72,
-              }
-            }
-          />
-          <View
-            collapsable={false}
-            pointerEvents="none"
-            style={
-              Object {
-                "borderRadius": 16,
-                "bottom": 0,
-                "elevation": 6,
-                "left": 0,
-                "opacity": 1,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-                "transform": Array [
-                  Object {
-                    "translateX": 0,
-                  },
-                ],
-                "width": 56,
-              }
-            }
-          />
-        </View>
-        <View
           collapsable={false}
-          pointerEvents="box-none"
+          pointerEvents="none"
           style={
             Object {
               "borderRadius": 16,
-              "flexDirection": "row",
-              "overflow": "hidden",
+              "bottom": 0,
+              "elevation": 6,
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": 72,
+            }
+          }
+        />
+        <View
+          collapsable={false}
+          pointerEvents="none"
+          style={
+            Object {
+              "borderRadius": 16,
+              "bottom": 0,
+              "elevation": 6,
+              "left": 0,
+              "opacity": 1,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "transform": Array [
+                Object {
+                  "translateX": 0,
+                },
+              ],
+              "width": 56,
+            }
+          }
+        />
+      </View>
+      <View
+        collapsable={false}
+        pointerEvents="box-none"
+        style={
+          Object {
+            "borderRadius": 16,
+            "flexDirection": "row",
+            "overflow": "hidden",
+          }
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            Object {
+              "backgroundColor": "rgba(234, 221, 255, 1)",
+              "borderRadius": 16,
+              "height": 56,
+              "left": -16,
+              "right": undefined,
+              "transform": Array [
+                Object {
+                  "translateX": 0,
+                },
+              ],
+              "width": 72,
             }
           }
         >
           <View
-            collapsable={false}
-            style={
+            accessibilityLabel="text"
+            accessibilityRole="button"
+            accessibilityState={
               Object {
-                "backgroundColor": "rgba(234, 221, 255, 1)",
-                "borderRadius": 16,
-                "height": 56,
-                "left": -16,
-                "right": undefined,
-                "transform": Array [
-                  Object {
-                    "translateX": 0,
-                  },
-                ],
-                "width": 72,
+                "disabled": false,
               }
             }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                false,
+                Object {
+                  "borderRadius": 16,
+                },
+              ]
+            }
+            testID="animated-fab"
           >
             <View
-              accessibilityLabel="text"
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "disabled": false,
-                }
-              }
-              accessible={true}
-              collapsable={false}
-              focusable={true}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Array [
                   Object {
-                    "overflow": "hidden",
+                    "height": 56,
                   },
-                  false,
                   Object {
                     "borderRadius": 16,
+                    "width": 72,
                   },
                 ]
               }
-              testID="animated-fab"
-            >
-              <View
-                style={
-                  Array [
-                    Object {
-                      "height": 56,
-                    },
-                    Object {
-                      "borderRadius": 16,
-                      "width": 72,
-                    },
-                  ]
-                }
-              />
-            </View>
+            />
           </View>
         </View>
       </View>
-      <View
-        collapsable={false}
-        pointerEvents="none"
-        style={
-          Object {
-            "alignItems": "center",
-            "height": 56,
-            "justifyContent": "center",
-            "left": -16,
-            "position": "absolute",
-            "right": undefined,
-            "transform": Array [
-              Object {
-                "translateX": 16,
-              },
-            ],
-            "width": 56,
-          }
+    </View>
+    <View
+      collapsable={false}
+      pointerEvents="none"
+      style={
+        Object {
+          "alignItems": "center",
+          "height": 56,
+          "justifyContent": "center",
+          "left": -16,
+          "position": "absolute",
+          "right": undefined,
+          "transform": Array [
+            Object {
+              "translateX": 16,
+            },
+          ],
+          "width": 56,
         }
-      >
-        <Text
-          accessibilityElementsHidden={true}
-          allowFontScaling={false}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "rgba(33, 0, 93, 1)",
-                "fontSize": 24,
-              },
-              Array [
-                Object {
-                  "lineHeight": 24,
-                  "transform": Array [
-                    Object {
-                      "scaleX": 1,
-                    },
-                  ],
-                },
-                Object {
-                  "backgroundColor": "transparent",
-                },
-              ],
-              Object {
-                "fontFamily": "Material Design Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          󰐕
-        </Text>
-      </View>
-      <View
+      }
+    >
+      <Text
+        accessibilityElementsHidden={true}
+        allowFontScaling={false}
+        importantForAccessibility="no-hide-descendants"
         pointerEvents="none"
-      >
-        <Text
-          collapsable={false}
-          ellipsizeMode="tail"
-          numberOfLines={1}
-          onTextLayout={[Function]}
-          style={
+        selectable={false}
+        style={
+          Array [
             Object {
               "color": "rgba(33, 0, 93, 1)",
-              "fontFamily": "System",
-              "fontSize": 14,
-              "fontWeight": "500",
-              "left": 16,
-              "letterSpacing": 0.1,
-              "lineHeight": 20,
-              "minWidth": 0,
-              "opacity": 0,
-              "position": "absolute",
-              "textAlign": "left",
-              "top": -28,
-              "transform": Array [
-                Object {
-                  "translateX": 56,
-                },
-              ],
-              "writingDirection": "ltr",
-            }
+              "fontSize": 24,
+            },
+            Array [
+              Object {
+                "lineHeight": 24,
+                "transform": Array [
+                  Object {
+                    "scaleX": 1,
+                  },
+                ],
+              },
+              Object {
+                "backgroundColor": "transparent",
+              },
+            ],
+            Object {
+              "fontFamily": "Material Design Icons",
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {},
+          ]
+        }
+      >
+        󰐕
+      </Text>
+    </View>
+    <View
+      pointerEvents="none"
+    >
+      <Text
+        collapsable={false}
+        ellipsizeMode="tail"
+        numberOfLines={1}
+        onTextLayout={[Function]}
+        style={
+          Object {
+            "color": "rgba(33, 0, 93, 1)",
+            "fontFamily": "System",
+            "fontSize": 14,
+            "fontWeight": "500",
+            "left": 16,
+            "letterSpacing": 0.1,
+            "lineHeight": 20,
+            "minWidth": 0,
+            "opacity": 0,
+            "position": "absolute",
+            "textAlign": "left",
+            "top": -28,
+            "transform": Array [
+              Object {
+                "translateX": 56,
+              },
+            ],
+            "writingDirection": "ltr",
           }
-          testID="animated-fab-text"
-        >
-          text
-        </Text>
-      </View>
+        }
+        testID="animated-fab-text"
+      >
+        text
+      </Text>
     </View>
   </View>
 </View>
@@ -637,6 +617,8 @@ exports[`renders animated fab with label on the right by default 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderRadius": 16,
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -647,255 +629,243 @@ exports[`renders animated fab with label on the right by default 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="animated-fab-container-middle-layer"
+    testID="animated-fab-container"
   >
     <View
       collapsable={false}
       style={
         Object {
-          "backgroundColor": "transparent",
           "borderRadius": 16,
-          "flex": undefined,
+          "height": 56,
         }
       }
-      testID="animated-fab-container"
     >
       <View
-        collapsable={false}
         style={
-          Object {
-            "borderRadius": 16,
-            "height": 56,
-          }
+          Array [
+            Object {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "elevation": 0,
+            },
+          ]
         }
       >
         <View
-          style={
-            Array [
-              Object {
-                "bottom": 0,
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              },
-              Object {
-                "elevation": 0,
-              },
-            ]
-          }
-        >
-          <View
-            collapsable={false}
-            pointerEvents="none"
-            style={
-              Object {
-                "borderRadius": 16,
-                "bottom": 0,
-                "elevation": 6,
-                "left": 0,
-                "opacity": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-                "width": 72,
-              }
-            }
-          />
-          <View
-            collapsable={false}
-            pointerEvents="none"
-            style={
-              Object {
-                "borderRadius": 16,
-                "bottom": 0,
-                "elevation": 6,
-                "left": 0,
-                "opacity": 1,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-                "transform": Array [
-                  Object {
-                    "translateX": 16,
-                  },
-                ],
-                "width": 56,
-              }
-            }
-          />
-        </View>
-        <View
           collapsable={false}
-          pointerEvents="box-none"
+          pointerEvents="none"
           style={
             Object {
               "borderRadius": 16,
-              "flexDirection": "row",
-              "overflow": "hidden",
+              "bottom": 0,
+              "elevation": 6,
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": 72,
+            }
+          }
+        />
+        <View
+          collapsable={false}
+          pointerEvents="none"
+          style={
+            Object {
+              "borderRadius": 16,
+              "bottom": 0,
+              "elevation": 6,
+              "left": 0,
+              "opacity": 1,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "transform": Array [
+                Object {
+                  "translateX": 16,
+                },
+              ],
+              "width": 56,
+            }
+          }
+        />
+      </View>
+      <View
+        collapsable={false}
+        pointerEvents="box-none"
+        style={
+          Object {
+            "borderRadius": 16,
+            "flexDirection": "row",
+            "overflow": "hidden",
+          }
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            Object {
+              "backgroundColor": "rgba(234, 221, 255, 1)",
+              "borderRadius": 16,
+              "height": 56,
+              "left": 16,
+              "right": undefined,
+              "transform": Array [
+                Object {
+                  "translateX": 0,
+                },
+              ],
+              "width": 72,
             }
           }
         >
           <View
-            collapsable={false}
-            style={
+            accessibilityLabel="text"
+            accessibilityRole="button"
+            accessibilityState={
               Object {
-                "backgroundColor": "rgba(234, 221, 255, 1)",
-                "borderRadius": 16,
-                "height": 56,
-                "left": 16,
-                "right": undefined,
-                "transform": Array [
-                  Object {
-                    "translateX": 0,
-                  },
-                ],
-                "width": 72,
+                "disabled": false,
               }
             }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                false,
+                Object {
+                  "borderRadius": 16,
+                },
+              ]
+            }
+            testID="animated-fab"
           >
             <View
-              accessibilityLabel="text"
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "disabled": false,
-                }
-              }
-              accessible={true}
-              collapsable={false}
-              focusable={true}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Array [
                   Object {
-                    "overflow": "hidden",
+                    "height": 56,
                   },
-                  false,
                   Object {
                     "borderRadius": 16,
+                    "width": 72,
                   },
                 ]
               }
-              testID="animated-fab"
-            >
-              <View
-                style={
-                  Array [
-                    Object {
-                      "height": 56,
-                    },
-                    Object {
-                      "borderRadius": 16,
-                      "width": 72,
-                    },
-                  ]
-                }
-              />
-            </View>
+            />
           </View>
         </View>
       </View>
-      <View
-        collapsable={false}
-        pointerEvents="none"
-        style={
-          Object {
-            "alignItems": "center",
-            "height": 56,
-            "justifyContent": "center",
-            "left": 16,
-            "position": "absolute",
-            "right": undefined,
-            "transform": Array [
-              Object {
-                "translateX": 0,
-              },
-            ],
-            "width": 56,
-          }
+    </View>
+    <View
+      collapsable={false}
+      pointerEvents="none"
+      style={
+        Object {
+          "alignItems": "center",
+          "height": 56,
+          "justifyContent": "center",
+          "left": 16,
+          "position": "absolute",
+          "right": undefined,
+          "transform": Array [
+            Object {
+              "translateX": 0,
+            },
+          ],
+          "width": 56,
         }
-      >
-        <Text
-          accessibilityElementsHidden={true}
-          allowFontScaling={false}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "rgba(33, 0, 93, 1)",
-                "fontSize": 24,
-              },
-              Array [
-                Object {
-                  "lineHeight": 24,
-                  "transform": Array [
-                    Object {
-                      "scaleX": 1,
-                    },
-                  ],
-                },
-                Object {
-                  "backgroundColor": "transparent",
-                },
-              ],
-              Object {
-                "fontFamily": "Material Design Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          󰐕
-        </Text>
-      </View>
-      <View
+      }
+    >
+      <Text
+        accessibilityElementsHidden={true}
+        allowFontScaling={false}
+        importantForAccessibility="no-hide-descendants"
         pointerEvents="none"
-      >
-        <Text
-          collapsable={false}
-          ellipsizeMode="tail"
-          numberOfLines={1}
-          onTextLayout={[Function]}
-          style={
+        selectable={false}
+        style={
+          Array [
             Object {
               "color": "rgba(33, 0, 93, 1)",
-              "fontFamily": "System",
-              "fontSize": 14,
-              "fontWeight": "500",
-              "letterSpacing": 0.1,
-              "lineHeight": 20,
-              "minWidth": 0,
-              "opacity": 0,
-              "position": "absolute",
-              "right": 16,
-              "textAlign": "left",
-              "top": -28,
-              "transform": Array [
-                Object {
-                  "translateX": 56,
-                },
-              ],
-              "writingDirection": "ltr",
-            }
+              "fontSize": 24,
+            },
+            Array [
+              Object {
+                "lineHeight": 24,
+                "transform": Array [
+                  Object {
+                    "scaleX": 1,
+                  },
+                ],
+              },
+              Object {
+                "backgroundColor": "transparent",
+              },
+            ],
+            Object {
+              "fontFamily": "Material Design Icons",
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {},
+          ]
+        }
+      >
+        󰐕
+      </Text>
+    </View>
+    <View
+      pointerEvents="none"
+    >
+      <Text
+        collapsable={false}
+        ellipsizeMode="tail"
+        numberOfLines={1}
+        onTextLayout={[Function]}
+        style={
+          Object {
+            "color": "rgba(33, 0, 93, 1)",
+            "fontFamily": "System",
+            "fontSize": 14,
+            "fontWeight": "500",
+            "letterSpacing": 0.1,
+            "lineHeight": 20,
+            "minWidth": 0,
+            "opacity": 0,
+            "position": "absolute",
+            "right": 16,
+            "textAlign": "left",
+            "top": -28,
+            "transform": Array [
+              Object {
+                "translateX": 56,
+              },
+            ],
+            "writingDirection": "ltr",
           }
-          testID="animated-fab-text"
-        >
-          text
-        </Text>
-      </View>
+        }
+        testID="animated-fab-text"
+      >
+        text
+      </Text>
     </View>
   </View>
 </View>

--- a/src/components/__tests__/__snapshots__/AnimatedFAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/AnimatedFAB.test.tsx.snap
@@ -6,6 +6,8 @@ exports[`renders animated fab 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 16,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -295,6 +297,8 @@ exports[`renders animated fab with label on the left 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 16,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -586,6 +590,8 @@ exports[`renders animated fab with label on the right by default 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 16,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,

--- a/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
@@ -9,7 +9,9 @@ exports[`render visible banner, with custom theme 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -21,6 +23,8 @@ exports[`render visible banner, with custom theme 1`] = `
       "shadowRadius": 3,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -39,7 +43,7 @@ exports[`render visible banner, with custom theme 1`] = `
         "shadowRadius": 1,
       }
     }
-    testID="surface-inner-layer"
+    testID="surface-middle-layer"
   >
     <View
       collapsable={false}
@@ -47,7 +51,6 @@ exports[`render visible banner, with custom theme 1`] = `
         Object {
           "backgroundColor": "rgb(247, 243, 249)",
           "flex": undefined,
-          "opacity": 1,
         }
       }
       testID="surface"
@@ -138,7 +141,10 @@ exports[`render visible banner, with custom theme 1`] = `
                   "bottom": undefined,
                   "end": undefined,
                   "flex": undefined,
+                  "height": undefined,
                   "left": undefined,
+                  "margin": 4,
+                  "opacity": undefined,
                   "position": undefined,
                   "right": undefined,
                   "shadowColor": "#000",
@@ -150,6 +156,8 @@ exports[`render visible banner, with custom theme 1`] = `
                   "shadowRadius": 0,
                   "start": undefined,
                   "top": undefined,
+                  "transform": undefined,
+                  "width": undefined,
                 }
               }
               testID="button-container-outer-layer"
@@ -168,7 +176,7 @@ exports[`render visible banner, with custom theme 1`] = `
                     "shadowRadius": 0,
                   }
                 }
-                testID="button-container-inner-layer"
+                testID="button-container-middle-layer"
               >
                 <View
                   collapsable={false}
@@ -180,7 +188,6 @@ exports[`render visible banner, with custom theme 1`] = `
                       "borderStyle": "solid",
                       "borderWidth": 0,
                       "flex": undefined,
-                      "margin": 4,
                       "minWidth": "auto",
                     }
                   }
@@ -301,7 +308,9 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 0,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -313,6 +322,8 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
       "shadowRadius": 3,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -331,7 +342,7 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
         "shadowRadius": 1,
       }
     }
-    testID="surface-inner-layer"
+    testID="surface-middle-layer"
   >
     <View
       collapsable={false}
@@ -339,7 +350,6 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
         Object {
           "backgroundColor": "rgb(247, 243, 249)",
           "flex": undefined,
-          "opacity": 0,
         }
       }
       testID="surface"
@@ -450,7 +460,9 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -462,6 +474,8 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
       "shadowRadius": 3,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -480,7 +494,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
         "shadowRadius": 1,
       }
     }
-    testID="surface-inner-layer"
+    testID="surface-middle-layer"
   >
     <View
       collapsable={false}
@@ -488,7 +502,6 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
         Object {
           "backgroundColor": "rgb(247, 243, 249)",
           "flex": undefined,
-          "opacity": 1,
         }
       }
       testID="surface"
@@ -601,7 +614,10 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                   "bottom": undefined,
                   "end": undefined,
                   "flex": undefined,
+                  "height": undefined,
                   "left": undefined,
+                  "margin": 4,
+                  "opacity": undefined,
                   "position": undefined,
                   "right": undefined,
                   "shadowColor": "#000",
@@ -613,6 +629,8 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                   "shadowRadius": 0,
                   "start": undefined,
                   "top": undefined,
+                  "transform": undefined,
+                  "width": undefined,
                 }
               }
               testID="button-container-outer-layer"
@@ -631,7 +649,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                     "shadowRadius": 0,
                   }
                 }
-                testID="button-container-inner-layer"
+                testID="button-container-middle-layer"
               >
                 <View
                   collapsable={false}
@@ -643,7 +661,6 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                       "borderStyle": "solid",
                       "borderWidth": 0,
                       "flex": undefined,
-                      "margin": 4,
                       "minWidth": "auto",
                     }
                   }
@@ -764,7 +781,9 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -776,6 +795,8 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
       "shadowRadius": 3,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -794,7 +815,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
         "shadowRadius": 1,
       }
     }
-    testID="surface-inner-layer"
+    testID="surface-middle-layer"
   >
     <View
       collapsable={false}
@@ -802,7 +823,6 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
         Object {
           "backgroundColor": "rgb(247, 243, 249)",
           "flex": undefined,
-          "opacity": 1,
         }
       }
       testID="surface"
@@ -893,7 +913,10 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   "bottom": undefined,
                   "end": undefined,
                   "flex": undefined,
+                  "height": undefined,
                   "left": undefined,
+                  "margin": 4,
+                  "opacity": undefined,
                   "position": undefined,
                   "right": undefined,
                   "shadowColor": "#000",
@@ -905,6 +928,8 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   "shadowRadius": 0,
                   "start": undefined,
                   "top": undefined,
+                  "transform": undefined,
+                  "width": undefined,
                 }
               }
               testID="button-container-outer-layer"
@@ -923,7 +948,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                     "shadowRadius": 0,
                   }
                 }
-                testID="button-container-inner-layer"
+                testID="button-container-middle-layer"
               >
                 <View
                   collapsable={false}
@@ -935,7 +960,6 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                       "borderStyle": "solid",
                       "borderWidth": 0,
                       "flex": undefined,
-                      "margin": 4,
                       "minWidth": "auto",
                     }
                   }
@@ -1047,7 +1071,10 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   "bottom": undefined,
                   "end": undefined,
                   "flex": undefined,
+                  "height": undefined,
                   "left": undefined,
+                  "margin": 4,
+                  "opacity": undefined,
                   "position": undefined,
                   "right": undefined,
                   "shadowColor": "#000",
@@ -1059,6 +1086,8 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   "shadowRadius": 0,
                   "start": undefined,
                   "top": undefined,
+                  "transform": undefined,
+                  "width": undefined,
                 }
               }
               testID="button-container-outer-layer"
@@ -1077,7 +1106,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                     "shadowRadius": 0,
                   }
                 }
-                testID="button-container-inner-layer"
+                testID="button-container-middle-layer"
               >
                 <View
                   collapsable={false}
@@ -1089,7 +1118,6 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                       "borderStyle": "solid",
                       "borderWidth": 0,
                       "flex": undefined,
-                      "margin": 4,
                       "minWidth": "auto",
                     }
                   }
@@ -1210,7 +1238,9 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1222,6 +1252,8 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
       "shadowRadius": 3,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -1240,7 +1272,7 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
         "shadowRadius": 1,
       }
     }
-    testID="surface-inner-layer"
+    testID="surface-middle-layer"
   >
     <View
       collapsable={false}
@@ -1248,7 +1280,6 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
         Object {
           "backgroundColor": "rgb(247, 243, 249)",
           "flex": undefined,
-          "opacity": 1,
         }
       }
       testID="surface"
@@ -1369,7 +1400,9 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1381,6 +1414,8 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
       "shadowRadius": 3,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -1399,7 +1434,7 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
         "shadowRadius": 1,
       }
     }
-    testID="surface-inner-layer"
+    testID="surface-middle-layer"
   >
     <View
       collapsable={false}
@@ -1407,7 +1442,6 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
         Object {
           "backgroundColor": "rgb(247, 243, 249)",
           "flex": undefined,
-          "opacity": 1,
         }
       }
       testID="surface"

--- a/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
@@ -33,6 +33,7 @@ exports[`render visible banner, with custom theme 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(247, 243, 249)",
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -43,110 +44,126 @@ exports[`render visible banner, with custom theme 1`] = `
         "shadowRadius": 1,
       }
     }
-    testID="surface-middle-layer"
+    testID="surface"
   >
     <View
-      collapsable={false}
       style={
-        Object {
-          "backgroundColor": "rgb(247, 243, 249)",
-          "flex": undefined,
-        }
+        Array [
+          Object {
+            "alignSelf": "center",
+            "maxWidth": 960,
+            "overflow": "hidden",
+            "width": "100%",
+          },
+          undefined,
+        ]
       }
-      testID="surface"
     >
       <View
+        collapsable={false}
         style={
-          Array [
-            Object {
-              "alignSelf": "center",
-              "maxWidth": 960,
-              "overflow": "hidden",
-              "width": "100%",
-            },
-            undefined,
-          ]
+          Object {
+            "height": 0,
+          }
         }
+      />
+      <View
+        collapsable={false}
+        onLayout={[Function]}
+        style={Object {}}
       >
         <View
-          collapsable={false}
           style={
             Object {
-              "height": 0,
+              "flexDirection": "row",
+              "justifyContent": "flex-start",
+              "marginBottom": 0,
+              "marginHorizontal": 8,
+              "marginTop": 16,
             }
           }
-        />
-        <View
-          collapsable={false}
-          onLayout={[Function]}
-          style={Object {}}
         >
-          <View
+          <Text
+            accessibilityLiveRegion="polite"
+            accessibilityRole="alert"
             style={
-              Object {
-                "flexDirection": "row",
-                "justifyContent": "flex-start",
-                "marginBottom": 0,
-                "marginHorizontal": 8,
-                "marginTop": 16,
-              }
-            }
-          >
-            <Text
-              accessibilityLiveRegion="polite"
-              accessibilityRole="alert"
-              style={
+              Array [
+                Object {
+                  "textAlign": "left",
+                },
+                Object {
+                  "color": "rgba(28, 27, 31, 1)",
+                  "fontFamily": "System",
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
                 Array [
                   Object {
-                    "textAlign": "left",
+                    "flex": 1,
+                    "margin": 8,
                   },
                   Object {
                     "color": "rgba(28, 27, 31, 1)",
-                    "fontFamily": "System",
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
                   },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Array [
-                    Object {
-                      "flex": 1,
-                      "margin": 8,
-                    },
-                    Object {
-                      "color": "rgba(28, 27, 31, 1)",
-                    },
-                  ],
-                ]
-              }
-            >
-              Custom theme
-            </Text>
-          </View>
+                ],
+              ]
+            }
+          >
+            Custom theme
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+              "justifyContent": "flex-end",
+              "margin": 4,
+            }
+          }
+        >
           <View
+            collapsable={false}
             style={
               Object {
-                "flexDirection": "row",
-                "justifyContent": "flex-end",
+                "alignSelf": undefined,
+                "bottom": undefined,
+                "end": undefined,
+                "flex": undefined,
+                "height": undefined,
+                "left": undefined,
                 "margin": 4,
+                "opacity": undefined,
+                "position": undefined,
+                "right": undefined,
+                "shadowColor": "#000",
+                "shadowOffset": Object {
+                  "height": 0,
+                  "width": 0,
+                },
+                "shadowOpacity": 0,
+                "shadowRadius": 0,
+                "start": undefined,
+                "top": undefined,
+                "transform": undefined,
+                "width": undefined,
               }
             }
+            testID="button-container-outer-layer"
           >
             <View
               collapsable={false}
               style={
                 Object {
-                  "alignSelf": undefined,
-                  "bottom": undefined,
-                  "end": undefined,
+                  "backgroundColor": "transparent",
+                  "borderColor": "transparent",
+                  "borderRadius": 20,
+                  "borderStyle": "solid",
+                  "borderWidth": 0,
                   "flex": undefined,
-                  "height": undefined,
-                  "left": undefined,
-                  "margin": 4,
-                  "opacity": undefined,
-                  "position": undefined,
-                  "right": undefined,
+                  "minWidth": "auto",
                   "shadowColor": "#000",
                   "shadowOffset": Object {
                     "height": 0,
@@ -154,140 +171,103 @@ exports[`render visible banner, with custom theme 1`] = `
                   },
                   "shadowOpacity": 0,
                   "shadowRadius": 0,
-                  "start": undefined,
-                  "top": undefined,
-                  "transform": undefined,
-                  "width": undefined,
                 }
               }
-              testID="button-container-outer-layer"
+              testID="button-container"
             >
               <View
-                collapsable={false}
-                style={
+                accessibilityRole="button"
+                accessibilityState={
                   Object {
-                    "flex": undefined,
-                    "shadowColor": "#000",
-                    "shadowOffset": Object {
-                      "height": 0,
-                      "width": 0,
-                    },
-                    "shadowOpacity": 0,
-                    "shadowRadius": 0,
+                    "disabled": false,
                   }
                 }
-                testID="button-container-middle-layer"
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Array [
+                    Object {
+                      "overflow": "hidden",
+                    },
+                    false,
+                    Object {
+                      "borderRadius": 20,
+                    },
+                  ]
+                }
+                testID="button"
               >
                 <View
-                  collapsable={false}
                   style={
-                    Object {
-                      "backgroundColor": "transparent",
-                      "borderColor": "transparent",
-                      "borderRadius": 20,
-                      "borderStyle": "solid",
-                      "borderWidth": 0,
-                      "flex": undefined,
-                      "minWidth": "auto",
-                    }
-                  }
-                  testID="button-container"
-                >
-                  <View
-                    accessibilityRole="button"
-                    accessibilityState={
+                    Array [
                       Object {
-                        "disabled": false,
-                      }
-                    }
-                    accessible={true}
-                    collapsable={false}
-                    focusable={true}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onResponderGrant={[Function]}
-                    onResponderMove={[Function]}
-                    onResponderRelease={[Function]}
-                    onResponderTerminate={[Function]}
-                    onResponderTerminationRequest={[Function]}
-                    onStartShouldSetResponder={[Function]}
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "justifyContent": "center",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  <Text
+                    numberOfLines={1}
+                    selectable={false}
                     style={
                       Array [
                         Object {
-                          "overflow": "hidden",
+                          "fontFamily": "System",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.1,
+                          "lineHeight": 20,
                         },
-                        false,
                         Object {
-                          "borderRadius": 20,
+                          "textAlign": "left",
                         },
-                      ]
-                    }
-                    testID="button"
-                  >
-                    <View
-                      style={
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
                         Array [
                           Object {
-                            "alignItems": "center",
-                            "flexDirection": "row",
-                            "justifyContent": "center",
+                            "marginHorizontal": 16,
+                            "marginVertical": 9,
+                            "textAlign": "center",
+                          },
+                          false,
+                          Object {
+                            "marginHorizontal": 12,
+                          },
+                          Object {
+                            "marginHorizontal": 8,
+                          },
+                          false,
+                          Object {
+                            "color": "#043",
+                            "fontFamily": "System",
+                            "fontSize": 14,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.1,
+                            "lineHeight": 20,
                           },
                           undefined,
-                        ]
-                      }
-                    >
-                      <Text
-                        numberOfLines={1}
-                        selectable={false}
-                        style={
-                          Array [
-                            Object {
-                              "fontFamily": "System",
-                              "fontSize": 14,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.1,
-                              "lineHeight": 20,
-                            },
-                            Object {
-                              "textAlign": "left",
-                            },
-                            Object {
-                              "color": "rgba(28, 27, 31, 1)",
-                              "writingDirection": "ltr",
-                            },
-                            Array [
-                              Object {
-                                "marginHorizontal": 16,
-                                "marginVertical": 9,
-                                "textAlign": "center",
-                              },
-                              false,
-                              Object {
-                                "marginHorizontal": 12,
-                              },
-                              Object {
-                                "marginHorizontal": 8,
-                              },
-                              false,
-                              Object {
-                                "color": "#043",
-                                "fontFamily": "System",
-                                "fontSize": 14,
-                                "fontWeight": "500",
-                                "letterSpacing": 0.1,
-                                "lineHeight": 20,
-                              },
-                              undefined,
-                            ],
-                          ]
-                        }
-                        testID="button-text"
-                      >
-                        first
-                      </Text>
-                    </View>
-                  </View>
+                        ],
+                      ]
+                    }
+                    testID="button-text"
+                  >
+                    first
+                  </Text>
                 </View>
               </View>
             </View>
@@ -332,6 +312,7 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(247, 243, 249)",
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -342,109 +323,98 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
         "shadowRadius": 1,
       }
     }
-    testID="surface-middle-layer"
+    testID="surface"
   >
     <View
-      collapsable={false}
       style={
-        Object {
-          "backgroundColor": "rgb(247, 243, 249)",
-          "flex": undefined,
-        }
+        Array [
+          Object {
+            "alignSelf": "center",
+            "maxWidth": 960,
+            "overflow": "hidden",
+            "width": "100%",
+          },
+          undefined,
+        ]
       }
-      testID="surface"
     >
       <View
+        collapsable={false}
         style={
-          Array [
-            Object {
-              "alignSelf": "center",
-              "maxWidth": 960,
-              "overflow": "hidden",
-              "width": "100%",
-            },
-            undefined,
-          ]
+          Object {
+            "height": 0,
+          }
+        }
+      />
+      <View
+        collapsable={false}
+        onLayout={[Function]}
+        style={
+          Object {
+            "opacity": 0,
+            "position": "absolute",
+            "top": 0,
+            "transform": Array [
+              Object {
+                "translateY": -0,
+              },
+            ],
+            "width": "100%",
+          }
         }
       >
         <View
-          collapsable={false}
           style={
             Object {
-              "height": 0,
-            }
-          }
-        />
-        <View
-          collapsable={false}
-          onLayout={[Function]}
-          style={
-            Object {
-              "opacity": 0,
-              "position": "absolute",
-              "top": 0,
-              "transform": Array [
-                Object {
-                  "translateY": -0,
-                },
-              ],
-              "width": "100%",
+              "flexDirection": "row",
+              "justifyContent": "flex-start",
+              "marginBottom": 0,
+              "marginHorizontal": 8,
+              "marginTop": 16,
             }
           }
         >
-          <View
+          <Text
+            accessibilityLiveRegion="none"
+            accessibilityRole="alert"
             style={
-              Object {
-                "flexDirection": "row",
-                "justifyContent": "flex-start",
-                "marginBottom": 0,
-                "marginHorizontal": 8,
-                "marginTop": 16,
-              }
-            }
-          >
-            <Text
-              accessibilityLiveRegion="none"
-              accessibilityRole="alert"
-              style={
+              Array [
+                Object {
+                  "textAlign": "left",
+                },
+                Object {
+                  "color": "rgba(28, 27, 31, 1)",
+                  "fontFamily": "System",
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
                 Array [
                   Object {
-                    "textAlign": "left",
+                    "flex": 1,
+                    "margin": 8,
                   },
                   Object {
                     "color": "rgba(28, 27, 31, 1)",
-                    "fontFamily": "System",
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
                   },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Array [
-                    Object {
-                      "flex": 1,
-                      "margin": 8,
-                    },
-                    Object {
-                      "color": "rgba(28, 27, 31, 1)",
-                    },
-                  ],
-                ]
-              }
-            >
-              Two line text string with two actions. One to two lines is preferable on mobile.
-            </Text>
-          </View>
-          <View
-            style={
-              Object {
-                "flexDirection": "row",
-                "justifyContent": "flex-end",
-                "margin": 4,
-              }
+                ],
+              ]
             }
-          />
+          >
+            Two line text string with two actions. One to two lines is preferable on mobile.
+          </Text>
         </View>
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+              "justifyContent": "flex-end",
+              "margin": 4,
+            }
+          }
+        />
       </View>
     </View>
   </View>
@@ -484,6 +454,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(247, 243, 249)",
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -494,132 +465,148 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
         "shadowRadius": 1,
       }
     }
-    testID="surface-middle-layer"
+    testID="surface"
   >
     <View
-      collapsable={false}
       style={
-        Object {
-          "backgroundColor": "rgb(247, 243, 249)",
-          "flex": undefined,
-        }
+        Array [
+          Object {
+            "alignSelf": "center",
+            "maxWidth": 960,
+            "overflow": "hidden",
+            "width": "100%",
+          },
+          undefined,
+        ]
       }
-      testID="surface"
     >
       <View
+        collapsable={false}
         style={
-          Array [
-            Object {
-              "alignSelf": "center",
-              "maxWidth": 960,
-              "overflow": "hidden",
-              "width": "100%",
-            },
-            undefined,
-          ]
+          Object {
+            "height": 0,
+          }
         }
+      />
+      <View
+        collapsable={false}
+        onLayout={[Function]}
+        style={Object {}}
       >
         <View
-          collapsable={false}
           style={
             Object {
-              "height": 0,
+              "flexDirection": "row",
+              "justifyContent": "flex-start",
+              "marginBottom": 0,
+              "marginHorizontal": 8,
+              "marginTop": 16,
             }
           }
-        />
-        <View
-          collapsable={false}
-          onLayout={[Function]}
-          style={Object {}}
         >
           <View
             style={
               Object {
-                "flexDirection": "row",
-                "justifyContent": "flex-start",
-                "marginBottom": 0,
-                "marginHorizontal": 8,
-                "marginTop": 16,
+                "margin": 8,
               }
             }
           >
-            <View
-              style={
+            <Image
+              accessibilityIgnoresInvertColors={true}
+              source={
                 Object {
-                  "margin": 8,
+                  "uri": "https://callstack.com/images/team/Satya.png",
                 }
               }
-            >
-              <Image
-                accessibilityIgnoresInvertColors={true}
-                source={
-                  Object {
-                    "uri": "https://callstack.com/images/team/Satya.png",
-                  }
-                }
-                style={
-                  Object {
-                    "height": 40,
-                    "width": 40,
-                  }
-                }
-              />
-            </View>
-            <Text
-              accessibilityLiveRegion="polite"
-              accessibilityRole="alert"
               style={
+                Object {
+                  "height": 40,
+                  "width": 40,
+                }
+              }
+            />
+          </View>
+          <Text
+            accessibilityLiveRegion="polite"
+            accessibilityRole="alert"
+            style={
+              Array [
+                Object {
+                  "textAlign": "left",
+                },
+                Object {
+                  "color": "rgba(28, 27, 31, 1)",
+                  "fontFamily": "System",
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
                 Array [
                   Object {
-                    "textAlign": "left",
+                    "flex": 1,
+                    "margin": 8,
                   },
                   Object {
                     "color": "rgba(28, 27, 31, 1)",
-                    "fontFamily": "System",
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
                   },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Array [
-                    Object {
-                      "flex": 1,
-                      "margin": 8,
-                    },
-                    Object {
-                      "color": "rgba(28, 27, 31, 1)",
-                    },
-                  ],
-                ]
-              }
-            >
-              Two line text string with two actions. One to two lines is preferable on mobile.
-            </Text>
-          </View>
+                ],
+              ]
+            }
+          >
+            Two line text string with two actions. One to two lines is preferable on mobile.
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+              "justifyContent": "flex-end",
+              "margin": 4,
+            }
+          }
+        >
           <View
+            collapsable={false}
             style={
               Object {
-                "flexDirection": "row",
-                "justifyContent": "flex-end",
+                "alignSelf": undefined,
+                "bottom": undefined,
+                "end": undefined,
+                "flex": undefined,
+                "height": undefined,
+                "left": undefined,
                 "margin": 4,
+                "opacity": undefined,
+                "position": undefined,
+                "right": undefined,
+                "shadowColor": "#000",
+                "shadowOffset": Object {
+                  "height": 0,
+                  "width": 0,
+                },
+                "shadowOpacity": 0,
+                "shadowRadius": 0,
+                "start": undefined,
+                "top": undefined,
+                "transform": undefined,
+                "width": undefined,
               }
             }
+            testID="button-container-outer-layer"
           >
             <View
               collapsable={false}
               style={
                 Object {
-                  "alignSelf": undefined,
-                  "bottom": undefined,
-                  "end": undefined,
+                  "backgroundColor": "transparent",
+                  "borderColor": "transparent",
+                  "borderRadius": 20,
+                  "borderStyle": "solid",
+                  "borderWidth": 0,
                   "flex": undefined,
-                  "height": undefined,
-                  "left": undefined,
-                  "margin": 4,
-                  "opacity": undefined,
-                  "position": undefined,
-                  "right": undefined,
+                  "minWidth": "auto",
                   "shadowColor": "#000",
                   "shadowOffset": Object {
                     "height": 0,
@@ -627,140 +614,103 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                   },
                   "shadowOpacity": 0,
                   "shadowRadius": 0,
-                  "start": undefined,
-                  "top": undefined,
-                  "transform": undefined,
-                  "width": undefined,
                 }
               }
-              testID="button-container-outer-layer"
+              testID="button-container"
             >
               <View
-                collapsable={false}
-                style={
+                accessibilityRole="button"
+                accessibilityState={
                   Object {
-                    "flex": undefined,
-                    "shadowColor": "#000",
-                    "shadowOffset": Object {
-                      "height": 0,
-                      "width": 0,
-                    },
-                    "shadowOpacity": 0,
-                    "shadowRadius": 0,
+                    "disabled": false,
                   }
                 }
-                testID="button-container-middle-layer"
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Array [
+                    Object {
+                      "overflow": "hidden",
+                    },
+                    false,
+                    Object {
+                      "borderRadius": 20,
+                    },
+                  ]
+                }
+                testID="button"
               >
                 <View
-                  collapsable={false}
                   style={
-                    Object {
-                      "backgroundColor": "transparent",
-                      "borderColor": "transparent",
-                      "borderRadius": 20,
-                      "borderStyle": "solid",
-                      "borderWidth": 0,
-                      "flex": undefined,
-                      "minWidth": "auto",
-                    }
-                  }
-                  testID="button-container"
-                >
-                  <View
-                    accessibilityRole="button"
-                    accessibilityState={
+                    Array [
                       Object {
-                        "disabled": false,
-                      }
-                    }
-                    accessible={true}
-                    collapsable={false}
-                    focusable={true}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onResponderGrant={[Function]}
-                    onResponderMove={[Function]}
-                    onResponderRelease={[Function]}
-                    onResponderTerminate={[Function]}
-                    onResponderTerminationRequest={[Function]}
-                    onStartShouldSetResponder={[Function]}
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "justifyContent": "center",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  <Text
+                    numberOfLines={1}
+                    selectable={false}
                     style={
                       Array [
                         Object {
-                          "overflow": "hidden",
+                          "fontFamily": "System",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.1,
+                          "lineHeight": 20,
                         },
-                        false,
                         Object {
-                          "borderRadius": 20,
+                          "textAlign": "left",
                         },
-                      ]
-                    }
-                    testID="button"
-                  >
-                    <View
-                      style={
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
                         Array [
                           Object {
-                            "alignItems": "center",
-                            "flexDirection": "row",
-                            "justifyContent": "center",
+                            "marginHorizontal": 16,
+                            "marginVertical": 9,
+                            "textAlign": "center",
+                          },
+                          false,
+                          Object {
+                            "marginHorizontal": 12,
+                          },
+                          Object {
+                            "marginHorizontal": 8,
+                          },
+                          false,
+                          Object {
+                            "color": "rgba(103, 80, 164, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 14,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.1,
+                            "lineHeight": 20,
                           },
                           undefined,
-                        ]
-                      }
-                    >
-                      <Text
-                        numberOfLines={1}
-                        selectable={false}
-                        style={
-                          Array [
-                            Object {
-                              "fontFamily": "System",
-                              "fontSize": 14,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.1,
-                              "lineHeight": 20,
-                            },
-                            Object {
-                              "textAlign": "left",
-                            },
-                            Object {
-                              "color": "rgba(28, 27, 31, 1)",
-                              "writingDirection": "ltr",
-                            },
-                            Array [
-                              Object {
-                                "marginHorizontal": 16,
-                                "marginVertical": 9,
-                                "textAlign": "center",
-                              },
-                              false,
-                              Object {
-                                "marginHorizontal": 12,
-                              },
-                              Object {
-                                "marginHorizontal": 8,
-                              },
-                              false,
-                              Object {
-                                "color": "rgba(103, 80, 164, 1)",
-                                "fontFamily": "System",
-                                "fontSize": 14,
-                                "fontWeight": "500",
-                                "letterSpacing": 0.1,
-                                "lineHeight": 20,
-                              },
-                              undefined,
-                            ],
-                          ]
-                        }
-                        testID="button-text"
-                      >
-                        first
-                      </Text>
-                    </View>
-                  </View>
+                        ],
+                      ]
+                    }
+                    testID="button-text"
+                  >
+                    first
+                  </Text>
                 </View>
               </View>
             </View>
@@ -805,6 +755,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(247, 243, 249)",
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -815,110 +766,126 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
         "shadowRadius": 1,
       }
     }
-    testID="surface-middle-layer"
+    testID="surface"
   >
     <View
-      collapsable={false}
       style={
-        Object {
-          "backgroundColor": "rgb(247, 243, 249)",
-          "flex": undefined,
-        }
+        Array [
+          Object {
+            "alignSelf": "center",
+            "maxWidth": 960,
+            "overflow": "hidden",
+            "width": "100%",
+          },
+          undefined,
+        ]
       }
-      testID="surface"
     >
       <View
+        collapsable={false}
         style={
-          Array [
-            Object {
-              "alignSelf": "center",
-              "maxWidth": 960,
-              "overflow": "hidden",
-              "width": "100%",
-            },
-            undefined,
-          ]
+          Object {
+            "height": 0,
+          }
         }
+      />
+      <View
+        collapsable={false}
+        onLayout={[Function]}
+        style={Object {}}
       >
         <View
-          collapsable={false}
           style={
             Object {
-              "height": 0,
+              "flexDirection": "row",
+              "justifyContent": "flex-start",
+              "marginBottom": 0,
+              "marginHorizontal": 8,
+              "marginTop": 16,
             }
           }
-        />
-        <View
-          collapsable={false}
-          onLayout={[Function]}
-          style={Object {}}
         >
-          <View
+          <Text
+            accessibilityLiveRegion="polite"
+            accessibilityRole="alert"
             style={
-              Object {
-                "flexDirection": "row",
-                "justifyContent": "flex-start",
-                "marginBottom": 0,
-                "marginHorizontal": 8,
-                "marginTop": 16,
-              }
-            }
-          >
-            <Text
-              accessibilityLiveRegion="polite"
-              accessibilityRole="alert"
-              style={
+              Array [
+                Object {
+                  "textAlign": "left",
+                },
+                Object {
+                  "color": "rgba(28, 27, 31, 1)",
+                  "fontFamily": "System",
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
                 Array [
                   Object {
-                    "textAlign": "left",
+                    "flex": 1,
+                    "margin": 8,
                   },
                   Object {
                     "color": "rgba(28, 27, 31, 1)",
-                    "fontFamily": "System",
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
                   },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Array [
-                    Object {
-                      "flex": 1,
-                      "margin": 8,
-                    },
-                    Object {
-                      "color": "rgba(28, 27, 31, 1)",
-                    },
-                  ],
-                ]
-              }
-            >
-              Two line text string with two actions. One to two lines is preferable on mobile.
-            </Text>
-          </View>
+                ],
+              ]
+            }
+          >
+            Two line text string with two actions. One to two lines is preferable on mobile.
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+              "justifyContent": "flex-end",
+              "margin": 4,
+            }
+          }
+        >
           <View
+            collapsable={false}
             style={
               Object {
-                "flexDirection": "row",
-                "justifyContent": "flex-end",
+                "alignSelf": undefined,
+                "bottom": undefined,
+                "end": undefined,
+                "flex": undefined,
+                "height": undefined,
+                "left": undefined,
                 "margin": 4,
+                "opacity": undefined,
+                "position": undefined,
+                "right": undefined,
+                "shadowColor": "#000",
+                "shadowOffset": Object {
+                  "height": 0,
+                  "width": 0,
+                },
+                "shadowOpacity": 0,
+                "shadowRadius": 0,
+                "start": undefined,
+                "top": undefined,
+                "transform": undefined,
+                "width": undefined,
               }
             }
+            testID="button-container-outer-layer"
           >
             <View
               collapsable={false}
               style={
                 Object {
-                  "alignSelf": undefined,
-                  "bottom": undefined,
-                  "end": undefined,
+                  "backgroundColor": "transparent",
+                  "borderColor": "transparent",
+                  "borderRadius": 20,
+                  "borderStyle": "solid",
+                  "borderWidth": 0,
                   "flex": undefined,
-                  "height": undefined,
-                  "left": undefined,
-                  "margin": 4,
-                  "opacity": undefined,
-                  "position": undefined,
-                  "right": undefined,
+                  "minWidth": "auto",
                   "shadowColor": "#000",
                   "shadowOffset": Object {
                     "height": 0,
@@ -926,157 +893,147 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   },
                   "shadowOpacity": 0,
                   "shadowRadius": 0,
-                  "start": undefined,
-                  "top": undefined,
-                  "transform": undefined,
-                  "width": undefined,
                 }
               }
-              testID="button-container-outer-layer"
+              testID="button-container"
             >
               <View
-                collapsable={false}
-                style={
+                accessibilityRole="button"
+                accessibilityState={
                   Object {
-                    "flex": undefined,
-                    "shadowColor": "#000",
-                    "shadowOffset": Object {
-                      "height": 0,
-                      "width": 0,
-                    },
-                    "shadowOpacity": 0,
-                    "shadowRadius": 0,
+                    "disabled": false,
                   }
                 }
-                testID="button-container-middle-layer"
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Array [
+                    Object {
+                      "overflow": "hidden",
+                    },
+                    false,
+                    Object {
+                      "borderRadius": 20,
+                    },
+                  ]
+                }
+                testID="button"
               >
                 <View
-                  collapsable={false}
                   style={
-                    Object {
-                      "backgroundColor": "transparent",
-                      "borderColor": "transparent",
-                      "borderRadius": 20,
-                      "borderStyle": "solid",
-                      "borderWidth": 0,
-                      "flex": undefined,
-                      "minWidth": "auto",
-                    }
-                  }
-                  testID="button-container"
-                >
-                  <View
-                    accessibilityRole="button"
-                    accessibilityState={
+                    Array [
                       Object {
-                        "disabled": false,
-                      }
-                    }
-                    accessible={true}
-                    collapsable={false}
-                    focusable={true}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onResponderGrant={[Function]}
-                    onResponderMove={[Function]}
-                    onResponderRelease={[Function]}
-                    onResponderTerminate={[Function]}
-                    onResponderTerminationRequest={[Function]}
-                    onStartShouldSetResponder={[Function]}
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "justifyContent": "center",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  <Text
+                    numberOfLines={1}
+                    selectable={false}
                     style={
                       Array [
                         Object {
-                          "overflow": "hidden",
+                          "fontFamily": "System",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.1,
+                          "lineHeight": 20,
                         },
-                        false,
                         Object {
-                          "borderRadius": 20,
+                          "textAlign": "left",
                         },
-                      ]
-                    }
-                    testID="button"
-                  >
-                    <View
-                      style={
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
                         Array [
                           Object {
-                            "alignItems": "center",
-                            "flexDirection": "row",
-                            "justifyContent": "center",
+                            "marginHorizontal": 16,
+                            "marginVertical": 9,
+                            "textAlign": "center",
+                          },
+                          false,
+                          Object {
+                            "marginHorizontal": 12,
+                          },
+                          Object {
+                            "marginHorizontal": 8,
+                          },
+                          false,
+                          Object {
+                            "color": "rgba(103, 80, 164, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 14,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.1,
+                            "lineHeight": 20,
                           },
                           undefined,
-                        ]
-                      }
-                    >
-                      <Text
-                        numberOfLines={1}
-                        selectable={false}
-                        style={
-                          Array [
-                            Object {
-                              "fontFamily": "System",
-                              "fontSize": 14,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.1,
-                              "lineHeight": 20,
-                            },
-                            Object {
-                              "textAlign": "left",
-                            },
-                            Object {
-                              "color": "rgba(28, 27, 31, 1)",
-                              "writingDirection": "ltr",
-                            },
-                            Array [
-                              Object {
-                                "marginHorizontal": 16,
-                                "marginVertical": 9,
-                                "textAlign": "center",
-                              },
-                              false,
-                              Object {
-                                "marginHorizontal": 12,
-                              },
-                              Object {
-                                "marginHorizontal": 8,
-                              },
-                              false,
-                              Object {
-                                "color": "rgba(103, 80, 164, 1)",
-                                "fontFamily": "System",
-                                "fontSize": 14,
-                                "fontWeight": "500",
-                                "letterSpacing": 0.1,
-                                "lineHeight": 20,
-                              },
-                              undefined,
-                            ],
-                          ]
-                        }
-                        testID="button-text"
-                      >
-                        first
-                      </Text>
-                    </View>
-                  </View>
+                        ],
+                      ]
+                    }
+                    testID="button-text"
+                  >
+                    first
+                  </Text>
                 </View>
               </View>
             </View>
+          </View>
+          <View
+            collapsable={false}
+            style={
+              Object {
+                "alignSelf": undefined,
+                "bottom": undefined,
+                "end": undefined,
+                "flex": undefined,
+                "height": undefined,
+                "left": undefined,
+                "margin": 4,
+                "opacity": undefined,
+                "position": undefined,
+                "right": undefined,
+                "shadowColor": "#000",
+                "shadowOffset": Object {
+                  "height": 0,
+                  "width": 0,
+                },
+                "shadowOpacity": 0,
+                "shadowRadius": 0,
+                "start": undefined,
+                "top": undefined,
+                "transform": undefined,
+                "width": undefined,
+              }
+            }
+            testID="button-container-outer-layer"
+          >
             <View
               collapsable={false}
               style={
                 Object {
-                  "alignSelf": undefined,
-                  "bottom": undefined,
-                  "end": undefined,
+                  "backgroundColor": "transparent",
+                  "borderColor": "transparent",
+                  "borderRadius": 20,
+                  "borderStyle": "solid",
+                  "borderWidth": 0,
                   "flex": undefined,
-                  "height": undefined,
-                  "left": undefined,
-                  "margin": 4,
-                  "opacity": undefined,
-                  "position": undefined,
-                  "right": undefined,
+                  "minWidth": "auto",
                   "shadowColor": "#000",
                   "shadowOffset": Object {
                     "height": 0,
@@ -1084,140 +1041,103 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   },
                   "shadowOpacity": 0,
                   "shadowRadius": 0,
-                  "start": undefined,
-                  "top": undefined,
-                  "transform": undefined,
-                  "width": undefined,
                 }
               }
-              testID="button-container-outer-layer"
+              testID="button-container"
             >
               <View
-                collapsable={false}
-                style={
+                accessibilityRole="button"
+                accessibilityState={
                   Object {
-                    "flex": undefined,
-                    "shadowColor": "#000",
-                    "shadowOffset": Object {
-                      "height": 0,
-                      "width": 0,
-                    },
-                    "shadowOpacity": 0,
-                    "shadowRadius": 0,
+                    "disabled": false,
                   }
                 }
-                testID="button-container-middle-layer"
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Array [
+                    Object {
+                      "overflow": "hidden",
+                    },
+                    false,
+                    Object {
+                      "borderRadius": 20,
+                    },
+                  ]
+                }
+                testID="button"
               >
                 <View
-                  collapsable={false}
                   style={
-                    Object {
-                      "backgroundColor": "transparent",
-                      "borderColor": "transparent",
-                      "borderRadius": 20,
-                      "borderStyle": "solid",
-                      "borderWidth": 0,
-                      "flex": undefined,
-                      "minWidth": "auto",
-                    }
-                  }
-                  testID="button-container"
-                >
-                  <View
-                    accessibilityRole="button"
-                    accessibilityState={
+                    Array [
                       Object {
-                        "disabled": false,
-                      }
-                    }
-                    accessible={true}
-                    collapsable={false}
-                    focusable={true}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onResponderGrant={[Function]}
-                    onResponderMove={[Function]}
-                    onResponderRelease={[Function]}
-                    onResponderTerminate={[Function]}
-                    onResponderTerminationRequest={[Function]}
-                    onStartShouldSetResponder={[Function]}
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "justifyContent": "center",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  <Text
+                    numberOfLines={1}
+                    selectable={false}
                     style={
                       Array [
                         Object {
-                          "overflow": "hidden",
+                          "fontFamily": "System",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.1,
+                          "lineHeight": 20,
                         },
-                        false,
                         Object {
-                          "borderRadius": 20,
+                          "textAlign": "left",
                         },
-                      ]
-                    }
-                    testID="button"
-                  >
-                    <View
-                      style={
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
                         Array [
                           Object {
-                            "alignItems": "center",
-                            "flexDirection": "row",
-                            "justifyContent": "center",
+                            "marginHorizontal": 16,
+                            "marginVertical": 9,
+                            "textAlign": "center",
+                          },
+                          false,
+                          Object {
+                            "marginHorizontal": 12,
+                          },
+                          Object {
+                            "marginHorizontal": 8,
+                          },
+                          false,
+                          Object {
+                            "color": "rgba(103, 80, 164, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 14,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.1,
+                            "lineHeight": 20,
                           },
                           undefined,
-                        ]
-                      }
-                    >
-                      <Text
-                        numberOfLines={1}
-                        selectable={false}
-                        style={
-                          Array [
-                            Object {
-                              "fontFamily": "System",
-                              "fontSize": 14,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.1,
-                              "lineHeight": 20,
-                            },
-                            Object {
-                              "textAlign": "left",
-                            },
-                            Object {
-                              "color": "rgba(28, 27, 31, 1)",
-                              "writingDirection": "ltr",
-                            },
-                            Array [
-                              Object {
-                                "marginHorizontal": 16,
-                                "marginVertical": 9,
-                                "textAlign": "center",
-                              },
-                              false,
-                              Object {
-                                "marginHorizontal": 12,
-                              },
-                              Object {
-                                "marginHorizontal": 8,
-                              },
-                              false,
-                              Object {
-                                "color": "rgba(103, 80, 164, 1)",
-                                "fontFamily": "System",
-                                "fontSize": 14,
-                                "fontWeight": "500",
-                                "letterSpacing": 0.1,
-                                "lineHeight": 20,
-                              },
-                              undefined,
-                            ],
-                          ]
-                        }
-                        testID="button-text"
-                      >
-                        second
-                      </Text>
-                    </View>
-                  </View>
+                        ],
+                      ]
+                    }
+                    testID="button-text"
+                  >
+                    second
+                  </Text>
                 </View>
               </View>
             </View>
@@ -1262,6 +1182,7 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(247, 243, 249)",
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -1272,119 +1193,108 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
         "shadowRadius": 1,
       }
     }
-    testID="surface-middle-layer"
+    testID="surface"
   >
     <View
-      collapsable={false}
       style={
-        Object {
-          "backgroundColor": "rgb(247, 243, 249)",
-          "flex": undefined,
-        }
+        Array [
+          Object {
+            "alignSelf": "center",
+            "maxWidth": 960,
+            "overflow": "hidden",
+            "width": "100%",
+          },
+          undefined,
+        ]
       }
-      testID="surface"
     >
       <View
+        collapsable={false}
         style={
-          Array [
-            Object {
-              "alignSelf": "center",
-              "maxWidth": 960,
-              "overflow": "hidden",
-              "width": "100%",
-            },
-            undefined,
-          ]
+          Object {
+            "height": 0,
+          }
         }
+      />
+      <View
+        collapsable={false}
+        onLayout={[Function]}
+        style={Object {}}
       >
         <View
-          collapsable={false}
           style={
             Object {
-              "height": 0,
+              "flexDirection": "row",
+              "justifyContent": "flex-start",
+              "marginBottom": 0,
+              "marginHorizontal": 8,
+              "marginTop": 16,
             }
           }
-        />
-        <View
-          collapsable={false}
-          onLayout={[Function]}
-          style={Object {}}
         >
           <View
             style={
               Object {
-                "flexDirection": "row",
-                "justifyContent": "flex-start",
-                "marginBottom": 0,
-                "marginHorizontal": 8,
-                "marginTop": 16,
+                "margin": 8,
               }
             }
           >
-            <View
-              style={
+            <Image
+              accessibilityIgnoresInvertColors={true}
+              source={
                 Object {
-                  "margin": 8,
+                  "uri": "https://callstack.com/images/team/Satya.png",
                 }
               }
-            >
-              <Image
-                accessibilityIgnoresInvertColors={true}
-                source={
-                  Object {
-                    "uri": "https://callstack.com/images/team/Satya.png",
-                  }
-                }
-                style={
-                  Object {
-                    "height": 40,
-                    "width": 40,
-                  }
-                }
-              />
-            </View>
-            <Text
-              accessibilityLiveRegion="polite"
-              accessibilityRole="alert"
               style={
+                Object {
+                  "height": 40,
+                  "width": 40,
+                }
+              }
+            />
+          </View>
+          <Text
+            accessibilityLiveRegion="polite"
+            accessibilityRole="alert"
+            style={
+              Array [
+                Object {
+                  "textAlign": "left",
+                },
+                Object {
+                  "color": "rgba(28, 27, 31, 1)",
+                  "fontFamily": "System",
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
                 Array [
                   Object {
-                    "textAlign": "left",
+                    "flex": 1,
+                    "margin": 8,
                   },
                   Object {
                     "color": "rgba(28, 27, 31, 1)",
-                    "fontFamily": "System",
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
                   },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Array [
-                    Object {
-                      "flex": 1,
-                      "margin": 8,
-                    },
-                    Object {
-                      "color": "rgba(28, 27, 31, 1)",
-                    },
-                  ],
-                ]
-              }
-            >
-              Two line text string with two actions. One to two lines is preferable on mobile.
-            </Text>
-          </View>
-          <View
-            style={
-              Object {
-                "flexDirection": "row",
-                "justifyContent": "flex-end",
-                "margin": 4,
-              }
+                ],
+              ]
             }
-          />
+          >
+            Two line text string with two actions. One to two lines is preferable on mobile.
+          </Text>
         </View>
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+              "justifyContent": "flex-end",
+              "margin": 4,
+            }
+          }
+        />
       </View>
     </View>
   </View>
@@ -1424,6 +1334,7 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(247, 243, 249)",
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -1434,97 +1345,86 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
         "shadowRadius": 1,
       }
     }
-    testID="surface-middle-layer"
+    testID="surface"
   >
     <View
-      collapsable={false}
       style={
-        Object {
-          "backgroundColor": "rgb(247, 243, 249)",
-          "flex": undefined,
-        }
+        Array [
+          Object {
+            "alignSelf": "center",
+            "maxWidth": 960,
+            "overflow": "hidden",
+            "width": "100%",
+          },
+          undefined,
+        ]
       }
-      testID="surface"
     >
       <View
+        collapsable={false}
         style={
-          Array [
-            Object {
-              "alignSelf": "center",
-              "maxWidth": 960,
-              "overflow": "hidden",
-              "width": "100%",
-            },
-            undefined,
-          ]
+          Object {
+            "height": 0,
+          }
         }
+      />
+      <View
+        collapsable={false}
+        onLayout={[Function]}
+        style={Object {}}
       >
         <View
-          collapsable={false}
           style={
             Object {
-              "height": 0,
+              "flexDirection": "row",
+              "justifyContent": "flex-start",
+              "marginBottom": 0,
+              "marginHorizontal": 8,
+              "marginTop": 16,
             }
           }
-        />
-        <View
-          collapsable={false}
-          onLayout={[Function]}
-          style={Object {}}
         >
-          <View
+          <Text
+            accessibilityLiveRegion="polite"
+            accessibilityRole="alert"
             style={
-              Object {
-                "flexDirection": "row",
-                "justifyContent": "flex-start",
-                "marginBottom": 0,
-                "marginHorizontal": 8,
-                "marginTop": 16,
-              }
-            }
-          >
-            <Text
-              accessibilityLiveRegion="polite"
-              accessibilityRole="alert"
-              style={
+              Array [
+                Object {
+                  "textAlign": "left",
+                },
+                Object {
+                  "color": "rgba(28, 27, 31, 1)",
+                  "fontFamily": "System",
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
                 Array [
                   Object {
-                    "textAlign": "left",
+                    "flex": 1,
+                    "margin": 8,
                   },
                   Object {
                     "color": "rgba(28, 27, 31, 1)",
-                    "fontFamily": "System",
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
                   },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Array [
-                    Object {
-                      "flex": 1,
-                      "margin": 8,
-                    },
-                    Object {
-                      "color": "rgba(28, 27, 31, 1)",
-                    },
-                  ],
-                ]
-              }
-            >
-              Two line text string with two actions. One to two lines is preferable on mobile.
-            </Text>
-          </View>
-          <View
-            style={
-              Object {
-                "flexDirection": "row",
-                "justifyContent": "flex-end",
-                "margin": 4,
-              }
+                ],
+              ]
             }
-          />
+          >
+            Two line text string with two actions. One to two lines is preferable on mobile.
+          </Text>
         </View>
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+              "justifyContent": "flex-end",
+              "margin": 4,
+            }
+          }
+        />
       </View>
     </View>
   </View>

--- a/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`render visible banner, with custom theme 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(247, 243, 249)",
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -129,6 +130,8 @@ exports[`render visible banner, with custom theme 1`] = `
             style={
               Object {
                 "alignSelf": undefined,
+                "backgroundColor": "transparent",
+                "borderRadius": 20,
                 "bottom": undefined,
                 "end": undefined,
                 "flex": undefined,
@@ -285,6 +288,7 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(247, 243, 249)",
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -427,6 +431,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(247, 243, 249)",
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -572,6 +577,8 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
             style={
               Object {
                 "alignSelf": undefined,
+                "backgroundColor": "transparent",
+                "borderRadius": 20,
                 "bottom": undefined,
                 "end": undefined,
                 "flex": undefined,
@@ -728,6 +735,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(247, 243, 249)",
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -851,6 +859,8 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
             style={
               Object {
                 "alignSelf": undefined,
+                "backgroundColor": "transparent",
+                "borderRadius": 20,
                 "bottom": undefined,
                 "end": undefined,
                 "flex": undefined,
@@ -999,6 +1009,8 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
             style={
               Object {
                 "alignSelf": undefined,
+                "backgroundColor": "transparent",
+                "borderRadius": 20,
                 "bottom": undefined,
                 "end": undefined,
                 "flex": undefined,
@@ -1155,6 +1167,7 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(247, 243, 249)",
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -1307,6 +1320,7 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(247, 243, 249)",
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
@@ -78,7 +78,9 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": 0,
+        "opacity": undefined,
         "position": undefined,
         "right": 0,
         "shadowColor": "#000",
@@ -90,6 +92,8 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
         "shadowRadius": 0,
         "start": undefined,
         "top": undefined,
+        "transform": undefined,
+        "width": undefined,
       }
     }
     testID="bottom-navigation-bar-outer-layer"
@@ -108,7 +112,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
           "shadowRadius": 0,
         }
       }
-      testID="bottom-navigation-bar-inner-layer"
+      testID="bottom-navigation-bar-middle-layer"
     >
       <View
         collapsable={false}
@@ -831,7 +835,9 @@ exports[`hides labels in shifting bottom navigation 1`] = `
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": 0,
+        "opacity": undefined,
         "position": undefined,
         "right": 0,
         "shadowColor": "#000",
@@ -843,6 +849,8 @@ exports[`hides labels in shifting bottom navigation 1`] = `
         "shadowRadius": 0,
         "start": undefined,
         "top": undefined,
+        "transform": undefined,
+        "width": undefined,
       }
     }
     testID="bottom-navigation-bar-outer-layer"
@@ -861,7 +869,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
           "shadowRadius": 0,
         }
       }
-      testID="bottom-navigation-bar-inner-layer"
+      testID="bottom-navigation-bar-middle-layer"
     >
       <View
         collapsable={false}
@@ -1716,7 +1724,9 @@ exports[`renders bottom navigation with getLazy 1`] = `
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": 0,
+        "opacity": undefined,
         "position": undefined,
         "right": 0,
         "shadowColor": "#000",
@@ -1728,6 +1738,8 @@ exports[`renders bottom navigation with getLazy 1`] = `
         "shadowRadius": 0,
         "start": undefined,
         "top": undefined,
+        "transform": undefined,
+        "width": undefined,
       }
     }
     testID="bottom-navigation-bar-outer-layer"
@@ -1746,7 +1758,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
           "shadowRadius": 0,
         }
       }
-      testID="bottom-navigation-bar-inner-layer"
+      testID="bottom-navigation-bar-middle-layer"
     >
       <View
         collapsable={false}
@@ -3430,7 +3442,9 @@ exports[`renders bottom navigation with scene animation 1`] = `
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": 0,
+        "opacity": undefined,
         "position": undefined,
         "right": 0,
         "shadowColor": "#000",
@@ -3442,6 +3456,8 @@ exports[`renders bottom navigation with scene animation 1`] = `
         "shadowRadius": 0,
         "start": undefined,
         "top": undefined,
+        "transform": undefined,
+        "width": undefined,
       }
     }
     testID="bottom-navigation-bar-outer-layer"
@@ -3460,7 +3476,7 @@ exports[`renders bottom navigation with scene animation 1`] = `
           "shadowRadius": 0,
         }
       }
-      testID="bottom-navigation-bar-inner-layer"
+      testID="bottom-navigation-bar-middle-layer"
     >
       <View
         collapsable={false}
@@ -4904,7 +4920,9 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": 0,
+        "opacity": undefined,
         "position": undefined,
         "right": 0,
         "shadowColor": "#000",
@@ -4916,6 +4934,8 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
         "shadowRadius": 0,
         "start": undefined,
         "top": undefined,
+        "transform": undefined,
+        "width": undefined,
       }
     }
     testID="bottom-navigation-bar-outer-layer"
@@ -4934,7 +4954,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
           "shadowRadius": 0,
         }
       }
-      testID="bottom-navigation-bar-inner-layer"
+      testID="bottom-navigation-bar-middle-layer"
     >
       <View
         collapsable={false}
@@ -5597,7 +5617,9 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": 0,
+        "opacity": undefined,
         "position": undefined,
         "right": 0,
         "shadowColor": "#000",
@@ -5609,6 +5631,8 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
         "shadowRadius": 0,
         "start": undefined,
         "top": undefined,
+        "transform": undefined,
+        "width": undefined,
       }
     }
     testID="bottom-navigation-bar-outer-layer"
@@ -5627,7 +5651,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
           "shadowRadius": 0,
         }
       }
-      testID="bottom-navigation-bar-inner-layer"
+      testID="bottom-navigation-bar-middle-layer"
     >
       <View
         collapsable={false}
@@ -6571,7 +6595,9 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": 0,
+        "opacity": undefined,
         "position": undefined,
         "right": 0,
         "shadowColor": "#000",
@@ -6583,6 +6609,8 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
         "shadowRadius": 0,
         "start": undefined,
         "top": undefined,
+        "transform": undefined,
+        "width": undefined,
       }
     }
     testID="bottom-navigation-bar-outer-layer"
@@ -6601,7 +6629,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
           "shadowRadius": 0,
         }
       }
-      testID="bottom-navigation-bar-inner-layer"
+      testID="bottom-navigation-bar-middle-layer"
     >
       <View
         collapsable={false}
@@ -7669,7 +7697,9 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": 0,
+        "opacity": undefined,
         "position": undefined,
         "right": 0,
         "shadowColor": "#000",
@@ -7681,6 +7711,8 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
         "shadowRadius": 0,
         "start": undefined,
         "top": undefined,
+        "transform": undefined,
+        "width": undefined,
       }
     }
     testID="bottom-navigation-bar-outer-layer"
@@ -7699,7 +7731,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
           "shadowRadius": 0,
         }
       }
-      testID="bottom-navigation-bar-inner-layer"
+      testID="bottom-navigation-bar-middle-layer"
     >
       <View
         collapsable={false}
@@ -8623,7 +8655,9 @@ exports[`renders non-shifting bottom navigation 1`] = `
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": 0,
+        "opacity": undefined,
         "position": undefined,
         "right": 0,
         "shadowColor": "#000",
@@ -8635,6 +8669,8 @@ exports[`renders non-shifting bottom navigation 1`] = `
         "shadowRadius": 0,
         "start": undefined,
         "top": undefined,
+        "transform": undefined,
+        "width": undefined,
       }
     }
     testID="bottom-navigation-bar-outer-layer"
@@ -8653,7 +8689,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
           "shadowRadius": 0,
         }
       }
-      testID="bottom-navigation-bar-inner-layer"
+      testID="bottom-navigation-bar-middle-layer"
     >
       <View
         collapsable={false}
@@ -9721,7 +9757,9 @@ exports[`renders shifting bottom navigation 1`] = `
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": 0,
+        "opacity": undefined,
         "position": undefined,
         "right": 0,
         "shadowColor": "#000",
@@ -9733,6 +9771,8 @@ exports[`renders shifting bottom navigation 1`] = `
         "shadowRadius": 0,
         "start": undefined,
         "top": undefined,
+        "transform": undefined,
+        "width": undefined,
       }
     }
     testID="bottom-navigation-bar-outer-layer"
@@ -9751,7 +9791,7 @@ exports[`renders shifting bottom navigation 1`] = `
           "shadowRadius": 0,
         }
       }
-      testID="bottom-navigation-bar-inner-layer"
+      testID="bottom-navigation-bar-middle-layer"
     >
       <View
         collapsable={false}

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
@@ -100,8 +100,11 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
   >
     <View
       collapsable={false}
+      onLayout={[Function]}
+      pointerEvents="none"
       style={
         Object {
+          "backgroundColor": "transparent",
           "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
@@ -112,82 +115,84 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
           "shadowRadius": 0,
         }
       }
-      testID="bottom-navigation-bar-middle-layer"
+      testID="bottom-navigation-bar"
     >
       <View
         collapsable={false}
-        onLayout={[Function]}
-        pointerEvents="none"
         style={
           Object {
-            "backgroundColor": "transparent",
-            "flex": undefined,
+            "alignItems": "center",
+            "backgroundColor": "rgb(243, 237, 246)",
+            "overflow": "hidden",
           }
         }
-        testID="bottom-navigation-bar"
+        testID="bottom-navigation-bar-content"
       >
         <View
-          collapsable={false}
+          accessibilityRole="tablist"
           style={
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "rgb(243, 237, 246)",
-              "overflow": "hidden",
-            }
+            Array [
+              Object {
+                "flexDirection": "row",
+              },
+              Object {
+                "marginBottom": 0,
+                "marginHorizontal": 0,
+              },
+              false,
+            ]
           }
-          testID="bottom-navigation-bar-content"
+          testID="bottom-navigation-bar-content-wrapper"
         >
           <View
-            accessibilityRole="tablist"
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": true,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
+                  "flex": 1,
+                  "paddingVertical": 6,
                 },
                 Object {
-                  "marginBottom": 0,
-                  "marginHorizontal": 0,
+                  "paddingVertical": 0,
                 },
-                false,
               ]
             }
-            testID="bottom-navigation-bar-content-wrapper"
           >
             <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": true,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "alignItems": "center",
+                  "height": 80,
+                  "justifyContent": "center",
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "alignItems": "center",
-                    "height": 80,
+                    "alignSelf": "center",
+                    "height": 32,
                     "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "width": 32,
                   }
                 }
               >
@@ -196,208 +201,208 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                   style={
                     Object {
                       "alignSelf": "center",
+                      "backgroundColor": "rgba(232, 222, 248, 1)",
+                      "borderRadius": 16,
                       "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "width": 32,
+                      "transform": Array [
+                        Object {
+                          "scaleX": 1,
+                        },
+                      ],
+                      "width": 64,
+                    }
+                  }
+                />
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
-                      Object {
-                        "alignSelf": "center",
-                        "backgroundColor": "rgba(232, 222, 248, 1)",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "transform": Array [
+                      Array [
+                        Object {
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
                           Object {
-                            "scaleX": 1,
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
                           },
                         ],
-                        "width": 64,
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰍉
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰍉
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
                     }
                   />
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰍉
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰍉
-                    </Text>
-                  </View>
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "left": 0,
-                          "position": "absolute",
-                        },
-                        Object {
-                          "right": 0,
-                          "top": 2,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
                 </View>
               </View>
             </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
               }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "alignItems": "center",
+                  "height": 80,
+                  "justifyContent": "center",
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "alignItems": "center",
-                    "height": 80,
+                    "alignSelf": "center",
+                    "height": 32,
                     "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "width": 32,
                   }
                 }
               >
@@ -405,192 +410,192 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "width": 32,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰄀
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰄀
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
                         },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
                         Object {
-                          "right": 0,
-                          "top": 2,
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
                         },
+                        Object {},
                       ]
                     }
                   >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
+                    󰄀
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
                         Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰄀
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
-                    />
-                  </View>
+                    }
+                  />
                 </View>
               </View>
             </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
               }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "alignItems": "center",
+                  "height": 80,
+                  "justifyContent": "center",
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "alignItems": "center",
-                    "height": 80,
+                    "alignSelf": "center",
+                    "height": 32,
                     "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "width": 32,
                   }
                 }
               >
@@ -598,154 +603,139 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "width": 32,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰚇
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰚇
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
                         },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
                         Object {
-                          "right": 0,
-                          "top": 2,
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
                         },
+                        Object {},
                       ]
                     }
                   >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
+                    󰚇
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
                         Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰚇
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
-                    />
-                  </View>
+                    }
+                  />
                 </View>
               </View>
             </View>
@@ -857,8 +847,11 @@ exports[`hides labels in shifting bottom navigation 1`] = `
   >
     <View
       collapsable={false}
+      onLayout={[Function]}
+      pointerEvents="none"
       style={
         Object {
+          "backgroundColor": "transparent",
           "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
@@ -869,82 +862,84 @@ exports[`hides labels in shifting bottom navigation 1`] = `
           "shadowRadius": 0,
         }
       }
-      testID="bottom-navigation-bar-middle-layer"
+      testID="bottom-navigation-bar"
     >
       <View
         collapsable={false}
-        onLayout={[Function]}
-        pointerEvents="none"
         style={
           Object {
-            "backgroundColor": "transparent",
-            "flex": undefined,
+            "alignItems": "center",
+            "backgroundColor": "rgb(243, 237, 246)",
+            "overflow": "hidden",
           }
         }
-        testID="bottom-navigation-bar"
+        testID="bottom-navigation-bar-content"
       >
         <View
-          collapsable={false}
+          accessibilityRole="tablist"
           style={
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "rgb(243, 237, 246)",
-              "overflow": "hidden",
-            }
+            Array [
+              Object {
+                "flexDirection": "row",
+              },
+              Object {
+                "marginBottom": 0,
+                "marginHorizontal": 0,
+              },
+              false,
+            ]
           }
-          testID="bottom-navigation-bar-content"
+          testID="bottom-navigation-bar-content-wrapper"
         >
           <View
-            accessibilityRole="tablist"
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": true,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
+                  "flex": 1,
+                  "paddingVertical": 6,
                 },
                 Object {
-                  "marginBottom": 0,
-                  "marginHorizontal": 0,
+                  "paddingVertical": 0,
                 },
-                false,
               ]
             }
-            testID="bottom-navigation-bar-content-wrapper"
           >
             <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": true,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "alignItems": "center",
+                  "height": 80,
+                  "justifyContent": "center",
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "alignItems": "center",
-                    "height": 80,
+                    "alignSelf": "center",
+                    "height": 32,
                     "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "width": 32,
                   }
                 }
               >
@@ -953,208 +948,208 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                   style={
                     Object {
                       "alignSelf": "center",
+                      "backgroundColor": "rgba(232, 222, 248, 1)",
+                      "borderRadius": 16,
                       "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "width": 32,
+                      "transform": Array [
+                        Object {
+                          "scaleX": 1,
+                        },
+                      ],
+                      "width": 64,
+                    }
+                  }
+                />
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
-                      Object {
-                        "alignSelf": "center",
-                        "backgroundColor": "rgba(232, 222, 248, 1)",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "transform": Array [
+                      Array [
+                        Object {
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
                           Object {
-                            "scaleX": 1,
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
                           },
                         ],
-                        "width": 64,
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰍉
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰍉
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
                     }
                   />
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰍉
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰍉
-                    </Text>
-                  </View>
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "left": 0,
-                          "position": "absolute",
-                        },
-                        Object {
-                          "right": 0,
-                          "top": 2,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
                 </View>
               </View>
             </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
               }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "alignItems": "center",
+                  "height": 80,
+                  "justifyContent": "center",
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "alignItems": "center",
-                    "height": 80,
+                    "alignSelf": "center",
+                    "height": 32,
                     "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "width": 32,
                   }
                 }
               >
@@ -1162,192 +1157,192 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "width": 32,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰄀
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰄀
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
                         },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
                         Object {
-                          "right": 0,
-                          "top": 2,
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
                         },
+                        Object {},
                       ]
                     }
                   >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
+                    󰄀
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
                         Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰄀
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
-                    />
-                  </View>
+                    }
+                  />
                 </View>
               </View>
             </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
               }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "alignItems": "center",
+                  "height": 80,
+                  "justifyContent": "center",
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "alignItems": "center",
-                    "height": 80,
+                    "alignSelf": "center",
+                    "height": 32,
                     "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "width": 32,
                   }
                 }
               >
@@ -1355,154 +1350,139 @@ exports[`hides labels in shifting bottom navigation 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "width": 32,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰚇
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰚇
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
                         },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
                         Object {
-                          "right": 0,
-                          "top": 2,
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
                         },
+                        Object {},
                       ]
                     }
                   >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
+                    󰚇
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
                         Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰚇
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
-                    />
-                  </View>
+                    }
+                  />
                 </View>
               </View>
             </View>
@@ -1746,8 +1726,11 @@ exports[`renders bottom navigation with getLazy 1`] = `
   >
     <View
       collapsable={false}
+      onLayout={[Function]}
+      pointerEvents="none"
       style={
         Object {
+          "backgroundColor": "transparent",
           "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
@@ -1758,81 +1741,83 @@ exports[`renders bottom navigation with getLazy 1`] = `
           "shadowRadius": 0,
         }
       }
-      testID="bottom-navigation-bar-middle-layer"
+      testID="bottom-navigation-bar"
     >
       <View
         collapsable={false}
-        onLayout={[Function]}
-        pointerEvents="none"
         style={
           Object {
-            "backgroundColor": "transparent",
-            "flex": undefined,
+            "alignItems": "center",
+            "backgroundColor": "rgb(243, 237, 246)",
+            "overflow": "hidden",
           }
         }
-        testID="bottom-navigation-bar"
+        testID="bottom-navigation-bar-content"
       >
         <View
-          collapsable={false}
+          accessibilityRole="tablist"
           style={
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "rgb(243, 237, 246)",
-              "overflow": "hidden",
-            }
+            Array [
+              Object {
+                "flexDirection": "row",
+              },
+              Object {
+                "marginBottom": 0,
+                "marginHorizontal": 0,
+              },
+              false,
+            ]
           }
-          testID="bottom-navigation-bar-content"
+          testID="bottom-navigation-bar-content-wrapper"
         >
           <View
-            accessibilityRole="tablist"
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": true,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
+                  "flex": 1,
+                  "paddingVertical": 6,
                 },
                 Object {
-                  "marginBottom": 0,
-                  "marginHorizontal": 0,
+                  "paddingVertical": 0,
                 },
-                false,
               ]
             }
-            testID="bottom-navigation-bar-content-wrapper"
           >
             <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": true,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "width": 32,
                   }
                 }
               >
@@ -1841,323 +1826,163 @@ exports[`renders bottom navigation with getLazy 1`] = `
                   style={
                     Object {
                       "alignSelf": "center",
+                      "backgroundColor": "rgba(232, 222, 248, 1)",
+                      "borderRadius": 16,
                       "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "width": 32,
+                      "transform": Array [
+                        Object {
+                          "scaleX": 1,
+                        },
+                      ],
+                      "width": 64,
+                    }
+                  }
+                />
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
-                      Object {
-                        "alignSelf": "center",
-                        "backgroundColor": "rgba(232, 222, 248, 1)",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "transform": Array [
+                      Array [
+                        Object {
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
                           Object {
-                            "scaleX": 1,
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
                           },
                         ],
-                        "width": 64,
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰍉
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰍉
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
                     }
                   />
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰍉
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰍉
-                    </Text>
-                  </View>
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "left": 0,
-                          "position": "absolute",
-                        },
-                        Object {
-                          "right": 0,
-                          "top": 2,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
-                </View>
-                <View
-                  collapsable={false}
-                  style={
-                    Object {
-                      "height": 16,
-                      "paddingBottom": 2,
-                    }
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
-                        Array [
-                          Object {
-                            "fontFamily": "System",
-                            "fontSize": 12,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.5,
-                            "lineHeight": 16,
-                          },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(28, 27, 31, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 0
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "fontFamily": "System",
-                            "fontSize": 12,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.5,
-                            "lineHeight": 16,
-                          },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(28, 27, 31, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 0
-                    </Text>
-                  </View>
                 </View>
               </View>
-            </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
-              }
-            >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "height": 16,
+                    "paddingBottom": 2,
                   }
                 }
               >
@@ -2165,307 +1990,159 @@ exports[`renders bottom navigation with getLazy 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "width": 32,
+                      "bottom": 0,
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰄀
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰄀
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    maxFontSizeMultiplier={1}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
                         },
                         Object {
-                          "right": 0,
-                          "top": 2,
+                          "textAlign": "left",
                         },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(28, 27, 31, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
                       ]
                     }
                   >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
+                    Route: 0
+                  </Text>
                 </View>
                 <View
                   collapsable={false}
                   style={
                     Object {
-                      "height": 16,
-                      "paddingBottom": 2,
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    selectable={false}
                     style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
                         Array [
                           Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
                             "letterSpacing": 0.5,
                             "lineHeight": 16,
                           },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(73, 69, 79, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 1
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
+                        ],
+                      ]
                     }
                   >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "fontFamily": "System",
-                            "fontSize": 12,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.5,
-                            "lineHeight": 16,
-                          },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(73, 69, 79, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 1
-                    </Text>
-                  </View>
+                    Route: 0
+                  </Text>
                 </View>
               </View>
             </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
               }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "width": 32,
                   }
                 }
               >
@@ -2473,307 +2150,147 @@ exports[`renders bottom navigation with getLazy 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "width": 32,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰚇
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰚇
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
                         },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
                         Object {
-                          "right": 0,
-                          "top": 2,
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
                         },
+                        Object {},
                       ]
                     }
                   >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
+                    󰄀
+                  </Text>
                 </View>
                 <View
                   collapsable={false}
                   style={
                     Object {
-                      "height": 16,
-                      "paddingBottom": 2,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
+                      Array [
+                        Object {
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
                         Array [
                           Object {
-                            "fontFamily": "System",
-                            "fontSize": 12,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.5,
-                            "lineHeight": 16,
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
                           },
                           Object {
-                            "textAlign": "left",
+                            "backgroundColor": "transparent",
                           },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(73, 69, 79, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 2
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
                     }
                   >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "fontFamily": "System",
-                            "fontSize": 12,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.5,
-                            "lineHeight": 16,
-                          },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(73, 69, 79, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
+                    󰄀
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
-                    >
-                      Route: 2
-                    </Text>
-                  </View>
+                    }
+                  />
                 </View>
               </View>
-            </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
-              }
-            >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "height": 16,
+                    "paddingBottom": 2,
                   }
                 }
               >
@@ -2781,307 +2298,159 @@ exports[`renders bottom navigation with getLazy 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "width": 32,
+                      "bottom": 0,
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰋑
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰋑
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    maxFontSizeMultiplier={1}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
                         },
                         Object {
-                          "right": 0,
-                          "top": 2,
+                          "textAlign": "left",
                         },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
                       ]
                     }
                   >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
+                    Route: 1
+                  </Text>
                 </View>
                 <View
                   collapsable={false}
                   style={
                     Object {
-                      "height": 16,
-                      "paddingBottom": 2,
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    selectable={false}
                     style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
                         Array [
                           Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(73, 69, 79, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
                             "letterSpacing": 0.5,
                             "lineHeight": 16,
                           },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(73, 69, 79, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 3
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
+                        ],
+                      ]
                     }
                   >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "fontFamily": "System",
-                            "fontSize": 12,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.5,
-                            "lineHeight": 16,
-                          },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(73, 69, 79, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 3
-                    </Text>
-                  </View>
+                    Route: 1
+                  </Text>
                 </View>
               </View>
             </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
               }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "width": 32,
                   }
                 }
               >
@@ -3089,270 +2458,871 @@ exports[`renders bottom navigation with getLazy 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "width": 32,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰒛
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰒛
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
                         },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
                         Object {
-                          "right": 0,
-                          "top": 2,
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
                         },
+                        Object {},
                       ]
                     }
                   >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
+                    󰚇
+                  </Text>
                 </View>
                 <View
                   collapsable={false}
                   style={
                     Object {
-                      "height": 16,
-                      "paddingBottom": 2,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
+                      Array [
+                        Object {
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
                         Array [
                           Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰚇
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "height": 16,
+                    "paddingBottom": 2,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(73, 69, 79, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
                             "letterSpacing": 0.5,
                             "lineHeight": 16,
                           },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(73, 69, 79, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 4
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
+                        ],
+                      ]
                     }
                   >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      selectable={false}
-                      style={
+                    Route: 2
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
                         Array [
                           Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(73, 69, 79, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
                             "letterSpacing": 0.5,
                             "lineHeight": 16,
                           },
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 2
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "width": 32,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
                           Object {
-                            "textAlign": "left",
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
                           },
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
+                            "backgroundColor": "transparent",
                           },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(73, 69, 79, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰋑
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰋑
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
-                    >
-                      Route: 4
-                    </Text>
-                  </View>
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "height": 16,
+                    "paddingBottom": 2,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 3
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 3
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "width": 32,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰒛
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰒛
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "height": 16,
+                    "paddingBottom": 2,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 4
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 4
+                  </Text>
                 </View>
               </View>
             </View>
@@ -3464,8 +3434,11 @@ exports[`renders bottom navigation with scene animation 1`] = `
   >
     <View
       collapsable={false}
+      onLayout={[Function]}
+      pointerEvents="none"
       style={
         Object {
+          "backgroundColor": "transparent",
           "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
@@ -3476,81 +3449,88 @@ exports[`renders bottom navigation with scene animation 1`] = `
           "shadowRadius": 0,
         }
       }
-      testID="bottom-navigation-bar-middle-layer"
+      testID="bottom-navigation-bar"
     >
       <View
         collapsable={false}
-        onLayout={[Function]}
-        pointerEvents="none"
         style={
           Object {
-            "backgroundColor": "transparent",
-            "flex": undefined,
+            "alignItems": "center",
+            "backgroundColor": "rgb(243, 237, 246)",
+            "overflow": "hidden",
           }
         }
-        testID="bottom-navigation-bar"
+        testID="bottom-navigation-bar-content"
       >
         <View
-          collapsable={false}
+          accessibilityRole="tablist"
           style={
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "rgb(243, 237, 246)",
-              "overflow": "hidden",
-            }
+            Array [
+              Object {
+                "flexDirection": "row",
+              },
+              Object {
+                "marginBottom": 0,
+                "marginHorizontal": 0,
+              },
+              false,
+            ]
           }
-          testID="bottom-navigation-bar-content"
+          testID="bottom-navigation-bar-content-wrapper"
         >
           <View
-            accessibilityRole="tablist"
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": true,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
+                  "flex": 1,
+                  "paddingVertical": 6,
                 },
                 Object {
-                  "marginBottom": 0,
-                  "marginHorizontal": 0,
+                  "paddingVertical": 0,
                 },
-                false,
               ]
             }
-            testID="bottom-navigation-bar-content-wrapper"
           >
             <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": true,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "transform": Array [
+                      Object {
+                        "translateY": 0,
+                      },
+                    ],
+                    "width": 32,
                   }
                 }
               >
@@ -3559,275 +3539,163 @@ exports[`renders bottom navigation with scene animation 1`] = `
                   style={
                     Object {
                       "alignSelf": "center",
+                      "backgroundColor": "rgba(232, 222, 248, 1)",
+                      "borderRadius": 16,
                       "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
                       "transform": Array [
                         Object {
-                          "translateY": 0,
+                          "scaleX": 1,
                         },
                       ],
-                      "width": 32,
+                      "width": 64,
+                    }
+                  }
+                />
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
-                      Object {
-                        "alignSelf": "center",
-                        "backgroundColor": "rgba(232, 222, 248, 1)",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "transform": Array [
+                      Array [
+                        Object {
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
                           Object {
-                            "scaleX": 1,
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
                           },
                         ],
-                        "width": 64,
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰍉
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰍉
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
                     }
                   />
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰍉
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰍉
-                    </Text>
-                  </View>
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "left": 0,
-                          "position": "absolute",
-                        },
-                        Object {
-                          "right": 0,
-                          "top": 2,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
-                </View>
-                <View
-                  collapsable={false}
-                  style={
-                    Object {
-                      "height": 16,
-                      "paddingBottom": 2,
-                    }
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
-                        Array [
-                          Object {
-                            "fontFamily": "System",
-                            "fontSize": 12,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.5,
-                            "lineHeight": 16,
-                          },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(28, 27, 31, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 0
-                    </Text>
-                  </View>
                 </View>
               </View>
-            </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
-              }
-            >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "height": 16,
+                    "paddingBottom": 2,
                   }
                 }
               >
@@ -3835,259 +3703,111 @@ exports[`renders bottom navigation with scene animation 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "transform": Array [
-                        Object {
-                          "translateY": 7,
-                        },
-                      ],
-                      "width": 32,
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰄀
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰄀
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    maxFontSizeMultiplier={1}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
-                        },
-                        Object {
-                          "right": 0,
-                          "top": 2,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
                           "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
-                </View>
-                <View
-                  collapsable={false}
-                  style={
-                    Object {
-                      "height": 16,
-                      "paddingBottom": 2,
-                    }
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
                         Array [
                           Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
                             "letterSpacing": 0.5,
                             "lineHeight": 16,
                           },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(73, 69, 79, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 1
-                    </Text>
-                  </View>
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 0
+                  </Text>
                 </View>
               </View>
             </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
               }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "transform": Array [
+                      Object {
+                        "translateY": 7,
+                      },
+                    ],
+                    "width": 32,
                   }
                 }
               >
@@ -4095,259 +3815,147 @@ exports[`renders bottom navigation with scene animation 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "transform": Array [
-                        Object {
-                          "translateY": 7,
-                        },
-                      ],
-                      "width": 32,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰚇
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰚇
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
                         },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
                         Object {
-                          "right": 0,
-                          "top": 2,
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
                         },
+                        Object {},
                       ]
                     }
                   >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
+                    󰄀
+                  </Text>
                 </View>
                 <View
                   collapsable={false}
                   style={
                     Object {
-                      "height": 16,
-                      "paddingBottom": 2,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
+                      Array [
+                        Object {
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
                         Array [
                           Object {
-                            "fontFamily": "System",
-                            "fontSize": 12,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.5,
-                            "lineHeight": 16,
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
                           },
                           Object {
-                            "textAlign": "left",
+                            "backgroundColor": "transparent",
                           },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(73, 69, 79, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰄀
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
-                    >
-                      Route: 2
-                    </Text>
-                  </View>
+                    }
+                  />
                 </View>
               </View>
-            </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
-              }
-            >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "height": 16,
+                    "paddingBottom": 2,
                   }
                 }
               >
@@ -4355,259 +3963,111 @@ exports[`renders bottom navigation with scene animation 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "transform": Array [
-                        Object {
-                          "translateY": 7,
-                        },
-                      ],
-                      "width": 32,
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰋑
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰋑
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    maxFontSizeMultiplier={1}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
-                        },
-                        Object {
-                          "right": 0,
-                          "top": 2,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
                           "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
-                </View>
-                <View
-                  collapsable={false}
-                  style={
-                    Object {
-                      "height": 16,
-                      "paddingBottom": 2,
-                    }
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
                         Array [
                           Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(73, 69, 79, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
                             "letterSpacing": 0.5,
                             "lineHeight": 16,
                           },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(73, 69, 79, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 3
-                    </Text>
-                  </View>
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 1
+                  </Text>
                 </View>
               </View>
             </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
               }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "transform": Array [
+                      Object {
+                        "translateY": 7,
+                      },
+                    ],
+                    "width": 32,
                   }
                 }
               >
@@ -4615,222 +4075,722 @@ exports[`renders bottom navigation with scene animation 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "transform": Array [
-                        Object {
-                          "translateY": 7,
-                        },
-                      ],
-                      "width": 32,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰒛
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰒛
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
                         },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
                         Object {
-                          "right": 0,
-                          "top": 2,
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
                         },
+                        Object {},
                       ]
                     }
                   >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
+                    󰚇
+                  </Text>
                 </View>
                 <View
                   collapsable={false}
                   style={
                     Object {
-                      "height": 16,
-                      "paddingBottom": 2,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
+                      Array [
+                        Object {
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
                         Array [
                           Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰚇
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "height": 16,
+                    "paddingBottom": 2,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(73, 69, 79, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
                             "letterSpacing": 0.5,
                             "lineHeight": 16,
                           },
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 2
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "transform": Array [
+                      Object {
+                        "translateY": 7,
+                      },
+                    ],
+                    "width": 32,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
                           Object {
-                            "textAlign": "left",
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
                           },
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
+                            "backgroundColor": "transparent",
                           },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(73, 69, 79, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰋑
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰋑
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
-                    >
-                      Route: 4
-                    </Text>
-                  </View>
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "height": 16,
+                    "paddingBottom": 2,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 3
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "transform": Array [
+                      Object {
+                        "translateY": 7,
+                      },
+                    ],
+                    "width": 32,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰒛
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰒛
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "height": 16,
+                    "paddingBottom": 2,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 4
+                  </Text>
                 </View>
               </View>
             </View>
@@ -4942,8 +4902,11 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
   >
     <View
       collapsable={false}
+      onLayout={[Function]}
+      pointerEvents="none"
       style={
         Object {
+          "backgroundColor": "transparent",
           "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
@@ -4954,81 +4917,83 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
           "shadowRadius": 0,
         }
       }
-      testID="bottom-navigation-bar-middle-layer"
+      testID="bottom-navigation-bar"
     >
       <View
         collapsable={false}
-        onLayout={[Function]}
-        pointerEvents="none"
         style={
           Object {
-            "backgroundColor": "transparent",
-            "flex": undefined,
+            "alignItems": "center",
+            "backgroundColor": "rgb(243, 237, 246)",
+            "overflow": "hidden",
           }
         }
-        testID="bottom-navigation-bar"
+        testID="bottom-navigation-bar-content"
       >
         <View
-          collapsable={false}
+          accessibilityRole="tablist"
           style={
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "rgb(243, 237, 246)",
-              "overflow": "hidden",
-            }
+            Array [
+              Object {
+                "flexDirection": "row",
+              },
+              Object {
+                "marginBottom": 0,
+                "marginHorizontal": 0,
+              },
+              false,
+            ]
           }
-          testID="bottom-navigation-bar-content"
+          testID="bottom-navigation-bar-content-wrapper"
         >
           <View
-            accessibilityRole="tablist"
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": true,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
+                  "flex": 1,
+                  "paddingVertical": 6,
                 },
                 Object {
-                  "marginBottom": 0,
-                  "marginHorizontal": 0,
+                  "paddingVertical": 0,
                 },
-                false,
               ]
             }
-            testID="bottom-navigation-bar-content-wrapper"
           >
             <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": true,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "width": 32,
                   }
                 }
               >
@@ -5037,188 +5002,97 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
                   style={
                     Object {
                       "alignSelf": "center",
+                      "backgroundColor": "rgba(232, 222, 248, 1)",
+                      "borderRadius": 16,
                       "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "width": 32,
+                      "transform": Array [
+                        Object {
+                          "scaleX": 1,
+                        },
+                      ],
+                      "width": 64,
+                    }
+                  }
+                />
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
+                  <icon
+                    color="rgba(29, 25, 43, 1)"
+                  />
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <icon
+                    color="rgba(73, 69, 79, 1)"
+                  />
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
                     collapsable={false}
+                    numberOfLines={1}
                     style={
                       Object {
-                        "alignSelf": "center",
-                        "backgroundColor": "rgba(232, 222, 248, 1)",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "transform": Array [
-                          Object {
-                            "scaleX": 1,
-                          },
-                        ],
-                        "width": 64,
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
                     }
                   />
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <icon
-                      color="rgba(29, 25, 43, 1)"
-                    />
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <icon
-                      color="rgba(73, 69, 79, 1)"
-                    />
-                  </View>
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "left": 0,
-                          "position": "absolute",
-                        },
-                        Object {
-                          "right": 0,
-                          "top": 2,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
-                </View>
-                <View
-                  collapsable={false}
-                  style={
-                    Object {
-                      "height": 16,
-                      "paddingBottom": 2,
-                    }
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <text
-                      color="rgba(28, 27, 31, 1)"
-                    >
-                      Route: 0
-                    </text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <text
-                      color="rgba(28, 27, 31, 1)"
-                    >
-                      Route: 0
-                    </text>
-                  </View>
                 </View>
               </View>
-            </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
-              }
-            >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "height": 16,
+                    "paddingBottom": 2,
                   }
                 }
               >
@@ -5226,172 +5100,90 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "width": 32,
+                      "bottom": 0,
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
+                  <text
+                    color="rgba(28, 27, 31, 1)"
                   >
-                    <icon
-                      color="rgba(29, 25, 43, 1)"
-                    />
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <icon
-                      color="rgba(73, 69, 79, 1)"
-                    />
-                  </View>
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "left": 0,
-                          "position": "absolute",
-                        },
-                        Object {
-                          "right": 0,
-                          "top": 2,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
+                    Route: 0
+                  </text>
                 </View>
                 <View
                   collapsable={false}
                   style={
                     Object {
-                      "height": 16,
-                      "paddingBottom": 2,
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
+                  <text
+                    color="rgba(28, 27, 31, 1)"
                   >
-                    <text
-                      color="rgba(73, 69, 79, 1)"
-                    >
-                      Route: 1
-                    </text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <text
-                      color="rgba(73, 69, 79, 1)"
-                    >
-                      Route: 1
-                    </text>
-                  </View>
+                    Route: 0
+                  </text>
                 </View>
               </View>
             </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
               }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "width": 32,
                   }
                 }
               >
@@ -5399,135 +5191,293 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "width": 32,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <icon
-                      color="rgba(29, 25, 43, 1)"
-                    />
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <icon
-                      color="rgba(73, 69, 79, 1)"
-                    />
-                  </View>
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "left": 0,
-                          "position": "absolute",
-                        },
-                        Object {
-                          "right": 0,
-                          "top": 2,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
+                  <icon
+                    color="rgba(29, 25, 43, 1)"
+                  />
                 </View>
                 <View
                   collapsable={false}
                   style={
                     Object {
-                      "height": 16,
-                      "paddingBottom": 2,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
+                  <icon
+                    color="rgba(73, 69, 79, 1)"
+                  />
+                </View>
+                <View
+                  style={
+                    Array [
                       Object {
-                        "bottom": 0,
                         "left": 0,
                         "position": "absolute",
+                      },
+                      Object {
                         "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <text
-                      color="rgba(73, 69, 79, 1)"
-                    >
-                      Route: 2
-                    </text>
-                  </View>
-                  <View
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
                     collapsable={false}
+                    numberOfLines={1}
                     style={
                       Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
                     }
+                  />
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "height": 16,
+                    "paddingBottom": 2,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <text
+                    color="rgba(73, 69, 79, 1)"
                   >
-                    <text
-                      color="rgba(73, 69, 79, 1)"
-                    >
-                      Route: 2
-                    </text>
-                  </View>
+                    Route: 1
+                  </text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <text
+                    color="rgba(73, 69, 79, 1)"
+                  >
+                    Route: 1
+                  </text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "width": 32,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <icon
+                    color="rgba(29, 25, 43, 1)"
+                  />
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <icon
+                    color="rgba(73, 69, 79, 1)"
+                  />
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "height": 16,
+                    "paddingBottom": 2,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <text
+                    color="rgba(73, 69, 79, 1)"
+                  >
+                    Route: 2
+                  </text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <text
+                    color="rgba(73, 69, 79, 1)"
+                  >
+                    Route: 2
+                  </text>
                 </View>
               </View>
             </View>
@@ -5639,8 +5589,11 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
   >
     <View
       collapsable={false}
+      onLayout={[Function]}
+      pointerEvents="none"
       style={
         Object {
+          "backgroundColor": "transparent",
           "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
@@ -5651,81 +5604,88 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
           "shadowRadius": 0,
         }
       }
-      testID="bottom-navigation-bar-middle-layer"
+      testID="bottom-navigation-bar"
     >
       <View
         collapsable={false}
-        onLayout={[Function]}
-        pointerEvents="none"
         style={
           Object {
-            "backgroundColor": "transparent",
-            "flex": undefined,
+            "alignItems": "center",
+            "backgroundColor": "rgb(243, 237, 246)",
+            "overflow": "hidden",
           }
         }
-        testID="bottom-navigation-bar"
+        testID="bottom-navigation-bar-content"
       >
         <View
-          collapsable={false}
+          accessibilityRole="tablist"
           style={
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "rgb(243, 237, 246)",
-              "overflow": "hidden",
-            }
+            Array [
+              Object {
+                "flexDirection": "row",
+              },
+              Object {
+                "marginBottom": 0,
+                "marginHorizontal": 0,
+              },
+              false,
+            ]
           }
-          testID="bottom-navigation-bar-content"
+          testID="bottom-navigation-bar-content-wrapper"
         >
           <View
-            accessibilityRole="tablist"
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": true,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
+                  "flex": 1,
+                  "paddingVertical": 6,
                 },
                 Object {
-                  "marginBottom": 0,
-                  "marginHorizontal": 0,
+                  "paddingVertical": 0,
                 },
-                false,
               ]
             }
-            testID="bottom-navigation-bar-content-wrapper"
           >
             <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": true,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "transform": Array [
+                      Object {
+                        "translateY": 0,
+                      },
+                    ],
+                    "width": 32,
                   }
                 }
               >
@@ -5734,175 +5694,97 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
                   style={
                     Object {
                       "alignSelf": "center",
+                      "backgroundColor": "rgba(232, 222, 248, 1)",
+                      "borderRadius": 16,
                       "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
                       "transform": Array [
                         Object {
-                          "translateY": 0,
+                          "scaleX": 1,
                         },
                       ],
-                      "width": 32,
+                      "width": 64,
+                    }
+                  }
+                />
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
+                  <icon
+                    color="rgba(29, 25, 43, 1)"
+                  />
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <icon
+                    color="rgba(73, 69, 79, 1)"
+                  />
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
                     collapsable={false}
+                    numberOfLines={1}
                     style={
                       Object {
-                        "alignSelf": "center",
-                        "backgroundColor": "rgba(232, 222, 248, 1)",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "transform": Array [
-                          Object {
-                            "scaleX": 1,
-                          },
-                        ],
-                        "width": 64,
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
                     }
                   />
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <icon
-                      color="rgba(29, 25, 43, 1)"
-                    />
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <icon
-                      color="rgba(73, 69, 79, 1)"
-                    />
-                  </View>
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "left": 0,
-                          "position": "absolute",
-                        },
-                        Object {
-                          "right": 0,
-                          "top": 2,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
-                </View>
-                <View
-                  collapsable={false}
-                  style={
-                    Object {
-                      "height": 16,
-                      "paddingBottom": 2,
-                    }
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <text
-                      color="rgba(28, 27, 31, 1)"
-                    >
-                      Route: 0
-                    </text>
-                  </View>
                 </View>
               </View>
-            </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
-              }
-            >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "height": 16,
+                    "paddingBottom": 2,
                   }
                 }
               >
@@ -5910,159 +5792,77 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "transform": Array [
-                        Object {
-                          "translateY": 7,
-                        },
-                      ],
-                      "width": 32,
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
+                  <text
+                    color="rgba(28, 27, 31, 1)"
                   >
-                    <icon
-                      color="rgba(29, 25, 43, 1)"
-                    />
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <icon
-                      color="rgba(73, 69, 79, 1)"
-                    />
-                  </View>
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "left": 0,
-                          "position": "absolute",
-                        },
-                        Object {
-                          "right": 0,
-                          "top": 2,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
-                </View>
-                <View
-                  collapsable={false}
-                  style={
-                    Object {
-                      "height": 16,
-                      "paddingBottom": 2,
-                    }
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <text
-                      color="rgba(73, 69, 79, 1)"
-                    >
-                      Route: 1
-                    </text>
-                  </View>
+                    Route: 0
+                  </text>
                 </View>
               </View>
             </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
               }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "transform": Array [
+                      Object {
+                        "translateY": 7,
+                      },
+                    ],
+                    "width": 32,
                   }
                 }
               >
@@ -6070,159 +5870,81 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "transform": Array [
-                        Object {
-                          "translateY": 7,
-                        },
-                      ],
-                      "width": 32,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <icon
-                      color="rgba(29, 25, 43, 1)"
-                    />
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <icon
-                      color="rgba(73, 69, 79, 1)"
-                    />
-                  </View>
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "left": 0,
-                          "position": "absolute",
-                        },
-                        Object {
-                          "right": 0,
-                          "top": 2,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
+                  <icon
+                    color="rgba(29, 25, 43, 1)"
+                  />
                 </View>
                 <View
                   collapsable={false}
                   style={
                     Object {
-                      "height": 16,
-                      "paddingBottom": 2,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
+                  <icon
+                    color="rgba(73, 69, 79, 1)"
+                  />
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
                     collapsable={false}
+                    numberOfLines={1}
                     style={
                       Object {
-                        "bottom": 0,
-                        "left": 0,
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
                         "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
                     }
-                  >
-                    <text
-                      color="rgba(73, 69, 79, 1)"
-                    >
-                      Route: 2
-                    </text>
-                  </View>
+                  />
                 </View>
               </View>
-            </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
-              }
-            >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "height": 16,
+                    "paddingBottom": 2,
                   }
                 }
               >
@@ -6230,159 +5952,77 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "transform": Array [
-                        Object {
-                          "translateY": 7,
-                        },
-                      ],
-                      "width": 32,
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
+                  <text
+                    color="rgba(73, 69, 79, 1)"
                   >
-                    <icon
-                      color="rgba(29, 25, 43, 1)"
-                    />
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <icon
-                      color="rgba(73, 69, 79, 1)"
-                    />
-                  </View>
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "left": 0,
-                          "position": "absolute",
-                        },
-                        Object {
-                          "right": 0,
-                          "top": 2,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
-                </View>
-                <View
-                  collapsable={false}
-                  style={
-                    Object {
-                      "height": 16,
-                      "paddingBottom": 2,
-                    }
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <text
-                      color="rgba(73, 69, 79, 1)"
-                    >
-                      Route: 3
-                    </text>
-                  </View>
+                    Route: 1
+                  </text>
                 </View>
               </View>
             </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
               }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "transform": Array [
+                      Object {
+                        "translateY": 7,
+                      },
+                    ],
+                    "width": 32,
                   }
                 }
               >
@@ -6390,122 +6030,422 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "transform": Array [
-                        Object {
-                          "translateY": 7,
-                        },
-                      ],
-                      "width": 32,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <icon
-                      color="rgba(29, 25, 43, 1)"
-                    />
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <icon
-                      color="rgba(73, 69, 79, 1)"
-                    />
-                  </View>
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "left": 0,
-                          "position": "absolute",
-                        },
-                        Object {
-                          "right": 0,
-                          "top": 2,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
+                  <icon
+                    color="rgba(29, 25, 43, 1)"
+                  />
                 </View>
                 <View
                   collapsable={false}
                   style={
                     Object {
-                      "height": 16,
-                      "paddingBottom": 2,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
+                  <icon
+                    color="rgba(73, 69, 79, 1)"
+                  />
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
                     collapsable={false}
+                    numberOfLines={1}
                     style={
                       Object {
-                        "bottom": 0,
-                        "left": 0,
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
                         "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
                     }
+                  />
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "height": 16,
+                    "paddingBottom": 2,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <text
+                    color="rgba(73, 69, 79, 1)"
                   >
-                    <text
-                      color="rgba(73, 69, 79, 1)"
-                    >
-                      Route: 4
-                    </text>
-                  </View>
+                    Route: 2
+                  </text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "transform": Array [
+                      Object {
+                        "translateY": 7,
+                      },
+                    ],
+                    "width": 32,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <icon
+                    color="rgba(29, 25, 43, 1)"
+                  />
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <icon
+                    color="rgba(73, 69, 79, 1)"
+                  />
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "height": 16,
+                    "paddingBottom": 2,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <text
+                    color="rgba(73, 69, 79, 1)"
+                  >
+                    Route: 3
+                  </text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "transform": Array [
+                      Object {
+                        "translateY": 7,
+                      },
+                    ],
+                    "width": 32,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <icon
+                    color="rgba(29, 25, 43, 1)"
+                  />
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <icon
+                    color="rgba(73, 69, 79, 1)"
+                  />
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "height": 16,
+                    "paddingBottom": 2,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <text
+                    color="rgba(73, 69, 79, 1)"
+                  >
+                    Route: 4
+                  </text>
                 </View>
               </View>
             </View>
@@ -6617,8 +6557,11 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
   >
     <View
       collapsable={false}
+      onLayout={[Function]}
+      pointerEvents="none"
       style={
         Object {
+          "backgroundColor": "transparent",
           "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
@@ -6629,81 +6572,83 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
           "shadowRadius": 0,
         }
       }
-      testID="bottom-navigation-bar-middle-layer"
+      testID="bottom-navigation-bar"
     >
       <View
         collapsable={false}
-        onLayout={[Function]}
-        pointerEvents="none"
         style={
           Object {
-            "backgroundColor": "transparent",
-            "flex": undefined,
+            "alignItems": "center",
+            "backgroundColor": "rgb(243, 237, 246)",
+            "overflow": "hidden",
           }
         }
-        testID="bottom-navigation-bar"
+        testID="bottom-navigation-bar-content"
       >
         <View
-          collapsable={false}
+          accessibilityRole="tablist"
           style={
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "rgb(243, 237, 246)",
-              "overflow": "hidden",
-            }
+            Array [
+              Object {
+                "flexDirection": "row",
+              },
+              Object {
+                "marginBottom": 0,
+                "marginHorizontal": 0,
+              },
+              false,
+            ]
           }
-          testID="bottom-navigation-bar-content"
+          testID="bottom-navigation-bar-content-wrapper"
         >
           <View
-            accessibilityRole="tablist"
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": true,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
+                  "flex": 1,
+                  "paddingVertical": 6,
                 },
                 Object {
-                  "marginBottom": 0,
-                  "marginHorizontal": 0,
+                  "paddingVertical": 0,
                 },
-                false,
               ]
             }
-            testID="bottom-navigation-bar-content-wrapper"
           >
             <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": true,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "width": 32,
                   }
                 }
               >
@@ -6712,323 +6657,163 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                   style={
                     Object {
                       "alignSelf": "center",
+                      "backgroundColor": "rgba(232, 222, 248, 1)",
+                      "borderRadius": 16,
                       "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "width": 32,
+                      "transform": Array [
+                        Object {
+                          "scaleX": 1,
+                        },
+                      ],
+                      "width": 64,
+                    }
+                  }
+                />
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
-                      Object {
-                        "alignSelf": "center",
-                        "backgroundColor": "rgba(232, 222, 248, 1)",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "transform": Array [
+                      Array [
+                        Object {
+                          "color": "#FBF7DB",
+                          "fontSize": 24,
+                        },
+                        Array [
                           Object {
-                            "scaleX": 1,
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
                           },
                         ],
-                        "width": 64,
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰍉
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "#853D4B",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰍉
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
                     }
                   />
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "#FBF7DB",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰍉
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "#853D4B",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰍉
-                    </Text>
-                  </View>
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "left": 0,
-                          "position": "absolute",
-                        },
-                        Object {
-                          "right": 0,
-                          "top": 2,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
-                </View>
-                <View
-                  collapsable={false}
-                  style={
-                    Object {
-                      "height": 16,
-                      "paddingBottom": 2,
-                    }
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
-                        Array [
-                          Object {
-                            "fontFamily": "System",
-                            "fontSize": 12,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.5,
-                            "lineHeight": 16,
-                          },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "#FBF7DB",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 0
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "fontFamily": "System",
-                            "fontSize": 12,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.5,
-                            "lineHeight": 16,
-                          },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "#853D4B",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 0
-                    </Text>
-                  </View>
                 </View>
               </View>
-            </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
-              }
-            >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "height": 16,
+                    "paddingBottom": 2,
                   }
                 }
               >
@@ -7036,307 +6821,159 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "width": 32,
+                      "bottom": 0,
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "#FBF7DB",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰄀
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "#853D4B",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰄀
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    maxFontSizeMultiplier={1}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
                         },
                         Object {
-                          "right": 0,
-                          "top": 2,
+                          "textAlign": "left",
                         },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "#FBF7DB",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
                       ]
                     }
                   >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
+                    Route: 0
+                  </Text>
                 </View>
                 <View
                   collapsable={false}
                   style={
                     Object {
-                      "height": 16,
-                      "paddingBottom": 2,
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    selectable={false}
                     style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
                         Array [
                           Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "#853D4B",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
                             "letterSpacing": 0.5,
                             "lineHeight": 16,
                           },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "#FBF7DB",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 1
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
+                        ],
+                      ]
                     }
                   >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "fontFamily": "System",
-                            "fontSize": 12,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.5,
-                            "lineHeight": 16,
-                          },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "#853D4B",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 1
-                    </Text>
-                  </View>
+                    Route: 0
+                  </Text>
                 </View>
               </View>
             </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
               }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "width": 32,
                   }
                 }
               >
@@ -7344,270 +6981,563 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "width": 32,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "#FBF7DB",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰚇
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "#853D4B",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰚇
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
+                          "color": "#FBF7DB",
+                          "fontSize": 24,
                         },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
                         Object {
-                          "right": 0,
-                          "top": 2,
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
                         },
+                        Object {},
                       ]
                     }
                   >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
+                    󰄀
+                  </Text>
                 </View>
                 <View
                   collapsable={false}
                   style={
                     Object {
-                      "height": 16,
-                      "paddingBottom": 2,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
+                      Array [
+                        Object {
+                          "color": "#853D4B",
+                          "fontSize": 24,
+                        },
                         Array [
                           Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰄀
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "height": 16,
+                    "paddingBottom": 2,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "#FBF7DB",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
                             "letterSpacing": 0.5,
                             "lineHeight": 16,
                           },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "#FBF7DB",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 2
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
+                        ],
+                      ]
                     }
                   >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      selectable={false}
-                      style={
+                    Route: 1
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
                         Array [
                           Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "#853D4B",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
                             "letterSpacing": 0.5,
                             "lineHeight": 16,
                           },
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 1
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "width": 32,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "#FBF7DB",
+                          "fontSize": 24,
+                        },
+                        Array [
                           Object {
-                            "textAlign": "left",
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
                           },
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
+                            "backgroundColor": "transparent",
                           },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "#853D4B",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰚇
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "#853D4B",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰚇
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
-                    >
-                      Route: 2
-                    </Text>
-                  </View>
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "height": 16,
+                    "paddingBottom": 2,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "#FBF7DB",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 2
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "#853D4B",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 2
+                  </Text>
                 </View>
               </View>
             </View>
@@ -7719,8 +7649,11 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
   >
     <View
       collapsable={false}
+      onLayout={[Function]}
+      pointerEvents="none"
       style={
         Object {
+          "backgroundColor": "transparent",
           "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
@@ -7731,81 +7664,88 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
           "shadowRadius": 0,
         }
       }
-      testID="bottom-navigation-bar-middle-layer"
+      testID="bottom-navigation-bar"
     >
       <View
         collapsable={false}
-        onLayout={[Function]}
-        pointerEvents="none"
         style={
           Object {
-            "backgroundColor": "transparent",
-            "flex": undefined,
+            "alignItems": "center",
+            "backgroundColor": "rgb(243, 237, 246)",
+            "overflow": "hidden",
           }
         }
-        testID="bottom-navigation-bar"
+        testID="bottom-navigation-bar-content"
       >
         <View
-          collapsable={false}
+          accessibilityRole="tablist"
           style={
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "rgb(243, 237, 246)",
-              "overflow": "hidden",
-            }
+            Array [
+              Object {
+                "flexDirection": "row",
+              },
+              Object {
+                "marginBottom": 0,
+                "marginHorizontal": 0,
+              },
+              false,
+            ]
           }
-          testID="bottom-navigation-bar-content"
+          testID="bottom-navigation-bar-content-wrapper"
         >
           <View
-            accessibilityRole="tablist"
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": true,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
+                  "flex": 1,
+                  "paddingVertical": 6,
                 },
                 Object {
-                  "marginBottom": 0,
-                  "marginHorizontal": 0,
+                  "paddingVertical": 0,
                 },
-                false,
               ]
             }
-            testID="bottom-navigation-bar-content-wrapper"
           >
             <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": true,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "transform": Array [
+                      Object {
+                        "translateY": 0,
+                      },
+                    ],
+                    "width": 32,
                   }
                 }
               >
@@ -7814,275 +7754,163 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                   style={
                     Object {
                       "alignSelf": "center",
+                      "backgroundColor": "rgba(232, 222, 248, 1)",
+                      "borderRadius": 16,
                       "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
                       "transform": Array [
                         Object {
-                          "translateY": 0,
+                          "scaleX": 1,
                         },
                       ],
-                      "width": 32,
+                      "width": 64,
+                    }
+                  }
+                />
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
-                      Object {
-                        "alignSelf": "center",
-                        "backgroundColor": "rgba(232, 222, 248, 1)",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "transform": Array [
+                      Array [
+                        Object {
+                          "color": "#FBF7DB",
+                          "fontSize": 24,
+                        },
+                        Array [
                           Object {
-                            "scaleX": 1,
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
                           },
                         ],
-                        "width": 64,
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰍉
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "#853D4B",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰍉
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
                     }
                   />
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "#FBF7DB",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰍉
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "#853D4B",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰍉
-                    </Text>
-                  </View>
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "left": 0,
-                          "position": "absolute",
-                        },
-                        Object {
-                          "right": 0,
-                          "top": 2,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
-                </View>
-                <View
-                  collapsable={false}
-                  style={
-                    Object {
-                      "height": 16,
-                      "paddingBottom": 2,
-                    }
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
-                        Array [
-                          Object {
-                            "fontFamily": "System",
-                            "fontSize": 12,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.5,
-                            "lineHeight": 16,
-                          },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "#FBF7DB",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 0
-                    </Text>
-                  </View>
                 </View>
               </View>
-            </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
-              }
-            >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "height": 16,
+                    "paddingBottom": 2,
                   }
                 }
               >
@@ -8090,259 +7918,111 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "transform": Array [
-                        Object {
-                          "translateY": 7,
-                        },
-                      ],
-                      "width": 32,
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "#FBF7DB",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰄀
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "#853D4B",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰄀
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    maxFontSizeMultiplier={1}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
-                        },
-                        Object {
-                          "right": 0,
-                          "top": 2,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
                           "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
-                </View>
-                <View
-                  collapsable={false}
-                  style={
-                    Object {
-                      "height": 16,
-                      "paddingBottom": 2,
-                    }
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
                         Array [
                           Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "#FBF7DB",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
                             "letterSpacing": 0.5,
                             "lineHeight": 16,
                           },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "#FBF7DB",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 1
-                    </Text>
-                  </View>
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 0
+                  </Text>
                 </View>
               </View>
             </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
               }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "transform": Array [
+                      Object {
+                        "translateY": 7,
+                      },
+                    ],
+                    "width": 32,
                   }
                 }
               >
@@ -8350,222 +8030,462 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "transform": Array [
-                        Object {
-                          "translateY": 7,
-                        },
-                      ],
-                      "width": 32,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "#FBF7DB",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰚇
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "#853D4B",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰚇
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
+                          "color": "#FBF7DB",
+                          "fontSize": 24,
                         },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
                         Object {
-                          "right": 0,
-                          "top": 2,
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
                         },
+                        Object {},
                       ]
                     }
                   >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
+                    󰄀
+                  </Text>
                 </View>
                 <View
                   collapsable={false}
                   style={
                     Object {
-                      "height": 16,
-                      "paddingBottom": 2,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
+                      Array [
+                        Object {
+                          "color": "#853D4B",
+                          "fontSize": 24,
+                        },
                         Array [
                           Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰄀
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "height": 16,
+                    "paddingBottom": 2,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "#FBF7DB",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
                             "letterSpacing": 0.5,
                             "lineHeight": 16,
                           },
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 1
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "transform": Array [
+                      Object {
+                        "translateY": 7,
+                      },
+                    ],
+                    "width": 32,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "#FBF7DB",
+                          "fontSize": 24,
+                        },
+                        Array [
                           Object {
-                            "textAlign": "left",
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
                           },
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
+                            "backgroundColor": "transparent",
                           },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "#FBF7DB",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰚇
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "#853D4B",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰚇
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
-                    >
-                      Route: 2
-                    </Text>
-                  </View>
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "height": 16,
+                    "paddingBottom": 2,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "#FBF7DB",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 2
+                  </Text>
                 </View>
               </View>
             </View>
@@ -8677,8 +8597,11 @@ exports[`renders non-shifting bottom navigation 1`] = `
   >
     <View
       collapsable={false}
+      onLayout={[Function]}
+      pointerEvents="none"
       style={
         Object {
+          "backgroundColor": "transparent",
           "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
@@ -8689,81 +8612,83 @@ exports[`renders non-shifting bottom navigation 1`] = `
           "shadowRadius": 0,
         }
       }
-      testID="bottom-navigation-bar-middle-layer"
+      testID="bottom-navigation-bar"
     >
       <View
         collapsable={false}
-        onLayout={[Function]}
-        pointerEvents="none"
         style={
           Object {
-            "backgroundColor": "transparent",
-            "flex": undefined,
+            "alignItems": "center",
+            "backgroundColor": "rgb(243, 237, 246)",
+            "overflow": "hidden",
           }
         }
-        testID="bottom-navigation-bar"
+        testID="bottom-navigation-bar-content"
       >
         <View
-          collapsable={false}
+          accessibilityRole="tablist"
           style={
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "rgb(243, 237, 246)",
-              "overflow": "hidden",
-            }
+            Array [
+              Object {
+                "flexDirection": "row",
+              },
+              Object {
+                "marginBottom": 0,
+                "marginHorizontal": 0,
+              },
+              false,
+            ]
           }
-          testID="bottom-navigation-bar-content"
+          testID="bottom-navigation-bar-content-wrapper"
         >
           <View
-            accessibilityRole="tablist"
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": true,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
+                  "flex": 1,
+                  "paddingVertical": 6,
                 },
                 Object {
-                  "marginBottom": 0,
-                  "marginHorizontal": 0,
+                  "paddingVertical": 0,
                 },
-                false,
               ]
             }
-            testID="bottom-navigation-bar-content-wrapper"
           >
             <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": true,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "width": 32,
                   }
                 }
               >
@@ -8772,323 +8697,163 @@ exports[`renders non-shifting bottom navigation 1`] = `
                   style={
                     Object {
                       "alignSelf": "center",
+                      "backgroundColor": "rgba(232, 222, 248, 1)",
+                      "borderRadius": 16,
                       "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "width": 32,
+                      "transform": Array [
+                        Object {
+                          "scaleX": 1,
+                        },
+                      ],
+                      "width": 64,
+                    }
+                  }
+                />
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
-                      Object {
-                        "alignSelf": "center",
-                        "backgroundColor": "rgba(232, 222, 248, 1)",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "transform": Array [
+                      Array [
+                        Object {
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
                           Object {
-                            "scaleX": 1,
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
                           },
                         ],
-                        "width": 64,
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰍉
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰍉
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
                     }
                   />
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰍉
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰍉
-                    </Text>
-                  </View>
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "left": 0,
-                          "position": "absolute",
-                        },
-                        Object {
-                          "right": 0,
-                          "top": 2,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
-                </View>
-                <View
-                  collapsable={false}
-                  style={
-                    Object {
-                      "height": 16,
-                      "paddingBottom": 2,
-                    }
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
-                        Array [
-                          Object {
-                            "fontFamily": "System",
-                            "fontSize": 12,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.5,
-                            "lineHeight": 16,
-                          },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(28, 27, 31, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 0
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "fontFamily": "System",
-                            "fontSize": 12,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.5,
-                            "lineHeight": 16,
-                          },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(28, 27, 31, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 0
-                    </Text>
-                  </View>
                 </View>
               </View>
-            </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
-              }
-            >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "height": 16,
+                    "paddingBottom": 2,
                   }
                 }
               >
@@ -9096,307 +8861,159 @@ exports[`renders non-shifting bottom navigation 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "width": 32,
+                      "bottom": 0,
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰄀
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰄀
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    maxFontSizeMultiplier={1}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
                         },
                         Object {
-                          "right": 0,
-                          "top": 2,
+                          "textAlign": "left",
                         },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(28, 27, 31, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
                       ]
                     }
                   >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
+                    Route: 0
+                  </Text>
                 </View>
                 <View
                   collapsable={false}
                   style={
                     Object {
-                      "height": 16,
-                      "paddingBottom": 2,
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    selectable={false}
                     style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
                         Array [
                           Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
                             "letterSpacing": 0.5,
                             "lineHeight": 16,
                           },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(73, 69, 79, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 1
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
+                        ],
+                      ]
                     }
                   >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "fontFamily": "System",
-                            "fontSize": 12,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.5,
-                            "lineHeight": 16,
-                          },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(73, 69, 79, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 1
-                    </Text>
-                  </View>
+                    Route: 0
+                  </Text>
                 </View>
               </View>
             </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
               }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "width": 32,
                   }
                 }
               >
@@ -9404,270 +9021,563 @@ exports[`renders non-shifting bottom navigation 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "width": 32,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰚇
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰚇
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
                         },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
                         Object {
-                          "right": 0,
-                          "top": 2,
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
                         },
+                        Object {},
                       ]
                     }
                   >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
+                    󰄀
+                  </Text>
                 </View>
                 <View
                   collapsable={false}
                   style={
                     Object {
-                      "height": 16,
-                      "paddingBottom": 2,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
+                      Array [
+                        Object {
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
                         Array [
                           Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰄀
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "height": 16,
+                    "paddingBottom": 2,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(73, 69, 79, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
                             "letterSpacing": 0.5,
                             "lineHeight": 16,
                           },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(73, 69, 79, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 2
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
+                        ],
+                      ]
                     }
                   >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      selectable={false}
-                      style={
+                    Route: 1
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
                         Array [
                           Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(73, 69, 79, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
                             "letterSpacing": 0.5,
                             "lineHeight": 16,
                           },
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 1
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "width": 32,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
                           Object {
-                            "textAlign": "left",
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
                           },
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
+                            "backgroundColor": "transparent",
                           },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(73, 69, 79, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰚇
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰚇
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
-                    >
-                      Route: 2
-                    </Text>
-                  </View>
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "height": 16,
+                    "paddingBottom": 2,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 2
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 2
+                  </Text>
                 </View>
               </View>
             </View>
@@ -9779,8 +9689,11 @@ exports[`renders shifting bottom navigation 1`] = `
   >
     <View
       collapsable={false}
+      onLayout={[Function]}
+      pointerEvents="none"
       style={
         Object {
+          "backgroundColor": "transparent",
           "flex": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
@@ -9791,81 +9704,88 @@ exports[`renders shifting bottom navigation 1`] = `
           "shadowRadius": 0,
         }
       }
-      testID="bottom-navigation-bar-middle-layer"
+      testID="bottom-navigation-bar"
     >
       <View
         collapsable={false}
-        onLayout={[Function]}
-        pointerEvents="none"
         style={
           Object {
-            "backgroundColor": "transparent",
-            "flex": undefined,
+            "alignItems": "center",
+            "backgroundColor": "rgb(243, 237, 246)",
+            "overflow": "hidden",
           }
         }
-        testID="bottom-navigation-bar"
+        testID="bottom-navigation-bar-content"
       >
         <View
-          collapsable={false}
+          accessibilityRole="tablist"
           style={
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "rgb(243, 237, 246)",
-              "overflow": "hidden",
-            }
+            Array [
+              Object {
+                "flexDirection": "row",
+              },
+              Object {
+                "marginBottom": 0,
+                "marginHorizontal": 0,
+              },
+              false,
+            ]
           }
-          testID="bottom-navigation-bar-content"
+          testID="bottom-navigation-bar-content-wrapper"
         >
           <View
-            accessibilityRole="tablist"
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": true,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
-                  "flexDirection": "row",
+                  "flex": 1,
+                  "paddingVertical": 6,
                 },
                 Object {
-                  "marginBottom": 0,
-                  "marginHorizontal": 0,
+                  "paddingVertical": 0,
                 },
-                false,
               ]
             }
-            testID="bottom-navigation-bar-content-wrapper"
           >
             <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": true,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "transform": Array [
+                      Object {
+                        "translateY": 0,
+                      },
+                    ],
+                    "width": 32,
                   }
                 }
               >
@@ -9874,275 +9794,163 @@ exports[`renders shifting bottom navigation 1`] = `
                   style={
                     Object {
                       "alignSelf": "center",
+                      "backgroundColor": "rgba(232, 222, 248, 1)",
+                      "borderRadius": 16,
                       "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
                       "transform": Array [
                         Object {
-                          "translateY": 0,
+                          "scaleX": 1,
                         },
                       ],
-                      "width": 32,
+                      "width": 64,
+                    }
+                  }
+                />
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
-                      Object {
-                        "alignSelf": "center",
-                        "backgroundColor": "rgba(232, 222, 248, 1)",
-                        "borderRadius": 16,
-                        "height": 32,
-                        "transform": Array [
+                      Array [
+                        Object {
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
                           Object {
-                            "scaleX": 1,
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
                           },
                         ],
-                        "width": 64,
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰍉
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰍉
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
                     }
                   />
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰍉
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰍉
-                    </Text>
-                  </View>
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "left": 0,
-                          "position": "absolute",
-                        },
-                        Object {
-                          "right": 0,
-                          "top": 2,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
-                </View>
-                <View
-                  collapsable={false}
-                  style={
-                    Object {
-                      "height": 16,
-                      "paddingBottom": 2,
-                    }
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
-                        Array [
-                          Object {
-                            "fontFamily": "System",
-                            "fontSize": 12,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.5,
-                            "lineHeight": 16,
-                          },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(28, 27, 31, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 0
-                    </Text>
-                  </View>
                 </View>
               </View>
-            </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
-              }
-            >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "height": 16,
+                    "paddingBottom": 2,
                   }
                 }
               >
@@ -10150,259 +9958,111 @@ exports[`renders shifting bottom navigation 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "transform": Array [
-                        Object {
-                          "translateY": 7,
-                        },
-                      ],
-                      "width": 32,
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰄀
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰄀
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    maxFontSizeMultiplier={1}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
-                        },
-                        Object {
-                          "right": 0,
-                          "top": 2,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
                           "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
-                </View>
-                <View
-                  collapsable={false}
-                  style={
-                    Object {
-                      "height": 16,
-                      "paddingBottom": 2,
-                    }
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
                         Array [
                           Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
                             "letterSpacing": 0.5,
                             "lineHeight": 16,
                           },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(73, 69, 79, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 1
-                    </Text>
-                  </View>
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 0
+                  </Text>
                 </View>
               </View>
             </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
               }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "transform": Array [
+                      Object {
+                        "translateY": 7,
+                      },
+                    ],
+                    "width": 32,
                   }
                 }
               >
@@ -10410,259 +10070,147 @@ exports[`renders shifting bottom navigation 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "transform": Array [
-                        Object {
-                          "translateY": 7,
-                        },
-                      ],
-                      "width": 32,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰚇
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰚇
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
                         },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
                         Object {
-                          "right": 0,
-                          "top": 2,
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
                         },
+                        Object {},
                       ]
                     }
                   >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
+                    󰄀
+                  </Text>
                 </View>
                 <View
                   collapsable={false}
                   style={
                     Object {
-                      "height": 16,
-                      "paddingBottom": 2,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
+                      Array [
+                        Object {
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
                         Array [
                           Object {
-                            "fontFamily": "System",
-                            "fontSize": 12,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.5,
-                            "lineHeight": 16,
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
                           },
                           Object {
-                            "textAlign": "left",
+                            "backgroundColor": "transparent",
                           },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(73, 69, 79, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰄀
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
-                    >
-                      Route: 2
-                    </Text>
-                  </View>
+                    }
+                  />
                 </View>
               </View>
-            </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
-              }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
-              }
-            >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "height": 16,
+                    "paddingBottom": 2,
                   }
                 }
               >
@@ -10670,259 +10218,111 @@ exports[`renders shifting bottom navigation 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "transform": Array [
-                        Object {
-                          "translateY": 7,
-                        },
-                      ],
-                      "width": 32,
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰋑
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰋑
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    maxFontSizeMultiplier={1}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
-                        },
-                        Object {
-                          "right": 0,
-                          "top": 2,
-                        },
-                      ]
-                    }
-                  >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
                           "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
-                </View>
-                <View
-                  collapsable={false}
-                  style={
-                    Object {
-                      "height": 16,
-                      "paddingBottom": 2,
-                    }
-                  }
-                >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
                         Array [
                           Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(73, 69, 79, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
                             "letterSpacing": 0.5,
                             "lineHeight": 16,
                           },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(73, 69, 79, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
-                      }
-                    >
-                      Route: 3
-                    </Text>
-                  </View>
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 1
+                  </Text>
                 </View>
               </View>
             </View>
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "selected": false,
-                }
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
               }
-              accessible={true}
-              focusable={true}
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
               style={
-                Array [
-                  Object {
-                    "flex": 1,
-                    "paddingVertical": 6,
-                  },
-                  Object {
-                    "paddingVertical": 0,
-                  },
-                ]
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
               }
             >
               <View
-                pointerEvents="none"
+                collapsable={false}
                 style={
                   Object {
-                    "paddingBottom": 16,
-                    "paddingTop": 12,
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "transform": Array [
+                      Object {
+                        "translateY": 7,
+                      },
+                    ],
+                    "width": 32,
                   }
                 }
               >
@@ -10930,222 +10330,722 @@ exports[`renders shifting bottom navigation 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "alignSelf": "center",
-                      "height": 32,
-                      "justifyContent": "center",
-                      "marginBottom": 4,
-                      "marginHorizontal": 12,
-                      "marginTop": 0,
-                      "transform": Array [
-                        Object {
-                          "translateY": 7,
-                        },
-                      ],
-                      "width": 32,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(29, 25, 43, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰒛
-                    </Text>
-                  </View>
-                  <View
-                    collapsable={false}
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 1,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityElementsHidden={true}
-                      allowFontScaling={false}
-                      importantForAccessibility="no-hide-descendants"
-                      pointerEvents="none"
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "color": "rgba(73, 69, 79, 1)",
-                            "fontSize": 24,
-                          },
-                          Array [
-                            Object {
-                              "lineHeight": 24,
-                              "transform": Array [
-                                Object {
-                                  "scaleX": 1,
-                                },
-                              ],
-                            },
-                            Object {
-                              "backgroundColor": "transparent",
-                            },
-                          ],
-                          Object {
-                            "fontFamily": "Material Design Icons",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          Object {},
-                        ]
-                      }
-                    >
-                      󰒛
-                    </Text>
-                  </View>
-                  <View
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
                       Array [
                         Object {
-                          "left": 0,
-                          "position": "absolute",
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
                         },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
                         Object {
-                          "right": 0,
-                          "top": 2,
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
                         },
+                        Object {},
                       ]
                     }
                   >
-                    <Text
-                      collapsable={false}
-                      numberOfLines={1}
-                      style={
-                        Object {
-                          "alignSelf": "flex-end",
-                          "backgroundColor": "rgba(179, 38, 30, 1)",
-                          "borderRadius": 8,
-                          "color": "rgba(255, 255, 255, 1)",
-                          "fontSize": 8,
-                          "height": 16,
-                          "lineHeight": 16,
-                          "minWidth": 16,
-                          "opacity": 0,
-                          "overflow": "hidden",
-                          "paddingHorizontal": 3,
-                          "textAlign": "center",
-                          "textAlignVertical": "center",
-                        }
-                      }
-                    />
-                  </View>
+                    󰚇
+                  </Text>
                 </View>
                 <View
                   collapsable={false}
                   style={
                     Object {
-                      "height": 16,
-                      "paddingBottom": 2,
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
                     }
                   }
                 >
-                  <View
-                    collapsable={false}
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
                     style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "opacity": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1}
-                      style={
+                      Array [
+                        Object {
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
                         Array [
                           Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰚇
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "height": 16,
+                    "paddingBottom": 2,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(73, 69, 79, 1)",
                             "fontFamily": "System",
                             "fontSize": 12,
                             "fontWeight": "500",
                             "letterSpacing": 0.5,
                             "lineHeight": 16,
                           },
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 2
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "transform": Array [
+                      Object {
+                        "translateY": 7,
+                      },
+                    ],
+                    "width": 32,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
                           Object {
-                            "textAlign": "left",
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
                           },
                           Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
+                            "backgroundColor": "transparent",
                           },
-                          Array [
-                            Object {
-                              "backgroundColor": "transparent",
-                              "fontSize": 12,
-                              "height": 56,
-                              "textAlign": "center",
-                            },
-                            Object {
-                              "color": "rgba(73, 69, 79, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 12,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.5,
-                              "lineHeight": 16,
-                            },
-                          ],
-                        ]
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰋑
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰋑
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
                       }
-                    >
-                      Route: 4
-                    </Text>
-                  </View>
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "height": 16,
+                    "paddingBottom": 2,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 3
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "selected": false,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                  "paddingVertical": 6,
+                },
+                Object {
+                  "paddingVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                Object {
+                  "paddingBottom": 16,
+                  "paddingTop": 12,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "height": 32,
+                    "justifyContent": "center",
+                    "marginBottom": 4,
+                    "marginHorizontal": 12,
+                    "marginTop": 0,
+                    "transform": Array [
+                      Object {
+                        "translateY": 7,
+                      },
+                    ],
+                    "width": 32,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(29, 25, 43, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰒛
+                  </Text>
+                </View>
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 4,
+                    }
+                  }
+                >
+                  <Text
+                    accessibilityElementsHidden={true}
+                    allowFontScaling={false}
+                    importantForAccessibility="no-hide-descendants"
+                    pointerEvents="none"
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(73, 69, 79, 1)",
+                          "fontSize": 24,
+                        },
+                        Array [
+                          Object {
+                            "lineHeight": 24,
+                            "transform": Array [
+                              Object {
+                                "scaleX": 1,
+                              },
+                            ],
+                          },
+                          Object {
+                            "backgroundColor": "transparent",
+                          },
+                        ],
+                        Object {
+                          "fontFamily": "Material Design Icons",
+                          "fontStyle": "normal",
+                          "fontWeight": "normal",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    󰒛
+                  </Text>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "left": 0,
+                        "position": "absolute",
+                      },
+                      Object {
+                        "right": 0,
+                        "top": 2,
+                      },
+                    ]
+                  }
+                >
+                  <Text
+                    collapsable={false}
+                    numberOfLines={1}
+                    style={
+                      Object {
+                        "alignSelf": "flex-end",
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 8,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "fontSize": 8,
+                        "height": 16,
+                        "lineHeight": 16,
+                        "minWidth": 16,
+                        "opacity": 0,
+                        "overflow": "hidden",
+                        "paddingHorizontal": 3,
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      }
+                    }
+                  />
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  Object {
+                    "height": 16,
+                    "paddingBottom": 2,
+                  }
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          Object {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ]
+                    }
+                  >
+                    Route: 4
+                  </Text>
                 </View>
               </View>
             </View>

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
@@ -75,6 +75,7 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "transparent",
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
@@ -822,6 +823,7 @@ exports[`hides labels in shifting bottom navigation 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "transparent",
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
@@ -1701,6 +1703,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "transparent",
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
@@ -3409,6 +3412,7 @@ exports[`renders bottom navigation with scene animation 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "transparent",
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
@@ -4877,6 +4881,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "transparent",
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
@@ -5564,6 +5569,7 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "transparent",
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
@@ -6532,6 +6538,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "transparent",
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
@@ -7624,6 +7631,7 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "transparent",
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
@@ -8572,6 +8580,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "transparent",
         "bottom": 0,
         "end": undefined,
         "flex": undefined,
@@ -9664,6 +9673,7 @@ exports[`renders shifting bottom navigation 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "transparent",
         "bottom": 0,
         "end": undefined,
         "flex": undefined,

--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -33,7 +33,13 @@ exports[`renders button with an accessibility hint 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderColor": "transparent",
+        "borderRadius": 20,
+        "borderStyle": "solid",
+        "borderWidth": 0,
         "flex": undefined,
+        "minWidth": 64,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -43,116 +49,100 @@ exports[`renders button with an accessibility hint 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-middle-layer"
+    testID="button-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityHint="hint"
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "transparent",
-          "borderColor": "transparent",
-          "borderRadius": 20,
-          "borderStyle": "solid",
-          "borderWidth": 0,
-          "flex": undefined,
-          "minWidth": 64,
+          "disabled": true,
         }
       }
-      testID="button-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 20,
+          },
+        ]
+      }
+      testID="button"
     >
       <View
-        accessibilityHint="hint"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            Object {
-              "borderRadius": 20,
-            },
+            undefined,
           ]
         }
-        testID="button"
       >
-        <View
+        <Text
+          numberOfLines={1}
+          selectable={false}
           style={
             Array [
               Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "center",
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
               },
-              undefined,
-            ]
-          }
-        >
-          <Text
-            numberOfLines={1}
-            selectable={false}
-            style={
+              Object {
+                "textAlign": "left",
+              },
+              Object {
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
+              },
               Array [
                 Object {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                false,
+                Object {
+                  "marginHorizontal": 12,
+                },
+                undefined,
+                false,
+                Object {
+                  "color": "rgba(103, 80, 164, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
                   "letterSpacing": 0.1,
                   "lineHeight": 20,
                 },
-                Object {
-                  "textAlign": "left",
-                },
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "writingDirection": "ltr",
-                },
-                Array [
-                  Object {
-                    "marginHorizontal": 16,
-                    "marginVertical": 9,
-                    "textAlign": "center",
-                  },
-                  false,
-                  Object {
-                    "marginHorizontal": 12,
-                  },
-                  undefined,
-                  false,
-                  Object {
-                    "color": "rgba(103, 80, 164, 1)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0.1,
-                    "lineHeight": 20,
-                  },
-                  undefined,
-                ],
-              ]
-            }
-            testID="button-text"
-          >
-            Button with accessibility hint
-          </Text>
-        </View>
+                undefined,
+              ],
+            ]
+          }
+          testID="button-text"
+        >
+          Button with accessibility hint
+        </Text>
       </View>
     </View>
   </View>
@@ -192,7 +182,13 @@ exports[`renders button with an accessibility label 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderColor": "transparent",
+        "borderRadius": 20,
+        "borderStyle": "solid",
+        "borderWidth": 0,
         "flex": undefined,
+        "minWidth": 64,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -202,116 +198,100 @@ exports[`renders button with an accessibility label 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-middle-layer"
+    testID="button-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityLabel="label"
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "transparent",
-          "borderColor": "transparent",
-          "borderRadius": 20,
-          "borderStyle": "solid",
-          "borderWidth": 0,
-          "flex": undefined,
-          "minWidth": 64,
+          "disabled": true,
         }
       }
-      testID="button-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 20,
+          },
+        ]
+      }
+      testID="button"
     >
       <View
-        accessibilityLabel="label"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            Object {
-              "borderRadius": 20,
-            },
+            undefined,
           ]
         }
-        testID="button"
       >
-        <View
+        <Text
+          numberOfLines={1}
+          selectable={false}
           style={
             Array [
               Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "center",
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
               },
-              undefined,
-            ]
-          }
-        >
-          <Text
-            numberOfLines={1}
-            selectable={false}
-            style={
+              Object {
+                "textAlign": "left",
+              },
+              Object {
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
+              },
               Array [
                 Object {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                false,
+                Object {
+                  "marginHorizontal": 12,
+                },
+                undefined,
+                false,
+                Object {
+                  "color": "rgba(103, 80, 164, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
                   "letterSpacing": 0.1,
                   "lineHeight": 20,
                 },
-                Object {
-                  "textAlign": "left",
-                },
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "writingDirection": "ltr",
-                },
-                Array [
-                  Object {
-                    "marginHorizontal": 16,
-                    "marginVertical": 9,
-                    "textAlign": "center",
-                  },
-                  false,
-                  Object {
-                    "marginHorizontal": 12,
-                  },
-                  undefined,
-                  false,
-                  Object {
-                    "color": "rgba(103, 80, 164, 1)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0.1,
-                    "lineHeight": 20,
-                  },
-                  undefined,
-                ],
-              ]
-            }
-            testID="button-text"
-          >
-            Button with accessibility label
-          </Text>
-        </View>
+                undefined,
+              ],
+            ]
+          }
+          testID="button-text"
+        >
+          Button with accessibility label
+        </Text>
       </View>
     </View>
   </View>
@@ -351,7 +331,13 @@ exports[`renders button with button color 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "#e91e63",
+        "borderColor": "transparent",
+        "borderRadius": 20,
+        "borderStyle": "solid",
+        "borderWidth": 0,
         "flex": undefined,
+        "minWidth": 64,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -361,115 +347,99 @@ exports[`renders button with button color 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-middle-layer"
+    testID="button-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "#e91e63",
-          "borderColor": "transparent",
-          "borderRadius": 20,
-          "borderStyle": "solid",
-          "borderWidth": 0,
-          "flex": undefined,
-          "minWidth": 64,
+          "disabled": true,
         }
       }
-      testID="button-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 20,
+          },
+        ]
+      }
+      testID="button"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            Object {
-              "borderRadius": 20,
-            },
+            undefined,
           ]
         }
-        testID="button"
       >
-        <View
+        <Text
+          numberOfLines={1}
+          selectable={false}
           style={
             Array [
               Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "center",
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
               },
-              undefined,
-            ]
-          }
-        >
-          <Text
-            numberOfLines={1}
-            selectable={false}
-            style={
+              Object {
+                "textAlign": "left",
+              },
+              Object {
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
+              },
               Array [
                 Object {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                false,
+                Object {
+                  "marginHorizontal": 12,
+                },
+                undefined,
+                false,
+                Object {
+                  "color": "rgba(103, 80, 164, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
                   "letterSpacing": 0.1,
                   "lineHeight": 20,
                 },
-                Object {
-                  "textAlign": "left",
-                },
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "writingDirection": "ltr",
-                },
-                Array [
-                  Object {
-                    "marginHorizontal": 16,
-                    "marginVertical": 9,
-                    "textAlign": "center",
-                  },
-                  false,
-                  Object {
-                    "marginHorizontal": 12,
-                  },
-                  undefined,
-                  false,
-                  Object {
-                    "color": "rgba(103, 80, 164, 1)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0.1,
-                    "lineHeight": 20,
-                  },
-                  undefined,
-                ],
-              ]
-            }
-            testID="button-text"
-          >
-            Custom Button
-          </Text>
-        </View>
+                undefined,
+              ],
+            ]
+          }
+          testID="button-text"
+        >
+          Custom Button
+        </Text>
       </View>
     </View>
   </View>
@@ -509,7 +479,13 @@ exports[`renders button with color 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderColor": "transparent",
+        "borderRadius": 20,
+        "borderStyle": "solid",
+        "borderWidth": 0,
         "flex": undefined,
+        "minWidth": 64,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -519,115 +495,99 @@ exports[`renders button with color 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-middle-layer"
+    testID="button-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "transparent",
-          "borderColor": "transparent",
-          "borderRadius": 20,
-          "borderStyle": "solid",
-          "borderWidth": 0,
-          "flex": undefined,
-          "minWidth": 64,
+          "disabled": true,
         }
       }
-      testID="button-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 20,
+          },
+        ]
+      }
+      testID="button"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            Object {
-              "borderRadius": 20,
-            },
+            undefined,
           ]
         }
-        testID="button"
       >
-        <View
+        <Text
+          numberOfLines={1}
+          selectable={false}
           style={
             Array [
               Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "center",
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
               },
-              undefined,
-            ]
-          }
-        >
-          <Text
-            numberOfLines={1}
-            selectable={false}
-            style={
+              Object {
+                "textAlign": "left",
+              },
+              Object {
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
+              },
               Array [
                 Object {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                false,
+                Object {
+                  "marginHorizontal": 12,
+                },
+                undefined,
+                false,
+                Object {
+                  "color": "#e91e63",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
                   "letterSpacing": 0.1,
                   "lineHeight": 20,
                 },
-                Object {
-                  "textAlign": "left",
-                },
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "writingDirection": "ltr",
-                },
-                Array [
-                  Object {
-                    "marginHorizontal": 16,
-                    "marginVertical": 9,
-                    "textAlign": "center",
-                  },
-                  false,
-                  Object {
-                    "marginHorizontal": 12,
-                  },
-                  undefined,
-                  false,
-                  Object {
-                    "color": "#e91e63",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0.1,
-                    "lineHeight": 20,
-                  },
-                  undefined,
-                ],
-              ]
-            }
-            testID="button-text"
-          >
-            Custom Button
-          </Text>
-        </View>
+                undefined,
+              ],
+            ]
+          }
+          testID="button-text"
+        >
+          Custom Button
+        </Text>
       </View>
     </View>
   </View>
@@ -667,7 +627,13 @@ exports[`renders button with custom testID 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderColor": "transparent",
+        "borderRadius": 20,
+        "borderStyle": "solid",
+        "borderWidth": 0,
         "flex": undefined,
+        "minWidth": 64,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -677,115 +643,99 @@ exports[`renders button with custom testID 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="custom:testID-container-middle-layer"
+    testID="custom:testID-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "transparent",
-          "borderColor": "transparent",
-          "borderRadius": 20,
-          "borderStyle": "solid",
-          "borderWidth": 0,
-          "flex": undefined,
-          "minWidth": 64,
+          "disabled": true,
         }
       }
-      testID="custom:testID-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 20,
+          },
+        ]
+      }
+      testID="custom:testID"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            Object {
-              "borderRadius": 20,
-            },
+            undefined,
           ]
         }
-        testID="custom:testID"
       >
-        <View
+        <Text
+          numberOfLines={1}
+          selectable={false}
           style={
             Array [
               Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "center",
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
               },
-              undefined,
-            ]
-          }
-        >
-          <Text
-            numberOfLines={1}
-            selectable={false}
-            style={
+              Object {
+                "textAlign": "left",
+              },
+              Object {
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
+              },
               Array [
                 Object {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                false,
+                Object {
+                  "marginHorizontal": 12,
+                },
+                undefined,
+                false,
+                Object {
+                  "color": "rgba(103, 80, 164, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
                   "letterSpacing": 0.1,
                   "lineHeight": 20,
                 },
-                Object {
-                  "textAlign": "left",
-                },
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "writingDirection": "ltr",
-                },
-                Array [
-                  Object {
-                    "marginHorizontal": 16,
-                    "marginVertical": 9,
-                    "textAlign": "center",
-                  },
-                  false,
-                  Object {
-                    "marginHorizontal": 12,
-                  },
-                  undefined,
-                  false,
-                  Object {
-                    "color": "rgba(103, 80, 164, 1)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0.1,
-                    "lineHeight": 20,
-                  },
-                  undefined,
-                ],
-              ]
-            }
-            testID="custom:testID-text"
-          >
-            Button with custom testID
-          </Text>
-        </View>
+                undefined,
+              ],
+            ]
+          }
+          testID="custom:testID-text"
+        >
+          Button with custom testID
+        </Text>
       </View>
     </View>
   </View>
@@ -825,7 +775,13 @@ exports[`renders button with icon 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderColor": "transparent",
+        "borderRadius": 20,
+        "borderStyle": "solid",
+        "borderWidth": 0,
         "flex": undefined,
+        "minWidth": 64,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -835,171 +791,155 @@ exports[`renders button with icon 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-middle-layer"
+    testID="button-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "transparent",
-          "borderColor": "transparent",
-          "borderRadius": 20,
-          "borderStyle": "solid",
-          "borderWidth": 0,
-          "flex": undefined,
-          "minWidth": 64,
+          "disabled": true,
         }
       }
-      testID="button-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 20,
+          },
+        ]
+      }
+      testID="button"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            Object {
-              "borderRadius": 20,
-            },
+            undefined,
           ]
         }
-        testID="button"
       >
         <View
           style={
             Array [
               Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "center",
+                "marginLeft": 12,
+                "marginRight": -4,
               },
-              undefined,
+              Object {
+                "marginLeft": 16,
+                "marginRight": -16,
+              },
+              Object {
+                "marginLeft": 12,
+                "marginRight": -8,
+              },
             ]
           }
+          testID="button-icon-container"
         >
-          <View
-            style={
-              Array [
-                Object {
-                  "marginLeft": 12,
-                  "marginRight": -4,
-                },
-                Object {
-                  "marginLeft": 16,
-                  "marginRight": -16,
-                },
-                Object {
-                  "marginLeft": 12,
-                  "marginRight": -8,
-                },
-              ]
-            }
-            testID="button-icon-container"
-          >
-            <Text
-              accessibilityElementsHidden={true}
-              allowFontScaling={false}
-              importantForAccessibility="no-hide-descendants"
-              pointerEvents="none"
-              selectable={false}
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(103, 80, 164, 1)",
-                    "fontSize": 18,
-                  },
-                  Array [
-                    Object {
-                      "lineHeight": 18,
-                      "transform": Array [
-                        Object {
-                          "scaleX": 1,
-                        },
-                      ],
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ],
-                  Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
-              }
-            >
-              󰄀
-            </Text>
-          </View>
           <Text
-            numberOfLines={1}
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
             selectable={false}
             style={
               Array [
                 Object {
+                  "color": "rgba(103, 80, 164, 1)",
+                  "fontSize": 18,
+                },
+                Array [
+                  Object {
+                    "lineHeight": 18,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  Object {
+                    "backgroundColor": "transparent",
+                  },
+                ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            󰄀
+          </Text>
+        </View>
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
+              },
+              Object {
+                "textAlign": "left",
+              },
+              Object {
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
+              },
+              Array [
+                Object {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                false,
+                Object {
+                  "marginHorizontal": 16,
+                },
+                undefined,
+                false,
+                Object {
+                  "color": "rgba(103, 80, 164, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
                   "letterSpacing": 0.1,
                   "lineHeight": 20,
                 },
-                Object {
-                  "textAlign": "left",
-                },
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "writingDirection": "ltr",
-                },
-                Array [
-                  Object {
-                    "marginHorizontal": 16,
-                    "marginVertical": 9,
-                    "textAlign": "center",
-                  },
-                  false,
-                  Object {
-                    "marginHorizontal": 16,
-                  },
-                  undefined,
-                  false,
-                  Object {
-                    "color": "rgba(103, 80, 164, 1)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0.1,
-                    "lineHeight": 20,
-                  },
-                  undefined,
-                ],
-              ]
-            }
-            testID="button-text"
-          >
-            Icon Button
-          </Text>
-        </View>
+                undefined,
+              ],
+            ]
+          }
+          testID="button-text"
+        >
+          Icon Button
+        </Text>
       </View>
     </View>
   </View>
@@ -1039,7 +979,13 @@ exports[`renders button with icon in reverse order 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderColor": "transparent",
+        "borderRadius": 20,
+        "borderStyle": "solid",
+        "borderWidth": 0,
         "flex": undefined,
+        "minWidth": 64,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -1049,173 +995,157 @@ exports[`renders button with icon in reverse order 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-middle-layer"
+    testID="button-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "transparent",
-          "borderColor": "transparent",
-          "borderRadius": 20,
-          "borderStyle": "solid",
-          "borderWidth": 0,
-          "flex": undefined,
-          "minWidth": 64,
+          "disabled": true,
         }
       }
-      testID="button-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 20,
+          },
+        ]
+      }
+      testID="button"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
             Object {
-              "borderRadius": 20,
+              "flexDirection": "row-reverse",
             },
           ]
         }
-        testID="button"
       >
         <View
           style={
             Array [
               Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "center",
+                "marginLeft": -4,
+                "marginRight": 12,
               },
               Object {
-                "flexDirection": "row-reverse",
+                "marginLeft": -16,
+                "marginRight": 16,
+              },
+              Object {
+                "marginLeft": -8,
+                "marginRight": 12,
               },
             ]
           }
+          testID="button-icon-container"
         >
-          <View
-            style={
-              Array [
-                Object {
-                  "marginLeft": -4,
-                  "marginRight": 12,
-                },
-                Object {
-                  "marginLeft": -16,
-                  "marginRight": 16,
-                },
-                Object {
-                  "marginLeft": -8,
-                  "marginRight": 12,
-                },
-              ]
-            }
-            testID="button-icon-container"
-          >
-            <Text
-              accessibilityElementsHidden={true}
-              allowFontScaling={false}
-              importantForAccessibility="no-hide-descendants"
-              pointerEvents="none"
-              selectable={false}
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(103, 80, 164, 1)",
-                    "fontSize": 18,
-                  },
-                  Array [
-                    Object {
-                      "lineHeight": 18,
-                      "transform": Array [
-                        Object {
-                          "scaleX": 1,
-                        },
-                      ],
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ],
-                  Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
-              }
-            >
-              󰅂
-            </Text>
-          </View>
           <Text
-            numberOfLines={1}
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
             selectable={false}
             style={
               Array [
                 Object {
+                  "color": "rgba(103, 80, 164, 1)",
+                  "fontSize": 18,
+                },
+                Array [
+                  Object {
+                    "lineHeight": 18,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  Object {
+                    "backgroundColor": "transparent",
+                  },
+                ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            󰅂
+          </Text>
+        </View>
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
+              },
+              Object {
+                "textAlign": "left",
+              },
+              Object {
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
+              },
+              Array [
+                Object {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                false,
+                Object {
+                  "marginHorizontal": 16,
+                },
+                undefined,
+                false,
+                Object {
+                  "color": "rgba(103, 80, 164, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
                   "letterSpacing": 0.1,
                   "lineHeight": 20,
                 },
-                Object {
-                  "textAlign": "left",
-                },
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "writingDirection": "ltr",
-                },
-                Array [
-                  Object {
-                    "marginHorizontal": 16,
-                    "marginVertical": 9,
-                    "textAlign": "center",
-                  },
-                  false,
-                  Object {
-                    "marginHorizontal": 16,
-                  },
-                  undefined,
-                  false,
-                  Object {
-                    "color": "rgba(103, 80, 164, 1)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0.1,
-                    "lineHeight": 20,
-                  },
-                  undefined,
-                ],
-              ]
-            }
-            testID="button-text"
-          >
-            Right Icon
-          </Text>
-        </View>
+                undefined,
+              ],
+            ]
+          }
+          testID="button-text"
+        >
+          Right Icon
+        </Text>
       </View>
     </View>
   </View>
@@ -1255,7 +1185,13 @@ exports[`renders contained contained with mode 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(103, 80, 164, 1)",
+        "borderColor": "transparent",
+        "borderRadius": 20,
+        "borderStyle": "solid",
+        "borderWidth": 0,
         "flex": undefined,
+        "minWidth": 64,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -1265,116 +1201,100 @@ exports[`renders contained contained with mode 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-middle-layer"
+    testID="button-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "rgba(103, 80, 164, 1)",
-          "borderColor": "transparent",
-          "borderRadius": 20,
-          "borderStyle": "solid",
-          "borderWidth": 0,
-          "flex": undefined,
-          "minWidth": 64,
+          "disabled": true,
         }
       }
-      testID="button-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 20,
+          },
+        ]
+      }
+      testID="button"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            Object {
-              "borderRadius": 20,
-            },
+            undefined,
           ]
         }
-        testID="button"
       >
-        <View
+        <Text
+          numberOfLines={1}
+          selectable={false}
           style={
             Array [
               Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "center",
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
               },
-              undefined,
-            ]
-          }
-        >
-          <Text
-            numberOfLines={1}
-            selectable={false}
-            style={
+              Object {
+                "textAlign": "left",
+              },
+              Object {
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
+              },
               Array [
                 Object {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                false,
+                Object {
+                  "marginHorizontal": 24,
+                  "marginVertical": 10,
+                },
+                undefined,
+                false,
+                Object {
+                  "color": "rgba(255, 255, 255, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
                   "letterSpacing": 0.1,
                   "lineHeight": 20,
                 },
-                Object {
-                  "textAlign": "left",
-                },
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "writingDirection": "ltr",
-                },
-                Array [
-                  Object {
-                    "marginHorizontal": 16,
-                    "marginVertical": 9,
-                    "textAlign": "center",
-                  },
-                  false,
-                  Object {
-                    "marginHorizontal": 24,
-                    "marginVertical": 10,
-                  },
-                  undefined,
-                  false,
-                  Object {
-                    "color": "rgba(255, 255, 255, 1)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0.1,
-                    "lineHeight": 20,
-                  },
-                  undefined,
-                ],
-              ]
-            }
-            testID="button-text"
-          >
-            Contained Button
-          </Text>
-        </View>
+                undefined,
+              ],
+            ]
+          }
+          testID="button-text"
+        >
+          Contained Button
+        </Text>
       </View>
     </View>
   </View>
@@ -1414,7 +1334,13 @@ exports[`renders disabled button 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderColor": "transparent",
+        "borderRadius": 20,
+        "borderStyle": "solid",
+        "borderWidth": 0,
         "flex": undefined,
+        "minWidth": 64,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -1424,115 +1350,99 @@ exports[`renders disabled button 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-middle-layer"
+    testID="button-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "transparent",
-          "borderColor": "transparent",
-          "borderRadius": 20,
-          "borderStyle": "solid",
-          "borderWidth": 0,
-          "flex": undefined,
-          "minWidth": 64,
+          "disabled": true,
         }
       }
-      testID="button-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 20,
+          },
+        ]
+      }
+      testID="button"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            Object {
-              "borderRadius": 20,
-            },
+            undefined,
           ]
         }
-        testID="button"
       >
-        <View
+        <Text
+          numberOfLines={1}
+          selectable={false}
           style={
             Array [
               Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "center",
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
               },
-              undefined,
-            ]
-          }
-        >
-          <Text
-            numberOfLines={1}
-            selectable={false}
-            style={
+              Object {
+                "textAlign": "left",
+              },
+              Object {
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
+              },
               Array [
                 Object {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                false,
+                Object {
+                  "marginHorizontal": 12,
+                },
+                undefined,
+                false,
+                Object {
+                  "color": "rgba(28, 27, 31, 0.38)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
                   "letterSpacing": 0.1,
                   "lineHeight": 20,
                 },
-                Object {
-                  "textAlign": "left",
-                },
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "writingDirection": "ltr",
-                },
-                Array [
-                  Object {
-                    "marginHorizontal": 16,
-                    "marginVertical": 9,
-                    "textAlign": "center",
-                  },
-                  false,
-                  Object {
-                    "marginHorizontal": 12,
-                  },
-                  undefined,
-                  false,
-                  Object {
-                    "color": "rgba(28, 27, 31, 0.38)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0.1,
-                    "lineHeight": 20,
-                  },
-                  undefined,
-                ],
-              ]
-            }
-            testID="button-text"
-          >
-            Disabled Button
-          </Text>
-        </View>
+                undefined,
+              ],
+            ]
+          }
+          testID="button-text"
+        >
+          Disabled Button
+        </Text>
       </View>
     </View>
   </View>
@@ -1572,7 +1482,13 @@ exports[`renders loading button 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderColor": "transparent",
+        "borderRadius": 20,
+        "borderStyle": "solid",
+        "borderWidth": 0,
         "flex": undefined,
+        "minWidth": 64,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -1582,105 +1498,104 @@ exports[`renders loading button 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-middle-layer"
+    testID="button-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "transparent",
-          "borderColor": "transparent",
-          "borderRadius": 20,
-          "borderStyle": "solid",
-          "borderWidth": 0,
-          "flex": undefined,
-          "minWidth": 64,
+          "disabled": true,
         }
       }
-      testID="button-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 20,
+          },
+        ]
+      }
+      testID="button"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            Object {
-              "borderRadius": 20,
-            },
+            undefined,
           ]
         }
-        testID="button"
       >
         <View
+          accessibilityRole="progressbar"
+          accessibilityState={
+            Object {
+              "busy": true,
+            }
+          }
+          accessible={true}
           style={
             Array [
               Object {
                 "alignItems": "center",
-                "flexDirection": "row",
                 "justifyContent": "center",
               },
-              undefined,
+              Array [
+                Object {
+                  "marginLeft": 12,
+                  "marginRight": -4,
+                },
+                Object {
+                  "marginLeft": 16,
+                  "marginRight": -16,
+                },
+                Object {
+                  "marginLeft": 12,
+                  "marginRight": -8,
+                },
+              ],
             ]
           }
         >
           <View
-            accessibilityRole="progressbar"
-            accessibilityState={
-              Object {
-                "busy": true,
-              }
-            }
-            accessible={true}
+            collapsable={false}
             style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                },
-                Array [
-                  Object {
-                    "marginLeft": 12,
-                    "marginRight": -4,
-                  },
-                  Object {
-                    "marginLeft": 16,
-                    "marginRight": -16,
-                  },
-                  Object {
-                    "marginLeft": 12,
-                    "marginRight": -8,
-                  },
-                ],
-              ]
+              Object {
+                "height": 18,
+                "opacity": 1,
+                "width": 18,
+              }
             }
           >
             <View
               collapsable={false}
               style={
                 Object {
-                  "height": 18,
-                  "opacity": 1,
-                  "width": 18,
+                  "alignItems": "center",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                 }
               }
             >
@@ -1688,13 +1603,13 @@ exports[`renders loading button 1`] = `
                 collapsable={false}
                 style={
                   Object {
-                    "alignItems": "center",
-                    "bottom": 0,
-                    "justifyContent": "center",
-                    "left": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
+                    "height": 18,
+                    "transform": Array [
+                      Object {
+                        "rotate": "45deg",
+                      },
+                    ],
+                    "width": 18,
                   }
                 }
               >
@@ -1702,12 +1617,8 @@ exports[`renders loading button 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "height": 18,
-                      "transform": Array [
-                        Object {
-                          "rotate": "45deg",
-                        },
-                      ],
+                      "height": 9,
+                      "overflow": "hidden",
                       "width": 18,
                     }
                   }
@@ -1716,8 +1627,15 @@ exports[`renders loading button 1`] = `
                     collapsable={false}
                     style={
                       Object {
-                        "height": 9,
-                        "overflow": "hidden",
+                        "height": 18,
+                        "transform": Array [
+                          Object {
+                            "translateY": 0,
+                          },
+                          Object {
+                            "rotate": "-165deg",
+                          },
+                        ],
                         "width": 18,
                       }
                     }
@@ -1726,15 +1644,8 @@ exports[`renders loading button 1`] = `
                       collapsable={false}
                       style={
                         Object {
-                          "height": 18,
-                          "transform": Array [
-                            Object {
-                              "translateY": 0,
-                            },
-                            Object {
-                              "rotate": "-165deg",
-                            },
-                          ],
+                          "height": 9,
+                          "overflow": "hidden",
                           "width": 18,
                         }
                       }
@@ -1743,40 +1654,44 @@ exports[`renders loading button 1`] = `
                         collapsable={false}
                         style={
                           Object {
-                            "height": 9,
-                            "overflow": "hidden",
+                            "borderColor": "rgba(103, 80, 164, 1)",
+                            "borderRadius": 9,
+                            "borderWidth": 1.8,
+                            "height": 18,
                             "width": 18,
                           }
                         }
-                      >
-                        <View
-                          collapsable={false}
-                          style={
-                            Object {
-                              "borderColor": "rgba(103, 80, 164, 1)",
-                              "borderRadius": 9,
-                              "borderWidth": 1.8,
-                              "height": 18,
-                              "width": 18,
-                            }
-                          }
-                        />
-                      </View>
+                      />
                     </View>
                   </View>
                 </View>
               </View>
+            </View>
+            <View
+              collapsable={false}
+              style={
+                Object {
+                  "alignItems": "center",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            >
               <View
                 collapsable={false}
                 style={
                   Object {
-                    "alignItems": "center",
-                    "bottom": 0,
-                    "justifyContent": "center",
-                    "left": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
+                    "height": 18,
+                    "transform": Array [
+                      Object {
+                        "rotate": "45deg",
+                      },
+                    ],
+                    "width": 18,
                   }
                 }
               >
@@ -1784,12 +1699,9 @@ exports[`renders loading button 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "height": 18,
-                      "transform": Array [
-                        Object {
-                          "rotate": "45deg",
-                        },
-                      ],
+                      "height": 9,
+                      "overflow": "hidden",
+                      "top": 9,
                       "width": 18,
                     }
                   }
@@ -1798,9 +1710,15 @@ exports[`renders loading button 1`] = `
                     collapsable={false}
                     style={
                       Object {
-                        "height": 9,
-                        "overflow": "hidden",
-                        "top": 9,
+                        "height": 18,
+                        "transform": Array [
+                          Object {
+                            "translateY": -9,
+                          },
+                          Object {
+                            "rotate": "345deg",
+                          },
+                        ],
                         "width": 18,
                       }
                     }
@@ -1809,15 +1727,8 @@ exports[`renders loading button 1`] = `
                       collapsable={false}
                       style={
                         Object {
-                          "height": 18,
-                          "transform": Array [
-                            Object {
-                              "translateY": -9,
-                            },
-                            Object {
-                              "rotate": "345deg",
-                            },
-                          ],
+                          "height": 9,
+                          "overflow": "hidden",
                           "width": 18,
                         }
                       }
@@ -1826,79 +1737,68 @@ exports[`renders loading button 1`] = `
                         collapsable={false}
                         style={
                           Object {
-                            "height": 9,
-                            "overflow": "hidden",
+                            "borderColor": "rgba(103, 80, 164, 1)",
+                            "borderRadius": 9,
+                            "borderWidth": 1.8,
+                            "height": 18,
                             "width": 18,
                           }
                         }
-                      >
-                        <View
-                          collapsable={false}
-                          style={
-                            Object {
-                              "borderColor": "rgba(103, 80, 164, 1)",
-                              "borderRadius": 9,
-                              "borderWidth": 1.8,
-                              "height": 18,
-                              "width": 18,
-                            }
-                          }
-                        />
-                      </View>
+                      />
                     </View>
                   </View>
                 </View>
               </View>
             </View>
           </View>
-          <Text
-            numberOfLines={1}
-            selectable={false}
-            style={
+        </View>
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
+              },
+              Object {
+                "textAlign": "left",
+              },
+              Object {
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
+              },
               Array [
                 Object {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                false,
+                Object {
+                  "marginHorizontal": 16,
+                },
+                undefined,
+                false,
+                Object {
+                  "color": "rgba(103, 80, 164, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
                   "letterSpacing": 0.1,
                   "lineHeight": 20,
                 },
-                Object {
-                  "textAlign": "left",
-                },
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "writingDirection": "ltr",
-                },
-                Array [
-                  Object {
-                    "marginHorizontal": 16,
-                    "marginVertical": 9,
-                    "textAlign": "center",
-                  },
-                  false,
-                  Object {
-                    "marginHorizontal": 16,
-                  },
-                  undefined,
-                  false,
-                  Object {
-                    "color": "rgba(103, 80, 164, 1)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0.1,
-                    "lineHeight": 20,
-                  },
-                  undefined,
-                ],
-              ]
-            }
-            testID="button-text"
-          >
-            Loading Button
-          </Text>
-        </View>
+                undefined,
+              ],
+            ]
+          }
+          testID="button-text"
+        >
+          Loading Button
+        </Text>
       </View>
     </View>
   </View>
@@ -1938,7 +1838,13 @@ exports[`renders outlined button with mode 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderColor": "rgba(121, 116, 126, 1)",
+        "borderRadius": 20,
+        "borderStyle": "solid",
+        "borderWidth": 1,
         "flex": undefined,
+        "minWidth": 64,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -1948,116 +1854,100 @@ exports[`renders outlined button with mode 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-middle-layer"
+    testID="button-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "transparent",
-          "borderColor": "rgba(121, 116, 126, 1)",
-          "borderRadius": 20,
-          "borderStyle": "solid",
-          "borderWidth": 1,
-          "flex": undefined,
-          "minWidth": 64,
+          "disabled": true,
         }
       }
-      testID="button-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 20,
+          },
+        ]
+      }
+      testID="button"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            Object {
-              "borderRadius": 20,
-            },
+            undefined,
           ]
         }
-        testID="button"
       >
-        <View
+        <Text
+          numberOfLines={1}
+          selectable={false}
           style={
             Array [
               Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "center",
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
               },
-              undefined,
-            ]
-          }
-        >
-          <Text
-            numberOfLines={1}
-            selectable={false}
-            style={
+              Object {
+                "textAlign": "left",
+              },
+              Object {
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
+              },
               Array [
                 Object {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                false,
+                Object {
+                  "marginHorizontal": 24,
+                  "marginVertical": 10,
+                },
+                undefined,
+                false,
+                Object {
+                  "color": "rgba(103, 80, 164, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
                   "letterSpacing": 0.1,
                   "lineHeight": 20,
                 },
-                Object {
-                  "textAlign": "left",
-                },
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "writingDirection": "ltr",
-                },
-                Array [
-                  Object {
-                    "marginHorizontal": 16,
-                    "marginVertical": 9,
-                    "textAlign": "center",
-                  },
-                  false,
-                  Object {
-                    "marginHorizontal": 24,
-                    "marginVertical": 10,
-                  },
-                  undefined,
-                  false,
-                  Object {
-                    "color": "rgba(103, 80, 164, 1)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0.1,
-                    "lineHeight": 20,
-                  },
-                  undefined,
-                ],
-              ]
-            }
-            testID="button-text"
-          >
-            Outlined Button
-          </Text>
-        </View>
+                undefined,
+              ],
+            ]
+          }
+          testID="button-text"
+        >
+          Outlined Button
+        </Text>
       </View>
     </View>
   </View>
@@ -2097,7 +1987,13 @@ exports[`renders text button by default 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderColor": "transparent",
+        "borderRadius": 20,
+        "borderStyle": "solid",
+        "borderWidth": 0,
         "flex": undefined,
+        "minWidth": 64,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -2107,115 +2003,99 @@ exports[`renders text button by default 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-middle-layer"
+    testID="button-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "transparent",
-          "borderColor": "transparent",
-          "borderRadius": 20,
-          "borderStyle": "solid",
-          "borderWidth": 0,
-          "flex": undefined,
-          "minWidth": 64,
+          "disabled": true,
         }
       }
-      testID="button-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 20,
+          },
+        ]
+      }
+      testID="button"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            Object {
-              "borderRadius": 20,
-            },
+            undefined,
           ]
         }
-        testID="button"
       >
-        <View
+        <Text
+          numberOfLines={1}
+          selectable={false}
           style={
             Array [
               Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "center",
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
               },
-              undefined,
-            ]
-          }
-        >
-          <Text
-            numberOfLines={1}
-            selectable={false}
-            style={
+              Object {
+                "textAlign": "left",
+              },
+              Object {
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
+              },
               Array [
                 Object {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                false,
+                Object {
+                  "marginHorizontal": 12,
+                },
+                undefined,
+                false,
+                Object {
+                  "color": "rgba(103, 80, 164, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
                   "letterSpacing": 0.1,
                   "lineHeight": 20,
                 },
-                Object {
-                  "textAlign": "left",
-                },
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "writingDirection": "ltr",
-                },
-                Array [
-                  Object {
-                    "marginHorizontal": 16,
-                    "marginVertical": 9,
-                    "textAlign": "center",
-                  },
-                  false,
-                  Object {
-                    "marginHorizontal": 12,
-                  },
-                  undefined,
-                  false,
-                  Object {
-                    "color": "rgba(103, 80, 164, 1)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0.1,
-                    "lineHeight": 20,
-                  },
-                  undefined,
-                ],
-              ]
-            }
-            testID="button-text"
-          >
-            Text Button
-          </Text>
-        </View>
+                undefined,
+              ],
+            ]
+          }
+          testID="button-text"
+        >
+          Text Button
+        </Text>
       </View>
     </View>
   </View>
@@ -2255,7 +2135,13 @@ exports[`renders text button with mode 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderColor": "transparent",
+        "borderRadius": 20,
+        "borderStyle": "solid",
+        "borderWidth": 0,
         "flex": undefined,
+        "minWidth": 64,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -2265,115 +2151,99 @@ exports[`renders text button with mode 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-middle-layer"
+    testID="button-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "transparent",
-          "borderColor": "transparent",
-          "borderRadius": 20,
-          "borderStyle": "solid",
-          "borderWidth": 0,
-          "flex": undefined,
-          "minWidth": 64,
+          "disabled": true,
         }
       }
-      testID="button-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 20,
+          },
+        ]
+      }
+      testID="button"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            Object {
-              "borderRadius": 20,
-            },
+            undefined,
           ]
         }
-        testID="button"
       >
-        <View
+        <Text
+          numberOfLines={1}
+          selectable={false}
           style={
             Array [
               Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "center",
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
               },
-              undefined,
-            ]
-          }
-        >
-          <Text
-            numberOfLines={1}
-            selectable={false}
-            style={
+              Object {
+                "textAlign": "left",
+              },
+              Object {
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
+              },
               Array [
                 Object {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                false,
+                Object {
+                  "marginHorizontal": 12,
+                },
+                undefined,
+                false,
+                Object {
+                  "color": "rgba(103, 80, 164, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
                   "letterSpacing": 0.1,
                   "lineHeight": 20,
                 },
-                Object {
-                  "textAlign": "left",
-                },
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "writingDirection": "ltr",
-                },
-                Array [
-                  Object {
-                    "marginHorizontal": 16,
-                    "marginVertical": 9,
-                    "textAlign": "center",
-                  },
-                  false,
-                  Object {
-                    "marginHorizontal": 12,
-                  },
-                  undefined,
-                  false,
-                  Object {
-                    "color": "rgba(103, 80, 164, 1)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0.1,
-                    "lineHeight": 20,
-                  },
-                  undefined,
-                ],
-              ]
-            }
-            testID="button-text"
-          >
-            Text Button
-          </Text>
-        </View>
+                undefined,
+              ],
+            ]
+          }
+          testID="button-text"
+        >
+          Text Button
+        </Text>
       </View>
     </View>
   </View>

--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -9,7 +9,9 @@ exports[`renders button with an accessibility hint 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -21,6 +23,8 @@ exports[`renders button with an accessibility hint 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -39,7 +43,7 @@ exports[`renders button with an accessibility hint 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-inner-layer"
+    testID="button-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -164,7 +168,9 @@ exports[`renders button with an accessibility label 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -176,6 +182,8 @@ exports[`renders button with an accessibility label 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -194,7 +202,7 @@ exports[`renders button with an accessibility label 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-inner-layer"
+    testID="button-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -319,7 +327,9 @@ exports[`renders button with button color 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -331,6 +341,8 @@ exports[`renders button with button color 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -349,7 +361,7 @@ exports[`renders button with button color 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-inner-layer"
+    testID="button-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -473,7 +485,9 @@ exports[`renders button with color 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -485,6 +499,8 @@ exports[`renders button with color 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -503,7 +519,7 @@ exports[`renders button with color 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-inner-layer"
+    testID="button-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -627,7 +643,9 @@ exports[`renders button with custom testID 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -639,6 +657,8 @@ exports[`renders button with custom testID 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="custom:testID-container-outer-layer"
@@ -657,7 +677,7 @@ exports[`renders button with custom testID 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="custom:testID-container-inner-layer"
+    testID="custom:testID-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -781,7 +801,9 @@ exports[`renders button with icon 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -793,6 +815,8 @@ exports[`renders button with icon 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -811,7 +835,7 @@ exports[`renders button with icon 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-inner-layer"
+    testID="button-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -991,7 +1015,9 @@ exports[`renders button with icon in reverse order 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1003,6 +1029,8 @@ exports[`renders button with icon in reverse order 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -1021,7 +1049,7 @@ exports[`renders button with icon in reverse order 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-inner-layer"
+    testID="button-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -1203,7 +1231,9 @@ exports[`renders contained contained with mode 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1215,6 +1245,8 @@ exports[`renders contained contained with mode 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -1233,7 +1265,7 @@ exports[`renders contained contained with mode 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-inner-layer"
+    testID="button-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -1358,7 +1390,9 @@ exports[`renders disabled button 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1370,6 +1404,8 @@ exports[`renders disabled button 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -1388,7 +1424,7 @@ exports[`renders disabled button 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-inner-layer"
+    testID="button-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -1512,7 +1548,9 @@ exports[`renders loading button 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1524,6 +1562,8 @@ exports[`renders loading button 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -1542,7 +1582,7 @@ exports[`renders loading button 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-inner-layer"
+    testID="button-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -1874,7 +1914,9 @@ exports[`renders outlined button with mode 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1886,6 +1928,8 @@ exports[`renders outlined button with mode 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -1904,7 +1948,7 @@ exports[`renders outlined button with mode 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-inner-layer"
+    testID="button-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -2029,7 +2073,9 @@ exports[`renders text button by default 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -2041,6 +2087,8 @@ exports[`renders text button by default 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -2059,7 +2107,7 @@ exports[`renders text button by default 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-inner-layer"
+    testID="button-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -2183,7 +2231,9 @@ exports[`renders text button with mode 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -2195,6 +2245,8 @@ exports[`renders text button with mode 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -2213,7 +2265,7 @@ exports[`renders text button with mode 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="button-container-inner-layer"
+    testID="button-container-middle-layer"
   >
     <View
       collapsable={false}

--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -6,6 +6,8 @@ exports[`renders button with an accessibility hint 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -155,6 +157,8 @@ exports[`renders button with an accessibility label 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -304,6 +308,8 @@ exports[`renders button with button color 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "#e91e63",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -452,6 +458,8 @@ exports[`renders button with color 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -600,6 +608,8 @@ exports[`renders button with custom testID 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -748,6 +758,8 @@ exports[`renders button with icon 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -952,6 +964,8 @@ exports[`renders button with icon in reverse order 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -1158,6 +1172,8 @@ exports[`renders contained contained with mode 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(103, 80, 164, 1)",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -1307,6 +1323,8 @@ exports[`renders disabled button 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -1455,6 +1473,8 @@ exports[`renders loading button 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -1811,6 +1831,8 @@ exports[`renders outlined button with mode 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -1960,6 +1982,8 @@ exports[`renders text button by default 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -2108,6 +2132,8 @@ exports[`renders text button with mode 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,

--- a/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -33,7 +33,13 @@ exports[`renders chip with close button 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(232, 222, 248, 1)",
+        "borderColor": "rgba(121, 116, 126, 1)",
+        "borderRadius": 8,
+        "borderStyle": "solid",
+        "borderWidth": 0,
         "flex": undefined,
+        "flexDirection": "column",
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -43,200 +49,66 @@ exports[`renders chip with close button 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="chip-container-middle-layer"
+    testID="chip-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "rgba(232, 222, 248, 1)",
-          "borderColor": "rgba(121, 116, 126, 1)",
-          "borderRadius": 8,
-          "borderStyle": "solid",
-          "borderWidth": 0,
-          "flex": undefined,
-          "flexDirection": "column",
+          "disabled": true,
+          "selected": false,
         }
       }
-      testID="chip-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Array [
+            Object {
+              "borderRadius": 8,
+            },
+            Object {
+              "flexGrow": 1,
+            },
+          ],
+        ]
+      }
+      testID="chip"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-            "selected": false,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "flexGrow": 1,
+              "paddingLeft": 4,
+              "position": "relative",
             },
-            false,
-            Array [
-              Object {
-                "borderRadius": 8,
-              },
-              Object {
-                "flexGrow": 1,
-              },
-            ],
+            Object {
+              "paddingLeft": 0,
+            },
+            Object {
+              "paddingRight": 34,
+            },
           ]
         }
-        testID="chip"
       >
         <View
-          style={
-            Array [
-              Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "flexGrow": 1,
-                "paddingLeft": 4,
-                "position": "relative",
-              },
-              Object {
-                "paddingLeft": 0,
-              },
-              Object {
-                "paddingRight": 34,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "alignSelf": "center",
-                  "padding": 4,
-                },
-                Object {
-                  "paddingLeft": 8,
-                  "paddingRight": 0,
-                },
-                null,
-              ]
-            }
-          >
-            <Text
-              accessibilityElementsHidden={true}
-              allowFontScaling={false}
-              importantForAccessibility="no-hide-descendants"
-              pointerEvents="none"
-              selectable={false}
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(103, 80, 164, 1)",
-                    "fontSize": 18,
-                  },
-                  Array [
-                    Object {
-                      "lineHeight": 18,
-                      "transform": Array [
-                        Object {
-                          "scaleX": 1,
-                        },
-                      ],
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ],
-                  Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
-              }
-            >
-              󰋼
-            </Text>
-          </View>
-          <Text
-            numberOfLines={1}
-            selectable={false}
-            style={
-              Array [
-                Object {
-                  "fontFamily": "System",
-                  "fontSize": 14,
-                  "fontWeight": "500",
-                  "letterSpacing": 0.1,
-                  "lineHeight": 20,
-                },
-                Object {
-                  "textAlign": "left",
-                },
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "writingDirection": "ltr",
-                },
-                Array [
-                  Object {
-                    "marginVertical": 6,
-                    "textAlignVertical": "center",
-                  },
-                  Object {
-                    "color": "rgba(29, 25, 43, 1)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0.1,
-                    "lineHeight": 20,
-                  },
-                  Object {
-                    "marginLeft": 8,
-                    "marginRight": 0,
-                  },
-                  undefined,
-                ],
-              ]
-            }
-          >
-            Example Chip
-          </Text>
-        </View>
-      </View>
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "height": "100%",
-            "justifyContent": "center",
-            "position": "absolute",
-            "right": 0,
-          }
-        }
-      >
-        <View
-          accessibilityLabel="Close"
-          accessibilityRole="button"
-          accessible={true}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Array [
               Object {
@@ -244,12 +116,10 @@ exports[`renders chip with close button 1`] = `
                 "padding": 4,
               },
               Object {
-                "marginRight": 4,
+                "paddingLeft": 8,
+                "paddingRight": 0,
               },
-              Object {
-                "marginRight": 8,
-                "padding": 0,
-              },
+              null,
             ]
           }
         >
@@ -262,7 +132,7 @@ exports[`renders chip with close button 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(29, 25, 43, 1)",
+                  "color": "rgba(103, 80, 164, 1)",
                   "fontSize": 18,
                 },
                 Array [
@@ -287,9 +157,129 @@ exports[`renders chip with close button 1`] = `
               ]
             }
           >
-            󰅖
+            󰋼
           </Text>
         </View>
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
+              },
+              Object {
+                "textAlign": "left",
+              },
+              Object {
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
+              },
+              Array [
+                Object {
+                  "marginVertical": 6,
+                  "textAlignVertical": "center",
+                },
+                Object {
+                  "color": "rgba(29, 25, 43, 1)",
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                Object {
+                  "marginLeft": 8,
+                  "marginRight": 0,
+                },
+                undefined,
+              ],
+            ]
+          }
+        >
+          Example Chip
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "height": "100%",
+          "justifyContent": "center",
+          "position": "absolute",
+          "right": 0,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Close"
+        accessibilityRole="button"
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Array [
+            Object {
+              "alignSelf": "center",
+              "padding": 4,
+            },
+            Object {
+              "marginRight": 4,
+            },
+            Object {
+              "marginRight": 8,
+              "padding": 0,
+            },
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          allowFontScaling={false}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "color": "rgba(29, 25, 43, 1)",
+                "fontSize": 18,
+              },
+              Array [
+                Object {
+                  "lineHeight": 18,
+                  "transform": Array [
+                    Object {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                Object {
+                  "backgroundColor": "transparent",
+                },
+              ],
+              Object {
+                "fontFamily": "Material Design Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          󰅖
+        </Text>
       </View>
     </View>
   </View>
@@ -329,7 +319,13 @@ exports[`renders chip with custom close button 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(232, 222, 248, 1)",
+        "borderColor": "rgba(121, 116, 126, 1)",
+        "borderRadius": 8,
+        "borderStyle": "solid",
+        "borderWidth": 0,
         "flex": undefined,
+        "flexDirection": "column",
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -339,200 +335,66 @@ exports[`renders chip with custom close button 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="chip-container-middle-layer"
+    testID="chip-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "rgba(232, 222, 248, 1)",
-          "borderColor": "rgba(121, 116, 126, 1)",
-          "borderRadius": 8,
-          "borderStyle": "solid",
-          "borderWidth": 0,
-          "flex": undefined,
-          "flexDirection": "column",
+          "disabled": true,
+          "selected": false,
         }
       }
-      testID="chip-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Array [
+            Object {
+              "borderRadius": 8,
+            },
+            Object {
+              "flexGrow": 1,
+            },
+          ],
+        ]
+      }
+      testID="chip"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-            "selected": false,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "flexGrow": 1,
+              "paddingLeft": 4,
+              "position": "relative",
             },
-            false,
-            Array [
-              Object {
-                "borderRadius": 8,
-              },
-              Object {
-                "flexGrow": 1,
-              },
-            ],
+            Object {
+              "paddingLeft": 0,
+            },
+            Object {
+              "paddingRight": 34,
+            },
           ]
         }
-        testID="chip"
       >
         <View
-          style={
-            Array [
-              Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "flexGrow": 1,
-                "paddingLeft": 4,
-                "position": "relative",
-              },
-              Object {
-                "paddingLeft": 0,
-              },
-              Object {
-                "paddingRight": 34,
-              },
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "alignSelf": "center",
-                  "padding": 4,
-                },
-                Object {
-                  "paddingLeft": 8,
-                  "paddingRight": 0,
-                },
-                null,
-              ]
-            }
-          >
-            <Text
-              accessibilityElementsHidden={true}
-              allowFontScaling={false}
-              importantForAccessibility="no-hide-descendants"
-              pointerEvents="none"
-              selectable={false}
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(103, 80, 164, 1)",
-                    "fontSize": 18,
-                  },
-                  Array [
-                    Object {
-                      "lineHeight": 18,
-                      "transform": Array [
-                        Object {
-                          "scaleX": 1,
-                        },
-                      ],
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ],
-                  Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
-              }
-            >
-              󰋼
-            </Text>
-          </View>
-          <Text
-            numberOfLines={1}
-            selectable={false}
-            style={
-              Array [
-                Object {
-                  "fontFamily": "System",
-                  "fontSize": 14,
-                  "fontWeight": "500",
-                  "letterSpacing": 0.1,
-                  "lineHeight": 20,
-                },
-                Object {
-                  "textAlign": "left",
-                },
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "writingDirection": "ltr",
-                },
-                Array [
-                  Object {
-                    "marginVertical": 6,
-                    "textAlignVertical": "center",
-                  },
-                  Object {
-                    "color": "rgba(29, 25, 43, 1)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0.1,
-                    "lineHeight": 20,
-                  },
-                  Object {
-                    "marginLeft": 8,
-                    "marginRight": 0,
-                  },
-                  undefined,
-                ],
-              ]
-            }
-          >
-            Example Chip
-          </Text>
-        </View>
-      </View>
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "height": "100%",
-            "justifyContent": "center",
-            "position": "absolute",
-            "right": 0,
-          }
-        }
-      >
-        <View
-          accessibilityLabel="Close"
-          accessibilityRole="button"
-          accessible={true}
-          focusable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Array [
               Object {
@@ -540,12 +402,10 @@ exports[`renders chip with custom close button 1`] = `
                 "padding": 4,
               },
               Object {
-                "marginRight": 4,
+                "paddingLeft": 8,
+                "paddingRight": 0,
               },
-              Object {
-                "marginRight": 8,
-                "padding": 0,
-              },
+              null,
             ]
           }
         >
@@ -558,7 +418,7 @@ exports[`renders chip with custom close button 1`] = `
             style={
               Array [
                 Object {
-                  "color": "rgba(29, 25, 43, 1)",
+                  "color": "rgba(103, 80, 164, 1)",
                   "fontSize": 18,
                 },
                 Array [
@@ -583,9 +443,129 @@ exports[`renders chip with custom close button 1`] = `
               ]
             }
           >
-            󰁅
+            󰋼
           </Text>
         </View>
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
+              },
+              Object {
+                "textAlign": "left",
+              },
+              Object {
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
+              },
+              Array [
+                Object {
+                  "marginVertical": 6,
+                  "textAlignVertical": "center",
+                },
+                Object {
+                  "color": "rgba(29, 25, 43, 1)",
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                Object {
+                  "marginLeft": 8,
+                  "marginRight": 0,
+                },
+                undefined,
+              ],
+            ]
+          }
+        >
+          Example Chip
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "height": "100%",
+          "justifyContent": "center",
+          "position": "absolute",
+          "right": 0,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Close"
+        accessibilityRole="button"
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Array [
+            Object {
+              "alignSelf": "center",
+              "padding": 4,
+            },
+            Object {
+              "marginRight": 4,
+            },
+            Object {
+              "marginRight": 8,
+              "padding": 0,
+            },
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          allowFontScaling={false}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "color": "rgba(29, 25, 43, 1)",
+                "fontSize": 18,
+              },
+              Array [
+                Object {
+                  "lineHeight": 18,
+                  "transform": Array [
+                    Object {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                Object {
+                  "backgroundColor": "transparent",
+                },
+              ],
+              Object {
+                "fontFamily": "Material Design Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          󰁅
+        </Text>
       </View>
     </View>
   </View>
@@ -625,7 +605,13 @@ exports[`renders chip with icon 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(232, 222, 248, 1)",
+        "borderColor": "rgba(121, 116, 126, 1)",
+        "borderRadius": 8,
+        "borderStyle": "solid",
+        "borderWidth": 0,
         "flex": undefined,
+        "flexDirection": "column",
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -635,138 +621,143 @@ exports[`renders chip with icon 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="chip-container-middle-layer"
+    testID="chip-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "rgba(232, 222, 248, 1)",
-          "borderColor": "rgba(121, 116, 126, 1)",
-          "borderRadius": 8,
-          "borderStyle": "solid",
-          "borderWidth": 0,
-          "flex": undefined,
-          "flexDirection": "column",
+          "disabled": true,
+          "selected": false,
         }
       }
-      testID="chip-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Array [
+            Object {
+              "borderRadius": 8,
+            },
+            Object {
+              "flexGrow": 1,
+            },
+          ],
+        ]
+      }
+      testID="chip"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-            "selected": false,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "flexGrow": 1,
+              "paddingLeft": 4,
+              "position": "relative",
             },
-            false,
-            Array [
-              Object {
-                "borderRadius": 8,
-              },
-              Object {
-                "flexGrow": 1,
-              },
-            ],
+            Object {
+              "paddingLeft": 0,
+            },
+            Object {
+              "paddingRight": 0,
+            },
           ]
         }
-        testID="chip"
       >
         <View
           style={
             Array [
               Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "flexGrow": 1,
-                "paddingLeft": 4,
-                "position": "relative",
+                "alignSelf": "center",
+                "padding": 4,
               },
               Object {
-                "paddingLeft": 0,
-              },
-              Object {
+                "paddingLeft": 8,
                 "paddingRight": 0,
               },
+              null,
             ]
           }
         >
-          <View
-            style={
-              Array [
-                Object {
-                  "alignSelf": "center",
-                  "padding": 4,
-                },
-                Object {
-                  "paddingLeft": 8,
-                  "paddingRight": 0,
-                },
-                null,
-              ]
-            }
-          >
-            <Text
-              accessibilityElementsHidden={true}
-              allowFontScaling={false}
-              importantForAccessibility="no-hide-descendants"
-              pointerEvents="none"
-              selectable={false}
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(103, 80, 164, 1)",
-                    "fontSize": 18,
-                  },
-                  Array [
-                    Object {
-                      "lineHeight": 18,
-                      "transform": Array [
-                        Object {
-                          "scaleX": 1,
-                        },
-                      ],
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ],
-                  Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
-              }
-            >
-              󰋼
-            </Text>
-          </View>
           <Text
-            numberOfLines={1}
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
             selectable={false}
             style={
               Array [
                 Object {
+                  "color": "rgba(103, 80, 164, 1)",
+                  "fontSize": 18,
+                },
+                Array [
+                  Object {
+                    "lineHeight": 18,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  Object {
+                    "backgroundColor": "transparent",
+                  },
+                ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            󰋼
+          </Text>
+        </View>
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
+              },
+              Object {
+                "textAlign": "left",
+              },
+              Object {
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
+              },
+              Array [
+                Object {
+                  "marginVertical": 6,
+                  "textAlignVertical": "center",
+                },
+                Object {
+                  "color": "rgba(29, 25, 43, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -774,37 +765,16 @@ exports[`renders chip with icon 1`] = `
                   "lineHeight": 20,
                 },
                 Object {
-                  "textAlign": "left",
+                  "marginLeft": 8,
+                  "marginRight": 16,
                 },
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "writingDirection": "ltr",
-                },
-                Array [
-                  Object {
-                    "marginVertical": 6,
-                    "textAlignVertical": "center",
-                  },
-                  Object {
-                    "color": "rgba(29, 25, 43, 1)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0.1,
-                    "lineHeight": 20,
-                  },
-                  Object {
-                    "marginLeft": 8,
-                    "marginRight": 16,
-                  },
-                  undefined,
-                ],
-              ]
-            }
-          >
-            Example Chip
-          </Text>
-        </View>
+                undefined,
+              ],
+            ]
+          }
+        >
+          Example Chip
+        </Text>
       </View>
     </View>
   </View>
@@ -844,7 +814,13 @@ exports[`renders chip with onPress 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(232, 222, 248, 1)",
+        "borderColor": "rgba(121, 116, 126, 1)",
+        "borderRadius": 8,
+        "borderStyle": "solid",
+        "borderWidth": 0,
         "flex": undefined,
+        "flexDirection": "column",
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -854,86 +830,91 @@ exports[`renders chip with onPress 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="chip-container-middle-layer"
+    testID="chip-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "rgba(232, 222, 248, 1)",
-          "borderColor": "rgba(121, 116, 126, 1)",
-          "borderRadius": 8,
-          "borderStyle": "solid",
-          "borderWidth": 0,
-          "flex": undefined,
-          "flexDirection": "column",
+          "disabled": false,
+          "selected": false,
         }
       }
-      testID="chip-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Array [
+            Object {
+              "borderRadius": 8,
+            },
+            Object {
+              "flexGrow": 1,
+            },
+          ],
+        ]
+      }
+      testID="chip"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": false,
-            "selected": false,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "flexGrow": 1,
+              "paddingLeft": 4,
+              "position": "relative",
             },
-            false,
-            Array [
-              Object {
-                "borderRadius": 8,
-              },
-              Object {
-                "flexGrow": 1,
-              },
-            ],
+            Object {
+              "paddingLeft": 0,
+            },
+            Object {
+              "paddingRight": 0,
+            },
           ]
         }
-        testID="chip"
       >
-        <View
+        <Text
+          numberOfLines={1}
+          selectable={false}
           style={
             Array [
               Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "flexGrow": 1,
-                "paddingLeft": 4,
-                "position": "relative",
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
               },
               Object {
-                "paddingLeft": 0,
+                "textAlign": "left",
               },
               Object {
-                "paddingRight": 0,
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
               },
-            ]
-          }
-        >
-          <Text
-            numberOfLines={1}
-            selectable={false}
-            style={
               Array [
                 Object {
+                  "marginVertical": 6,
+                  "textAlignVertical": "center",
+                },
+                Object {
+                  "color": "rgba(29, 25, 43, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -941,37 +922,16 @@ exports[`renders chip with onPress 1`] = `
                   "lineHeight": 20,
                 },
                 Object {
-                  "textAlign": "left",
+                  "marginLeft": 16,
+                  "marginRight": 16,
                 },
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "writingDirection": "ltr",
-                },
-                Array [
-                  Object {
-                    "marginVertical": 6,
-                    "textAlignVertical": "center",
-                  },
-                  Object {
-                    "color": "rgba(29, 25, 43, 1)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0.1,
-                    "lineHeight": 20,
-                  },
-                  Object {
-                    "marginLeft": 16,
-                    "marginRight": 16,
-                  },
-                  undefined,
-                ],
-              ]
-            }
-          >
-            Example Chip
-          </Text>
-        </View>
+                undefined,
+              ],
+            ]
+          }
+        >
+          Example Chip
+        </Text>
       </View>
     </View>
   </View>
@@ -1011,7 +971,13 @@ exports[`renders outlined disabled chip 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderColor": "rgba(73, 69, 79, 0.12)",
+        "borderRadius": 8,
+        "borderStyle": "solid",
+        "borderWidth": 1,
         "flex": undefined,
+        "flexDirection": "column",
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -1021,86 +987,91 @@ exports[`renders outlined disabled chip 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="chip-container-middle-layer"
+    testID="chip-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "transparent",
-          "borderColor": "rgba(73, 69, 79, 0.12)",
-          "borderRadius": 8,
-          "borderStyle": "solid",
-          "borderWidth": 1,
-          "flex": undefined,
-          "flexDirection": "column",
+          "disabled": true,
+          "selected": false,
         }
       }
-      testID="chip-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Array [
+            Object {
+              "borderRadius": 8,
+            },
+            Object {
+              "flexGrow": 1,
+            },
+          ],
+        ]
+      }
+      testID="chip"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-            "selected": false,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "flexGrow": 1,
+              "paddingLeft": 4,
+              "position": "relative",
             },
-            false,
-            Array [
-              Object {
-                "borderRadius": 8,
-              },
-              Object {
-                "flexGrow": 1,
-              },
-            ],
+            Object {
+              "paddingLeft": 0,
+            },
+            Object {
+              "paddingRight": 0,
+            },
           ]
         }
-        testID="chip"
       >
-        <View
+        <Text
+          numberOfLines={1}
+          selectable={false}
           style={
             Array [
               Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "flexGrow": 1,
-                "paddingLeft": 4,
-                "position": "relative",
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
               },
               Object {
-                "paddingLeft": 0,
+                "textAlign": "left",
               },
               Object {
-                "paddingRight": 0,
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
               },
-            ]
-          }
-        >
-          <Text
-            numberOfLines={1}
-            selectable={false}
-            style={
               Array [
                 Object {
+                  "marginVertical": 6,
+                  "textAlignVertical": "center",
+                },
+                Object {
+                  "color": "rgba(28, 27, 31, 0.38)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -1108,37 +1079,16 @@ exports[`renders outlined disabled chip 1`] = `
                   "lineHeight": 20,
                 },
                 Object {
-                  "textAlign": "left",
+                  "marginLeft": 16,
+                  "marginRight": 16,
                 },
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "writingDirection": "ltr",
-                },
-                Array [
-                  Object {
-                    "marginVertical": 6,
-                    "textAlignVertical": "center",
-                  },
-                  Object {
-                    "color": "rgba(28, 27, 31, 0.38)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0.1,
-                    "lineHeight": 20,
-                  },
-                  Object {
-                    "marginLeft": 16,
-                    "marginRight": 16,
-                  },
-                  undefined,
-                ],
-              ]
-            }
-          >
-            Example Chip
-          </Text>
-        </View>
+                undefined,
+              ],
+            ]
+          }
+        >
+          Example Chip
+        </Text>
       </View>
     </View>
   </View>
@@ -1178,7 +1128,13 @@ exports[`renders selected chip 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgb(232, 222, 248)",
+        "borderColor": "rgba(121, 116, 126, 1)",
+        "borderRadius": 8,
+        "borderStyle": "solid",
+        "borderWidth": 0,
         "flex": undefined,
+        "flexDirection": "column",
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -1188,138 +1144,143 @@ exports[`renders selected chip 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="chip-container-middle-layer"
+    testID="chip-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "rgb(232, 222, 248)",
-          "borderColor": "rgba(121, 116, 126, 1)",
-          "borderRadius": 8,
-          "borderStyle": "solid",
-          "borderWidth": 0,
-          "flex": undefined,
-          "flexDirection": "column",
+          "disabled": true,
+          "selected": true,
         }
       }
-      testID="chip-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Array [
+            Object {
+              "borderRadius": 8,
+            },
+            Object {
+              "flexGrow": 1,
+            },
+          ],
+        ]
+      }
+      testID="chip"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-            "selected": true,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "flexGrow": 1,
+              "paddingLeft": 4,
+              "position": "relative",
             },
-            false,
-            Array [
-              Object {
-                "borderRadius": 8,
-              },
-              Object {
-                "flexGrow": 1,
-              },
-            ],
+            Object {
+              "paddingLeft": 0,
+            },
+            Object {
+              "paddingRight": 0,
+            },
           ]
         }
-        testID="chip"
       >
         <View
           style={
             Array [
               Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "flexGrow": 1,
-                "paddingLeft": 4,
-                "position": "relative",
+                "alignSelf": "center",
+                "padding": 4,
               },
               Object {
-                "paddingLeft": 0,
-              },
-              Object {
+                "paddingLeft": 8,
                 "paddingRight": 0,
               },
+              null,
             ]
           }
         >
-          <View
-            style={
-              Array [
-                Object {
-                  "alignSelf": "center",
-                  "padding": 4,
-                },
-                Object {
-                  "paddingLeft": 8,
-                  "paddingRight": 0,
-                },
-                null,
-              ]
-            }
-          >
-            <Text
-              accessibilityElementsHidden={true}
-              allowFontScaling={false}
-              importantForAccessibility="no-hide-descendants"
-              pointerEvents="none"
-              selectable={false}
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(29, 25, 43, 1)",
-                    "fontSize": 18,
-                  },
-                  Array [
-                    Object {
-                      "lineHeight": 18,
-                      "transform": Array [
-                        Object {
-                          "scaleX": 1,
-                        },
-                      ],
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ],
-                  Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
-              }
-            >
-              󰄬
-            </Text>
-          </View>
           <Text
-            numberOfLines={1}
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
             selectable={false}
             style={
               Array [
                 Object {
+                  "color": "rgba(29, 25, 43, 1)",
+                  "fontSize": 18,
+                },
+                Array [
+                  Object {
+                    "lineHeight": 18,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  Object {
+                    "backgroundColor": "transparent",
+                  },
+                ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            󰄬
+          </Text>
+        </View>
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
+              },
+              Object {
+                "textAlign": "left",
+              },
+              Object {
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
+              },
+              Array [
+                Object {
+                  "marginVertical": 6,
+                  "textAlignVertical": "center",
+                },
+                Object {
+                  "color": "rgba(29, 25, 43, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
@@ -1327,37 +1288,16 @@ exports[`renders selected chip 1`] = `
                   "lineHeight": 20,
                 },
                 Object {
-                  "textAlign": "left",
+                  "marginLeft": 8,
+                  "marginRight": 16,
                 },
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "writingDirection": "ltr",
-                },
-                Array [
-                  Object {
-                    "marginVertical": 6,
-                    "textAlignVertical": "center",
-                  },
-                  Object {
-                    "color": "rgba(29, 25, 43, 1)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0.1,
-                    "lineHeight": 20,
-                  },
-                  Object {
-                    "marginLeft": 8,
-                    "marginRight": 16,
-                  },
-                  undefined,
-                ],
-              ]
-            }
-          >
-            Example Chip
-          </Text>
-        </View>
+                undefined,
+              ],
+            ]
+          }
+        >
+          Example Chip
+        </Text>
       </View>
     </View>
   </View>

--- a/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -9,7 +9,9 @@ exports[`renders chip with close button 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -21,6 +23,8 @@ exports[`renders chip with close button 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="chip-container-outer-layer"
@@ -39,7 +43,7 @@ exports[`renders chip with close button 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="chip-container-inner-layer"
+    testID="chip-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -301,7 +305,9 @@ exports[`renders chip with custom close button 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -313,6 +319,8 @@ exports[`renders chip with custom close button 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="chip-container-outer-layer"
@@ -331,7 +339,7 @@ exports[`renders chip with custom close button 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="chip-container-inner-layer"
+    testID="chip-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -593,7 +601,9 @@ exports[`renders chip with icon 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -605,6 +615,8 @@ exports[`renders chip with icon 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="chip-container-outer-layer"
@@ -623,7 +635,7 @@ exports[`renders chip with icon 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="chip-container-inner-layer"
+    testID="chip-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -808,7 +820,9 @@ exports[`renders chip with onPress 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -820,6 +834,8 @@ exports[`renders chip with onPress 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="chip-container-outer-layer"
@@ -838,7 +854,7 @@ exports[`renders chip with onPress 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="chip-container-inner-layer"
+    testID="chip-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -971,7 +987,9 @@ exports[`renders outlined disabled chip 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -983,6 +1001,8 @@ exports[`renders outlined disabled chip 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="chip-container-outer-layer"
@@ -1001,7 +1021,7 @@ exports[`renders outlined disabled chip 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="chip-container-inner-layer"
+    testID="chip-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -1134,7 +1154,9 @@ exports[`renders selected chip 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1146,6 +1168,8 @@ exports[`renders selected chip 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="chip-container-outer-layer"
@@ -1164,7 +1188,7 @@ exports[`renders selected chip 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="chip-container-inner-layer"
+    testID="chip-container-middle-layer"
   >
     <View
       collapsable={false}

--- a/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -6,6 +6,8 @@ exports[`renders chip with close button 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(232, 222, 248, 1)",
+      "borderRadius": 8,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -292,6 +294,8 @@ exports[`renders chip with custom close button 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(232, 222, 248, 1)",
+      "borderRadius": 8,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -578,6 +582,8 @@ exports[`renders chip with icon 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(232, 222, 248, 1)",
+      "borderRadius": 8,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -787,6 +793,8 @@ exports[`renders chip with onPress 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(232, 222, 248, 1)",
+      "borderRadius": 8,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -944,6 +952,8 @@ exports[`renders outlined disabled chip 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 8,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -1101,6 +1111,8 @@ exports[`renders selected chip 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(232, 222, 248)",
+      "borderRadius": 8,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,

--- a/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -272,7 +272,10 @@ exports[`renders data table pagination 1`] = `
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -284,6 +287,8 @@ exports[`renders data table pagination 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -292,7 +297,7 @@ exports[`renders data table pagination 1`] = `
         collapsable={false}
         style={
           Object {
-            "flex": undefined,
+            "flex": 1,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -302,22 +307,19 @@ exports[`renders data table pagination 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-inner-layer"
+        testID="icon-button-container-middle-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
-              "backgroundColor": undefined,
+              "backgroundColor": "transparent",
               "borderColor": "rgba(121, 116, 126, 1)",
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
-              "flex": undefined,
-              "height": 40,
-              "margin": 6,
+              "flex": 1,
               "overflow": "hidden",
-              "width": 40,
             }
           }
           testID="icon-button-container"
@@ -421,7 +423,10 @@ exports[`renders data table pagination 1`] = `
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -433,6 +438,8 @@ exports[`renders data table pagination 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -441,7 +448,7 @@ exports[`renders data table pagination 1`] = `
         collapsable={false}
         style={
           Object {
-            "flex": undefined,
+            "flex": 1,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -451,22 +458,19 @@ exports[`renders data table pagination 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-inner-layer"
+        testID="icon-button-container-middle-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
-              "backgroundColor": undefined,
+              "backgroundColor": "transparent",
               "borderColor": "rgba(121, 116, 126, 1)",
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
-              "flex": undefined,
-              "height": 40,
-              "margin": 6,
+              "flex": 1,
               "overflow": "hidden",
-              "width": 40,
             }
           }
           testID="icon-button-container"
@@ -628,7 +632,10 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -640,6 +647,8 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -648,7 +657,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
         collapsable={false}
         style={
           Object {
-            "flex": undefined,
+            "flex": 1,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -658,22 +667,19 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-inner-layer"
+        testID="icon-button-container-middle-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
-              "backgroundColor": undefined,
+              "backgroundColor": "transparent",
               "borderColor": "rgba(121, 116, 126, 1)",
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
-              "flex": undefined,
-              "height": 40,
-              "margin": 6,
+              "flex": 1,
               "overflow": "hidden",
-              "width": 40,
             }
           }
           testID="icon-button-container"
@@ -777,7 +783,10 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -789,6 +798,8 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -797,7 +808,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
         collapsable={false}
         style={
           Object {
-            "flex": undefined,
+            "flex": 1,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -807,22 +818,19 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-inner-layer"
+        testID="icon-button-container-middle-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
-              "backgroundColor": undefined,
+              "backgroundColor": "transparent",
               "borderColor": "rgba(121, 116, 126, 1)",
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
-              "flex": undefined,
-              "height": 40,
-              "margin": 6,
+              "flex": 1,
               "overflow": "hidden",
-              "width": 40,
             }
           }
           testID="icon-button-container"
@@ -926,7 +934,10 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -938,6 +949,8 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -946,7 +959,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
         collapsable={false}
         style={
           Object {
-            "flex": undefined,
+            "flex": 1,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -956,22 +969,19 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-inner-layer"
+        testID="icon-button-container-middle-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
-              "backgroundColor": undefined,
+              "backgroundColor": "transparent",
               "borderColor": "rgba(121, 116, 126, 1)",
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
-              "flex": undefined,
-              "height": 40,
-              "margin": 6,
+              "flex": 1,
               "overflow": "hidden",
-              "width": 40,
             }
           }
           testID="icon-button-container"
@@ -1075,7 +1085,10 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -1087,6 +1100,8 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -1095,7 +1110,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
         collapsable={false}
         style={
           Object {
-            "flex": undefined,
+            "flex": 1,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1105,22 +1120,19 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-inner-layer"
+        testID="icon-button-container-middle-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
-              "backgroundColor": undefined,
+              "backgroundColor": "transparent",
               "borderColor": "rgba(121, 116, 126, 1)",
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
-              "flex": undefined,
-              "height": 40,
-              "margin": 6,
+              "flex": 1,
               "overflow": "hidden",
-              "width": 40,
             }
           }
           testID="icon-button-container"
@@ -1282,7 +1294,10 @@ exports[`renders data table pagination with label 1`] = `
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -1294,6 +1309,8 @@ exports[`renders data table pagination with label 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -1302,7 +1319,7 @@ exports[`renders data table pagination with label 1`] = `
         collapsable={false}
         style={
           Object {
-            "flex": undefined,
+            "flex": 1,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1312,22 +1329,19 @@ exports[`renders data table pagination with label 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-inner-layer"
+        testID="icon-button-container-middle-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
-              "backgroundColor": undefined,
+              "backgroundColor": "transparent",
               "borderColor": "rgba(121, 116, 126, 1)",
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
-              "flex": undefined,
-              "height": 40,
-              "margin": 6,
+              "flex": 1,
               "overflow": "hidden",
-              "width": 40,
             }
           }
           testID="icon-button-container"
@@ -1431,7 +1445,10 @@ exports[`renders data table pagination with label 1`] = `
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -1443,6 +1460,8 @@ exports[`renders data table pagination with label 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -1451,7 +1470,7 @@ exports[`renders data table pagination with label 1`] = `
         collapsable={false}
         style={
           Object {
-            "flex": undefined,
+            "flex": 1,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1461,22 +1480,19 @@ exports[`renders data table pagination with label 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-inner-layer"
+        testID="icon-button-container-middle-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
-              "backgroundColor": undefined,
+              "backgroundColor": "transparent",
               "borderColor": "rgba(121, 116, 126, 1)",
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
-              "flex": undefined,
-              "height": 40,
-              "margin": 6,
+              "flex": 1,
               "overflow": "hidden",
-              "width": 40,
             }
           }
           testID="icon-button-container"
@@ -1644,7 +1660,10 @@ exports[`renders data table pagination with options select 1`] = `
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
+            "height": undefined,
             "left": undefined,
+            "marginRight": 16,
+            "opacity": undefined,
             "position": undefined,
             "right": undefined,
             "shadowColor": "#000",
@@ -1656,6 +1675,8 @@ exports[`renders data table pagination with options select 1`] = `
             "shadowRadius": 0,
             "start": undefined,
             "top": undefined,
+            "transform": undefined,
+            "width": undefined,
           }
         }
         testID="button-container-outer-layer"
@@ -1674,7 +1695,7 @@ exports[`renders data table pagination with options select 1`] = `
               "shadowRadius": 0,
             }
           }
-          testID="button-container-inner-layer"
+          testID="button-container-middle-layer"
         >
           <View
             collapsable={false}
@@ -1686,7 +1707,6 @@ exports[`renders data table pagination with options select 1`] = `
                 "borderStyle": "solid",
                 "borderWidth": 1,
                 "flex": undefined,
-                "marginRight": 16,
                 "minWidth": 64,
                 "textAlign": "center",
               }
@@ -1893,7 +1913,10 @@ exports[`renders data table pagination with options select 1`] = `
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -1905,6 +1928,8 @@ exports[`renders data table pagination with options select 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -1913,7 +1938,7 @@ exports[`renders data table pagination with options select 1`] = `
         collapsable={false}
         style={
           Object {
-            "flex": undefined,
+            "flex": 1,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1923,22 +1948,19 @@ exports[`renders data table pagination with options select 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-inner-layer"
+        testID="icon-button-container-middle-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
-              "backgroundColor": undefined,
+              "backgroundColor": "transparent",
               "borderColor": "rgba(121, 116, 126, 1)",
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
-              "flex": undefined,
-              "height": 40,
-              "margin": 6,
+              "flex": 1,
               "overflow": "hidden",
-              "width": 40,
             }
           }
           testID="icon-button-container"
@@ -2042,7 +2064,10 @@ exports[`renders data table pagination with options select 1`] = `
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -2054,6 +2079,8 @@ exports[`renders data table pagination with options select 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -2062,7 +2089,7 @@ exports[`renders data table pagination with options select 1`] = `
         collapsable={false}
         style={
           Object {
-            "flex": undefined,
+            "flex": 1,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -2072,22 +2099,19 @@ exports[`renders data table pagination with options select 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-inner-layer"
+        testID="icon-button-container-middle-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
-              "backgroundColor": undefined,
+              "backgroundColor": "transparent",
               "borderColor": "rgba(121, 116, 126, 1)",
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
-              "flex": undefined,
-              "height": 40,
-              "margin": 6,
+              "flex": 1,
               "overflow": "hidden",
-              "width": 40,
             }
           }
           testID="icon-button-container"
@@ -2191,7 +2215,10 @@ exports[`renders data table pagination with options select 1`] = `
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -2203,6 +2230,8 @@ exports[`renders data table pagination with options select 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -2211,7 +2240,7 @@ exports[`renders data table pagination with options select 1`] = `
         collapsable={false}
         style={
           Object {
-            "flex": undefined,
+            "flex": 1,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -2221,22 +2250,19 @@ exports[`renders data table pagination with options select 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-inner-layer"
+        testID="icon-button-container-middle-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
-              "backgroundColor": undefined,
+              "backgroundColor": "transparent",
               "borderColor": "rgba(121, 116, 126, 1)",
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
-              "flex": undefined,
-              "height": 40,
-              "margin": 6,
+              "flex": 1,
               "overflow": "hidden",
-              "width": 40,
             }
           }
           testID="icon-button-container"
@@ -2340,7 +2366,10 @@ exports[`renders data table pagination with options select 1`] = `
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -2352,6 +2381,8 @@ exports[`renders data table pagination with options select 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="icon-button-container-outer-layer"
@@ -2360,7 +2391,7 @@ exports[`renders data table pagination with options select 1`] = `
         collapsable={false}
         style={
           Object {
-            "flex": undefined,
+            "flex": 1,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -2370,22 +2401,19 @@ exports[`renders data table pagination with options select 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-inner-layer"
+        testID="icon-button-container-middle-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
-              "backgroundColor": undefined,
+              "backgroundColor": "transparent",
               "borderColor": "rgba(121, 116, 126, 1)",
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
-              "flex": undefined,
-              "height": 40,
-              "margin": 6,
+              "flex": 1,
               "overflow": "hidden",
-              "width": 40,
             }
           }
           testID="icon-button-container"

--- a/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -297,7 +297,13 @@ exports[`renders data table pagination 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderColor": "rgba(121, 116, 126, 1)",
+            "borderRadius": 20,
+            "borderWidth": 0,
+            "elevation": 0,
             "flex": 1,
+            "overflow": "hidden",
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -307,111 +313,95 @@ exports[`renders data table pagination 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-middle-layer"
+        testID="icon-button-container"
       >
         <View
-          collapsable={false}
-          style={
+          accessibilityComponentType="button"
+          accessibilityLabel="chevron-left"
+          accessibilityRole="button"
+          accessibilityState={
             Object {
-              "backgroundColor": "transparent",
-              "borderColor": "rgba(121, 116, 126, 1)",
-              "borderRadius": 20,
-              "borderWidth": 0,
-              "elevation": 0,
-              "flex": 1,
-              "overflow": "hidden",
+              "disabled": false,
             }
           }
-          testID="icon-button-container"
+          accessibilityTraits="button"
+          accessible={true}
+          centered={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 6,
+              "left": 6,
+              "right": 6,
+              "top": 6,
+            }
+          }
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              false,
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                Object {
+                  "borderRadius": 20,
+                },
+              ],
+            ]
+          }
+          testID="icon-button"
         >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="chevron-left"
-            accessibilityRole="button"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessibilityTraits="button"
-            accessible={true}
-            centered={true}
-            collapsable={false}
-            focusable={true}
-            hitSlop={
-              Object {
-                "bottom": 6,
-                "left": 6,
-                "right": 6,
-                "top": 6,
-              }
-            }
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
             style={
               Array [
                 Object {
-                  "overflow": "hidden",
+                  "color": "rgba(28, 27, 31, 1)",
+                  "fontSize": 24,
                 },
-                false,
                 Array [
                   Object {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
                   },
                   Object {
-                    "borderRadius": 20,
+                    "backgroundColor": "transparent",
                   },
                 ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
               ]
             }
-            testID="icon-button"
           >
-            <Text
-              accessibilityElementsHidden={true}
-              allowFontScaling={false}
-              importantForAccessibility="no-hide-descendants"
-              pointerEvents="none"
-              selectable={false}
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(28, 27, 31, 1)",
-                    "fontSize": 24,
-                  },
-                  Array [
-                    Object {
-                      "lineHeight": 24,
-                      "transform": Array [
-                        Object {
-                          "scaleX": 1,
-                        },
-                      ],
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ],
-                  Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
-              }
-            >
-              󰅁
-            </Text>
-          </View>
+            󰅁
+          </Text>
         </View>
       </View>
     </View>
@@ -448,7 +438,13 @@ exports[`renders data table pagination 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderColor": "rgba(121, 116, 126, 1)",
+            "borderRadius": 20,
+            "borderWidth": 0,
+            "elevation": 0,
             "flex": 1,
+            "overflow": "hidden",
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -458,111 +454,95 @@ exports[`renders data table pagination 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-middle-layer"
+        testID="icon-button-container"
       >
         <View
-          collapsable={false}
-          style={
+          accessibilityComponentType="button"
+          accessibilityLabel="chevron-right"
+          accessibilityRole="button"
+          accessibilityState={
             Object {
-              "backgroundColor": "transparent",
-              "borderColor": "rgba(121, 116, 126, 1)",
-              "borderRadius": 20,
-              "borderWidth": 0,
-              "elevation": 0,
-              "flex": 1,
-              "overflow": "hidden",
+              "disabled": false,
             }
           }
-          testID="icon-button-container"
+          accessibilityTraits="button"
+          accessible={true}
+          centered={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 6,
+              "left": 6,
+              "right": 6,
+              "top": 6,
+            }
+          }
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              false,
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                Object {
+                  "borderRadius": 20,
+                },
+              ],
+            ]
+          }
+          testID="icon-button"
         >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="chevron-right"
-            accessibilityRole="button"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessibilityTraits="button"
-            accessible={true}
-            centered={true}
-            collapsable={false}
-            focusable={true}
-            hitSlop={
-              Object {
-                "bottom": 6,
-                "left": 6,
-                "right": 6,
-                "top": 6,
-              }
-            }
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
             style={
               Array [
                 Object {
-                  "overflow": "hidden",
+                  "color": "rgba(28, 27, 31, 1)",
+                  "fontSize": 24,
                 },
-                false,
                 Array [
                   Object {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
                   },
                   Object {
-                    "borderRadius": 20,
+                    "backgroundColor": "transparent",
                   },
                 ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
               ]
             }
-            testID="icon-button"
           >
-            <Text
-              accessibilityElementsHidden={true}
-              allowFontScaling={false}
-              importantForAccessibility="no-hide-descendants"
-              pointerEvents="none"
-              selectable={false}
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(28, 27, 31, 1)",
-                    "fontSize": 24,
-                  },
-                  Array [
-                    Object {
-                      "lineHeight": 24,
-                      "transform": Array [
-                        Object {
-                          "scaleX": 1,
-                        },
-                      ],
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ],
-                  Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
-              }
-            >
-              󰅂
-            </Text>
-          </View>
+            󰅂
+          </Text>
         </View>
       </View>
     </View>
@@ -657,7 +637,13 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderColor": "rgba(121, 116, 126, 1)",
+            "borderRadius": 20,
+            "borderWidth": 0,
+            "elevation": 0,
             "flex": 1,
+            "overflow": "hidden",
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -667,111 +653,95 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-middle-layer"
+        testID="icon-button-container"
       >
         <View
-          collapsable={false}
-          style={
+          accessibilityComponentType="button"
+          accessibilityLabel="page-first"
+          accessibilityRole="button"
+          accessibilityState={
             Object {
-              "backgroundColor": "transparent",
-              "borderColor": "rgba(121, 116, 126, 1)",
-              "borderRadius": 20,
-              "borderWidth": 0,
-              "elevation": 0,
-              "flex": 1,
-              "overflow": "hidden",
+              "disabled": false,
             }
           }
-          testID="icon-button-container"
+          accessibilityTraits="button"
+          accessible={true}
+          centered={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 6,
+              "left": 6,
+              "right": 6,
+              "top": 6,
+            }
+          }
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              false,
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                Object {
+                  "borderRadius": 20,
+                },
+              ],
+            ]
+          }
+          testID="icon-button"
         >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="page-first"
-            accessibilityRole="button"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessibilityTraits="button"
-            accessible={true}
-            centered={true}
-            collapsable={false}
-            focusable={true}
-            hitSlop={
-              Object {
-                "bottom": 6,
-                "left": 6,
-                "right": 6,
-                "top": 6,
-              }
-            }
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
             style={
               Array [
                 Object {
-                  "overflow": "hidden",
+                  "color": "rgba(28, 27, 31, 1)",
+                  "fontSize": 24,
                 },
-                false,
                 Array [
                   Object {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
                   },
                   Object {
-                    "borderRadius": 20,
+                    "backgroundColor": "transparent",
                   },
                 ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
               ]
             }
-            testID="icon-button"
           >
-            <Text
-              accessibilityElementsHidden={true}
-              allowFontScaling={false}
-              importantForAccessibility="no-hide-descendants"
-              pointerEvents="none"
-              selectable={false}
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(28, 27, 31, 1)",
-                    "fontSize": 24,
-                  },
-                  Array [
-                    Object {
-                      "lineHeight": 24,
-                      "transform": Array [
-                        Object {
-                          "scaleX": 1,
-                        },
-                      ],
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ],
-                  Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
-              }
-            >
-              󰘀
-            </Text>
-          </View>
+            󰘀
+          </Text>
         </View>
       </View>
     </View>
@@ -808,7 +778,13 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderColor": "rgba(121, 116, 126, 1)",
+            "borderRadius": 20,
+            "borderWidth": 0,
+            "elevation": 0,
             "flex": 1,
+            "overflow": "hidden",
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -818,111 +794,95 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-middle-layer"
+        testID="icon-button-container"
       >
         <View
-          collapsable={false}
-          style={
+          accessibilityComponentType="button"
+          accessibilityLabel="chevron-left"
+          accessibilityRole="button"
+          accessibilityState={
             Object {
-              "backgroundColor": "transparent",
-              "borderColor": "rgba(121, 116, 126, 1)",
-              "borderRadius": 20,
-              "borderWidth": 0,
-              "elevation": 0,
-              "flex": 1,
-              "overflow": "hidden",
+              "disabled": false,
             }
           }
-          testID="icon-button-container"
+          accessibilityTraits="button"
+          accessible={true}
+          centered={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 6,
+              "left": 6,
+              "right": 6,
+              "top": 6,
+            }
+          }
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              false,
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                Object {
+                  "borderRadius": 20,
+                },
+              ],
+            ]
+          }
+          testID="icon-button"
         >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="chevron-left"
-            accessibilityRole="button"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessibilityTraits="button"
-            accessible={true}
-            centered={true}
-            collapsable={false}
-            focusable={true}
-            hitSlop={
-              Object {
-                "bottom": 6,
-                "left": 6,
-                "right": 6,
-                "top": 6,
-              }
-            }
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
             style={
               Array [
                 Object {
-                  "overflow": "hidden",
+                  "color": "rgba(28, 27, 31, 1)",
+                  "fontSize": 24,
                 },
-                false,
                 Array [
                   Object {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
                   },
                   Object {
-                    "borderRadius": 20,
+                    "backgroundColor": "transparent",
                   },
                 ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
               ]
             }
-            testID="icon-button"
           >
-            <Text
-              accessibilityElementsHidden={true}
-              allowFontScaling={false}
-              importantForAccessibility="no-hide-descendants"
-              pointerEvents="none"
-              selectable={false}
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(28, 27, 31, 1)",
-                    "fontSize": 24,
-                  },
-                  Array [
-                    Object {
-                      "lineHeight": 24,
-                      "transform": Array [
-                        Object {
-                          "scaleX": 1,
-                        },
-                      ],
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ],
-                  Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
-              }
-            >
-              󰅁
-            </Text>
-          </View>
+            󰅁
+          </Text>
         </View>
       </View>
     </View>
@@ -959,7 +919,13 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderColor": "rgba(121, 116, 126, 1)",
+            "borderRadius": 20,
+            "borderWidth": 0,
+            "elevation": 0,
             "flex": 1,
+            "overflow": "hidden",
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -969,111 +935,95 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-middle-layer"
+        testID="icon-button-container"
       >
         <View
-          collapsable={false}
-          style={
+          accessibilityComponentType="button"
+          accessibilityLabel="chevron-right"
+          accessibilityRole="button"
+          accessibilityState={
             Object {
-              "backgroundColor": "transparent",
-              "borderColor": "rgba(121, 116, 126, 1)",
-              "borderRadius": 20,
-              "borderWidth": 0,
-              "elevation": 0,
-              "flex": 1,
-              "overflow": "hidden",
+              "disabled": false,
             }
           }
-          testID="icon-button-container"
+          accessibilityTraits="button"
+          accessible={true}
+          centered={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 6,
+              "left": 6,
+              "right": 6,
+              "top": 6,
+            }
+          }
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              false,
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                Object {
+                  "borderRadius": 20,
+                },
+              ],
+            ]
+          }
+          testID="icon-button"
         >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="chevron-right"
-            accessibilityRole="button"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessibilityTraits="button"
-            accessible={true}
-            centered={true}
-            collapsable={false}
-            focusable={true}
-            hitSlop={
-              Object {
-                "bottom": 6,
-                "left": 6,
-                "right": 6,
-                "top": 6,
-              }
-            }
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
             style={
               Array [
                 Object {
-                  "overflow": "hidden",
+                  "color": "rgba(28, 27, 31, 1)",
+                  "fontSize": 24,
                 },
-                false,
                 Array [
                   Object {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
                   },
                   Object {
-                    "borderRadius": 20,
+                    "backgroundColor": "transparent",
                   },
                 ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
               ]
             }
-            testID="icon-button"
           >
-            <Text
-              accessibilityElementsHidden={true}
-              allowFontScaling={false}
-              importantForAccessibility="no-hide-descendants"
-              pointerEvents="none"
-              selectable={false}
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(28, 27, 31, 1)",
-                    "fontSize": 24,
-                  },
-                  Array [
-                    Object {
-                      "lineHeight": 24,
-                      "transform": Array [
-                        Object {
-                          "scaleX": 1,
-                        },
-                      ],
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ],
-                  Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
-              }
-            >
-              󰅂
-            </Text>
-          </View>
+            󰅂
+          </Text>
         </View>
       </View>
     </View>
@@ -1110,7 +1060,13 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderColor": "rgba(121, 116, 126, 1)",
+            "borderRadius": 20,
+            "borderWidth": 0,
+            "elevation": 0,
             "flex": 1,
+            "overflow": "hidden",
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1120,111 +1076,95 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-middle-layer"
+        testID="icon-button-container"
       >
         <View
-          collapsable={false}
-          style={
+          accessibilityComponentType="button"
+          accessibilityLabel="page-last"
+          accessibilityRole="button"
+          accessibilityState={
             Object {
-              "backgroundColor": "transparent",
-              "borderColor": "rgba(121, 116, 126, 1)",
-              "borderRadius": 20,
-              "borderWidth": 0,
-              "elevation": 0,
-              "flex": 1,
-              "overflow": "hidden",
+              "disabled": false,
             }
           }
-          testID="icon-button-container"
+          accessibilityTraits="button"
+          accessible={true}
+          centered={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 6,
+              "left": 6,
+              "right": 6,
+              "top": 6,
+            }
+          }
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              false,
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                Object {
+                  "borderRadius": 20,
+                },
+              ],
+            ]
+          }
+          testID="icon-button"
         >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="page-last"
-            accessibilityRole="button"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessibilityTraits="button"
-            accessible={true}
-            centered={true}
-            collapsable={false}
-            focusable={true}
-            hitSlop={
-              Object {
-                "bottom": 6,
-                "left": 6,
-                "right": 6,
-                "top": 6,
-              }
-            }
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
             style={
               Array [
                 Object {
-                  "overflow": "hidden",
+                  "color": "rgba(28, 27, 31, 1)",
+                  "fontSize": 24,
                 },
-                false,
                 Array [
                   Object {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
                   },
                   Object {
-                    "borderRadius": 20,
+                    "backgroundColor": "transparent",
                   },
                 ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
               ]
             }
-            testID="icon-button"
           >
-            <Text
-              accessibilityElementsHidden={true}
-              allowFontScaling={false}
-              importantForAccessibility="no-hide-descendants"
-              pointerEvents="none"
-              selectable={false}
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(28, 27, 31, 1)",
-                    "fontSize": 24,
-                  },
-                  Array [
-                    Object {
-                      "lineHeight": 24,
-                      "transform": Array [
-                        Object {
-                          "scaleX": 1,
-                        },
-                      ],
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ],
-                  Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
-              }
-            >
-              󰘁
-            </Text>
-          </View>
+            󰘁
+          </Text>
         </View>
       </View>
     </View>
@@ -1319,7 +1259,13 @@ exports[`renders data table pagination with label 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderColor": "rgba(121, 116, 126, 1)",
+            "borderRadius": 20,
+            "borderWidth": 0,
+            "elevation": 0,
             "flex": 1,
+            "overflow": "hidden",
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1329,111 +1275,95 @@ exports[`renders data table pagination with label 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-middle-layer"
+        testID="icon-button-container"
       >
         <View
-          collapsable={false}
-          style={
+          accessibilityComponentType="button"
+          accessibilityLabel="chevron-left"
+          accessibilityRole="button"
+          accessibilityState={
             Object {
-              "backgroundColor": "transparent",
-              "borderColor": "rgba(121, 116, 126, 1)",
-              "borderRadius": 20,
-              "borderWidth": 0,
-              "elevation": 0,
-              "flex": 1,
-              "overflow": "hidden",
+              "disabled": false,
             }
           }
-          testID="icon-button-container"
+          accessibilityTraits="button"
+          accessible={true}
+          centered={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 6,
+              "left": 6,
+              "right": 6,
+              "top": 6,
+            }
+          }
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              false,
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                Object {
+                  "borderRadius": 20,
+                },
+              ],
+            ]
+          }
+          testID="icon-button"
         >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="chevron-left"
-            accessibilityRole="button"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessibilityTraits="button"
-            accessible={true}
-            centered={true}
-            collapsable={false}
-            focusable={true}
-            hitSlop={
-              Object {
-                "bottom": 6,
-                "left": 6,
-                "right": 6,
-                "top": 6,
-              }
-            }
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
             style={
               Array [
                 Object {
-                  "overflow": "hidden",
+                  "color": "rgba(28, 27, 31, 1)",
+                  "fontSize": 24,
                 },
-                false,
                 Array [
                   Object {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
                   },
                   Object {
-                    "borderRadius": 20,
+                    "backgroundColor": "transparent",
                   },
                 ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
               ]
             }
-            testID="icon-button"
           >
-            <Text
-              accessibilityElementsHidden={true}
-              allowFontScaling={false}
-              importantForAccessibility="no-hide-descendants"
-              pointerEvents="none"
-              selectable={false}
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(28, 27, 31, 1)",
-                    "fontSize": 24,
-                  },
-                  Array [
-                    Object {
-                      "lineHeight": 24,
-                      "transform": Array [
-                        Object {
-                          "scaleX": 1,
-                        },
-                      ],
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ],
-                  Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
-              }
-            >
-              󰅁
-            </Text>
-          </View>
+            󰅁
+          </Text>
         </View>
       </View>
     </View>
@@ -1470,7 +1400,13 @@ exports[`renders data table pagination with label 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderColor": "rgba(121, 116, 126, 1)",
+            "borderRadius": 20,
+            "borderWidth": 0,
+            "elevation": 0,
             "flex": 1,
+            "overflow": "hidden",
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1480,111 +1416,95 @@ exports[`renders data table pagination with label 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-middle-layer"
+        testID="icon-button-container"
       >
         <View
-          collapsable={false}
-          style={
+          accessibilityComponentType="button"
+          accessibilityLabel="chevron-right"
+          accessibilityRole="button"
+          accessibilityState={
             Object {
-              "backgroundColor": "transparent",
-              "borderColor": "rgba(121, 116, 126, 1)",
-              "borderRadius": 20,
-              "borderWidth": 0,
-              "elevation": 0,
-              "flex": 1,
-              "overflow": "hidden",
+              "disabled": false,
             }
           }
-          testID="icon-button-container"
+          accessibilityTraits="button"
+          accessible={true}
+          centered={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 6,
+              "left": 6,
+              "right": 6,
+              "top": 6,
+            }
+          }
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              false,
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                Object {
+                  "borderRadius": 20,
+                },
+              ],
+            ]
+          }
+          testID="icon-button"
         >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="chevron-right"
-            accessibilityRole="button"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessibilityTraits="button"
-            accessible={true}
-            centered={true}
-            collapsable={false}
-            focusable={true}
-            hitSlop={
-              Object {
-                "bottom": 6,
-                "left": 6,
-                "right": 6,
-                "top": 6,
-              }
-            }
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
             style={
               Array [
                 Object {
-                  "overflow": "hidden",
+                  "color": "rgba(28, 27, 31, 1)",
+                  "fontSize": 24,
                 },
-                false,
                 Array [
                   Object {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
                   },
                   Object {
-                    "borderRadius": 20,
+                    "backgroundColor": "transparent",
                   },
                 ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
               ]
             }
-            testID="icon-button"
           >
-            <Text
-              accessibilityElementsHidden={true}
-              allowFontScaling={false}
-              importantForAccessibility="no-hide-descendants"
-              pointerEvents="none"
-              selectable={false}
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(28, 27, 31, 1)",
-                    "fontSize": 24,
-                  },
-                  Array [
-                    Object {
-                      "lineHeight": 24,
-                      "transform": Array [
-                        Object {
-                          "scaleX": 1,
-                        },
-                      ],
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ],
-                  Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
-              }
-            >
-              󰅂
-            </Text>
-          </View>
+            󰅂
+          </Text>
         </View>
       </View>
     </View>
@@ -1685,7 +1605,13 @@ exports[`renders data table pagination with options select 1`] = `
           collapsable={false}
           style={
             Object {
+              "backgroundColor": "transparent",
+              "borderColor": "rgba(121, 116, 126, 1)",
+              "borderRadius": 20,
+              "borderStyle": "solid",
+              "borderWidth": 1,
               "flex": undefined,
+              "minWidth": 64,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -1693,174 +1619,158 @@ exports[`renders data table pagination with options select 1`] = `
               },
               "shadowOpacity": 0,
               "shadowRadius": 0,
+              "textAlign": "center",
             }
           }
-          testID="button-container-middle-layer"
+          testID="button-container"
         >
           <View
-            collapsable={false}
-            style={
+            accessibilityRole="button"
+            accessibilityState={
               Object {
-                "backgroundColor": "transparent",
-                "borderColor": "rgba(121, 116, 126, 1)",
-                "borderRadius": 20,
-                "borderStyle": "solid",
-                "borderWidth": 1,
-                "flex": undefined,
-                "minWidth": 64,
-                "textAlign": "center",
+                "disabled": false,
               }
             }
-            testID="button-container"
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                false,
+                Object {
+                  "borderRadius": 20,
+                },
+              ]
+            }
+            testID="button"
           >
             <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "disabled": false,
-                }
-              }
-              accessible={true}
-              collapsable={false}
-              focusable={true}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Array [
                   Object {
-                    "overflow": "hidden",
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "justifyContent": "center",
                   },
-                  false,
                   Object {
-                    "borderRadius": 20,
+                    "flexDirection": "row-reverse",
                   },
                 ]
               }
-              testID="button"
             >
               <View
                 style={
                   Array [
                     Object {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "justifyContent": "center",
+                      "marginLeft": -4,
+                      "marginRight": 12,
                     },
                     Object {
-                      "flexDirection": "row-reverse",
+                      "marginLeft": -16,
+                      "marginRight": 16,
                     },
+                    false,
                   ]
                 }
+                testID="button-icon-container"
               >
-                <View
-                  style={
-                    Array [
-                      Object {
-                        "marginLeft": -4,
-                        "marginRight": 12,
-                      },
-                      Object {
-                        "marginLeft": -16,
-                        "marginRight": 16,
-                      },
-                      false,
-                    ]
-                  }
-                  testID="button-icon-container"
-                >
-                  <Text
-                    accessibilityElementsHidden={true}
-                    allowFontScaling={false}
-                    importantForAccessibility="no-hide-descendants"
-                    pointerEvents="none"
-                    selectable={false}
-                    style={
-                      Array [
-                        Object {
-                          "color": "rgba(103, 80, 164, 1)",
-                          "fontSize": 18,
-                        },
-                        Array [
-                          Object {
-                            "lineHeight": 18,
-                            "transform": Array [
-                              Object {
-                                "scaleX": 1,
-                              },
-                            ],
-                          },
-                          Object {
-                            "backgroundColor": "transparent",
-                          },
-                        ],
-                        Object {
-                          "fontFamily": "Material Design Icons",
-                          "fontStyle": "normal",
-                          "fontWeight": "normal",
-                        },
-                        Object {},
-                      ]
-                    }
-                  >
-                    󰍝
-                  </Text>
-                </View>
                 <Text
-                  numberOfLines={1}
+                  accessibilityElementsHidden={true}
+                  allowFontScaling={false}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
                   selectable={false}
                   style={
                     Array [
                       Object {
+                        "color": "rgba(103, 80, 164, 1)",
+                        "fontSize": 18,
+                      },
+                      Array [
+                        Object {
+                          "lineHeight": 18,
+                          "transform": Array [
+                            Object {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        Object {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                      Object {
+                        "fontFamily": "Material Design Icons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  󰍝
+                </Text>
+              </View>
+              <Text
+                numberOfLines={1}
+                selectable={false}
+                style={
+                  Array [
+                    Object {
+                      "fontFamily": "System",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "letterSpacing": 0.1,
+                      "lineHeight": 20,
+                    },
+                    Object {
+                      "textAlign": "left",
+                    },
+                    Object {
+                      "color": "rgba(28, 27, 31, 1)",
+                      "writingDirection": "ltr",
+                    },
+                    Array [
+                      Object {
+                        "marginHorizontal": 16,
+                        "marginVertical": 9,
+                        "textAlign": "center",
+                      },
+                      false,
+                      Object {
+                        "marginHorizontal": 24,
+                        "marginVertical": 10,
+                      },
+                      undefined,
+                      false,
+                      Object {
+                        "color": "rgba(103, 80, 164, 1)",
                         "fontFamily": "System",
                         "fontSize": 14,
                         "fontWeight": "500",
                         "letterSpacing": 0.1,
                         "lineHeight": 20,
                       },
-                      Object {
-                        "textAlign": "left",
-                      },
-                      Object {
-                        "color": "rgba(28, 27, 31, 1)",
-                        "writingDirection": "ltr",
-                      },
-                      Array [
-                        Object {
-                          "marginHorizontal": 16,
-                          "marginVertical": 9,
-                          "textAlign": "center",
-                        },
-                        false,
-                        Object {
-                          "marginHorizontal": 24,
-                          "marginVertical": 10,
-                        },
-                        undefined,
-                        false,
-                        Object {
-                          "color": "rgba(103, 80, 164, 1)",
-                          "fontFamily": "System",
-                          "fontSize": 14,
-                          "fontWeight": "500",
-                          "letterSpacing": 0.1,
-                          "lineHeight": 20,
-                        },
-                        undefined,
-                      ],
-                    ]
-                  }
-                  testID="button-text"
-                >
-                  2
-                </Text>
-              </View>
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="button-text"
+              >
+                2
+              </Text>
             </View>
           </View>
         </View>
@@ -1938,7 +1848,13 @@ exports[`renders data table pagination with options select 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderColor": "rgba(121, 116, 126, 1)",
+            "borderRadius": 20,
+            "borderWidth": 0,
+            "elevation": 0,
             "flex": 1,
+            "overflow": "hidden",
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1948,111 +1864,95 @@ exports[`renders data table pagination with options select 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-middle-layer"
+        testID="icon-button-container"
       >
         <View
-          collapsable={false}
-          style={
+          accessibilityComponentType="button"
+          accessibilityLabel="page-first"
+          accessibilityRole="button"
+          accessibilityState={
             Object {
-              "backgroundColor": "transparent",
-              "borderColor": "rgba(121, 116, 126, 1)",
-              "borderRadius": 20,
-              "borderWidth": 0,
-              "elevation": 0,
-              "flex": 1,
-              "overflow": "hidden",
+              "disabled": false,
             }
           }
-          testID="icon-button-container"
+          accessibilityTraits="button"
+          accessible={true}
+          centered={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 6,
+              "left": 6,
+              "right": 6,
+              "top": 6,
+            }
+          }
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              false,
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                Object {
+                  "borderRadius": 20,
+                },
+              ],
+            ]
+          }
+          testID="icon-button"
         >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="page-first"
-            accessibilityRole="button"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessibilityTraits="button"
-            accessible={true}
-            centered={true}
-            collapsable={false}
-            focusable={true}
-            hitSlop={
-              Object {
-                "bottom": 6,
-                "left": 6,
-                "right": 6,
-                "top": 6,
-              }
-            }
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
             style={
               Array [
                 Object {
-                  "overflow": "hidden",
+                  "color": "rgba(28, 27, 31, 1)",
+                  "fontSize": 24,
                 },
-                false,
                 Array [
                   Object {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
                   },
                   Object {
-                    "borderRadius": 20,
+                    "backgroundColor": "transparent",
                   },
                 ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
               ]
             }
-            testID="icon-button"
           >
-            <Text
-              accessibilityElementsHidden={true}
-              allowFontScaling={false}
-              importantForAccessibility="no-hide-descendants"
-              pointerEvents="none"
-              selectable={false}
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(28, 27, 31, 1)",
-                    "fontSize": 24,
-                  },
-                  Array [
-                    Object {
-                      "lineHeight": 24,
-                      "transform": Array [
-                        Object {
-                          "scaleX": 1,
-                        },
-                      ],
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ],
-                  Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
-              }
-            >
-              󰘀
-            </Text>
-          </View>
+            󰘀
+          </Text>
         </View>
       </View>
     </View>
@@ -2089,7 +1989,13 @@ exports[`renders data table pagination with options select 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderColor": "rgba(121, 116, 126, 1)",
+            "borderRadius": 20,
+            "borderWidth": 0,
+            "elevation": 0,
             "flex": 1,
+            "overflow": "hidden",
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -2099,111 +2005,95 @@ exports[`renders data table pagination with options select 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-middle-layer"
+        testID="icon-button-container"
       >
         <View
-          collapsable={false}
-          style={
+          accessibilityComponentType="button"
+          accessibilityLabel="chevron-left"
+          accessibilityRole="button"
+          accessibilityState={
             Object {
-              "backgroundColor": "transparent",
-              "borderColor": "rgba(121, 116, 126, 1)",
-              "borderRadius": 20,
-              "borderWidth": 0,
-              "elevation": 0,
-              "flex": 1,
-              "overflow": "hidden",
+              "disabled": false,
             }
           }
-          testID="icon-button-container"
+          accessibilityTraits="button"
+          accessible={true}
+          centered={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 6,
+              "left": 6,
+              "right": 6,
+              "top": 6,
+            }
+          }
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              false,
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                Object {
+                  "borderRadius": 20,
+                },
+              ],
+            ]
+          }
+          testID="icon-button"
         >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="chevron-left"
-            accessibilityRole="button"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessibilityTraits="button"
-            accessible={true}
-            centered={true}
-            collapsable={false}
-            focusable={true}
-            hitSlop={
-              Object {
-                "bottom": 6,
-                "left": 6,
-                "right": 6,
-                "top": 6,
-              }
-            }
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
             style={
               Array [
                 Object {
-                  "overflow": "hidden",
+                  "color": "rgba(28, 27, 31, 1)",
+                  "fontSize": 24,
                 },
-                false,
                 Array [
                   Object {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
                   },
                   Object {
-                    "borderRadius": 20,
+                    "backgroundColor": "transparent",
                   },
                 ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
               ]
             }
-            testID="icon-button"
           >
-            <Text
-              accessibilityElementsHidden={true}
-              allowFontScaling={false}
-              importantForAccessibility="no-hide-descendants"
-              pointerEvents="none"
-              selectable={false}
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(28, 27, 31, 1)",
-                    "fontSize": 24,
-                  },
-                  Array [
-                    Object {
-                      "lineHeight": 24,
-                      "transform": Array [
-                        Object {
-                          "scaleX": 1,
-                        },
-                      ],
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ],
-                  Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
-              }
-            >
-              󰅁
-            </Text>
-          </View>
+            󰅁
+          </Text>
         </View>
       </View>
     </View>
@@ -2240,7 +2130,13 @@ exports[`renders data table pagination with options select 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderColor": "rgba(121, 116, 126, 1)",
+            "borderRadius": 20,
+            "borderWidth": 0,
+            "elevation": 0,
             "flex": 1,
+            "overflow": "hidden",
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -2250,111 +2146,95 @@ exports[`renders data table pagination with options select 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-middle-layer"
+        testID="icon-button-container"
       >
         <View
-          collapsable={false}
-          style={
+          accessibilityComponentType="button"
+          accessibilityLabel="chevron-right"
+          accessibilityRole="button"
+          accessibilityState={
             Object {
-              "backgroundColor": "transparent",
-              "borderColor": "rgba(121, 116, 126, 1)",
-              "borderRadius": 20,
-              "borderWidth": 0,
-              "elevation": 0,
-              "flex": 1,
-              "overflow": "hidden",
+              "disabled": false,
             }
           }
-          testID="icon-button-container"
+          accessibilityTraits="button"
+          accessible={true}
+          centered={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 6,
+              "left": 6,
+              "right": 6,
+              "top": 6,
+            }
+          }
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              false,
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                Object {
+                  "borderRadius": 20,
+                },
+              ],
+            ]
+          }
+          testID="icon-button"
         >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="chevron-right"
-            accessibilityRole="button"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessibilityTraits="button"
-            accessible={true}
-            centered={true}
-            collapsable={false}
-            focusable={true}
-            hitSlop={
-              Object {
-                "bottom": 6,
-                "left": 6,
-                "right": 6,
-                "top": 6,
-              }
-            }
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
             style={
               Array [
                 Object {
-                  "overflow": "hidden",
+                  "color": "rgba(28, 27, 31, 1)",
+                  "fontSize": 24,
                 },
-                false,
                 Array [
                   Object {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
                   },
                   Object {
-                    "borderRadius": 20,
+                    "backgroundColor": "transparent",
                   },
                 ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
               ]
             }
-            testID="icon-button"
           >
-            <Text
-              accessibilityElementsHidden={true}
-              allowFontScaling={false}
-              importantForAccessibility="no-hide-descendants"
-              pointerEvents="none"
-              selectable={false}
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(28, 27, 31, 1)",
-                    "fontSize": 24,
-                  },
-                  Array [
-                    Object {
-                      "lineHeight": 24,
-                      "transform": Array [
-                        Object {
-                          "scaleX": 1,
-                        },
-                      ],
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ],
-                  Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
-              }
-            >
-              󰅂
-            </Text>
-          </View>
+            󰅂
+          </Text>
         </View>
       </View>
     </View>
@@ -2391,7 +2271,13 @@ exports[`renders data table pagination with options select 1`] = `
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderColor": "rgba(121, 116, 126, 1)",
+            "borderRadius": 20,
+            "borderWidth": 0,
+            "elevation": 0,
             "flex": 1,
+            "overflow": "hidden",
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -2401,111 +2287,95 @@ exports[`renders data table pagination with options select 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="icon-button-container-middle-layer"
+        testID="icon-button-container"
       >
         <View
-          collapsable={false}
-          style={
+          accessibilityComponentType="button"
+          accessibilityLabel="page-last"
+          accessibilityRole="button"
+          accessibilityState={
             Object {
-              "backgroundColor": "transparent",
-              "borderColor": "rgba(121, 116, 126, 1)",
-              "borderRadius": 20,
-              "borderWidth": 0,
-              "elevation": 0,
-              "flex": 1,
-              "overflow": "hidden",
+              "disabled": false,
             }
           }
-          testID="icon-button-container"
+          accessibilityTraits="button"
+          accessible={true}
+          centered={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 6,
+              "left": 6,
+              "right": 6,
+              "top": 6,
+            }
+          }
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              false,
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                Object {
+                  "borderRadius": 20,
+                },
+              ],
+            ]
+          }
+          testID="icon-button"
         >
-          <View
-            accessibilityComponentType="button"
-            accessibilityLabel="page-last"
-            accessibilityRole="button"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessibilityTraits="button"
-            accessible={true}
-            centered={true}
-            collapsable={false}
-            focusable={true}
-            hitSlop={
-              Object {
-                "bottom": 6,
-                "left": 6,
-                "right": 6,
-                "top": 6,
-              }
-            }
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
             style={
               Array [
                 Object {
-                  "overflow": "hidden",
+                  "color": "rgba(28, 27, 31, 1)",
+                  "fontSize": 24,
                 },
-                false,
                 Array [
                   Object {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
                   },
                   Object {
-                    "borderRadius": 20,
+                    "backgroundColor": "transparent",
                   },
                 ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
               ]
             }
-            testID="icon-button"
           >
-            <Text
-              accessibilityElementsHidden={true}
-              allowFontScaling={false}
-              importantForAccessibility="no-hide-descendants"
-              pointerEvents="none"
-              selectable={false}
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(28, 27, 31, 1)",
-                    "fontSize": 24,
-                  },
-                  Array [
-                    Object {
-                      "lineHeight": 24,
-                      "transform": Array [
-                        Object {
-                          "scaleX": 1,
-                        },
-                      ],
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ],
-                  Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
-              }
-            >
-              󰘁
-            </Text>
-          </View>
+            󰘁
+          </Text>
         </View>
       </View>
     </View>

--- a/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -269,6 +269,8 @@ exports[`renders data table pagination 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
@@ -410,6 +412,8 @@ exports[`renders data table pagination 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
@@ -609,6 +613,8 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
@@ -750,6 +756,8 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
@@ -891,6 +899,8 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
@@ -1032,6 +1042,8 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
@@ -1231,6 +1243,8 @@ exports[`renders data table pagination with label 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
@@ -1372,6 +1386,8 @@ exports[`renders data table pagination with label 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
@@ -1577,6 +1593,8 @@ exports[`renders data table pagination with options select 1`] = `
         style={
           Object {
             "alignSelf": undefined,
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
@@ -1820,6 +1838,8 @@ exports[`renders data table pagination with options select 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
@@ -1961,6 +1981,8 @@ exports[`renders data table pagination with options select 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
@@ -2102,6 +2124,8 @@ exports[`renders data table pagination with options select 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
@@ -2243,6 +2267,8 @@ exports[`renders data table pagination with options select 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,

--- a/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
@@ -9,7 +9,9 @@ exports[`renders FAB with custom size prop 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -21,6 +23,12 @@ exports[`renders FAB with custom size prop 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -39,7 +47,7 @@ exports[`renders FAB with custom size prop 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-inner-layer"
+    testID="fab-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -49,13 +57,7 @@ exports[`renders FAB with custom size prop 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 25,
           "flex": undefined,
-          "opacity": 1,
           "overflow": "hidden",
-          "transform": Array [
-            Object {
-              "scale": 1,
-            },
-          ],
         }
       }
       testID="fab-container"
@@ -194,7 +196,9 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -206,6 +210,12 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -224,7 +234,7 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-inner-layer"
+    testID="fab-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -234,13 +244,7 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 16,
           "flex": undefined,
-          "opacity": 1,
           "overflow": "hidden",
-          "transform": Array [
-            Object {
-              "scale": 1,
-            },
-          ],
         }
       }
       testID="fab-container"
@@ -379,7 +383,9 @@ exports[`renders default FAB 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -391,6 +397,12 @@ exports[`renders default FAB 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -409,7 +421,7 @@ exports[`renders default FAB 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-inner-layer"
+    testID="fab-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -419,13 +431,7 @@ exports[`renders default FAB 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 16,
           "flex": undefined,
-          "opacity": 1,
           "overflow": "hidden",
-          "transform": Array [
-            Object {
-              "scale": 1,
-            },
-          ],
         }
       }
       testID="fab-container"
@@ -564,7 +570,9 @@ exports[`renders disabled FAB 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -576,6 +584,12 @@ exports[`renders disabled FAB 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -594,7 +608,7 @@ exports[`renders disabled FAB 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="fab-container-inner-layer"
+    testID="fab-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -604,13 +618,7 @@ exports[`renders disabled FAB 1`] = `
           "backgroundColor": "rgba(28, 27, 31, 0.12)",
           "borderRadius": 16,
           "flex": undefined,
-          "opacity": 1,
           "overflow": "hidden",
-          "transform": Array [
-            Object {
-              "scale": 1,
-            },
-          ],
         }
       }
       testID="fab-container"
@@ -749,7 +757,9 @@ exports[`renders extended FAB 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -761,6 +771,12 @@ exports[`renders extended FAB 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -779,7 +795,7 @@ exports[`renders extended FAB 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-inner-layer"
+    testID="fab-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -789,13 +805,7 @@ exports[`renders extended FAB 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 16,
           "flex": undefined,
-          "opacity": 1,
           "overflow": "hidden",
-          "transform": Array [
-            Object {
-              "scale": 1,
-            },
-          ],
         }
       }
       testID="fab-container"
@@ -973,7 +983,9 @@ exports[`renders extended FAB with custom size prop 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -985,6 +997,12 @@ exports[`renders extended FAB with custom size prop 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -1003,7 +1021,7 @@ exports[`renders extended FAB with custom size prop 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-inner-layer"
+    testID="fab-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -1013,13 +1031,7 @@ exports[`renders extended FAB with custom size prop 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 25,
           "flex": undefined,
-          "opacity": 1,
           "overflow": "hidden",
-          "transform": Array [
-            Object {
-              "scale": 1,
-            },
-          ],
         }
       }
       testID="fab-container"
@@ -1196,7 +1208,9 @@ exports[`renders large FAB 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1208,6 +1222,12 @@ exports[`renders large FAB 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -1226,7 +1246,7 @@ exports[`renders large FAB 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-inner-layer"
+    testID="fab-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -1236,13 +1256,7 @@ exports[`renders large FAB 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 28,
           "flex": undefined,
-          "opacity": 1,
           "overflow": "hidden",
-          "transform": Array [
-            Object {
-              "scale": 1,
-            },
-          ],
         }
       }
       testID="fab-container"
@@ -1381,7 +1395,9 @@ exports[`renders loading FAB 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1393,6 +1409,12 @@ exports[`renders loading FAB 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -1411,7 +1433,7 @@ exports[`renders loading FAB 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-inner-layer"
+    testID="fab-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -1421,13 +1443,7 @@ exports[`renders loading FAB 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 16,
           "flex": undefined,
-          "opacity": 1,
           "overflow": "hidden",
-          "transform": Array [
-            Object {
-              "scale": 1,
-            },
-          ],
         }
       }
       testID="fab-container"
@@ -1691,7 +1707,9 @@ exports[`renders loading FAB with custom size prop 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -1703,6 +1721,12 @@ exports[`renders loading FAB with custom size prop 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -1721,7 +1745,7 @@ exports[`renders loading FAB with custom size prop 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-inner-layer"
+    testID="fab-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -1731,13 +1755,7 @@ exports[`renders loading FAB with custom size prop 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 25,
           "flex": undefined,
-          "opacity": 1,
           "overflow": "hidden",
-          "transform": Array [
-            Object {
-              "scale": 1,
-            },
-          ],
         }
       }
       testID="fab-container"
@@ -2001,7 +2019,9 @@ exports[`renders not visible FAB 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -2013,6 +2033,12 @@ exports[`renders not visible FAB 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -2031,7 +2057,7 @@ exports[`renders not visible FAB 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-inner-layer"
+    testID="fab-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -2041,13 +2067,7 @@ exports[`renders not visible FAB 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 16,
           "flex": undefined,
-          "opacity": 1,
           "overflow": "hidden",
-          "transform": Array [
-            Object {
-              "scale": 1,
-            },
-          ],
         }
       }
       testID="fab-container"
@@ -2186,7 +2206,9 @@ exports[`renders small FAB 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 1,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -2198,6 +2220,12 @@ exports[`renders small FAB 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 1,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -2216,7 +2244,7 @@ exports[`renders small FAB 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-inner-layer"
+    testID="fab-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -2226,13 +2254,7 @@ exports[`renders small FAB 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 12,
           "flex": undefined,
-          "opacity": 1,
           "overflow": "hidden",
-          "transform": Array [
-            Object {
-              "scale": 1,
-            },
-          ],
         }
       }
       testID="fab-container"
@@ -2371,7 +2393,9 @@ exports[`renders visible FAB 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": 0,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -2383,6 +2407,12 @@ exports[`renders visible FAB 1`] = `
       "shadowRadius": 8,
       "start": undefined,
       "top": undefined,
+      "transform": Array [
+        Object {
+          "scale": 0,
+        },
+      ],
+      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -2401,7 +2431,7 @@ exports[`renders visible FAB 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-inner-layer"
+    testID="fab-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -2411,13 +2441,7 @@ exports[`renders visible FAB 1`] = `
           "backgroundColor": "rgba(234, 221, 255, 1)",
           "borderRadius": 16,
           "flex": undefined,
-          "opacity": 0,
           "overflow": "hidden",
-          "transform": Array [
-            Object {
-              "scale": 0,
-            },
-          ],
         }
       }
       testID="fab-container"

--- a/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
@@ -6,6 +6,8 @@ exports[`renders FAB with custom size prop 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(234, 221, 255, 1)",
+      "borderRadius": 25,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -184,6 +186,8 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(234, 221, 255, 1)",
+      "borderRadius": 16,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -362,6 +366,8 @@ exports[`renders default FAB 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(234, 221, 255, 1)",
+      "borderRadius": 16,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -540,6 +546,8 @@ exports[`renders disabled FAB 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(28, 27, 31, 0.12)",
+      "borderRadius": 16,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -718,6 +726,8 @@ exports[`renders extended FAB 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(234, 221, 255, 1)",
+      "borderRadius": 16,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -935,6 +945,8 @@ exports[`renders extended FAB with custom size prop 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(234, 221, 255, 1)",
+      "borderRadius": 25,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -1151,6 +1163,8 @@ exports[`renders large FAB 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(234, 221, 255, 1)",
+      "borderRadius": 28,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -1329,6 +1343,8 @@ exports[`renders loading FAB 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(234, 221, 255, 1)",
+      "borderRadius": 16,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -1632,6 +1648,8 @@ exports[`renders loading FAB with custom size prop 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(234, 221, 255, 1)",
+      "borderRadius": 25,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -1935,6 +1953,8 @@ exports[`renders not visible FAB 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(234, 221, 255, 1)",
+      "borderRadius": 16,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -2113,6 +2133,8 @@ exports[`renders small FAB 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(234, 221, 255, 1)",
+      "borderRadius": 12,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -2291,6 +2313,8 @@ exports[`renders visible FAB 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(234, 221, 255, 1)",
+      "borderRadius": 16,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,

--- a/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
@@ -35,8 +35,11 @@ exports[`renders FAB with custom size prop 1`] = `
 >
   <View
     collapsable={false}
+    pointerEvents="auto"
     style={
       Object {
+        "backgroundColor": "rgba(234, 221, 255, 1)",
+        "borderRadius": 25,
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -47,138 +50,126 @@ exports[`renders FAB with custom size prop 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-middle-layer"
+    testID="fab-container"
   >
     <View
-      collapsable={false}
-      pointerEvents="auto"
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "rgba(234, 221, 255, 1)",
-          "borderRadius": 25,
-          "flex": undefined,
-          "overflow": "hidden",
+          "disabled": false,
         }
       }
-      testID="fab-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 25,
+          },
+        ]
+      }
+      testID="fab"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": false,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        pointerEvents="none"
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            undefined,
+            Object {
+              "borderRadius": 25,
+              "height": 100,
+              "width": 100,
+            },
           ]
         }
-        testID="fab"
+        testID="fab-content"
       >
         <View
-          pointerEvents="none"
           style={
             Array [
               Object {
                 "alignItems": "center",
-                "flexDirection": "row",
                 "justifyContent": "center",
               },
               Object {
-                "borderRadius": 25,
-                "height": 100,
-                "width": 100,
+                "height": 50,
+                "width": 50,
               },
             ]
           }
-          testID="fab-content"
         >
           <View
+            collapsable={false}
             style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                },
-                Object {
-                  "height": 50,
-                  "width": 50,
-                },
-              ]
+              Object {
+                "bottom": 0,
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "transform": Array [
+                  Object {
+                    "rotate": "0deg",
+                  },
+                ],
+              }
             }
           >
-            <View
-              collapsable={false}
+            <Text
+              accessibilityElementsHidden={true}
+              allowFontScaling={false}
+              importantForAccessibility="no-hide-descendants"
+              pointerEvents="none"
+              selectable={false}
               style={
-                Object {
-                  "bottom": 0,
-                  "left": 0,
-                  "opacity": 1,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                  "transform": Array [
-                    Object {
-                      "rotate": "0deg",
-                    },
-                  ],
-                }
-              }
-            >
-              <Text
-                accessibilityElementsHidden={true}
-                allowFontScaling={false}
-                importantForAccessibility="no-hide-descendants"
-                pointerEvents="none"
-                selectable={false}
-                style={
+                Array [
+                  Object {
+                    "color": "rgba(33, 0, 93, 1)",
+                    "fontSize": 50,
+                  },
                   Array [
                     Object {
-                      "color": "rgba(33, 0, 93, 1)",
-                      "fontSize": 50,
+                      "lineHeight": 50,
+                      "transform": Array [
+                        Object {
+                          "scaleX": 1,
+                        },
+                      ],
                     },
-                    Array [
-                      Object {
-                        "lineHeight": 50,
-                        "transform": Array [
-                          Object {
-                            "scaleX": 1,
-                          },
-                        ],
-                      },
-                      Object {
-                        "backgroundColor": "transparent",
-                      },
-                    ],
                     Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
+                      "backgroundColor": "transparent",
                     },
-                    Object {},
-                  ]
-                }
-              >
-                󰐕
-              </Text>
-            </View>
+                  ],
+                  Object {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  Object {},
+                ]
+              }
+            >
+              󰐕
+            </Text>
           </View>
         </View>
       </View>
@@ -222,8 +213,11 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
 >
   <View
     collapsable={false}
+    pointerEvents="auto"
     style={
       Object {
+        "backgroundColor": "rgba(234, 221, 255, 1)",
+        "borderRadius": 16,
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -234,138 +228,126 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-middle-layer"
+    testID="fab-container"
   >
     <View
-      collapsable={false}
-      pointerEvents="auto"
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "rgba(234, 221, 255, 1)",
-          "borderRadius": 16,
-          "flex": undefined,
-          "overflow": "hidden",
+          "disabled": false,
         }
       }
-      testID="fab-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 16,
+          },
+        ]
+      }
+      testID="fab"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": false,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        pointerEvents="none"
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            undefined,
+            Object {
+              "borderRadius": 16,
+              "height": 56,
+              "width": 56,
+            },
           ]
         }
-        testID="fab"
+        testID="fab-content"
       >
         <View
-          pointerEvents="none"
           style={
             Array [
               Object {
                 "alignItems": "center",
-                "flexDirection": "row",
                 "justifyContent": "center",
               },
               Object {
-                "borderRadius": 16,
-                "height": 56,
-                "width": 56,
+                "height": 24,
+                "width": 24,
               },
             ]
           }
-          testID="fab-content"
         >
           <View
+            collapsable={false}
             style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                },
-                Object {
-                  "height": 24,
-                  "width": 24,
-                },
-              ]
+              Object {
+                "bottom": 0,
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "transform": Array [
+                  Object {
+                    "rotate": "0deg",
+                  },
+                ],
+              }
             }
           >
-            <View
-              collapsable={false}
+            <Text
+              accessibilityElementsHidden={true}
+              allowFontScaling={false}
+              importantForAccessibility="no-hide-descendants"
+              pointerEvents="none"
+              selectable={false}
               style={
-                Object {
-                  "bottom": 0,
-                  "left": 0,
-                  "opacity": 1,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                  "transform": Array [
-                    Object {
-                      "rotate": "0deg",
-                    },
-                  ],
-                }
-              }
-            >
-              <Text
-                accessibilityElementsHidden={true}
-                allowFontScaling={false}
-                importantForAccessibility="no-hide-descendants"
-                pointerEvents="none"
-                selectable={false}
-                style={
+                Array [
+                  Object {
+                    "color": "#AA0114",
+                    "fontSize": 24,
+                  },
                   Array [
                     Object {
-                      "color": "#AA0114",
-                      "fontSize": 24,
+                      "lineHeight": 24,
+                      "transform": Array [
+                        Object {
+                          "scaleX": 1,
+                        },
+                      ],
                     },
-                    Array [
-                      Object {
-                        "lineHeight": 24,
-                        "transform": Array [
-                          Object {
-                            "scaleX": 1,
-                          },
-                        ],
-                      },
-                      Object {
-                        "backgroundColor": "transparent",
-                      },
-                    ],
                     Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
+                      "backgroundColor": "transparent",
                     },
-                    Object {},
-                  ]
-                }
-              >
-                󰐕
-              </Text>
-            </View>
+                  ],
+                  Object {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  Object {},
+                ]
+              }
+            >
+              󰐕
+            </Text>
           </View>
         </View>
       </View>
@@ -409,8 +391,11 @@ exports[`renders default FAB 1`] = `
 >
   <View
     collapsable={false}
+    pointerEvents="auto"
     style={
       Object {
+        "backgroundColor": "rgba(234, 221, 255, 1)",
+        "borderRadius": 16,
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -421,138 +406,126 @@ exports[`renders default FAB 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-middle-layer"
+    testID="fab-container"
   >
     <View
-      collapsable={false}
-      pointerEvents="auto"
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "rgba(234, 221, 255, 1)",
-          "borderRadius": 16,
-          "flex": undefined,
-          "overflow": "hidden",
+          "disabled": false,
         }
       }
-      testID="fab-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 16,
+          },
+        ]
+      }
+      testID="fab"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": false,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        pointerEvents="none"
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            undefined,
+            Object {
+              "borderRadius": 16,
+              "height": 56,
+              "width": 56,
+            },
           ]
         }
-        testID="fab"
+        testID="fab-content"
       >
         <View
-          pointerEvents="none"
           style={
             Array [
               Object {
                 "alignItems": "center",
-                "flexDirection": "row",
                 "justifyContent": "center",
               },
               Object {
-                "borderRadius": 16,
-                "height": 56,
-                "width": 56,
+                "height": 24,
+                "width": 24,
               },
             ]
           }
-          testID="fab-content"
         >
           <View
+            collapsable={false}
             style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                },
-                Object {
-                  "height": 24,
-                  "width": 24,
-                },
-              ]
+              Object {
+                "bottom": 0,
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "transform": Array [
+                  Object {
+                    "rotate": "0deg",
+                  },
+                ],
+              }
             }
           >
-            <View
-              collapsable={false}
+            <Text
+              accessibilityElementsHidden={true}
+              allowFontScaling={false}
+              importantForAccessibility="no-hide-descendants"
+              pointerEvents="none"
+              selectable={false}
               style={
-                Object {
-                  "bottom": 0,
-                  "left": 0,
-                  "opacity": 1,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                  "transform": Array [
-                    Object {
-                      "rotate": "0deg",
-                    },
-                  ],
-                }
-              }
-            >
-              <Text
-                accessibilityElementsHidden={true}
-                allowFontScaling={false}
-                importantForAccessibility="no-hide-descendants"
-                pointerEvents="none"
-                selectable={false}
-                style={
+                Array [
+                  Object {
+                    "color": "rgba(33, 0, 93, 1)",
+                    "fontSize": 24,
+                  },
                   Array [
                     Object {
-                      "color": "rgba(33, 0, 93, 1)",
-                      "fontSize": 24,
+                      "lineHeight": 24,
+                      "transform": Array [
+                        Object {
+                          "scaleX": 1,
+                        },
+                      ],
                     },
-                    Array [
-                      Object {
-                        "lineHeight": 24,
-                        "transform": Array [
-                          Object {
-                            "scaleX": 1,
-                          },
-                        ],
-                      },
-                      Object {
-                        "backgroundColor": "transparent",
-                      },
-                    ],
                     Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
+                      "backgroundColor": "transparent",
                     },
-                    Object {},
-                  ]
-                }
-              >
-                󰐕
-              </Text>
-            </View>
+                  ],
+                  Object {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  Object {},
+                ]
+              }
+            >
+              󰐕
+            </Text>
           </View>
         </View>
       </View>
@@ -596,8 +569,11 @@ exports[`renders disabled FAB 1`] = `
 >
   <View
     collapsable={false}
+    pointerEvents="auto"
     style={
       Object {
+        "backgroundColor": "rgba(28, 27, 31, 0.12)",
+        "borderRadius": 16,
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -608,138 +584,126 @@ exports[`renders disabled FAB 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="fab-container-middle-layer"
+    testID="fab-container"
   >
     <View
-      collapsable={false}
-      pointerEvents="auto"
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "rgba(28, 27, 31, 0.12)",
-          "borderRadius": 16,
-          "flex": undefined,
-          "overflow": "hidden",
+          "disabled": true,
         }
       }
-      testID="fab-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 16,
+          },
+        ]
+      }
+      testID="fab"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        pointerEvents="none"
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            undefined,
+            Object {
+              "borderRadius": 16,
+              "height": 56,
+              "width": 56,
+            },
           ]
         }
-        testID="fab"
+        testID="fab-content"
       >
         <View
-          pointerEvents="none"
           style={
             Array [
               Object {
                 "alignItems": "center",
-                "flexDirection": "row",
                 "justifyContent": "center",
               },
               Object {
-                "borderRadius": 16,
-                "height": 56,
-                "width": 56,
+                "height": 24,
+                "width": 24,
               },
             ]
           }
-          testID="fab-content"
         >
           <View
+            collapsable={false}
             style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                },
-                Object {
-                  "height": 24,
-                  "width": 24,
-                },
-              ]
+              Object {
+                "bottom": 0,
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "transform": Array [
+                  Object {
+                    "rotate": "0deg",
+                  },
+                ],
+              }
             }
           >
-            <View
-              collapsable={false}
+            <Text
+              accessibilityElementsHidden={true}
+              allowFontScaling={false}
+              importantForAccessibility="no-hide-descendants"
+              pointerEvents="none"
+              selectable={false}
               style={
-                Object {
-                  "bottom": 0,
-                  "left": 0,
-                  "opacity": 1,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                  "transform": Array [
-                    Object {
-                      "rotate": "0deg",
-                    },
-                  ],
-                }
-              }
-            >
-              <Text
-                accessibilityElementsHidden={true}
-                allowFontScaling={false}
-                importantForAccessibility="no-hide-descendants"
-                pointerEvents="none"
-                selectable={false}
-                style={
+                Array [
+                  Object {
+                    "color": "rgba(28, 27, 31, 0.38)",
+                    "fontSize": 24,
+                  },
                   Array [
                     Object {
-                      "color": "rgba(28, 27, 31, 0.38)",
-                      "fontSize": 24,
+                      "lineHeight": 24,
+                      "transform": Array [
+                        Object {
+                          "scaleX": 1,
+                        },
+                      ],
                     },
-                    Array [
-                      Object {
-                        "lineHeight": 24,
-                        "transform": Array [
-                          Object {
-                            "scaleX": 1,
-                          },
-                        ],
-                      },
-                      Object {
-                        "backgroundColor": "transparent",
-                      },
-                    ],
                     Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
+                      "backgroundColor": "transparent",
                     },
-                    Object {},
-                  ]
-                }
-              >
-                󰐕
-              </Text>
-            </View>
+                  ],
+                  Object {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  Object {},
+                ]
+              }
+            >
+              󰐕
+            </Text>
           </View>
         </View>
       </View>
@@ -783,8 +747,11 @@ exports[`renders extended FAB 1`] = `
 >
   <View
     collapsable={false}
+    pointerEvents="auto"
     style={
       Object {
+        "backgroundColor": "rgba(234, 221, 255, 1)",
+        "borderRadius": 16,
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -795,179 +762,167 @@ exports[`renders extended FAB 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-middle-layer"
+    testID="fab-container"
   >
     <View
-      collapsable={false}
-      pointerEvents="auto"
-      style={
+      accessibilityLabel="Add items"
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "rgba(234, 221, 255, 1)",
-          "borderRadius": 16,
-          "flex": undefined,
-          "overflow": "hidden",
+          "disabled": false,
         }
       }
-      testID="fab-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 16,
+          },
+        ]
+      }
+      testID="fab"
     >
       <View
-        accessibilityLabel="Add items"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": false,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        pointerEvents="none"
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            undefined,
+            Object {
+              "borderRadius": 16,
+              "height": 56,
+              "paddingHorizontal": 16,
+            },
           ]
         }
-        testID="fab"
+        testID="fab-content"
       >
         <View
-          pointerEvents="none"
           style={
             Array [
               Object {
                 "alignItems": "center",
-                "flexDirection": "row",
                 "justifyContent": "center",
               },
               Object {
-                "borderRadius": 16,
-                "height": 56,
-                "paddingHorizontal": 16,
+                "height": 24,
+                "width": 24,
               },
             ]
           }
-          testID="fab-content"
         >
           <View
+            collapsable={false}
             style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                },
-                Object {
-                  "height": 24,
-                  "width": 24,
-                },
-              ]
+              Object {
+                "bottom": 0,
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "transform": Array [
+                  Object {
+                    "rotate": "0deg",
+                  },
+                ],
+              }
             }
           >
-            <View
-              collapsable={false}
+            <Text
+              accessibilityElementsHidden={true}
+              allowFontScaling={false}
+              importantForAccessibility="no-hide-descendants"
+              pointerEvents="none"
+              selectable={false}
               style={
-                Object {
-                  "bottom": 0,
-                  "left": 0,
-                  "opacity": 1,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                  "transform": Array [
-                    Object {
-                      "rotate": "0deg",
-                    },
-                  ],
-                }
-              }
-            >
-              <Text
-                accessibilityElementsHidden={true}
-                allowFontScaling={false}
-                importantForAccessibility="no-hide-descendants"
-                pointerEvents="none"
-                selectable={false}
-                style={
+                Array [
+                  Object {
+                    "color": "rgba(33, 0, 93, 1)",
+                    "fontSize": 24,
+                  },
                   Array [
                     Object {
-                      "color": "rgba(33, 0, 93, 1)",
-                      "fontSize": 24,
+                      "lineHeight": 24,
+                      "transform": Array [
+                        Object {
+                          "scaleX": 1,
+                        },
+                      ],
                     },
-                    Array [
-                      Object {
-                        "lineHeight": 24,
-                        "transform": Array [
-                          Object {
-                            "scaleX": 1,
-                          },
-                        ],
-                      },
-                      Object {
-                        "backgroundColor": "transparent",
-                      },
-                    ],
                     Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
+                      "backgroundColor": "transparent",
                     },
-                    Object {},
-                  ]
-                }
-              >
-                󰐕
-              </Text>
-            </View>
+                  ],
+                  Object {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  Object {},
+                ]
+              }
+            >
+              󰐕
+            </Text>
           </View>
-          <Text
-            selectable={false}
-            style={
+        </View>
+        <Text
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
+              },
+              Object {
+                "textAlign": "left",
+              },
+              Object {
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
+              },
               Array [
                 Object {
+                  "marginHorizontal": 8,
+                },
+                false,
+                Object {
+                  "color": "rgba(33, 0, 93, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
                   "letterSpacing": 0.1,
                   "lineHeight": 20,
                 },
-                Object {
-                  "textAlign": "left",
-                },
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "writingDirection": "ltr",
-                },
-                Array [
-                  Object {
-                    "marginHorizontal": 8,
-                  },
-                  false,
-                  Object {
-                    "color": "rgba(33, 0, 93, 1)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0.1,
-                    "lineHeight": 20,
-                  },
-                ],
-              ]
-            }
-            testID="fab-text"
-          >
-            Add items
-          </Text>
-        </View>
+              ],
+            ]
+          }
+          testID="fab-text"
+        >
+          Add items
+        </Text>
       </View>
     </View>
   </View>
@@ -1009,8 +964,11 @@ exports[`renders extended FAB with custom size prop 1`] = `
 >
   <View
     collapsable={false}
+    pointerEvents="auto"
     style={
       Object {
+        "backgroundColor": "rgba(234, 221, 255, 1)",
+        "borderRadius": 25,
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -1021,178 +979,166 @@ exports[`renders extended FAB with custom size prop 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-middle-layer"
+    testID="fab-container"
   >
     <View
-      collapsable={false}
-      pointerEvents="auto"
-      style={
+      accessibilityLabel="Add items"
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "rgba(234, 221, 255, 1)",
-          "borderRadius": 25,
-          "flex": undefined,
-          "overflow": "hidden",
+          "disabled": false,
         }
       }
-      testID="fab-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 25,
+          },
+        ]
+      }
+      testID="fab"
     >
       <View
-        accessibilityLabel="Add items"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": false,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        pointerEvents="none"
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            undefined,
+            Object {
+              "height": 100,
+              "paddingHorizontal": 16,
+            },
           ]
         }
-        testID="fab"
+        testID="fab-content"
       >
         <View
-          pointerEvents="none"
           style={
             Array [
               Object {
                 "alignItems": "center",
-                "flexDirection": "row",
                 "justifyContent": "center",
               },
               Object {
-                "height": 100,
-                "paddingHorizontal": 16,
+                "height": 50,
+                "width": 50,
               },
             ]
           }
-          testID="fab-content"
         >
           <View
+            collapsable={false}
             style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                },
-                Object {
-                  "height": 50,
-                  "width": 50,
-                },
-              ]
+              Object {
+                "bottom": 0,
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "transform": Array [
+                  Object {
+                    "rotate": "0deg",
+                  },
+                ],
+              }
             }
           >
-            <View
-              collapsable={false}
+            <Text
+              accessibilityElementsHidden={true}
+              allowFontScaling={false}
+              importantForAccessibility="no-hide-descendants"
+              pointerEvents="none"
+              selectable={false}
               style={
-                Object {
-                  "bottom": 0,
-                  "left": 0,
-                  "opacity": 1,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                  "transform": Array [
-                    Object {
-                      "rotate": "0deg",
-                    },
-                  ],
-                }
-              }
-            >
-              <Text
-                accessibilityElementsHidden={true}
-                allowFontScaling={false}
-                importantForAccessibility="no-hide-descendants"
-                pointerEvents="none"
-                selectable={false}
-                style={
+                Array [
+                  Object {
+                    "color": "rgba(33, 0, 93, 1)",
+                    "fontSize": 50,
+                  },
                   Array [
                     Object {
-                      "color": "rgba(33, 0, 93, 1)",
-                      "fontSize": 50,
+                      "lineHeight": 50,
+                      "transform": Array [
+                        Object {
+                          "scaleX": 1,
+                        },
+                      ],
                     },
-                    Array [
-                      Object {
-                        "lineHeight": 50,
-                        "transform": Array [
-                          Object {
-                            "scaleX": 1,
-                          },
-                        ],
-                      },
-                      Object {
-                        "backgroundColor": "transparent",
-                      },
-                    ],
                     Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
+                      "backgroundColor": "transparent",
                     },
-                    Object {},
-                  ]
-                }
-              >
-                󰐕
-              </Text>
-            </View>
+                  ],
+                  Object {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  Object {},
+                ]
+              }
+            >
+              󰐕
+            </Text>
           </View>
-          <Text
-            selectable={false}
-            style={
+        </View>
+        <Text
+          selectable={false}
+          style={
+            Array [
+              Object {
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
+              },
+              Object {
+                "textAlign": "left",
+              },
+              Object {
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
+              },
               Array [
                 Object {
+                  "marginHorizontal": 8,
+                },
+                false,
+                Object {
+                  "color": "rgba(33, 0, 93, 1)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "500",
                   "letterSpacing": 0.1,
                   "lineHeight": 20,
                 },
-                Object {
-                  "textAlign": "left",
-                },
-                Object {
-                  "color": "rgba(28, 27, 31, 1)",
-                  "writingDirection": "ltr",
-                },
-                Array [
-                  Object {
-                    "marginHorizontal": 8,
-                  },
-                  false,
-                  Object {
-                    "color": "rgba(33, 0, 93, 1)",
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "500",
-                    "letterSpacing": 0.1,
-                    "lineHeight": 20,
-                  },
-                ],
-              ]
-            }
-            testID="fab-text"
-          >
-            Add items
-          </Text>
-        </View>
+              ],
+            ]
+          }
+          testID="fab-text"
+        >
+          Add items
+        </Text>
       </View>
     </View>
   </View>
@@ -1234,8 +1180,11 @@ exports[`renders large FAB 1`] = `
 >
   <View
     collapsable={false}
+    pointerEvents="auto"
     style={
       Object {
+        "backgroundColor": "rgba(234, 221, 255, 1)",
+        "borderRadius": 28,
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -1246,138 +1195,126 @@ exports[`renders large FAB 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-middle-layer"
+    testID="fab-container"
   >
     <View
-      collapsable={false}
-      pointerEvents="auto"
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "rgba(234, 221, 255, 1)",
-          "borderRadius": 28,
-          "flex": undefined,
-          "overflow": "hidden",
+          "disabled": false,
         }
       }
-      testID="fab-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 28,
+          },
+        ]
+      }
+      testID="fab"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": false,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        pointerEvents="none"
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            undefined,
+            Object {
+              "borderRadius": 28,
+              "height": 96,
+              "width": 96,
+            },
           ]
         }
-        testID="fab"
+        testID="fab-content"
       >
         <View
-          pointerEvents="none"
           style={
             Array [
               Object {
                 "alignItems": "center",
-                "flexDirection": "row",
                 "justifyContent": "center",
               },
               Object {
-                "borderRadius": 28,
-                "height": 96,
-                "width": 96,
+                "height": 36,
+                "width": 36,
               },
             ]
           }
-          testID="fab-content"
         >
           <View
+            collapsable={false}
             style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                },
-                Object {
-                  "height": 36,
-                  "width": 36,
-                },
-              ]
+              Object {
+                "bottom": 0,
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "transform": Array [
+                  Object {
+                    "rotate": "0deg",
+                  },
+                ],
+              }
             }
           >
-            <View
-              collapsable={false}
+            <Text
+              accessibilityElementsHidden={true}
+              allowFontScaling={false}
+              importantForAccessibility="no-hide-descendants"
+              pointerEvents="none"
+              selectable={false}
               style={
-                Object {
-                  "bottom": 0,
-                  "left": 0,
-                  "opacity": 1,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                  "transform": Array [
-                    Object {
-                      "rotate": "0deg",
-                    },
-                  ],
-                }
-              }
-            >
-              <Text
-                accessibilityElementsHidden={true}
-                allowFontScaling={false}
-                importantForAccessibility="no-hide-descendants"
-                pointerEvents="none"
-                selectable={false}
-                style={
+                Array [
+                  Object {
+                    "color": "rgba(33, 0, 93, 1)",
+                    "fontSize": 36,
+                  },
                   Array [
                     Object {
-                      "color": "rgba(33, 0, 93, 1)",
-                      "fontSize": 36,
+                      "lineHeight": 36,
+                      "transform": Array [
+                        Object {
+                          "scaleX": 1,
+                        },
+                      ],
                     },
-                    Array [
-                      Object {
-                        "lineHeight": 36,
-                        "transform": Array [
-                          Object {
-                            "scaleX": 1,
-                          },
-                        ],
-                      },
-                      Object {
-                        "backgroundColor": "transparent",
-                      },
-                    ],
                     Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
+                      "backgroundColor": "transparent",
                     },
-                    Object {},
-                  ]
-                }
-              >
-                󰐕
-              </Text>
-            </View>
+                  ],
+                  Object {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  Object {},
+                ]
+              }
+            >
+              󰐕
+            </Text>
           </View>
         </View>
       </View>
@@ -1421,8 +1358,11 @@ exports[`renders loading FAB 1`] = `
 >
   <View
     collapsable={false}
+    pointerEvents="auto"
     style={
       Object {
+        "backgroundColor": "rgba(234, 221, 255, 1)",
+        "borderRadius": 16,
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -1433,94 +1373,97 @@ exports[`renders loading FAB 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-middle-layer"
+    testID="fab-container"
   >
     <View
-      collapsable={false}
-      pointerEvents="auto"
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "rgba(234, 221, 255, 1)",
-          "borderRadius": 16,
-          "flex": undefined,
-          "overflow": "hidden",
+          "disabled": false,
         }
       }
-      testID="fab-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 16,
+          },
+        ]
+      }
+      testID="fab"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": false,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        pointerEvents="none"
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            undefined,
+            Object {
+              "borderRadius": 16,
+              "height": 56,
+              "width": 56,
+            },
           ]
         }
-        testID="fab"
+        testID="fab-content"
       >
         <View
-          pointerEvents="none"
+          accessibilityRole="progressbar"
+          accessibilityState={
+            Object {
+              "busy": true,
+            }
+          }
+          accessible={true}
           style={
             Array [
               Object {
                 "alignItems": "center",
-                "flexDirection": "row",
                 "justifyContent": "center",
               },
-              Object {
-                "borderRadius": 16,
-                "height": 56,
-                "width": 56,
-              },
+              undefined,
             ]
           }
-          testID="fab-content"
         >
           <View
-            accessibilityRole="progressbar"
-            accessibilityState={
-              Object {
-                "busy": true,
-              }
-            }
-            accessible={true}
+            collapsable={false}
             style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                },
-                undefined,
-              ]
+              Object {
+                "height": 18,
+                "opacity": 1,
+                "width": 18,
+              }
             }
           >
             <View
               collapsable={false}
               style={
                 Object {
-                  "height": 18,
-                  "opacity": 1,
-                  "width": 18,
+                  "alignItems": "center",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                 }
               }
             >
@@ -1528,13 +1471,13 @@ exports[`renders loading FAB 1`] = `
                 collapsable={false}
                 style={
                   Object {
-                    "alignItems": "center",
-                    "bottom": 0,
-                    "justifyContent": "center",
-                    "left": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
+                    "height": 18,
+                    "transform": Array [
+                      Object {
+                        "rotate": "45deg",
+                      },
+                    ],
+                    "width": 18,
                   }
                 }
               >
@@ -1542,12 +1485,8 @@ exports[`renders loading FAB 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "height": 18,
-                      "transform": Array [
-                        Object {
-                          "rotate": "45deg",
-                        },
-                      ],
+                      "height": 9,
+                      "overflow": "hidden",
                       "width": 18,
                     }
                   }
@@ -1556,8 +1495,15 @@ exports[`renders loading FAB 1`] = `
                     collapsable={false}
                     style={
                       Object {
-                        "height": 9,
-                        "overflow": "hidden",
+                        "height": 18,
+                        "transform": Array [
+                          Object {
+                            "translateY": 0,
+                          },
+                          Object {
+                            "rotate": "-165deg",
+                          },
+                        ],
                         "width": 18,
                       }
                     }
@@ -1566,15 +1512,8 @@ exports[`renders loading FAB 1`] = `
                       collapsable={false}
                       style={
                         Object {
-                          "height": 18,
-                          "transform": Array [
-                            Object {
-                              "translateY": 0,
-                            },
-                            Object {
-                              "rotate": "-165deg",
-                            },
-                          ],
+                          "height": 9,
+                          "overflow": "hidden",
                           "width": 18,
                         }
                       }
@@ -1583,40 +1522,44 @@ exports[`renders loading FAB 1`] = `
                         collapsable={false}
                         style={
                           Object {
-                            "height": 9,
-                            "overflow": "hidden",
+                            "borderColor": "rgba(33, 0, 93, 1)",
+                            "borderRadius": 9,
+                            "borderWidth": 1.8,
+                            "height": 18,
                             "width": 18,
                           }
                         }
-                      >
-                        <View
-                          collapsable={false}
-                          style={
-                            Object {
-                              "borderColor": "rgba(33, 0, 93, 1)",
-                              "borderRadius": 9,
-                              "borderWidth": 1.8,
-                              "height": 18,
-                              "width": 18,
-                            }
-                          }
-                        />
-                      </View>
+                      />
                     </View>
                   </View>
                 </View>
               </View>
+            </View>
+            <View
+              collapsable={false}
+              style={
+                Object {
+                  "alignItems": "center",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            >
               <View
                 collapsable={false}
                 style={
                   Object {
-                    "alignItems": "center",
-                    "bottom": 0,
-                    "justifyContent": "center",
-                    "left": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
+                    "height": 18,
+                    "transform": Array [
+                      Object {
+                        "rotate": "45deg",
+                      },
+                    ],
+                    "width": 18,
                   }
                 }
               >
@@ -1624,12 +1567,9 @@ exports[`renders loading FAB 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "height": 18,
-                      "transform": Array [
-                        Object {
-                          "rotate": "45deg",
-                        },
-                      ],
+                      "height": 9,
+                      "overflow": "hidden",
+                      "top": 9,
                       "width": 18,
                     }
                   }
@@ -1638,9 +1578,15 @@ exports[`renders loading FAB 1`] = `
                     collapsable={false}
                     style={
                       Object {
-                        "height": 9,
-                        "overflow": "hidden",
-                        "top": 9,
+                        "height": 18,
+                        "transform": Array [
+                          Object {
+                            "translateY": -9,
+                          },
+                          Object {
+                            "rotate": "345deg",
+                          },
+                        ],
                         "width": 18,
                       }
                     }
@@ -1649,15 +1595,8 @@ exports[`renders loading FAB 1`] = `
                       collapsable={false}
                       style={
                         Object {
-                          "height": 18,
-                          "transform": Array [
-                            Object {
-                              "translateY": -9,
-                            },
-                            Object {
-                              "rotate": "345deg",
-                            },
-                          ],
+                          "height": 9,
+                          "overflow": "hidden",
                           "width": 18,
                         }
                       }
@@ -1666,25 +1605,14 @@ exports[`renders loading FAB 1`] = `
                         collapsable={false}
                         style={
                           Object {
-                            "height": 9,
-                            "overflow": "hidden",
+                            "borderColor": "rgba(33, 0, 93, 1)",
+                            "borderRadius": 9,
+                            "borderWidth": 1.8,
+                            "height": 18,
                             "width": 18,
                           }
                         }
-                      >
-                        <View
-                          collapsable={false}
-                          style={
-                            Object {
-                              "borderColor": "rgba(33, 0, 93, 1)",
-                              "borderRadius": 9,
-                              "borderWidth": 1.8,
-                              "height": 18,
-                              "width": 18,
-                            }
-                          }
-                        />
-                      </View>
+                      />
                     </View>
                   </View>
                 </View>
@@ -1733,8 +1661,11 @@ exports[`renders loading FAB with custom size prop 1`] = `
 >
   <View
     collapsable={false}
+    pointerEvents="auto"
     style={
       Object {
+        "backgroundColor": "rgba(234, 221, 255, 1)",
+        "borderRadius": 25,
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -1745,94 +1676,97 @@ exports[`renders loading FAB with custom size prop 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-middle-layer"
+    testID="fab-container"
   >
     <View
-      collapsable={false}
-      pointerEvents="auto"
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "rgba(234, 221, 255, 1)",
-          "borderRadius": 25,
-          "flex": undefined,
-          "overflow": "hidden",
+          "disabled": false,
         }
       }
-      testID="fab-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 25,
+          },
+        ]
+      }
+      testID="fab"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": false,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        pointerEvents="none"
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            undefined,
+            Object {
+              "borderRadius": 25,
+              "height": 100,
+              "width": 100,
+            },
           ]
         }
-        testID="fab"
+        testID="fab-content"
       >
         <View
-          pointerEvents="none"
+          accessibilityRole="progressbar"
+          accessibilityState={
+            Object {
+              "busy": true,
+            }
+          }
+          accessible={true}
           style={
             Array [
               Object {
                 "alignItems": "center",
-                "flexDirection": "row",
                 "justifyContent": "center",
               },
-              Object {
-                "borderRadius": 25,
-                "height": 100,
-                "width": 100,
-              },
+              undefined,
             ]
           }
-          testID="fab-content"
         >
           <View
-            accessibilityRole="progressbar"
-            accessibilityState={
-              Object {
-                "busy": true,
-              }
-            }
-            accessible={true}
+            collapsable={false}
             style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                },
-                undefined,
-              ]
+              Object {
+                "height": 50,
+                "opacity": 1,
+                "width": 50,
+              }
             }
           >
             <View
               collapsable={false}
               style={
                 Object {
-                  "height": 50,
-                  "opacity": 1,
-                  "width": 50,
+                  "alignItems": "center",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                 }
               }
             >
@@ -1840,13 +1774,13 @@ exports[`renders loading FAB with custom size prop 1`] = `
                 collapsable={false}
                 style={
                   Object {
-                    "alignItems": "center",
-                    "bottom": 0,
-                    "justifyContent": "center",
-                    "left": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
+                    "height": 50,
+                    "transform": Array [
+                      Object {
+                        "rotate": "45deg",
+                      },
+                    ],
+                    "width": 50,
                   }
                 }
               >
@@ -1854,12 +1788,8 @@ exports[`renders loading FAB with custom size prop 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "height": 50,
-                      "transform": Array [
-                        Object {
-                          "rotate": "45deg",
-                        },
-                      ],
+                      "height": 25,
+                      "overflow": "hidden",
                       "width": 50,
                     }
                   }
@@ -1868,8 +1798,15 @@ exports[`renders loading FAB with custom size prop 1`] = `
                     collapsable={false}
                     style={
                       Object {
-                        "height": 25,
-                        "overflow": "hidden",
+                        "height": 50,
+                        "transform": Array [
+                          Object {
+                            "translateY": 0,
+                          },
+                          Object {
+                            "rotate": "-165deg",
+                          },
+                        ],
                         "width": 50,
                       }
                     }
@@ -1878,15 +1815,8 @@ exports[`renders loading FAB with custom size prop 1`] = `
                       collapsable={false}
                       style={
                         Object {
-                          "height": 50,
-                          "transform": Array [
-                            Object {
-                              "translateY": 0,
-                            },
-                            Object {
-                              "rotate": "-165deg",
-                            },
-                          ],
+                          "height": 25,
+                          "overflow": "hidden",
                           "width": 50,
                         }
                       }
@@ -1895,40 +1825,44 @@ exports[`renders loading FAB with custom size prop 1`] = `
                         collapsable={false}
                         style={
                           Object {
-                            "height": 25,
-                            "overflow": "hidden",
+                            "borderColor": "rgba(33, 0, 93, 1)",
+                            "borderRadius": 25,
+                            "borderWidth": 5,
+                            "height": 50,
                             "width": 50,
                           }
                         }
-                      >
-                        <View
-                          collapsable={false}
-                          style={
-                            Object {
-                              "borderColor": "rgba(33, 0, 93, 1)",
-                              "borderRadius": 25,
-                              "borderWidth": 5,
-                              "height": 50,
-                              "width": 50,
-                            }
-                          }
-                        />
-                      </View>
+                      />
                     </View>
                   </View>
                 </View>
               </View>
+            </View>
+            <View
+              collapsable={false}
+              style={
+                Object {
+                  "alignItems": "center",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            >
               <View
                 collapsable={false}
                 style={
                   Object {
-                    "alignItems": "center",
-                    "bottom": 0,
-                    "justifyContent": "center",
-                    "left": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
+                    "height": 50,
+                    "transform": Array [
+                      Object {
+                        "rotate": "45deg",
+                      },
+                    ],
+                    "width": 50,
                   }
                 }
               >
@@ -1936,12 +1870,9 @@ exports[`renders loading FAB with custom size prop 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "height": 50,
-                      "transform": Array [
-                        Object {
-                          "rotate": "45deg",
-                        },
-                      ],
+                      "height": 25,
+                      "overflow": "hidden",
+                      "top": 25,
                       "width": 50,
                     }
                   }
@@ -1950,9 +1881,15 @@ exports[`renders loading FAB with custom size prop 1`] = `
                     collapsable={false}
                     style={
                       Object {
-                        "height": 25,
-                        "overflow": "hidden",
-                        "top": 25,
+                        "height": 50,
+                        "transform": Array [
+                          Object {
+                            "translateY": -25,
+                          },
+                          Object {
+                            "rotate": "345deg",
+                          },
+                        ],
                         "width": 50,
                       }
                     }
@@ -1961,15 +1898,8 @@ exports[`renders loading FAB with custom size prop 1`] = `
                       collapsable={false}
                       style={
                         Object {
-                          "height": 50,
-                          "transform": Array [
-                            Object {
-                              "translateY": -25,
-                            },
-                            Object {
-                              "rotate": "345deg",
-                            },
-                          ],
+                          "height": 25,
+                          "overflow": "hidden",
                           "width": 50,
                         }
                       }
@@ -1978,25 +1908,14 @@ exports[`renders loading FAB with custom size prop 1`] = `
                         collapsable={false}
                         style={
                           Object {
-                            "height": 25,
-                            "overflow": "hidden",
+                            "borderColor": "rgba(33, 0, 93, 1)",
+                            "borderRadius": 25,
+                            "borderWidth": 5,
+                            "height": 50,
                             "width": 50,
                           }
                         }
-                      >
-                        <View
-                          collapsable={false}
-                          style={
-                            Object {
-                              "borderColor": "rgba(33, 0, 93, 1)",
-                              "borderRadius": 25,
-                              "borderWidth": 5,
-                              "height": 50,
-                              "width": 50,
-                            }
-                          }
-                        />
-                      </View>
+                      />
                     </View>
                   </View>
                 </View>
@@ -2045,8 +1964,11 @@ exports[`renders not visible FAB 1`] = `
 >
   <View
     collapsable={false}
+    pointerEvents="none"
     style={
       Object {
+        "backgroundColor": "rgba(234, 221, 255, 1)",
+        "borderRadius": 16,
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -2057,138 +1979,126 @@ exports[`renders not visible FAB 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-middle-layer"
+    testID="fab-container"
   >
     <View
-      collapsable={false}
-      pointerEvents="none"
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "rgba(234, 221, 255, 1)",
-          "borderRadius": 16,
-          "flex": undefined,
-          "overflow": "hidden",
+          "disabled": false,
         }
       }
-      testID="fab-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 16,
+          },
+        ]
+      }
+      testID="fab"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": false,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        pointerEvents="none"
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            undefined,
+            Object {
+              "borderRadius": 16,
+              "height": 56,
+              "width": 56,
+            },
           ]
         }
-        testID="fab"
+        testID="fab-content"
       >
         <View
-          pointerEvents="none"
           style={
             Array [
               Object {
                 "alignItems": "center",
-                "flexDirection": "row",
                 "justifyContent": "center",
               },
               Object {
-                "borderRadius": 16,
-                "height": 56,
-                "width": 56,
+                "height": 24,
+                "width": 24,
               },
             ]
           }
-          testID="fab-content"
         >
           <View
+            collapsable={false}
             style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                },
-                Object {
-                  "height": 24,
-                  "width": 24,
-                },
-              ]
+              Object {
+                "bottom": 0,
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "transform": Array [
+                  Object {
+                    "rotate": "0deg",
+                  },
+                ],
+              }
             }
           >
-            <View
-              collapsable={false}
+            <Text
+              accessibilityElementsHidden={true}
+              allowFontScaling={false}
+              importantForAccessibility="no-hide-descendants"
+              pointerEvents="none"
+              selectable={false}
               style={
-                Object {
-                  "bottom": 0,
-                  "left": 0,
-                  "opacity": 1,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                  "transform": Array [
-                    Object {
-                      "rotate": "0deg",
-                    },
-                  ],
-                }
-              }
-            >
-              <Text
-                accessibilityElementsHidden={true}
-                allowFontScaling={false}
-                importantForAccessibility="no-hide-descendants"
-                pointerEvents="none"
-                selectable={false}
-                style={
+                Array [
+                  Object {
+                    "color": "rgba(33, 0, 93, 1)",
+                    "fontSize": 24,
+                  },
                   Array [
                     Object {
-                      "color": "rgba(33, 0, 93, 1)",
-                      "fontSize": 24,
+                      "lineHeight": 24,
+                      "transform": Array [
+                        Object {
+                          "scaleX": 1,
+                        },
+                      ],
                     },
-                    Array [
-                      Object {
-                        "lineHeight": 24,
-                        "transform": Array [
-                          Object {
-                            "scaleX": 1,
-                          },
-                        ],
-                      },
-                      Object {
-                        "backgroundColor": "transparent",
-                      },
-                    ],
                     Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
+                      "backgroundColor": "transparent",
                     },
-                    Object {},
-                  ]
-                }
-              >
-                󰐕
-              </Text>
-            </View>
+                  ],
+                  Object {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  Object {},
+                ]
+              }
+            >
+              󰐕
+            </Text>
           </View>
         </View>
       </View>
@@ -2232,8 +2142,11 @@ exports[`renders small FAB 1`] = `
 >
   <View
     collapsable={false}
+    pointerEvents="auto"
     style={
       Object {
+        "backgroundColor": "rgba(234, 221, 255, 1)",
+        "borderRadius": 12,
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -2244,138 +2157,126 @@ exports[`renders small FAB 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-middle-layer"
+    testID="fab-container"
   >
     <View
-      collapsable={false}
-      pointerEvents="auto"
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "rgba(234, 221, 255, 1)",
-          "borderRadius": 12,
-          "flex": undefined,
-          "overflow": "hidden",
+          "disabled": false,
         }
       }
-      testID="fab-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 12,
+          },
+        ]
+      }
+      testID="fab"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": false,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        pointerEvents="none"
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            undefined,
+            Object {
+              "borderRadius": 12,
+              "height": 40,
+              "width": 40,
+            },
           ]
         }
-        testID="fab"
+        testID="fab-content"
       >
         <View
-          pointerEvents="none"
           style={
             Array [
               Object {
                 "alignItems": "center",
-                "flexDirection": "row",
                 "justifyContent": "center",
               },
               Object {
-                "borderRadius": 12,
-                "height": 40,
-                "width": 40,
+                "height": 24,
+                "width": 24,
               },
             ]
           }
-          testID="fab-content"
         >
           <View
+            collapsable={false}
             style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                },
-                Object {
-                  "height": 24,
-                  "width": 24,
-                },
-              ]
+              Object {
+                "bottom": 0,
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "transform": Array [
+                  Object {
+                    "rotate": "0deg",
+                  },
+                ],
+              }
             }
           >
-            <View
-              collapsable={false}
+            <Text
+              accessibilityElementsHidden={true}
+              allowFontScaling={false}
+              importantForAccessibility="no-hide-descendants"
+              pointerEvents="none"
+              selectable={false}
               style={
-                Object {
-                  "bottom": 0,
-                  "left": 0,
-                  "opacity": 1,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                  "transform": Array [
-                    Object {
-                      "rotate": "0deg",
-                    },
-                  ],
-                }
-              }
-            >
-              <Text
-                accessibilityElementsHidden={true}
-                allowFontScaling={false}
-                importantForAccessibility="no-hide-descendants"
-                pointerEvents="none"
-                selectable={false}
-                style={
+                Array [
+                  Object {
+                    "color": "rgba(33, 0, 93, 1)",
+                    "fontSize": 24,
+                  },
                   Array [
                     Object {
-                      "color": "rgba(33, 0, 93, 1)",
-                      "fontSize": 24,
+                      "lineHeight": 24,
+                      "transform": Array [
+                        Object {
+                          "scaleX": 1,
+                        },
+                      ],
                     },
-                    Array [
-                      Object {
-                        "lineHeight": 24,
-                        "transform": Array [
-                          Object {
-                            "scaleX": 1,
-                          },
-                        ],
-                      },
-                      Object {
-                        "backgroundColor": "transparent",
-                      },
-                    ],
                     Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
+                      "backgroundColor": "transparent",
                     },
-                    Object {},
-                  ]
-                }
-              >
-                󰐕
-              </Text>
-            </View>
+                  ],
+                  Object {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  Object {},
+                ]
+              }
+            >
+              󰐕
+            </Text>
           </View>
         </View>
       </View>
@@ -2419,8 +2320,11 @@ exports[`renders visible FAB 1`] = `
 >
   <View
     collapsable={false}
+    pointerEvents="auto"
     style={
       Object {
+        "backgroundColor": "rgba(234, 221, 255, 1)",
+        "borderRadius": 16,
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -2431,138 +2335,126 @@ exports[`renders visible FAB 1`] = `
         "shadowRadius": 3,
       }
     }
-    testID="fab-container-middle-layer"
+    testID="fab-container"
   >
     <View
-      collapsable={false}
-      pointerEvents="auto"
-      style={
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "rgba(234, 221, 255, 1)",
-          "borderRadius": 16,
-          "flex": undefined,
-          "overflow": "hidden",
+          "disabled": false,
         }
       }
-      testID="fab-container"
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Object {
+            "borderRadius": 16,
+          },
+        ]
+      }
+      testID="fab"
     >
       <View
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": false,
-          }
-        }
-        accessible={true}
-        collapsable={false}
-        focusable={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+        pointerEvents="none"
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
             },
-            false,
-            undefined,
+            Object {
+              "borderRadius": 16,
+              "height": 56,
+              "width": 56,
+            },
           ]
         }
-        testID="fab"
+        testID="fab-content"
       >
         <View
-          pointerEvents="none"
           style={
             Array [
               Object {
                 "alignItems": "center",
-                "flexDirection": "row",
                 "justifyContent": "center",
               },
               Object {
-                "borderRadius": 16,
-                "height": 56,
-                "width": 56,
+                "height": 24,
+                "width": 24,
               },
             ]
           }
-          testID="fab-content"
         >
           <View
+            collapsable={false}
             style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "justifyContent": "center",
-                },
-                Object {
-                  "height": 24,
-                  "width": 24,
-                },
-              ]
+              Object {
+                "bottom": 0,
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "transform": Array [
+                  Object {
+                    "rotate": "0deg",
+                  },
+                ],
+              }
             }
           >
-            <View
-              collapsable={false}
+            <Text
+              accessibilityElementsHidden={true}
+              allowFontScaling={false}
+              importantForAccessibility="no-hide-descendants"
+              pointerEvents="none"
+              selectable={false}
               style={
-                Object {
-                  "bottom": 0,
-                  "left": 0,
-                  "opacity": 1,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                  "transform": Array [
-                    Object {
-                      "rotate": "0deg",
-                    },
-                  ],
-                }
-              }
-            >
-              <Text
-                accessibilityElementsHidden={true}
-                allowFontScaling={false}
-                importantForAccessibility="no-hide-descendants"
-                pointerEvents="none"
-                selectable={false}
-                style={
+                Array [
+                  Object {
+                    "color": "rgba(33, 0, 93, 1)",
+                    "fontSize": 24,
+                  },
                   Array [
                     Object {
-                      "color": "rgba(33, 0, 93, 1)",
-                      "fontSize": 24,
+                      "lineHeight": 24,
+                      "transform": Array [
+                        Object {
+                          "scaleX": 1,
+                        },
+                      ],
                     },
-                    Array [
-                      Object {
-                        "lineHeight": 24,
-                        "transform": Array [
-                          Object {
-                            "scaleX": 1,
-                          },
-                        ],
-                      },
-                      Object {
-                        "backgroundColor": "transparent",
-                      },
-                    ],
                     Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
+                      "backgroundColor": "transparent",
                     },
-                    Object {},
-                  ]
-                }
-              >
-                󰐕
-              </Text>
-            </View>
+                  ],
+                  Object {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  Object {},
+                ]
+              }
+            >
+              󰐕
+            </Text>
           </View>
         </View>
       </View>

--- a/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
@@ -34,7 +34,13 @@ exports[`renders disabled icon button 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderColor": "rgba(28, 27, 31, 0.12)",
+        "borderRadius": 20,
+        "borderWidth": 0,
+        "elevation": 0,
         "flex": 1,
+        "overflow": "hidden",
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -44,115 +50,99 @@ exports[`renders disabled icon button 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="icon-button-container-middle-layer"
+    testID="icon-button-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityComponentType="button"
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "transparent",
-          "borderColor": "rgba(28, 27, 31, 0.12)",
-          "borderRadius": 20,
-          "borderWidth": 0,
-          "elevation": 0,
-          "flex": 1,
-          "overflow": "hidden",
+          "disabled": true,
         }
       }
-      testID="icon-button-container"
-    >
-      <View
-        accessibilityComponentType="button"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-          }
+      accessibilityTraits={
+        Array [
+          "button",
+          "disabled",
+        ]
+      }
+      accessible={true}
+      centered={true}
+      collapsable={false}
+      focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 6,
+          "left": 6,
+          "right": 6,
+          "top": 6,
         }
-        accessibilityTraits={
+      }
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
           Array [
-            "button",
-            "disabled",
-          ]
-        }
-        accessible={true}
-        centered={true}
-        collapsable={false}
-        focusable={true}
-        hitSlop={
-          Object {
-            "bottom": 6,
-            "left": 6,
-            "right": 6,
-            "top": 6,
-          }
-        }
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+            Object {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            },
+            Object {
+              "borderRadius": 20,
+            },
+          ],
+        ]
+      }
+      testID="icon-button"
+    >
+      <Text
+        accessibilityElementsHidden={true}
+        allowFontScaling={false}
+        importantForAccessibility="no-hide-descendants"
+        pointerEvents="none"
+        selectable={false}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "color": "rgba(28, 27, 31, 0.38)",
+              "fontSize": 24,
             },
-            false,
             Array [
               Object {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
+                "lineHeight": 24,
+                "transform": Array [
+                  Object {
+                    "scaleX": 1,
+                  },
+                ],
               },
               Object {
-                "borderRadius": 20,
+                "backgroundColor": "transparent",
               },
             ],
+            Object {
+              "fontFamily": "Material Design Icons",
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {},
           ]
         }
-        testID="icon-button"
       >
-        <Text
-          accessibilityElementsHidden={true}
-          allowFontScaling={false}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "rgba(28, 27, 31, 0.38)",
-                "fontSize": 24,
-              },
-              Array [
-                Object {
-                  "lineHeight": 24,
-                  "transform": Array [
-                    Object {
-                      "scaleX": 1,
-                    },
-                  ],
-                },
-                Object {
-                  "backgroundColor": "transparent",
-                },
-              ],
-              Object {
-                "fontFamily": "Material Design Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          󰄀
-        </Text>
-      </View>
+        󰄀
+      </Text>
     </View>
   </View>
 </View>
@@ -192,7 +182,13 @@ exports[`renders icon button by default 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderColor": "rgba(121, 116, 126, 1)",
+        "borderRadius": 20,
+        "borderWidth": 0,
+        "elevation": 0,
         "flex": 1,
+        "overflow": "hidden",
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -202,110 +198,94 @@ exports[`renders icon button by default 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="icon-button-container-middle-layer"
+    testID="icon-button-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityComponentType="button"
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "transparent",
-          "borderColor": "rgba(121, 116, 126, 1)",
-          "borderRadius": 20,
-          "borderWidth": 0,
-          "elevation": 0,
-          "flex": 1,
-          "overflow": "hidden",
+          "disabled": true,
         }
       }
-      testID="icon-button-container"
+      accessibilityTraits="button"
+      accessible={true}
+      centered={true}
+      collapsable={false}
+      focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 6,
+          "left": 6,
+          "right": 6,
+          "top": 6,
+        }
+      }
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Array [
+            Object {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            },
+            Object {
+              "borderRadius": 20,
+            },
+          ],
+        ]
+      }
+      testID="icon-button"
     >
-      <View
-        accessibilityComponentType="button"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-          }
-        }
-        accessibilityTraits="button"
-        accessible={true}
-        centered={true}
-        collapsable={false}
-        focusable={true}
-        hitSlop={
-          Object {
-            "bottom": 6,
-            "left": 6,
-            "right": 6,
-            "top": 6,
-          }
-        }
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+      <Text
+        accessibilityElementsHidden={true}
+        allowFontScaling={false}
+        importantForAccessibility="no-hide-descendants"
+        pointerEvents="none"
+        selectable={false}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "color": "rgba(73, 69, 79, 1)",
+              "fontSize": 24,
             },
-            false,
             Array [
               Object {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
+                "lineHeight": 24,
+                "transform": Array [
+                  Object {
+                    "scaleX": 1,
+                  },
+                ],
               },
               Object {
-                "borderRadius": 20,
+                "backgroundColor": "transparent",
               },
             ],
+            Object {
+              "fontFamily": "Material Design Icons",
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {},
           ]
         }
-        testID="icon-button"
       >
-        <Text
-          accessibilityElementsHidden={true}
-          allowFontScaling={false}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "rgba(73, 69, 79, 1)",
-                "fontSize": 24,
-              },
-              Array [
-                Object {
-                  "lineHeight": 24,
-                  "transform": Array [
-                    Object {
-                      "scaleX": 1,
-                    },
-                  ],
-                },
-                Object {
-                  "backgroundColor": "transparent",
-                },
-              ],
-              Object {
-                "fontFamily": "Material Design Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          󰄀
-        </Text>
-      </View>
+        󰄀
+      </Text>
     </View>
   </View>
 </View>
@@ -345,7 +325,13 @@ exports[`renders icon button with color 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderColor": "rgba(121, 116, 126, 1)",
+        "borderRadius": 20,
+        "borderWidth": 0,
+        "elevation": 0,
         "flex": 1,
+        "overflow": "hidden",
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -355,110 +341,94 @@ exports[`renders icon button with color 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="icon-button-container-middle-layer"
+    testID="icon-button-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityComponentType="button"
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "transparent",
-          "borderColor": "rgba(121, 116, 126, 1)",
-          "borderRadius": 20,
-          "borderWidth": 0,
-          "elevation": 0,
-          "flex": 1,
-          "overflow": "hidden",
+          "disabled": true,
         }
       }
-      testID="icon-button-container"
+      accessibilityTraits="button"
+      accessible={true}
+      centered={true}
+      collapsable={false}
+      focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 6,
+          "left": 6,
+          "right": 6,
+          "top": 6,
+        }
+      }
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Array [
+            Object {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            },
+            Object {
+              "borderRadius": 20,
+            },
+          ],
+        ]
+      }
+      testID="icon-button"
     >
-      <View
-        accessibilityComponentType="button"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-          }
-        }
-        accessibilityTraits="button"
-        accessible={true}
-        centered={true}
-        collapsable={false}
-        focusable={true}
-        hitSlop={
-          Object {
-            "bottom": 6,
-            "left": 6,
-            "right": 6,
-            "top": 6,
-          }
-        }
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+      <Text
+        accessibilityElementsHidden={true}
+        allowFontScaling={false}
+        importantForAccessibility="no-hide-descendants"
+        pointerEvents="none"
+        selectable={false}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "color": "#e91e63",
+              "fontSize": 24,
             },
-            false,
             Array [
               Object {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
+                "lineHeight": 24,
+                "transform": Array [
+                  Object {
+                    "scaleX": 1,
+                  },
+                ],
               },
               Object {
-                "borderRadius": 20,
+                "backgroundColor": "transparent",
               },
             ],
+            Object {
+              "fontFamily": "Material Design Icons",
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {},
           ]
         }
-        testID="icon-button"
       >
-        <Text
-          accessibilityElementsHidden={true}
-          allowFontScaling={false}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "#e91e63",
-                "fontSize": 24,
-              },
-              Array [
-                Object {
-                  "lineHeight": 24,
-                  "transform": Array [
-                    Object {
-                      "scaleX": 1,
-                    },
-                  ],
-                },
-                Object {
-                  "backgroundColor": "transparent",
-                },
-              ],
-              Object {
-                "fontFamily": "Material Design Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          󰄀
-        </Text>
-      </View>
+        󰄀
+      </Text>
     </View>
   </View>
 </View>
@@ -498,7 +468,13 @@ exports[`renders icon button with size 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderColor": "rgba(121, 116, 126, 1)",
+        "borderRadius": 23,
+        "borderWidth": 0,
+        "elevation": 0,
         "flex": 1,
+        "overflow": "hidden",
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -508,110 +484,94 @@ exports[`renders icon button with size 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="icon-button-container-middle-layer"
+    testID="icon-button-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityComponentType="button"
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "transparent",
-          "borderColor": "rgba(121, 116, 126, 1)",
-          "borderRadius": 23,
-          "borderWidth": 0,
-          "elevation": 0,
-          "flex": 1,
-          "overflow": "hidden",
+          "disabled": true,
         }
       }
-      testID="icon-button-container"
+      accessibilityTraits="button"
+      accessible={true}
+      centered={true}
+      collapsable={false}
+      focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 6,
+          "left": 6,
+          "right": 6,
+          "top": 6,
+        }
+      }
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Array [
+            Object {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            },
+            Object {
+              "borderRadius": 23,
+            },
+          ],
+        ]
+      }
+      testID="icon-button"
     >
-      <View
-        accessibilityComponentType="button"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-          }
-        }
-        accessibilityTraits="button"
-        accessible={true}
-        centered={true}
-        collapsable={false}
-        focusable={true}
-        hitSlop={
-          Object {
-            "bottom": 6,
-            "left": 6,
-            "right": 6,
-            "top": 6,
-          }
-        }
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+      <Text
+        accessibilityElementsHidden={true}
+        allowFontScaling={false}
+        importantForAccessibility="no-hide-descendants"
+        pointerEvents="none"
+        selectable={false}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "color": "rgba(73, 69, 79, 1)",
+              "fontSize": 30,
             },
-            false,
             Array [
               Object {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
+                "lineHeight": 30,
+                "transform": Array [
+                  Object {
+                    "scaleX": 1,
+                  },
+                ],
               },
               Object {
-                "borderRadius": 23,
+                "backgroundColor": "transparent",
               },
             ],
+            Object {
+              "fontFamily": "Material Design Icons",
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {},
           ]
         }
-        testID="icon-button"
       >
-        <Text
-          accessibilityElementsHidden={true}
-          allowFontScaling={false}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "rgba(73, 69, 79, 1)",
-                "fontSize": 30,
-              },
-              Array [
-                Object {
-                  "lineHeight": 30,
-                  "transform": Array [
-                    Object {
-                      "scaleX": 1,
-                    },
-                  ],
-                },
-                Object {
-                  "backgroundColor": "transparent",
-                },
-              ],
-              Object {
-                "fontFamily": "Material Design Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          󰄀
-        </Text>
-      </View>
+        󰄀
+      </Text>
     </View>
   </View>
 </View>
@@ -651,7 +611,13 @@ exports[`renders icon change animated 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderColor": "rgba(121, 116, 126, 1)",
+        "borderRadius": 20,
+        "borderWidth": 0,
+        "elevation": 0,
         "flex": 1,
+        "overflow": "hidden",
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -661,142 +627,126 @@ exports[`renders icon change animated 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="icon-button-container-middle-layer"
+    testID="icon-button-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityComponentType="button"
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "transparent",
-          "borderColor": "rgba(121, 116, 126, 1)",
-          "borderRadius": 20,
-          "borderWidth": 0,
-          "elevation": 0,
-          "flex": 1,
-          "overflow": "hidden",
+          "disabled": true,
         }
       }
-      testID="icon-button-container"
+      accessibilityTraits="button"
+      accessible={true}
+      centered={true}
+      collapsable={false}
+      focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 6,
+          "left": 6,
+          "right": 6,
+          "top": 6,
+        }
+      }
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          false,
+          Array [
+            Object {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            },
+            Object {
+              "borderRadius": 20,
+            },
+          ],
+        ]
+      }
+      testID="icon-button"
     >
       <View
-        accessibilityComponentType="button"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-          }
-        }
-        accessibilityTraits="button"
-        accessible={true}
-        centered={true}
-        collapsable={false}
-        focusable={true}
-        hitSlop={
-          Object {
-            "bottom": 6,
-            "left": 6,
-            "right": 6,
-            "top": 6,
-          }
-        }
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
-              "overflow": "hidden",
+              "alignItems": "center",
+              "justifyContent": "center",
             },
-            false,
-            Array [
-              Object {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
-              },
-              Object {
-                "borderRadius": 20,
-              },
-            ],
+            Object {
+              "height": 24,
+              "width": 24,
+            },
           ]
         }
-        testID="icon-button"
       >
         <View
+          collapsable={false}
           style={
-            Array [
-              Object {
-                "alignItems": "center",
-                "justifyContent": "center",
-              },
-              Object {
-                "height": 24,
-                "width": 24,
-              },
-            ]
+            Object {
+              "bottom": 0,
+              "left": 0,
+              "opacity": 1,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "transform": Array [
+                Object {
+                  "rotate": "0deg",
+                },
+              ],
+            }
           }
         >
-          <View
-            collapsable={false}
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
             style={
-              Object {
-                "bottom": 0,
-                "left": 0,
-                "opacity": 1,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-                "transform": Array [
-                  Object {
-                    "rotate": "0deg",
-                  },
-                ],
-              }
-            }
-          >
-            <Text
-              accessibilityElementsHidden={true}
-              allowFontScaling={false}
-              importantForAccessibility="no-hide-descendants"
-              pointerEvents="none"
-              selectable={false}
-              style={
+              Array [
+                Object {
+                  "color": "rgba(73, 69, 79, 1)",
+                  "fontSize": 24,
+                },
                 Array [
                   Object {
-                    "color": "rgba(73, 69, 79, 1)",
-                    "fontSize": 24,
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
                   },
-                  Array [
-                    Object {
-                      "lineHeight": 24,
-                      "transform": Array [
-                        Object {
-                          "scaleX": 1,
-                        },
-                      ],
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ],
                   Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
+                    "backgroundColor": "transparent",
                   },
-                  Object {},
-                ]
-              }
-            >
-              󰄀
-            </Text>
-          </View>
+                ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            󰄀
+          </Text>
         </View>
       </View>
     </View>

--- a/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
@@ -9,7 +9,10 @@ exports[`renders disabled icon button 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": 40,
       "left": undefined,
+      "margin": 6,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -21,6 +24,8 @@ exports[`renders disabled icon button 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": 40,
     }
   }
   testID="icon-button-container-outer-layer"
@@ -29,7 +34,7 @@ exports[`renders disabled icon button 1`] = `
     collapsable={false}
     style={
       Object {
-        "flex": undefined,
+        "flex": 1,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -39,22 +44,19 @@ exports[`renders disabled icon button 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="icon-button-container-inner-layer"
+    testID="icon-button-container-middle-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
-          "backgroundColor": undefined,
+          "backgroundColor": "transparent",
           "borderColor": "rgba(28, 27, 31, 0.12)",
           "borderRadius": 20,
           "borderWidth": 0,
           "elevation": 0,
-          "flex": undefined,
-          "height": 40,
-          "margin": 6,
+          "flex": 1,
           "overflow": "hidden",
-          "width": 40,
         }
       }
       testID="icon-button-container"
@@ -165,7 +167,10 @@ exports[`renders icon button by default 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": 40,
       "left": undefined,
+      "margin": 6,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -177,6 +182,8 @@ exports[`renders icon button by default 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": 40,
     }
   }
   testID="icon-button-container-outer-layer"
@@ -185,7 +192,7 @@ exports[`renders icon button by default 1`] = `
     collapsable={false}
     style={
       Object {
-        "flex": undefined,
+        "flex": 1,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -195,22 +202,19 @@ exports[`renders icon button by default 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="icon-button-container-inner-layer"
+    testID="icon-button-container-middle-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
-          "backgroundColor": undefined,
+          "backgroundColor": "transparent",
           "borderColor": "rgba(121, 116, 126, 1)",
           "borderRadius": 20,
           "borderWidth": 0,
           "elevation": 0,
-          "flex": undefined,
-          "height": 40,
-          "margin": 6,
+          "flex": 1,
           "overflow": "hidden",
-          "width": 40,
         }
       }
       testID="icon-button-container"
@@ -316,7 +320,10 @@ exports[`renders icon button with color 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": 40,
       "left": undefined,
+      "margin": 6,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -328,6 +335,8 @@ exports[`renders icon button with color 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": 40,
     }
   }
   testID="icon-button-container-outer-layer"
@@ -336,7 +345,7 @@ exports[`renders icon button with color 1`] = `
     collapsable={false}
     style={
       Object {
-        "flex": undefined,
+        "flex": 1,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -346,22 +355,19 @@ exports[`renders icon button with color 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="icon-button-container-inner-layer"
+    testID="icon-button-container-middle-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
-          "backgroundColor": undefined,
+          "backgroundColor": "transparent",
           "borderColor": "rgba(121, 116, 126, 1)",
           "borderRadius": 20,
           "borderWidth": 0,
           "elevation": 0,
-          "flex": undefined,
-          "height": 40,
-          "margin": 6,
+          "flex": 1,
           "overflow": "hidden",
-          "width": 40,
         }
       }
       testID="icon-button-container"
@@ -467,7 +473,10 @@ exports[`renders icon button with size 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": 46,
       "left": undefined,
+      "margin": 6,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -479,6 +488,8 @@ exports[`renders icon button with size 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": 46,
     }
   }
   testID="icon-button-container-outer-layer"
@@ -487,7 +498,7 @@ exports[`renders icon button with size 1`] = `
     collapsable={false}
     style={
       Object {
-        "flex": undefined,
+        "flex": 1,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -497,22 +508,19 @@ exports[`renders icon button with size 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="icon-button-container-inner-layer"
+    testID="icon-button-container-middle-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
-          "backgroundColor": undefined,
+          "backgroundColor": "transparent",
           "borderColor": "rgba(121, 116, 126, 1)",
           "borderRadius": 23,
           "borderWidth": 0,
           "elevation": 0,
-          "flex": undefined,
-          "height": 46,
-          "margin": 6,
+          "flex": 1,
           "overflow": "hidden",
-          "width": 46,
         }
       }
       testID="icon-button-container"
@@ -618,7 +626,10 @@ exports[`renders icon change animated 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": 40,
       "left": undefined,
+      "margin": 6,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -630,6 +641,8 @@ exports[`renders icon change animated 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": 40,
     }
   }
   testID="icon-button-container-outer-layer"
@@ -638,7 +651,7 @@ exports[`renders icon change animated 1`] = `
     collapsable={false}
     style={
       Object {
-        "flex": undefined,
+        "flex": 1,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -648,22 +661,19 @@ exports[`renders icon change animated 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="icon-button-container-inner-layer"
+    testID="icon-button-container-middle-layer"
   >
     <View
       collapsable={false}
       style={
         Object {
-          "backgroundColor": undefined,
+          "backgroundColor": "transparent",
           "borderColor": "rgba(121, 116, 126, 1)",
           "borderRadius": 20,
           "borderWidth": 0,
           "elevation": 0,
-          "flex": undefined,
-          "height": 40,
-          "margin": 6,
+          "flex": 1,
           "overflow": "hidden",
-          "width": 40,
         }
       }
       testID="icon-button-container"

--- a/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
@@ -6,6 +6,8 @@ exports[`renders disabled icon button 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -154,6 +156,8 @@ exports[`renders icon button by default 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -297,6 +301,8 @@ exports[`renders icon button with color 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -440,6 +446,8 @@ exports[`renders icon button with size 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 23,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -583,6 +591,8 @@ exports[`renders icon change animated 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 20,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -130,7 +130,13 @@ exports[`renders list item with custom description 1`] = `
               collapsable={false}
               style={
                 Object {
+                  "backgroundColor": "rgba(232, 222, 248, 1)",
+                  "borderColor": "rgba(121, 116, 126, 1)",
+                  "borderRadius": 8,
+                  "borderStyle": "solid",
+                  "borderWidth": 0,
                   "flex": undefined,
+                  "flexDirection": "column",
                   "shadowColor": "#000",
                   "shadowOffset": Object {
                     "height": 0,
@@ -140,138 +146,143 @@ exports[`renders list item with custom description 1`] = `
                   "shadowRadius": 0,
                 }
               }
-              testID="chip-container-middle-layer"
+              testID="chip-container"
             >
               <View
-                collapsable={false}
-                style={
+                accessibilityRole="button"
+                accessibilityState={
                   Object {
-                    "backgroundColor": "rgba(232, 222, 248, 1)",
-                    "borderColor": "rgba(121, 116, 126, 1)",
-                    "borderRadius": 8,
-                    "borderStyle": "solid",
-                    "borderWidth": 0,
-                    "flex": undefined,
-                    "flexDirection": "column",
+                    "disabled": false,
+                    "selected": false,
                   }
                 }
-                testID="chip-container"
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Array [
+                    Object {
+                      "overflow": "hidden",
+                    },
+                    false,
+                    Array [
+                      Object {
+                        "borderRadius": 8,
+                      },
+                      Object {
+                        "flexGrow": 1,
+                      },
+                    ],
+                  ]
+                }
+                testID="chip"
               >
                 <View
-                  accessibilityRole="button"
-                  accessibilityState={
-                    Object {
-                      "disabled": false,
-                      "selected": false,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Array [
                       Object {
-                        "overflow": "hidden",
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "flexGrow": 1,
+                        "paddingLeft": 4,
+                        "position": "relative",
                       },
-                      false,
-                      Array [
-                        Object {
-                          "borderRadius": 8,
-                        },
-                        Object {
-                          "flexGrow": 1,
-                        },
-                      ],
+                      Object {
+                        "paddingLeft": 0,
+                      },
+                      Object {
+                        "paddingRight": 0,
+                      },
                     ]
                   }
-                  testID="chip"
                 >
                   <View
                     style={
                       Array [
                         Object {
-                          "alignItems": "center",
-                          "flexDirection": "row",
-                          "flexGrow": 1,
-                          "paddingLeft": 4,
-                          "position": "relative",
+                          "alignSelf": "center",
+                          "padding": 4,
                         },
                         Object {
-                          "paddingLeft": 0,
-                        },
-                        Object {
+                          "paddingLeft": 8,
                           "paddingRight": 0,
                         },
+                        null,
                       ]
                     }
                   >
-                    <View
-                      style={
-                        Array [
-                          Object {
-                            "alignSelf": "center",
-                            "padding": 4,
-                          },
-                          Object {
-                            "paddingLeft": 8,
-                            "paddingRight": 0,
-                          },
-                          null,
-                        ]
-                      }
-                    >
-                      <Text
-                        accessibilityElementsHidden={true}
-                        allowFontScaling={false}
-                        importantForAccessibility="no-hide-descendants"
-                        pointerEvents="none"
-                        selectable={false}
-                        style={
-                          Array [
-                            Object {
-                              "color": "rgba(103, 80, 164, 1)",
-                              "fontSize": 18,
-                            },
-                            Array [
-                              Object {
-                                "lineHeight": 18,
-                                "transform": Array [
-                                  Object {
-                                    "scaleX": 1,
-                                  },
-                                ],
-                              },
-                              Object {
-                                "backgroundColor": "transparent",
-                              },
-                            ],
-                            Object {
-                              "fontFamily": "Material Design Icons",
-                              "fontStyle": "normal",
-                              "fontWeight": "normal",
-                            },
-                            Object {},
-                          ]
-                        }
-                      >
-                        󰈦
-                      </Text>
-                    </View>
                     <Text
-                      numberOfLines={1}
+                      accessibilityElementsHidden={true}
+                      allowFontScaling={false}
+                      importantForAccessibility="no-hide-descendants"
+                      pointerEvents="none"
                       selectable={false}
                       style={
                         Array [
                           Object {
+                            "color": "rgba(103, 80, 164, 1)",
+                            "fontSize": 18,
+                          },
+                          Array [
+                            Object {
+                              "lineHeight": 18,
+                              "transform": Array [
+                                Object {
+                                  "scaleX": 1,
+                                },
+                              ],
+                            },
+                            Object {
+                              "backgroundColor": "transparent",
+                            },
+                          ],
+                          Object {
+                            "fontFamily": "Material Design Icons",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          Object {},
+                        ]
+                      }
+                    >
+                      󰈦
+                    </Text>
+                  </View>
+                  <Text
+                    numberOfLines={1}
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.1,
+                          "lineHeight": 20,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          Object {
+                            "marginVertical": 6,
+                            "textAlignVertical": "center",
+                          },
+                          Object {
+                            "color": "rgba(29, 25, 43, 1)",
                             "fontFamily": "System",
                             "fontSize": 14,
                             "fontWeight": "500",
@@ -279,37 +290,16 @@ exports[`renders list item with custom description 1`] = `
                             "lineHeight": 20,
                           },
                           Object {
-                            "textAlign": "left",
+                            "marginLeft": 8,
+                            "marginRight": 16,
                           },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "marginVertical": 6,
-                              "textAlignVertical": "center",
-                            },
-                            Object {
-                              "color": "rgba(29, 25, 43, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 14,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.1,
-                              "lineHeight": 20,
-                            },
-                            Object {
-                              "marginLeft": 8,
-                              "marginRight": 16,
-                            },
-                            undefined,
-                          ],
-                        ]
-                      }
-                    >
-                      DOCS.pdf
-                    </Text>
-                  </View>
+                          undefined,
+                        ],
+                      ]
+                    }
+                  >
+                    DOCS.pdf
+                  </Text>
                 </View>
               </View>
             </View>

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -106,7 +106,9 @@ exports[`renders list item with custom description 1`] = `
                 "bottom": undefined,
                 "end": undefined,
                 "flex": undefined,
+                "height": undefined,
                 "left": undefined,
+                "opacity": undefined,
                 "position": undefined,
                 "right": undefined,
                 "shadowColor": "#000",
@@ -118,6 +120,8 @@ exports[`renders list item with custom description 1`] = `
                 "shadowRadius": 0,
                 "start": undefined,
                 "top": undefined,
+                "transform": undefined,
+                "width": undefined,
               }
             }
             testID="chip-container-outer-layer"
@@ -136,7 +140,7 @@ exports[`renders list item with custom description 1`] = `
                   "shadowRadius": 0,
                 }
               }
-              testID="chip-container-inner-layer"
+              testID="chip-container-middle-layer"
             >
               <View
                 collapsable={false}

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -103,6 +103,8 @@ exports[`renders list item with custom description 1`] = `
             style={
               Object {
                 "alignSelf": undefined,
+                "backgroundColor": "rgba(232, 222, 248, 1)",
+                "borderRadius": 8,
                 "bottom": undefined,
                 "end": undefined,
                 "flex": undefined,

--- a/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -46,549 +46,6 @@ Array [
           collapsable={false}
           style={
             Object {
-              "flex": undefined,
-              "shadowColor": "#000",
-              "shadowOffset": Object {
-                "height": 0,
-                "width": 0,
-              },
-              "shadowOpacity": 0,
-              "shadowRadius": 0,
-            }
-          }
-          testID="button-container-middle-layer"
-        >
-          <View
-            collapsable={false}
-            style={
-              Object {
-                "backgroundColor": "transparent",
-                "borderColor": "rgba(121, 116, 126, 1)",
-                "borderRadius": 20,
-                "borderStyle": "solid",
-                "borderWidth": 1,
-                "flex": undefined,
-                "minWidth": 64,
-              }
-            }
-            testID="button-container"
-          >
-            <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "disabled": true,
-                }
-              }
-              accessible={true}
-              collapsable={false}
-              focusable={true}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Array [
-                  Object {
-                    "overflow": "hidden",
-                  },
-                  false,
-                  Object {
-                    "borderRadius": 20,
-                  },
-                ]
-              }
-              testID="button"
-            >
-              <View
-                style={
-                  Array [
-                    Object {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "justifyContent": "center",
-                    },
-                    undefined,
-                  ]
-                }
-              >
-                <Text
-                  numberOfLines={1}
-                  selectable={false}
-                  style={
-                    Array [
-                      Object {
-                        "fontFamily": "System",
-                        "fontSize": 14,
-                        "fontWeight": "500",
-                        "letterSpacing": 0.1,
-                        "lineHeight": 20,
-                      },
-                      Object {
-                        "textAlign": "left",
-                      },
-                      Object {
-                        "color": "rgba(28, 27, 31, 1)",
-                        "writingDirection": "ltr",
-                      },
-                      Array [
-                        Object {
-                          "marginHorizontal": 16,
-                          "marginVertical": 9,
-                          "textAlign": "center",
-                        },
-                        false,
-                        Object {
-                          "marginHorizontal": 24,
-                          "marginVertical": 10,
-                        },
-                        undefined,
-                        false,
-                        Object {
-                          "color": "rgba(103, 80, 164, 1)",
-                          "fontFamily": "System",
-                          "fontSize": 14,
-                          "fontWeight": "500",
-                          "letterSpacing": 0.1,
-                          "lineHeight": 20,
-                        },
-                        undefined,
-                      ],
-                    ]
-                  }
-                  testID="button-text"
-                >
-                  Open menu
-                </Text>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>,
-  <View
-    collapsable={false}
-    pointerEvents="box-none"
-    style={
-      Object {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      }
-    }
-  >
-    <View
-      accessibilityLabel="Close menu"
-      accessibilityRole="button"
-      accessible={true}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        Object {
-          "bottom": 0,
-          "left": 0,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-        }
-      }
-    />
-    <View
-      accessibilityViewIsModal={true}
-      collapsable={false}
-      onAccessibilityEscape={[MockFunction]}
-      pointerEvents="box-none"
-      style={
-        Array [
-          Object {
-            "position": "absolute",
-          },
-          Object {
-            "left": 8,
-            "top": 8,
-          },
-          undefined,
-        ]
-      }
-    >
-      <View
-        collapsable={false}
-        style={
-          Object {
-            "transform": Array [
-              Object {
-                "translateX": -0,
-              },
-              Object {
-                "translateY": -0,
-              },
-            ],
-          }
-        }
-      >
-        <View
-          collapsable={false}
-          style={
-            Object {
-              "alignSelf": undefined,
-              "bottom": undefined,
-              "end": undefined,
-              "flex": undefined,
-              "height": undefined,
-              "left": undefined,
-              "opacity": 0,
-              "position": undefined,
-              "right": undefined,
-              "shadowColor": "#000",
-              "shadowOffset": Object {
-                "height": 2,
-                "width": 0,
-              },
-              "shadowOpacity": 0.15,
-              "shadowRadius": 6,
-              "start": undefined,
-              "top": undefined,
-              "transform": Array [
-                Object {
-                  "scaleX": 0,
-                },
-                Object {
-                  "scaleY": 0,
-                },
-              ],
-              "width": undefined,
-            }
-          }
-          testID="menu-surface-outer-layer"
-        >
-          <View
-            collapsable={false}
-            style={
-              Object {
-                "flex": undefined,
-                "shadowColor": "#000",
-                "shadowOffset": Object {
-                  "height": 1,
-                  "width": 0,
-                },
-                "shadowOpacity": 0.3,
-                "shadowRadius": 2,
-              }
-            }
-            testID="menu-surface-middle-layer"
-          >
-            <View
-              collapsable={false}
-              style={
-                Object {
-                  "backgroundColor": "rgb(243, 237, 246)",
-                  "borderRadius": 4,
-                  "borderTopLeftRadius": 0,
-                  "borderTopRightRadius": 0,
-                  "flex": undefined,
-                  "paddingVertical": 8,
-                }
-              }
-              testID="menu-surface"
-            >
-              <View
-                accessibilityRole="menuitem"
-                accessibilityState={
-                  Object {
-                    "disabled": false,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  Array [
-                    false,
-                    false,
-                    Array [
-                      Object {
-                        "height": 48,
-                        "justifyContent": "center",
-                        "maxWidth": 280,
-                        "minWidth": 112,
-                      },
-                      Object {
-                        "paddingHorizontal": 12,
-                      },
-                      undefined,
-                      undefined,
-                    ],
-                  ]
-                }
-                testID="menu-item"
-              >
-                <View
-                  style={
-                    Object {
-                      "flexDirection": "row",
-                    }
-                  }
-                >
-                  <View
-                    pointerEvents="none"
-                    style={
-                      Array [
-                        false,
-                        Object {
-                          "justifyContent": "center",
-                        },
-                        Object {
-                          "maxWidth": 268,
-                          "minWidth": 100,
-                        },
-                        Object {
-                          "marginLeft": 4,
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1.5}
-                      numberOfLines={1}
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "fontFamily": "System",
-                            "fontSize": 16,
-                            "fontWeight": "400",
-                            "letterSpacing": 0.15,
-                            "lineHeight": 24,
-                          },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            false,
-                            Object {
-                              "color": "rgba(28, 27, 31, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 16,
-                              "fontWeight": "400",
-                              "letterSpacing": 0.15,
-                              "lineHeight": 24,
-                            },
-                            undefined,
-                          ],
-                        ]
-                      }
-                      testID="menu-item-title"
-                    >
-                      Undo
-                    </Text>
-                  </View>
-                </View>
-              </View>
-              <View
-                accessibilityRole="menuitem"
-                accessibilityState={
-                  Object {
-                    "disabled": false,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  Array [
-                    false,
-                    false,
-                    Array [
-                      Object {
-                        "height": 48,
-                        "justifyContent": "center",
-                        "maxWidth": 280,
-                        "minWidth": 112,
-                      },
-                      Object {
-                        "paddingHorizontal": 12,
-                      },
-                      undefined,
-                      undefined,
-                    ],
-                  ]
-                }
-                testID="menu-item"
-              >
-                <View
-                  style={
-                    Object {
-                      "flexDirection": "row",
-                    }
-                  }
-                >
-                  <View
-                    pointerEvents="none"
-                    style={
-                      Array [
-                        false,
-                        Object {
-                          "justifyContent": "center",
-                        },
-                        Object {
-                          "maxWidth": 268,
-                          "minWidth": 100,
-                        },
-                        Object {
-                          "marginLeft": 4,
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1.5}
-                      numberOfLines={1}
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "fontFamily": "System",
-                            "fontSize": 16,
-                            "fontWeight": "400",
-                            "letterSpacing": 0.15,
-                            "lineHeight": 24,
-                          },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            false,
-                            Object {
-                              "color": "rgba(28, 27, 31, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 16,
-                              "fontWeight": "400",
-                              "letterSpacing": 0.15,
-                              "lineHeight": 24,
-                            },
-                            undefined,
-                          ],
-                        ]
-                      }
-                      testID="menu-item-title"
-                    >
-                      Redo
-                    </Text>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>,
-]
-`;
-
-exports[`renders not visible menu 1`] = `
-<View
-  collapsable={false}
-  pointerEvents="box-none"
-  style={
-    Object {
-      "flex": 1,
-    }
-  }
->
-  <View
-    collapsable={false}
-  >
-    <View
-      collapsable={false}
-      style={
-        Object {
-          "alignSelf": undefined,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
-          "height": undefined,
-          "left": undefined,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
-          "shadowColor": "#000",
-          "shadowOffset": Object {
-            "height": 0,
-            "width": 0,
-          },
-          "shadowOpacity": 0,
-          "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
-          "width": undefined,
-        }
-      }
-      testID="button-container-outer-layer"
-    >
-      <View
-        collapsable={false}
-        style={
-          Object {
-            "flex": undefined,
-            "shadowColor": "#000",
-            "shadowOffset": Object {
-              "height": 0,
-              "width": 0,
-            },
-            "shadowOpacity": 0,
-            "shadowRadius": 0,
-          }
-        }
-        testID="button-container-middle-layer"
-      >
-        <View
-          collapsable={false}
-          style={
-            Object {
               "backgroundColor": "transparent",
               "borderColor": "rgba(121, 116, 126, 1)",
               "borderRadius": 20,
@@ -596,6 +53,13 @@ exports[`renders not visible menu 1`] = `
               "borderWidth": 1,
               "flex": undefined,
               "minWidth": 64,
+              "shadowColor": "#000",
+              "shadowOffset": Object {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0,
+              "shadowRadius": 0,
             }
           }
           testID="button-container"
@@ -697,6 +161,512 @@ exports[`renders not visible menu 1`] = `
         </View>
       </View>
     </View>
+  </View>,
+  <View
+    collapsable={false}
+    pointerEvents="box-none"
+    style={
+      Object {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Close menu"
+      accessibilityRole="button"
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    />
+    <View
+      accessibilityViewIsModal={true}
+      collapsable={false}
+      onAccessibilityEscape={[MockFunction]}
+      pointerEvents="box-none"
+      style={
+        Array [
+          Object {
+            "position": "absolute",
+          },
+          Object {
+            "left": 8,
+            "top": 8,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          Object {
+            "transform": Array [
+              Object {
+                "translateX": -0,
+              },
+              Object {
+                "translateY": -0,
+              },
+            ],
+          }
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            Object {
+              "alignSelf": undefined,
+              "bottom": undefined,
+              "end": undefined,
+              "flex": undefined,
+              "height": undefined,
+              "left": undefined,
+              "opacity": 0,
+              "position": undefined,
+              "right": undefined,
+              "shadowColor": "#000",
+              "shadowOffset": Object {
+                "height": 2,
+                "width": 0,
+              },
+              "shadowOpacity": 0.15,
+              "shadowRadius": 6,
+              "start": undefined,
+              "top": undefined,
+              "transform": Array [
+                Object {
+                  "scaleX": 0,
+                },
+                Object {
+                  "scaleY": 0,
+                },
+              ],
+              "width": undefined,
+            }
+          }
+          testID="menu-surface-outer-layer"
+        >
+          <View
+            collapsable={false}
+            style={
+              Object {
+                "backgroundColor": "rgb(243, 237, 246)",
+                "borderRadius": 4,
+                "borderTopLeftRadius": 0,
+                "borderTopRightRadius": 0,
+                "flex": undefined,
+                "paddingVertical": 8,
+                "shadowColor": "#000",
+                "shadowOffset": Object {
+                  "height": 1,
+                  "width": 0,
+                },
+                "shadowOpacity": 0.3,
+                "shadowRadius": 2,
+              }
+            }
+            testID="menu-surface"
+          >
+            <View
+              accessibilityRole="menuitem"
+              accessibilityState={
+                Object {
+                  "disabled": false,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Array [
+                  false,
+                  false,
+                  Array [
+                    Object {
+                      "height": 48,
+                      "justifyContent": "center",
+                      "maxWidth": 280,
+                      "minWidth": 112,
+                    },
+                    Object {
+                      "paddingHorizontal": 12,
+                    },
+                    undefined,
+                    undefined,
+                  ],
+                ]
+              }
+              testID="menu-item"
+            >
+              <View
+                style={
+                  Object {
+                    "flexDirection": "row",
+                  }
+                }
+              >
+                <View
+                  pointerEvents="none"
+                  style={
+                    Array [
+                      false,
+                      Object {
+                        "justifyContent": "center",
+                      },
+                      Object {
+                        "maxWidth": 268,
+                        "minWidth": 100,
+                      },
+                      Object {
+                        "marginLeft": 4,
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1.5}
+                    numberOfLines={1}
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "letterSpacing": 0.15,
+                          "lineHeight": 24,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          false,
+                          Object {
+                            "color": "rgba(28, 27, 31, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 16,
+                            "fontWeight": "400",
+                            "letterSpacing": 0.15,
+                            "lineHeight": 24,
+                          },
+                          undefined,
+                        ],
+                      ]
+                    }
+                    testID="menu-item-title"
+                  >
+                    Undo
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View
+              accessibilityRole="menuitem"
+              accessibilityState={
+                Object {
+                  "disabled": false,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Array [
+                  false,
+                  false,
+                  Array [
+                    Object {
+                      "height": 48,
+                      "justifyContent": "center",
+                      "maxWidth": 280,
+                      "minWidth": 112,
+                    },
+                    Object {
+                      "paddingHorizontal": 12,
+                    },
+                    undefined,
+                    undefined,
+                  ],
+                ]
+              }
+              testID="menu-item"
+            >
+              <View
+                style={
+                  Object {
+                    "flexDirection": "row",
+                  }
+                }
+              >
+                <View
+                  pointerEvents="none"
+                  style={
+                    Array [
+                      false,
+                      Object {
+                        "justifyContent": "center",
+                      },
+                      Object {
+                        "maxWidth": 268,
+                        "minWidth": 100,
+                      },
+                      Object {
+                        "marginLeft": 4,
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1.5}
+                    numberOfLines={1}
+                    selectable={false}
+                    style={
+                      Array [
+                        Object {
+                          "fontFamily": "System",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "letterSpacing": 0.15,
+                          "lineHeight": 24,
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        Array [
+                          false,
+                          Object {
+                            "color": "rgba(28, 27, 31, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 16,
+                            "fontWeight": "400",
+                            "letterSpacing": 0.15,
+                            "lineHeight": 24,
+                          },
+                          undefined,
+                        ],
+                      ]
+                    }
+                    testID="menu-item-title"
+                  >
+                    Redo
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>,
+]
+`;
+
+exports[`renders not visible menu 1`] = `
+<View
+  collapsable={false}
+  pointerEvents="box-none"
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    collapsable={false}
+  >
+    <View
+      collapsable={false}
+      style={
+        Object {
+          "alignSelf": undefined,
+          "bottom": undefined,
+          "end": undefined,
+          "flex": undefined,
+          "height": undefined,
+          "left": undefined,
+          "opacity": undefined,
+          "position": undefined,
+          "right": undefined,
+          "shadowColor": "#000",
+          "shadowOffset": Object {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+          "start": undefined,
+          "top": undefined,
+          "transform": undefined,
+          "width": undefined,
+        }
+      }
+      testID="button-container-outer-layer"
+    >
+      <View
+        collapsable={false}
+        style={
+          Object {
+            "backgroundColor": "transparent",
+            "borderColor": "rgba(121, 116, 126, 1)",
+            "borderRadius": 20,
+            "borderStyle": "solid",
+            "borderWidth": 1,
+            "flex": undefined,
+            "minWidth": 64,
+            "shadowColor": "#000",
+            "shadowOffset": Object {
+              "height": 0,
+              "width": 0,
+            },
+            "shadowOpacity": 0,
+            "shadowRadius": 0,
+          }
+        }
+        testID="button-container"
+      >
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            Object {
+              "disabled": true,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              false,
+              Object {
+                "borderRadius": 20,
+              },
+            ]
+          }
+          testID="button"
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                },
+                undefined,
+              ]
+            }
+          >
+            <Text
+              numberOfLines={1}
+              selectable={false}
+              style={
+                Array [
+                  Object {
+                    "fontFamily": "System",
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                    "letterSpacing": 0.1,
+                    "lineHeight": 20,
+                  },
+                  Object {
+                    "textAlign": "left",
+                  },
+                  Object {
+                    "color": "rgba(28, 27, 31, 1)",
+                    "writingDirection": "ltr",
+                  },
+                  Array [
+                    Object {
+                      "marginHorizontal": 16,
+                      "marginVertical": 9,
+                      "textAlign": "center",
+                    },
+                    false,
+                    Object {
+                      "marginHorizontal": 24,
+                      "marginVertical": 10,
+                    },
+                    undefined,
+                    false,
+                    Object {
+                      "color": "rgba(103, 80, 164, 1)",
+                      "fontFamily": "System",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "letterSpacing": 0.1,
+                      "lineHeight": 20,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+              testID="button-text"
+            >
+              Open menu
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
   </View>
 </View>
 `;
@@ -747,7 +717,13 @@ Array [
           collapsable={false}
           style={
             Object {
+              "backgroundColor": "transparent",
+              "borderColor": "rgba(121, 116, 126, 1)",
+              "borderRadius": 20,
+              "borderStyle": "solid",
+              "borderWidth": 1,
               "flex": undefined,
+              "minWidth": 64,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -757,116 +733,100 @@ Array [
               "shadowRadius": 0,
             }
           }
-          testID="button-container-middle-layer"
+          testID="button-container"
         >
           <View
-            collapsable={false}
-            style={
+            accessibilityRole="button"
+            accessibilityState={
               Object {
-                "backgroundColor": "transparent",
-                "borderColor": "rgba(121, 116, 126, 1)",
-                "borderRadius": 20,
-                "borderStyle": "solid",
-                "borderWidth": 1,
-                "flex": undefined,
-                "minWidth": 64,
+                "disabled": true,
               }
             }
-            testID="button-container"
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                false,
+                Object {
+                  "borderRadius": 20,
+                },
+              ]
+            }
+            testID="button"
           >
             <View
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "disabled": true,
-                }
-              }
-              accessible={true}
-              collapsable={false}
-              focusable={true}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Array [
                   Object {
-                    "overflow": "hidden",
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "justifyContent": "center",
                   },
-                  false,
-                  Object {
-                    "borderRadius": 20,
-                  },
+                  undefined,
                 ]
               }
-              testID="button"
             >
-              <View
+              <Text
+                numberOfLines={1}
+                selectable={false}
                 style={
                   Array [
                     Object {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "justifyContent": "center",
+                      "fontFamily": "System",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "letterSpacing": 0.1,
+                      "lineHeight": 20,
                     },
-                    undefined,
-                  ]
-                }
-              >
-                <Text
-                  numberOfLines={1}
-                  selectable={false}
-                  style={
+                    Object {
+                      "textAlign": "left",
+                    },
+                    Object {
+                      "color": "rgba(28, 27, 31, 1)",
+                      "writingDirection": "ltr",
+                    },
                     Array [
                       Object {
+                        "marginHorizontal": 16,
+                        "marginVertical": 9,
+                        "textAlign": "center",
+                      },
+                      false,
+                      Object {
+                        "marginHorizontal": 24,
+                        "marginVertical": 10,
+                      },
+                      undefined,
+                      false,
+                      Object {
+                        "color": "rgba(103, 80, 164, 1)",
                         "fontFamily": "System",
                         "fontSize": 14,
                         "fontWeight": "500",
                         "letterSpacing": 0.1,
                         "lineHeight": 20,
                       },
-                      Object {
-                        "textAlign": "left",
-                      },
-                      Object {
-                        "color": "rgba(28, 27, 31, 1)",
-                        "writingDirection": "ltr",
-                      },
-                      Array [
-                        Object {
-                          "marginHorizontal": 16,
-                          "marginVertical": 9,
-                          "textAlign": "center",
-                        },
-                        false,
-                        Object {
-                          "marginHorizontal": 24,
-                          "marginVertical": 10,
-                        },
-                        undefined,
-                        false,
-                        Object {
-                          "color": "rgba(103, 80, 164, 1)",
-                          "fontFamily": "System",
-                          "fontSize": 14,
-                          "fontWeight": "500",
-                          "letterSpacing": 0.1,
-                          "lineHeight": 20,
-                        },
-                        undefined,
-                      ],
-                    ]
-                  }
-                  testID="button-text"
-                >
-                  Open menu
-                </Text>
-              </View>
+                      undefined,
+                    ],
+                  ]
+                }
+                testID="button-text"
+              >
+                Open menu
+              </Text>
             </View>
           </View>
         </View>
@@ -980,7 +940,10 @@ Array [
             collapsable={false}
             style={
               Object {
+                "backgroundColor": "rgb(243, 237, 246)",
+                "borderRadius": 4,
                 "flex": undefined,
+                "paddingVertical": 8,
                 "shadowColor": "#000",
                 "shadowOffset": Object {
                   "height": 1,
@@ -990,232 +953,219 @@ Array [
                 "shadowRadius": 2,
               }
             }
-            testID="menu-surface-middle-layer"
+            testID="menu-surface"
           >
             <View
-              collapsable={false}
-              style={
+              accessibilityRole="menuitem"
+              accessibilityState={
                 Object {
-                  "backgroundColor": "rgb(243, 237, 246)",
-                  "borderRadius": 4,
-                  "flex": undefined,
-                  "paddingVertical": 8,
+                  "disabled": false,
                 }
               }
-              testID="menu-surface"
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Array [
+                  false,
+                  false,
+                  Array [
+                    Object {
+                      "height": 48,
+                      "justifyContent": "center",
+                      "maxWidth": 280,
+                      "minWidth": 112,
+                    },
+                    Object {
+                      "paddingHorizontal": 12,
+                    },
+                    undefined,
+                    undefined,
+                  ],
+                ]
+              }
+              testID="menu-item"
             >
               <View
-                accessibilityRole="menuitem"
-                accessibilityState={
+                style={
                   Object {
-                    "disabled": false,
+                    "flexDirection": "row",
                   }
                 }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  Array [
-                    false,
-                    false,
-                    Array [
-                      Object {
-                        "height": 48,
-                        "justifyContent": "center",
-                        "maxWidth": 280,
-                        "minWidth": 112,
-                      },
-                      Object {
-                        "paddingHorizontal": 12,
-                      },
-                      undefined,
-                      undefined,
-                    ],
-                  ]
-                }
-                testID="menu-item"
               >
                 <View
+                  pointerEvents="none"
                   style={
-                    Object {
-                      "flexDirection": "row",
-                    }
+                    Array [
+                      false,
+                      Object {
+                        "justifyContent": "center",
+                      },
+                      Object {
+                        "maxWidth": 268,
+                        "minWidth": 100,
+                      },
+                      Object {
+                        "marginLeft": 4,
+                      },
+                      undefined,
+                    ]
                   }
                 >
-                  <View
-                    pointerEvents="none"
+                  <Text
+                    maxFontSizeMultiplier={1.5}
+                    numberOfLines={1}
+                    selectable={false}
                     style={
                       Array [
-                        false,
                         Object {
-                          "justifyContent": "center",
+                          "fontFamily": "System",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "letterSpacing": 0.15,
+                          "lineHeight": 24,
                         },
                         Object {
-                          "maxWidth": 268,
-                          "minWidth": 100,
+                          "textAlign": "left",
                         },
                         Object {
-                          "marginLeft": 4,
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
                         },
-                        undefined,
-                      ]
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1.5}
-                      numberOfLines={1}
-                      selectable={false}
-                      style={
                         Array [
+                          false,
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 16,
                             "fontWeight": "400",
                             "letterSpacing": 0.15,
                             "lineHeight": 24,
                           },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            false,
-                            Object {
-                              "color": "rgba(28, 27, 31, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 16,
-                              "fontWeight": "400",
-                              "letterSpacing": 0.15,
-                              "lineHeight": 24,
-                            },
-                            undefined,
-                          ],
-                        ]
-                      }
-                      testID="menu-item-title"
-                    >
-                      Undo
-                    </Text>
-                  </View>
+                          undefined,
+                        ],
+                      ]
+                    }
+                    testID="menu-item-title"
+                  >
+                    Undo
+                  </Text>
                 </View>
               </View>
+            </View>
+            <View
+              accessibilityRole="menuitem"
+              accessibilityState={
+                Object {
+                  "disabled": false,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Array [
+                  false,
+                  false,
+                  Array [
+                    Object {
+                      "height": 48,
+                      "justifyContent": "center",
+                      "maxWidth": 280,
+                      "minWidth": 112,
+                    },
+                    Object {
+                      "paddingHorizontal": 12,
+                    },
+                    undefined,
+                    undefined,
+                  ],
+                ]
+              }
+              testID="menu-item"
+            >
               <View
-                accessibilityRole="menuitem"
-                accessibilityState={
+                style={
                   Object {
-                    "disabled": false,
+                    "flexDirection": "row",
                   }
                 }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  Array [
-                    false,
-                    false,
-                    Array [
-                      Object {
-                        "height": 48,
-                        "justifyContent": "center",
-                        "maxWidth": 280,
-                        "minWidth": 112,
-                      },
-                      Object {
-                        "paddingHorizontal": 12,
-                      },
-                      undefined,
-                      undefined,
-                    ],
-                  ]
-                }
-                testID="menu-item"
               >
                 <View
+                  pointerEvents="none"
                   style={
-                    Object {
-                      "flexDirection": "row",
-                    }
+                    Array [
+                      false,
+                      Object {
+                        "justifyContent": "center",
+                      },
+                      Object {
+                        "maxWidth": 268,
+                        "minWidth": 100,
+                      },
+                      Object {
+                        "marginLeft": 4,
+                      },
+                      undefined,
+                    ]
                   }
                 >
-                  <View
-                    pointerEvents="none"
+                  <Text
+                    maxFontSizeMultiplier={1.5}
+                    numberOfLines={1}
+                    selectable={false}
                     style={
                       Array [
-                        false,
                         Object {
-                          "justifyContent": "center",
+                          "fontFamily": "System",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "letterSpacing": 0.15,
+                          "lineHeight": 24,
                         },
                         Object {
-                          "maxWidth": 268,
-                          "minWidth": 100,
+                          "textAlign": "left",
                         },
                         Object {
-                          "marginLeft": 4,
+                          "color": "rgba(28, 27, 31, 1)",
+                          "writingDirection": "ltr",
                         },
-                        undefined,
-                      ]
-                    }
-                  >
-                    <Text
-                      maxFontSizeMultiplier={1.5}
-                      numberOfLines={1}
-                      selectable={false}
-                      style={
                         Array [
+                          false,
                           Object {
+                            "color": "rgba(28, 27, 31, 1)",
                             "fontFamily": "System",
                             "fontSize": 16,
                             "fontWeight": "400",
                             "letterSpacing": 0.15,
                             "lineHeight": 24,
                           },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            false,
-                            Object {
-                              "color": "rgba(28, 27, 31, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 16,
-                              "fontWeight": "400",
-                              "letterSpacing": 0.15,
-                              "lineHeight": 24,
-                            },
-                            undefined,
-                          ],
-                        ]
-                      }
-                      testID="menu-item-title"
-                    >
-                      Redo
-                    </Text>
-                  </View>
+                          undefined,
+                        ],
+                      ]
+                    }
+                    testID="menu-item-title"
+                  >
+                    Redo
+                  </Text>
                 </View>
               </View>
             </View>

--- a/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -22,7 +22,9 @@ Array [
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
+            "height": undefined,
             "left": undefined,
+            "opacity": undefined,
             "position": undefined,
             "right": undefined,
             "shadowColor": "#000",
@@ -34,6 +36,8 @@ Array [
             "shadowRadius": 0,
             "start": undefined,
             "top": undefined,
+            "transform": undefined,
+            "width": undefined,
           }
         }
         testID="button-container-outer-layer"
@@ -52,7 +56,7 @@ Array [
               "shadowRadius": 0,
             }
           }
-          testID="button-container-inner-layer"
+          testID="button-container-middle-layer"
         >
           <View
             collapsable={false}
@@ -244,7 +248,9 @@ Array [
               "bottom": undefined,
               "end": undefined,
               "flex": undefined,
+              "height": undefined,
               "left": undefined,
+              "opacity": 0,
               "position": undefined,
               "right": undefined,
               "shadowColor": "#000",
@@ -256,6 +262,15 @@ Array [
               "shadowRadius": 6,
               "start": undefined,
               "top": undefined,
+              "transform": Array [
+                Object {
+                  "scaleX": 0,
+                },
+                Object {
+                  "scaleY": 0,
+                },
+              ],
+              "width": undefined,
             }
           }
           testID="menu-surface-outer-layer"
@@ -274,7 +289,7 @@ Array [
                 "shadowRadius": 2,
               }
             }
-            testID="menu-surface-inner-layer"
+            testID="menu-surface-middle-layer"
           >
             <View
               collapsable={false}
@@ -285,16 +300,7 @@ Array [
                   "borderTopLeftRadius": 0,
                   "borderTopRightRadius": 0,
                   "flex": undefined,
-                  "opacity": 0,
                   "paddingVertical": 8,
-                  "transform": Array [
-                    Object {
-                      "scaleX": 0,
-                    },
-                    Object {
-                      "scaleY": 0,
-                    },
-                  ],
                 }
               }
               testID="menu-surface"
@@ -543,7 +549,9 @@ exports[`renders not visible menu 1`] = `
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": undefined,
           "left": undefined,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -555,6 +563,8 @@ exports[`renders not visible menu 1`] = `
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": undefined,
         }
       }
       testID="button-container-outer-layer"
@@ -573,7 +583,7 @@ exports[`renders not visible menu 1`] = `
             "shadowRadius": 0,
           }
         }
-        testID="button-container-inner-layer"
+        testID="button-container-middle-layer"
       >
         <View
           collapsable={false}
@@ -713,7 +723,9 @@ Array [
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
+            "height": undefined,
             "left": undefined,
+            "opacity": undefined,
             "position": undefined,
             "right": undefined,
             "shadowColor": "#000",
@@ -725,6 +737,8 @@ Array [
             "shadowRadius": 0,
             "start": undefined,
             "top": undefined,
+            "transform": undefined,
+            "width": undefined,
           }
         }
         testID="button-container-outer-layer"
@@ -743,7 +757,7 @@ Array [
               "shadowRadius": 0,
             }
           }
-          testID="button-container-inner-layer"
+          testID="button-container-middle-layer"
         >
           <View
             collapsable={false}
@@ -935,7 +949,9 @@ Array [
               "bottom": undefined,
               "end": undefined,
               "flex": undefined,
+              "height": undefined,
               "left": undefined,
+              "opacity": 0,
               "position": undefined,
               "right": undefined,
               "shadowColor": "#000",
@@ -947,6 +963,15 @@ Array [
               "shadowRadius": 6,
               "start": undefined,
               "top": undefined,
+              "transform": Array [
+                Object {
+                  "scaleX": 0,
+                },
+                Object {
+                  "scaleY": 0,
+                },
+              ],
+              "width": undefined,
             }
           }
           testID="menu-surface-outer-layer"
@@ -965,7 +990,7 @@ Array [
                 "shadowRadius": 2,
               }
             }
-            testID="menu-surface-inner-layer"
+            testID="menu-surface-middle-layer"
           >
             <View
               collapsable={false}
@@ -974,16 +999,7 @@ Array [
                   "backgroundColor": "rgb(243, 237, 246)",
                   "borderRadius": 4,
                   "flex": undefined,
-                  "opacity": 0,
                   "paddingVertical": 8,
-                  "transform": Array [
-                    Object {
-                      "scaleX": 0,
-                    },
-                    Object {
-                      "scaleY": 0,
-                    },
-                  ],
                 }
               }
               testID="menu-surface"

--- a/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -19,6 +19,8 @@ Array [
         style={
           Object {
             "alignSelf": undefined,
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
@@ -235,6 +237,10 @@ Array [
           style={
             Object {
               "alignSelf": undefined,
+              "backgroundColor": "rgb(243, 237, 246)",
+              "borderRadius": 4,
+              "borderTopLeftRadius": 0,
+              "borderTopRightRadius": 0,
               "bottom": undefined,
               "end": undefined,
               "flex": undefined,
@@ -526,6 +532,8 @@ exports[`renders not visible menu 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
@@ -690,6 +698,8 @@ Array [
         style={
           Object {
             "alignSelf": undefined,
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
@@ -906,6 +916,8 @@ Array [
           style={
             Object {
               "alignSelf": undefined,
+              "backgroundColor": "rgb(243, 237, 246)",
+              "borderRadius": 4,
               "bottom": undefined,
               "end": undefined,
               "flex": undefined,

--- a/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
@@ -9,7 +9,9 @@ exports[`activity indicator snapshot test 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -21,6 +23,8 @@ exports[`activity indicator snapshot test 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="search-bar-container-outer-layer"
@@ -39,7 +43,7 @@ exports[`activity indicator snapshot test 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="search-bar-container-inner-layer"
+    testID="search-bar-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -62,7 +66,10 @@ exports[`activity indicator snapshot test 1`] = `
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
+            "height": 40,
             "left": undefined,
+            "margin": 6,
+            "opacity": undefined,
             "position": undefined,
             "right": undefined,
             "shadowColor": "#000",
@@ -74,6 +81,8 @@ exports[`activity indicator snapshot test 1`] = `
             "shadowRadius": 0,
             "start": undefined,
             "top": undefined,
+            "transform": undefined,
+            "width": 40,
           }
         }
         testID="icon-button-container-outer-layer"
@@ -82,7 +91,7 @@ exports[`activity indicator snapshot test 1`] = `
           collapsable={false}
           style={
             Object {
-              "flex": undefined,
+              "flex": 1,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -92,22 +101,19 @@ exports[`activity indicator snapshot test 1`] = `
               "shadowRadius": 0,
             }
           }
-          testID="icon-button-container-inner-layer"
+          testID="icon-button-container-middle-layer"
         >
           <View
             collapsable={false}
             style={
               Object {
-                "backgroundColor": undefined,
+                "backgroundColor": "transparent",
                 "borderColor": "rgba(121, 116, 126, 1)",
                 "borderRadius": 20,
                 "borderWidth": 0,
                 "elevation": 0,
-                "flex": undefined,
-                "height": 40,
-                "margin": 6,
+                "flex": 1,
                 "overflow": "hidden",
-                "width": 40,
               }
             }
             testID="icon-button-container"
@@ -451,7 +457,9 @@ exports[`renders with placeholder 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -463,6 +471,8 @@ exports[`renders with placeholder 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="search-bar-container-outer-layer"
@@ -481,7 +491,7 @@ exports[`renders with placeholder 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="search-bar-container-inner-layer"
+    testID="search-bar-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -504,7 +514,10 @@ exports[`renders with placeholder 1`] = `
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
+            "height": 40,
             "left": undefined,
+            "margin": 6,
+            "opacity": undefined,
             "position": undefined,
             "right": undefined,
             "shadowColor": "#000",
@@ -516,6 +529,8 @@ exports[`renders with placeholder 1`] = `
             "shadowRadius": 0,
             "start": undefined,
             "top": undefined,
+            "transform": undefined,
+            "width": 40,
           }
         }
         testID="icon-button-container-outer-layer"
@@ -524,7 +539,7 @@ exports[`renders with placeholder 1`] = `
           collapsable={false}
           style={
             Object {
-              "flex": undefined,
+              "flex": 1,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -534,22 +549,19 @@ exports[`renders with placeholder 1`] = `
               "shadowRadius": 0,
             }
           }
-          testID="icon-button-container-inner-layer"
+          testID="icon-button-container-middle-layer"
         >
           <View
             collapsable={false}
             style={
               Object {
-                "backgroundColor": undefined,
+                "backgroundColor": "transparent",
                 "borderColor": "rgba(121, 116, 126, 1)",
                 "borderRadius": 20,
                 "borderWidth": 0,
                 "elevation": 0,
-                "flex": undefined,
-                "height": 40,
-                "margin": 6,
+                "flex": 1,
                 "overflow": "hidden",
-                "width": 40,
               }
             }
             testID="icon-button-container"
@@ -703,7 +715,10 @@ exports[`renders with placeholder 1`] = `
               "bottom": undefined,
               "end": undefined,
               "flex": undefined,
+              "height": 40,
               "left": undefined,
+              "margin": 6,
+              "opacity": undefined,
               "position": undefined,
               "right": undefined,
               "shadowColor": "#000",
@@ -715,6 +730,8 @@ exports[`renders with placeholder 1`] = `
               "shadowRadius": 0,
               "start": undefined,
               "top": undefined,
+              "transform": undefined,
+              "width": 40,
             }
           }
           testID="icon-button-container-outer-layer"
@@ -723,7 +740,7 @@ exports[`renders with placeholder 1`] = `
             collapsable={false}
             style={
               Object {
-                "flex": undefined,
+                "flex": 1,
                 "shadowColor": "#000",
                 "shadowOffset": Object {
                   "height": 0,
@@ -733,22 +750,19 @@ exports[`renders with placeholder 1`] = `
                 "shadowRadius": 0,
               }
             }
-            testID="icon-button-container-inner-layer"
+            testID="icon-button-container-middle-layer"
           >
             <View
               collapsable={false}
               style={
                 Object {
-                  "backgroundColor": undefined,
+                  "backgroundColor": "transparent",
                   "borderColor": "rgba(121, 116, 126, 1)",
                   "borderRadius": 20,
                   "borderWidth": 0,
                   "elevation": 0,
-                  "flex": undefined,
-                  "height": 40,
-                  "margin": 6,
+                  "flex": 1,
                   "overflow": "hidden",
-                  "width": 40,
                 }
               }
               testID="icon-button-container"
@@ -859,7 +873,9 @@ exports[`renders with text 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": undefined,
       "left": undefined,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -871,6 +887,8 @@ exports[`renders with text 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": undefined,
     }
   }
   testID="search-bar-container-outer-layer"
@@ -889,7 +907,7 @@ exports[`renders with text 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="search-bar-container-inner-layer"
+    testID="search-bar-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -912,7 +930,10 @@ exports[`renders with text 1`] = `
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
+            "height": 40,
             "left": undefined,
+            "margin": 6,
+            "opacity": undefined,
             "position": undefined,
             "right": undefined,
             "shadowColor": "#000",
@@ -924,6 +945,8 @@ exports[`renders with text 1`] = `
             "shadowRadius": 0,
             "start": undefined,
             "top": undefined,
+            "transform": undefined,
+            "width": 40,
           }
         }
         testID="icon-button-container-outer-layer"
@@ -932,7 +955,7 @@ exports[`renders with text 1`] = `
           collapsable={false}
           style={
             Object {
-              "flex": undefined,
+              "flex": 1,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -942,22 +965,19 @@ exports[`renders with text 1`] = `
               "shadowRadius": 0,
             }
           }
-          testID="icon-button-container-inner-layer"
+          testID="icon-button-container-middle-layer"
         >
           <View
             collapsable={false}
             style={
               Object {
-                "backgroundColor": undefined,
+                "backgroundColor": "transparent",
                 "borderColor": "rgba(121, 116, 126, 1)",
                 "borderRadius": 20,
                 "borderWidth": 0,
                 "elevation": 0,
-                "flex": undefined,
-                "height": 40,
-                "margin": 6,
+                "flex": 1,
                 "overflow": "hidden",
-                "width": 40,
               }
             }
             testID="icon-button-container"
@@ -1107,7 +1127,10 @@ exports[`renders with text 1`] = `
               "bottom": undefined,
               "end": undefined,
               "flex": undefined,
+              "height": 40,
               "left": undefined,
+              "margin": 6,
+              "opacity": undefined,
               "position": undefined,
               "right": undefined,
               "shadowColor": "#000",
@@ -1119,6 +1142,8 @@ exports[`renders with text 1`] = `
               "shadowRadius": 0,
               "start": undefined,
               "top": undefined,
+              "transform": undefined,
+              "width": 40,
             }
           }
           testID="icon-button-container-outer-layer"
@@ -1127,7 +1152,7 @@ exports[`renders with text 1`] = `
             collapsable={false}
             style={
               Object {
-                "flex": undefined,
+                "flex": 1,
                 "shadowColor": "#000",
                 "shadowOffset": Object {
                   "height": 0,
@@ -1137,22 +1162,19 @@ exports[`renders with text 1`] = `
                 "shadowRadius": 0,
               }
             }
-            testID="icon-button-container-inner-layer"
+            testID="icon-button-container-middle-layer"
           >
             <View
               collapsable={false}
               style={
                 Object {
-                  "backgroundColor": undefined,
+                  "backgroundColor": "transparent",
                   "borderColor": "rgba(121, 116, 126, 1)",
                   "borderRadius": 20,
                   "borderWidth": 0,
                   "elevation": 0,
-                  "flex": undefined,
-                  "height": 40,
-                  "margin": 6,
+                  "flex": 1,
                   "overflow": "hidden",
-                  "width": 40,
                 }
               }
               testID="icon-button-container"

--- a/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
@@ -33,7 +33,11 @@ exports[`activity indicator snapshot test 1`] = `
     collapsable={false}
     style={
       Object {
+        "alignItems": "center",
+        "backgroundColor": "rgb(238, 232, 244)",
+        "borderRadius": 28,
         "flex": undefined,
+        "flexDirection": "row",
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -43,35 +47,48 @@ exports[`activity indicator snapshot test 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="search-bar-container-middle-layer"
+    testID="search-bar-container"
   >
     <View
       collapsable={false}
       style={
         Object {
-          "alignItems": "center",
-          "backgroundColor": "rgb(238, 232, 244)",
-          "borderRadius": 28,
+          "alignSelf": undefined,
+          "bottom": undefined,
+          "end": undefined,
           "flex": undefined,
-          "flexDirection": "row",
+          "height": 40,
+          "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
+          "position": undefined,
+          "right": undefined,
+          "shadowColor": "#000",
+          "shadowOffset": Object {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+          "start": undefined,
+          "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
-      testID="search-bar-container"
+      testID="icon-button-container-outer-layer"
     >
       <View
         collapsable={false}
         style={
           Object {
-            "alignSelf": undefined,
-            "bottom": undefined,
-            "end": undefined,
-            "flex": undefined,
-            "height": 40,
-            "left": undefined,
-            "margin": 6,
-            "opacity": undefined,
-            "position": undefined,
-            "right": undefined,
+            "backgroundColor": "transparent",
+            "borderColor": "rgba(121, 116, 126, 1)",
+            "borderRadius": 20,
+            "borderWidth": 0,
+            "elevation": 0,
+            "flex": 1,
+            "overflow": "hidden",
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -79,200 +96,178 @@ exports[`activity indicator snapshot test 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
-            "start": undefined,
-            "top": undefined,
-            "transform": undefined,
-            "width": 40,
           }
         }
-        testID="icon-button-container-outer-layer"
+        testID="icon-button-container"
       >
         <View
-          collapsable={false}
-          style={
+          accessibilityComponentType="button"
+          accessibilityLabel="search"
+          accessibilityRole="button"
+          accessibilityState={
             Object {
-              "flex": 1,
-              "shadowColor": "#000",
-              "shadowOffset": Object {
-                "height": 0,
-                "width": 0,
-              },
-              "shadowOpacity": 0,
-              "shadowRadius": 0,
+              "disabled": true,
             }
           }
-          testID="icon-button-container-middle-layer"
-        >
-          <View
-            collapsable={false}
-            style={
-              Object {
-                "backgroundColor": "transparent",
-                "borderColor": "rgba(121, 116, 126, 1)",
-                "borderRadius": 20,
-                "borderWidth": 0,
-                "elevation": 0,
-                "flex": 1,
-                "overflow": "hidden",
-              }
+          accessibilityTraits="button"
+          accessible={true}
+          centered={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 6,
+              "left": 6,
+              "right": 6,
+              "top": 6,
             }
-            testID="icon-button-container"
-          >
-            <View
-              accessibilityComponentType="button"
-              accessibilityLabel="search"
-              accessibilityRole="button"
-              accessibilityState={
+          }
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              false,
+              Array [
                 Object {
-                  "disabled": true,
-                }
-              }
-              accessibilityTraits="button"
-              accessible={true}
-              centered={true}
-              collapsable={false}
-              focusable={true}
-              hitSlop={
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
                 Object {
-                  "bottom": 6,
-                  "left": 6,
-                  "right": 6,
-                  "top": 6,
-                }
-              }
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
+                  "borderRadius": 20,
+                },
+              ],
+            ]
+          }
+          testID="icon-button"
+        >
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
+            style={
+              Array [
+                Object {
+                  "color": "rgba(73, 69, 79, 1)",
+                  "fontSize": 24,
+                },
                 Array [
                   Object {
-                    "overflow": "hidden",
-                  },
-                  false,
-                  Array [
-                    Object {
-                      "alignItems": "center",
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    },
-                    Object {
-                      "borderRadius": 20,
-                    },
-                  ],
-                ]
-              }
-              testID="icon-button"
-            >
-              <Text
-                accessibilityElementsHidden={true}
-                allowFontScaling={false}
-                importantForAccessibility="no-hide-descendants"
-                pointerEvents="none"
-                selectable={false}
-                style={
-                  Array [
-                    Object {
-                      "color": "rgba(73, 69, 79, 1)",
-                      "fontSize": 24,
-                    },
-                    Array [
+                    "lineHeight": 24,
+                    "transform": Array [
                       Object {
-                        "lineHeight": 24,
-                        "transform": Array [
-                          Object {
-                            "scaleX": 1,
-                          },
-                        ],
-                      },
-                      Object {
-                        "backgroundColor": "transparent",
+                        "scaleX": 1,
                       },
                     ],
-                    Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                󰍉
-              </Text>
-            </View>
-          </View>
+                  },
+                  Object {
+                    "backgroundColor": "transparent",
+                  },
+                ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            󰍉
+          </Text>
         </View>
       </View>
-      <TextInput
-        accessibilityRole="search"
-        keyboardAppearance="light"
-        placeholder=""
-        placeholderTextColor="rgba(28, 27, 31, 1)"
-        returnKeyType="search"
-        selectionColor="rgba(103, 80, 164, 1)"
-        style={
-          Array [
-            Object {
-              "alignSelf": "stretch",
-              "flex": 1,
-              "fontSize": 18,
-              "minWidth": 0,
-              "paddingLeft": 8,
-              "textAlign": "left",
-            },
-            Object {
-              "color": "rgba(73, 69, 79, 1)",
-              "fontFamily": "System",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "letterSpacing": 0.15,
-              "lineHeight": 0,
-            },
-            Object {
-              "minHeight": 56,
-              "paddingLeft": 0,
-            },
-            undefined,
-          ]
-        }
-        testID="search-bar"
-        underlineColorAndroid="transparent"
-        value=""
-      />
-      <View
-        accessibilityRole="progressbar"
-        accessibilityState={
+    </View>
+    <TextInput
+      accessibilityRole="search"
+      keyboardAppearance="light"
+      placeholder=""
+      placeholderTextColor="rgba(28, 27, 31, 1)"
+      returnKeyType="search"
+      selectionColor="rgba(103, 80, 164, 1)"
+      style={
+        Array [
           Object {
-            "busy": true,
+            "alignSelf": "stretch",
+            "flex": 1,
+            "fontSize": 18,
+            "minWidth": 0,
+            "paddingLeft": 8,
+            "textAlign": "left",
+          },
+          Object {
+            "color": "rgba(73, 69, 79, 1)",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "letterSpacing": 0.15,
+            "lineHeight": 0,
+          },
+          Object {
+            "minHeight": 56,
+            "paddingLeft": 0,
+          },
+          undefined,
+        ]
+      }
+      testID="search-bar"
+      underlineColorAndroid="transparent"
+      value=""
+    />
+    <View
+      accessibilityRole="progressbar"
+      accessibilityState={
+        Object {
+          "busy": true,
+        }
+      }
+      accessible={true}
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "justifyContent": "center",
+          },
+          Object {
+            "marginHorizontal": 16,
+          },
+        ]
+      }
+      testID="activity-indicator"
+    >
+      <View
+        collapsable={false}
+        style={
+          Object {
+            "height": 24,
+            "opacity": 1,
+            "width": 24,
           }
         }
-        accessible={true}
-        style={
-          Array [
-            Object {
-              "alignItems": "center",
-              "justifyContent": "center",
-            },
-            Object {
-              "marginHorizontal": 16,
-            },
-          ]
-        }
-        testID="activity-indicator"
       >
         <View
           collapsable={false}
           style={
             Object {
-              "height": 24,
-              "opacity": 1,
-              "width": 24,
+              "alignItems": "center",
+              "bottom": 0,
+              "justifyContent": "center",
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
             }
           }
         >
@@ -280,13 +275,13 @@ exports[`activity indicator snapshot test 1`] = `
             collapsable={false}
             style={
               Object {
-                "alignItems": "center",
-                "bottom": 0,
-                "justifyContent": "center",
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
+                "height": 24,
+                "transform": Array [
+                  Object {
+                    "rotate": "45deg",
+                  },
+                ],
+                "width": 24,
               }
             }
           >
@@ -294,12 +289,8 @@ exports[`activity indicator snapshot test 1`] = `
               collapsable={false}
               style={
                 Object {
-                  "height": 24,
-                  "transform": Array [
-                    Object {
-                      "rotate": "45deg",
-                    },
-                  ],
+                  "height": 12,
+                  "overflow": "hidden",
                   "width": 24,
                 }
               }
@@ -308,8 +299,15 @@ exports[`activity indicator snapshot test 1`] = `
                 collapsable={false}
                 style={
                   Object {
-                    "height": 12,
-                    "overflow": "hidden",
+                    "height": 24,
+                    "transform": Array [
+                      Object {
+                        "translateY": 0,
+                      },
+                      Object {
+                        "rotate": "-165deg",
+                      },
+                    ],
                     "width": 24,
                   }
                 }
@@ -318,15 +316,8 @@ exports[`activity indicator snapshot test 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "height": 24,
-                      "transform": Array [
-                        Object {
-                          "translateY": 0,
-                        },
-                        Object {
-                          "rotate": "-165deg",
-                        },
-                      ],
+                      "height": 12,
+                      "overflow": "hidden",
                       "width": 24,
                     }
                   }
@@ -335,40 +326,44 @@ exports[`activity indicator snapshot test 1`] = `
                     collapsable={false}
                     style={
                       Object {
-                        "height": 12,
-                        "overflow": "hidden",
+                        "borderColor": "rgba(103, 80, 164, 1)",
+                        "borderRadius": 12,
+                        "borderWidth": 2.4,
+                        "height": 24,
                         "width": 24,
                       }
                     }
-                  >
-                    <View
-                      collapsable={false}
-                      style={
-                        Object {
-                          "borderColor": "rgba(103, 80, 164, 1)",
-                          "borderRadius": 12,
-                          "borderWidth": 2.4,
-                          "height": 24,
-                          "width": 24,
-                        }
-                      }
-                    />
-                  </View>
+                  />
                 </View>
               </View>
             </View>
           </View>
+        </View>
+        <View
+          collapsable={false}
+          style={
+            Object {
+              "alignItems": "center",
+              "bottom": 0,
+              "justifyContent": "center",
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+        >
           <View
             collapsable={false}
             style={
               Object {
-                "alignItems": "center",
-                "bottom": 0,
-                "justifyContent": "center",
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
+                "height": 24,
+                "transform": Array [
+                  Object {
+                    "rotate": "45deg",
+                  },
+                ],
+                "width": 24,
               }
             }
           >
@@ -376,12 +371,9 @@ exports[`activity indicator snapshot test 1`] = `
               collapsable={false}
               style={
                 Object {
-                  "height": 24,
-                  "transform": Array [
-                    Object {
-                      "rotate": "45deg",
-                    },
-                  ],
+                  "height": 12,
+                  "overflow": "hidden",
+                  "top": 12,
                   "width": 24,
                 }
               }
@@ -390,9 +382,15 @@ exports[`activity indicator snapshot test 1`] = `
                 collapsable={false}
                 style={
                   Object {
-                    "height": 12,
-                    "overflow": "hidden",
-                    "top": 12,
+                    "height": 24,
+                    "transform": Array [
+                      Object {
+                        "translateY": -12,
+                      },
+                      Object {
+                        "rotate": "345deg",
+                      },
+                    ],
                     "width": 24,
                   }
                 }
@@ -401,15 +399,8 @@ exports[`activity indicator snapshot test 1`] = `
                   collapsable={false}
                   style={
                     Object {
-                      "height": 24,
-                      "transform": Array [
-                        Object {
-                          "translateY": -12,
-                        },
-                        Object {
-                          "rotate": "345deg",
-                        },
-                      ],
+                      "height": 12,
+                      "overflow": "hidden",
                       "width": 24,
                     }
                   }
@@ -418,25 +409,14 @@ exports[`activity indicator snapshot test 1`] = `
                     collapsable={false}
                     style={
                       Object {
-                        "height": 12,
-                        "overflow": "hidden",
+                        "borderColor": "rgba(103, 80, 164, 1)",
+                        "borderRadius": 12,
+                        "borderWidth": 2.4,
+                        "height": 24,
                         "width": 24,
                       }
                     }
-                  >
-                    <View
-                      collapsable={false}
-                      style={
-                        Object {
-                          "borderColor": "rgba(103, 80, 164, 1)",
-                          "borderRadius": 12,
-                          "borderWidth": 2.4,
-                          "height": 24,
-                          "width": 24,
-                        }
-                      }
-                    />
-                  </View>
+                  />
                 </View>
               </View>
             </View>
@@ -481,7 +461,11 @@ exports[`renders with placeholder 1`] = `
     collapsable={false}
     style={
       Object {
+        "alignItems": "center",
+        "backgroundColor": "rgb(238, 232, 244)",
+        "borderRadius": 28,
         "flex": undefined,
+        "flexDirection": "row",
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -491,20 +475,198 @@ exports[`renders with placeholder 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="search-bar-container-middle-layer"
+    testID="search-bar-container"
   >
     <View
       collapsable={false}
       style={
         Object {
-          "alignItems": "center",
-          "backgroundColor": "rgb(238, 232, 244)",
-          "borderRadius": 28,
+          "alignSelf": undefined,
+          "bottom": undefined,
+          "end": undefined,
           "flex": undefined,
-          "flexDirection": "row",
+          "height": 40,
+          "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
+          "position": undefined,
+          "right": undefined,
+          "shadowColor": "#000",
+          "shadowOffset": Object {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+          "start": undefined,
+          "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
-      testID="search-bar-container"
+      testID="icon-button-container-outer-layer"
+    >
+      <View
+        collapsable={false}
+        style={
+          Object {
+            "backgroundColor": "transparent",
+            "borderColor": "rgba(121, 116, 126, 1)",
+            "borderRadius": 20,
+            "borderWidth": 0,
+            "elevation": 0,
+            "flex": 1,
+            "overflow": "hidden",
+            "shadowColor": "#000",
+            "shadowOffset": Object {
+              "height": 0,
+              "width": 0,
+            },
+            "shadowOpacity": 0,
+            "shadowRadius": 0,
+          }
+        }
+        testID="icon-button-container"
+      >
+        <View
+          accessibilityComponentType="button"
+          accessibilityLabel="search"
+          accessibilityRole="button"
+          accessibilityState={
+            Object {
+              "disabled": true,
+            }
+          }
+          accessibilityTraits="button"
+          accessible={true}
+          centered={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 6,
+              "left": 6,
+              "right": 6,
+              "top": 6,
+            }
+          }
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              false,
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                Object {
+                  "borderRadius": 20,
+                },
+              ],
+            ]
+          }
+          testID="icon-button"
+        >
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
+            style={
+              Array [
+                Object {
+                  "color": "rgba(73, 69, 79, 1)",
+                  "fontSize": 24,
+                },
+                Array [
+                  Object {
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  Object {
+                    "backgroundColor": "transparent",
+                  },
+                ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            󰍉
+          </Text>
+        </View>
+      </View>
+    </View>
+    <TextInput
+      accessibilityRole="search"
+      keyboardAppearance="light"
+      placeholder="Search"
+      placeholderTextColor="rgba(28, 27, 31, 1)"
+      returnKeyType="search"
+      selectionColor="rgba(103, 80, 164, 1)"
+      style={
+        Array [
+          Object {
+            "alignSelf": "stretch",
+            "flex": 1,
+            "fontSize": 18,
+            "minWidth": 0,
+            "paddingLeft": 8,
+            "textAlign": "left",
+          },
+          Object {
+            "color": "rgba(73, 69, 79, 1)",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "letterSpacing": 0.15,
+            "lineHeight": 0,
+          },
+          Object {
+            "minHeight": 56,
+            "paddingLeft": 0,
+          },
+          undefined,
+        ]
+      }
+      testID="search-bar"
+      underlineColorAndroid="transparent"
+      value=""
+    />
+    <View
+      pointerEvents="none"
+      style={
+        Array [
+          Object {
+            "marginLeft": 16,
+            "position": "absolute",
+            "right": 0,
+          },
+          false,
+        ]
+      }
+      testID="search-bar-icon-wrapper"
     >
       <View
         collapsable={false}
@@ -539,7 +701,13 @@ exports[`renders with placeholder 1`] = `
           collapsable={false}
           style={
             Object {
+              "backgroundColor": "transparent",
+              "borderColor": "rgba(121, 116, 126, 1)",
+              "borderRadius": 20,
+              "borderWidth": 0,
+              "elevation": 0,
               "flex": 1,
+              "overflow": "hidden",
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -549,313 +717,95 @@ exports[`renders with placeholder 1`] = `
               "shadowRadius": 0,
             }
           }
-          testID="icon-button-container-middle-layer"
+          testID="icon-button-container"
         >
           <View
-            collapsable={false}
-            style={
+            accessibilityComponentType="button"
+            accessibilityLabel="clear"
+            accessibilityRole="button"
+            accessibilityState={
               Object {
-                "backgroundColor": "transparent",
-                "borderColor": "rgba(121, 116, 126, 1)",
-                "borderRadius": 20,
-                "borderWidth": 0,
-                "elevation": 0,
-                "flex": 1,
-                "overflow": "hidden",
+                "disabled": false,
               }
             }
-            testID="icon-button-container"
+            accessibilityTraits="button"
+            accessible={true}
+            centered={true}
+            collapsable={false}
+            focusable={true}
+            hitSlop={
+              Object {
+                "bottom": 6,
+                "left": 6,
+                "right": 6,
+                "top": 6,
+              }
+            }
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                false,
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                  },
+                  Object {
+                    "borderRadius": 20,
+                  },
+                ],
+              ]
+            }
+            testID="icon-button"
           >
-            <View
-              accessibilityComponentType="button"
-              accessibilityLabel="search"
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "disabled": true,
-                }
-              }
-              accessibilityTraits="button"
-              accessible={true}
-              centered={true}
-              collapsable={false}
-              focusable={true}
-              hitSlop={
-                Object {
-                  "bottom": 6,
-                  "left": 6,
-                  "right": 6,
-                  "top": 6,
-                }
-              }
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+            <Text
+              accessibilityElementsHidden={true}
+              allowFontScaling={false}
+              importantForAccessibility="no-hide-descendants"
+              pointerEvents="none"
+              selectable={false}
               style={
                 Array [
                   Object {
-                    "overflow": "hidden",
+                    "color": "rgba(255, 255, 255, 0)",
+                    "fontSize": 24,
                   },
-                  false,
                   Array [
                     Object {
-                      "alignItems": "center",
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    },
-                    Object {
-                      "borderRadius": 20,
-                    },
-                  ],
-                ]
-              }
-              testID="icon-button"
-            >
-              <Text
-                accessibilityElementsHidden={true}
-                allowFontScaling={false}
-                importantForAccessibility="no-hide-descendants"
-                pointerEvents="none"
-                selectable={false}
-                style={
-                  Array [
-                    Object {
-                      "color": "rgba(73, 69, 79, 1)",
-                      "fontSize": 24,
-                    },
-                    Array [
-                      Object {
-                        "lineHeight": 24,
-                        "transform": Array [
-                          Object {
-                            "scaleX": 1,
-                          },
-                        ],
-                      },
-                      Object {
-                        "backgroundColor": "transparent",
-                      },
-                    ],
-                    Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                󰍉
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-      <TextInput
-        accessibilityRole="search"
-        keyboardAppearance="light"
-        placeholder="Search"
-        placeholderTextColor="rgba(28, 27, 31, 1)"
-        returnKeyType="search"
-        selectionColor="rgba(103, 80, 164, 1)"
-        style={
-          Array [
-            Object {
-              "alignSelf": "stretch",
-              "flex": 1,
-              "fontSize": 18,
-              "minWidth": 0,
-              "paddingLeft": 8,
-              "textAlign": "left",
-            },
-            Object {
-              "color": "rgba(73, 69, 79, 1)",
-              "fontFamily": "System",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "letterSpacing": 0.15,
-              "lineHeight": 0,
-            },
-            Object {
-              "minHeight": 56,
-              "paddingLeft": 0,
-            },
-            undefined,
-          ]
-        }
-        testID="search-bar"
-        underlineColorAndroid="transparent"
-        value=""
-      />
-      <View
-        pointerEvents="none"
-        style={
-          Array [
-            Object {
-              "marginLeft": 16,
-              "position": "absolute",
-              "right": 0,
-            },
-            false,
-          ]
-        }
-        testID="search-bar-icon-wrapper"
-      >
-        <View
-          collapsable={false}
-          style={
-            Object {
-              "alignSelf": undefined,
-              "bottom": undefined,
-              "end": undefined,
-              "flex": undefined,
-              "height": 40,
-              "left": undefined,
-              "margin": 6,
-              "opacity": undefined,
-              "position": undefined,
-              "right": undefined,
-              "shadowColor": "#000",
-              "shadowOffset": Object {
-                "height": 0,
-                "width": 0,
-              },
-              "shadowOpacity": 0,
-              "shadowRadius": 0,
-              "start": undefined,
-              "top": undefined,
-              "transform": undefined,
-              "width": 40,
-            }
-          }
-          testID="icon-button-container-outer-layer"
-        >
-          <View
-            collapsable={false}
-            style={
-              Object {
-                "flex": 1,
-                "shadowColor": "#000",
-                "shadowOffset": Object {
-                  "height": 0,
-                  "width": 0,
-                },
-                "shadowOpacity": 0,
-                "shadowRadius": 0,
-              }
-            }
-            testID="icon-button-container-middle-layer"
-          >
-            <View
-              collapsable={false}
-              style={
-                Object {
-                  "backgroundColor": "transparent",
-                  "borderColor": "rgba(121, 116, 126, 1)",
-                  "borderRadius": 20,
-                  "borderWidth": 0,
-                  "elevation": 0,
-                  "flex": 1,
-                  "overflow": "hidden",
-                }
-              }
-              testID="icon-button-container"
-            >
-              <View
-                accessibilityComponentType="button"
-                accessibilityLabel="clear"
-                accessibilityRole="button"
-                accessibilityState={
-                  Object {
-                    "disabled": false,
-                  }
-                }
-                accessibilityTraits="button"
-                accessible={true}
-                centered={true}
-                collapsable={false}
-                focusable={true}
-                hitSlop={
-                  Object {
-                    "bottom": 6,
-                    "left": 6,
-                    "right": 6,
-                    "top": 6,
-                  }
-                }
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  Array [
-                    Object {
-                      "overflow": "hidden",
-                    },
-                    false,
-                    Array [
-                      Object {
-                        "alignItems": "center",
-                        "flexGrow": 1,
-                        "justifyContent": "center",
-                      },
-                      Object {
-                        "borderRadius": 20,
-                      },
-                    ],
-                  ]
-                }
-                testID="icon-button"
-              >
-                <Text
-                  accessibilityElementsHidden={true}
-                  allowFontScaling={false}
-                  importantForAccessibility="no-hide-descendants"
-                  pointerEvents="none"
-                  selectable={false}
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgba(255, 255, 255, 0)",
-                        "fontSize": 24,
-                      },
-                      Array [
+                      "lineHeight": 24,
+                      "transform": Array [
                         Object {
-                          "lineHeight": 24,
-                          "transform": Array [
-                            Object {
-                              "scaleX": 1,
-                            },
-                          ],
-                        },
-                        Object {
-                          "backgroundColor": "transparent",
+                          "scaleX": 1,
                         },
                       ],
-                      Object {
-                        "fontFamily": "Material Design Icons",
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
-                      },
-                      Object {},
-                    ]
-                  }
-                >
-                  󰅖
-                </Text>
-              </View>
-            </View>
+                    },
+                    Object {
+                      "backgroundColor": "transparent",
+                    },
+                  ],
+                  Object {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  Object {},
+                ]
+              }
+            >
+              󰅖
+            </Text>
           </View>
         </View>
       </View>
@@ -897,7 +847,11 @@ exports[`renders with text 1`] = `
     collapsable={false}
     style={
       Object {
+        "alignItems": "center",
+        "backgroundColor": "rgb(238, 232, 244)",
+        "borderRadius": 28,
         "flex": undefined,
+        "flexDirection": "row",
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -907,20 +861,194 @@ exports[`renders with text 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="search-bar-container-middle-layer"
+    testID="search-bar-container"
   >
     <View
       collapsable={false}
       style={
         Object {
-          "alignItems": "center",
-          "backgroundColor": "rgb(238, 232, 244)",
-          "borderRadius": 28,
+          "alignSelf": undefined,
+          "bottom": undefined,
+          "end": undefined,
           "flex": undefined,
-          "flexDirection": "row",
+          "height": 40,
+          "left": undefined,
+          "margin": 6,
+          "opacity": undefined,
+          "position": undefined,
+          "right": undefined,
+          "shadowColor": "#000",
+          "shadowOffset": Object {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+          "start": undefined,
+          "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
-      testID="search-bar-container"
+      testID="icon-button-container-outer-layer"
+    >
+      <View
+        collapsable={false}
+        style={
+          Object {
+            "backgroundColor": "transparent",
+            "borderColor": "rgba(121, 116, 126, 1)",
+            "borderRadius": 20,
+            "borderWidth": 0,
+            "elevation": 0,
+            "flex": 1,
+            "overflow": "hidden",
+            "shadowColor": "#000",
+            "shadowOffset": Object {
+              "height": 0,
+              "width": 0,
+            },
+            "shadowOpacity": 0,
+            "shadowRadius": 0,
+          }
+        }
+        testID="icon-button-container"
+      >
+        <View
+          accessibilityComponentType="button"
+          accessibilityLabel="search"
+          accessibilityRole="button"
+          accessibilityState={
+            Object {
+              "disabled": true,
+            }
+          }
+          accessibilityTraits="button"
+          accessible={true}
+          centered={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 6,
+              "left": 6,
+              "right": 6,
+              "top": 6,
+            }
+          }
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              false,
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                Object {
+                  "borderRadius": 20,
+                },
+              ],
+            ]
+          }
+          testID="icon-button"
+        >
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
+            style={
+              Array [
+                Object {
+                  "color": "rgba(73, 69, 79, 1)",
+                  "fontSize": 24,
+                },
+                Array [
+                  Object {
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  Object {
+                    "backgroundColor": "transparent",
+                  },
+                ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            󰍉
+          </Text>
+        </View>
+      </View>
+    </View>
+    <TextInput
+      accessibilityRole="search"
+      keyboardAppearance="light"
+      placeholder="Search"
+      placeholderTextColor="rgba(28, 27, 31, 1)"
+      returnKeyType="search"
+      selectionColor="rgba(103, 80, 164, 1)"
+      style={
+        Array [
+          Object {
+            "alignSelf": "stretch",
+            "flex": 1,
+            "fontSize": 18,
+            "minWidth": 0,
+            "paddingLeft": 8,
+            "textAlign": "left",
+          },
+          Object {
+            "color": "rgba(73, 69, 79, 1)",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "letterSpacing": 0.15,
+            "lineHeight": 0,
+          },
+          Object {
+            "minHeight": 56,
+            "paddingLeft": 0,
+          },
+          undefined,
+        ]
+      }
+      testID="search-bar"
+      underlineColorAndroid="transparent"
+      value="query"
+    />
+    <View
+      pointerEvents="auto"
+      style={
+        Array [
+          false,
+          false,
+        ]
+      }
+      testID="search-bar-icon-wrapper"
     >
       <View
         collapsable={false}
@@ -955,7 +1083,13 @@ exports[`renders with text 1`] = `
           collapsable={false}
           style={
             Object {
+              "backgroundColor": "transparent",
+              "borderColor": "rgba(121, 116, 126, 1)",
+              "borderRadius": 20,
+              "borderWidth": 0,
+              "elevation": 0,
               "flex": 1,
+              "overflow": "hidden",
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -965,309 +1099,95 @@ exports[`renders with text 1`] = `
               "shadowRadius": 0,
             }
           }
-          testID="icon-button-container-middle-layer"
+          testID="icon-button-container"
         >
           <View
-            collapsable={false}
-            style={
+            accessibilityComponentType="button"
+            accessibilityLabel="clear"
+            accessibilityRole="button"
+            accessibilityState={
               Object {
-                "backgroundColor": "transparent",
-                "borderColor": "rgba(121, 116, 126, 1)",
-                "borderRadius": 20,
-                "borderWidth": 0,
-                "elevation": 0,
-                "flex": 1,
-                "overflow": "hidden",
+                "disabled": false,
               }
             }
-            testID="icon-button-container"
+            accessibilityTraits="button"
+            accessible={true}
+            centered={true}
+            collapsable={false}
+            focusable={true}
+            hitSlop={
+              Object {
+                "bottom": 6,
+                "left": 6,
+                "right": 6,
+                "top": 6,
+              }
+            }
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                false,
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                  },
+                  Object {
+                    "borderRadius": 20,
+                  },
+                ],
+              ]
+            }
+            testID="icon-button"
           >
-            <View
-              accessibilityComponentType="button"
-              accessibilityLabel="search"
-              accessibilityRole="button"
-              accessibilityState={
-                Object {
-                  "disabled": true,
-                }
-              }
-              accessibilityTraits="button"
-              accessible={true}
-              centered={true}
-              collapsable={false}
-              focusable={true}
-              hitSlop={
-                Object {
-                  "bottom": 6,
-                  "left": 6,
-                  "right": 6,
-                  "top": 6,
-                }
-              }
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
+            <Text
+              accessibilityElementsHidden={true}
+              allowFontScaling={false}
+              importantForAccessibility="no-hide-descendants"
+              pointerEvents="none"
+              selectable={false}
               style={
                 Array [
                   Object {
-                    "overflow": "hidden",
+                    "color": "rgba(73, 69, 79, 1)",
+                    "fontSize": 24,
                   },
-                  false,
                   Array [
                     Object {
-                      "alignItems": "center",
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    },
-                    Object {
-                      "borderRadius": 20,
-                    },
-                  ],
-                ]
-              }
-              testID="icon-button"
-            >
-              <Text
-                accessibilityElementsHidden={true}
-                allowFontScaling={false}
-                importantForAccessibility="no-hide-descendants"
-                pointerEvents="none"
-                selectable={false}
-                style={
-                  Array [
-                    Object {
-                      "color": "rgba(73, 69, 79, 1)",
-                      "fontSize": 24,
-                    },
-                    Array [
-                      Object {
-                        "lineHeight": 24,
-                        "transform": Array [
-                          Object {
-                            "scaleX": 1,
-                          },
-                        ],
-                      },
-                      Object {
-                        "backgroundColor": "transparent",
-                      },
-                    ],
-                    Object {
-                      "fontFamily": "Material Design Icons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                󰍉
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-      <TextInput
-        accessibilityRole="search"
-        keyboardAppearance="light"
-        placeholder="Search"
-        placeholderTextColor="rgba(28, 27, 31, 1)"
-        returnKeyType="search"
-        selectionColor="rgba(103, 80, 164, 1)"
-        style={
-          Array [
-            Object {
-              "alignSelf": "stretch",
-              "flex": 1,
-              "fontSize": 18,
-              "minWidth": 0,
-              "paddingLeft": 8,
-              "textAlign": "left",
-            },
-            Object {
-              "color": "rgba(73, 69, 79, 1)",
-              "fontFamily": "System",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "letterSpacing": 0.15,
-              "lineHeight": 0,
-            },
-            Object {
-              "minHeight": 56,
-              "paddingLeft": 0,
-            },
-            undefined,
-          ]
-        }
-        testID="search-bar"
-        underlineColorAndroid="transparent"
-        value="query"
-      />
-      <View
-        pointerEvents="auto"
-        style={
-          Array [
-            false,
-            false,
-          ]
-        }
-        testID="search-bar-icon-wrapper"
-      >
-        <View
-          collapsable={false}
-          style={
-            Object {
-              "alignSelf": undefined,
-              "bottom": undefined,
-              "end": undefined,
-              "flex": undefined,
-              "height": 40,
-              "left": undefined,
-              "margin": 6,
-              "opacity": undefined,
-              "position": undefined,
-              "right": undefined,
-              "shadowColor": "#000",
-              "shadowOffset": Object {
-                "height": 0,
-                "width": 0,
-              },
-              "shadowOpacity": 0,
-              "shadowRadius": 0,
-              "start": undefined,
-              "top": undefined,
-              "transform": undefined,
-              "width": 40,
-            }
-          }
-          testID="icon-button-container-outer-layer"
-        >
-          <View
-            collapsable={false}
-            style={
-              Object {
-                "flex": 1,
-                "shadowColor": "#000",
-                "shadowOffset": Object {
-                  "height": 0,
-                  "width": 0,
-                },
-                "shadowOpacity": 0,
-                "shadowRadius": 0,
-              }
-            }
-            testID="icon-button-container-middle-layer"
-          >
-            <View
-              collapsable={false}
-              style={
-                Object {
-                  "backgroundColor": "transparent",
-                  "borderColor": "rgba(121, 116, 126, 1)",
-                  "borderRadius": 20,
-                  "borderWidth": 0,
-                  "elevation": 0,
-                  "flex": 1,
-                  "overflow": "hidden",
-                }
-              }
-              testID="icon-button-container"
-            >
-              <View
-                accessibilityComponentType="button"
-                accessibilityLabel="clear"
-                accessibilityRole="button"
-                accessibilityState={
-                  Object {
-                    "disabled": false,
-                  }
-                }
-                accessibilityTraits="button"
-                accessible={true}
-                centered={true}
-                collapsable={false}
-                focusable={true}
-                hitSlop={
-                  Object {
-                    "bottom": 6,
-                    "left": 6,
-                    "right": 6,
-                    "top": 6,
-                  }
-                }
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  Array [
-                    Object {
-                      "overflow": "hidden",
-                    },
-                    false,
-                    Array [
-                      Object {
-                        "alignItems": "center",
-                        "flexGrow": 1,
-                        "justifyContent": "center",
-                      },
-                      Object {
-                        "borderRadius": 20,
-                      },
-                    ],
-                  ]
-                }
-                testID="icon-button"
-              >
-                <Text
-                  accessibilityElementsHidden={true}
-                  allowFontScaling={false}
-                  importantForAccessibility="no-hide-descendants"
-                  pointerEvents="none"
-                  selectable={false}
-                  style={
-                    Array [
-                      Object {
-                        "color": "rgba(73, 69, 79, 1)",
-                        "fontSize": 24,
-                      },
-                      Array [
+                      "lineHeight": 24,
+                      "transform": Array [
                         Object {
-                          "lineHeight": 24,
-                          "transform": Array [
-                            Object {
-                              "scaleX": 1,
-                            },
-                          ],
-                        },
-                        Object {
-                          "backgroundColor": "transparent",
+                          "scaleX": 1,
                         },
                       ],
-                      Object {
-                        "fontFamily": "Material Design Icons",
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
-                      },
-                      Object {},
-                    ]
-                  }
-                >
-                  󰅖
-                </Text>
-              </View>
-            </View>
+                    },
+                    Object {
+                      "backgroundColor": "transparent",
+                    },
+                  ],
+                  Object {
+                    "fontFamily": "Material Design Icons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  Object {},
+                ]
+              }
+            >
+              󰅖
+            </Text>
           </View>
         </View>
       </View>

--- a/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
@@ -6,6 +6,8 @@ exports[`activity indicator snapshot test 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(238, 232, 244)",
+      "borderRadius": 28,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -54,6 +56,8 @@ exports[`activity indicator snapshot test 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
@@ -434,6 +438,8 @@ exports[`renders with placeholder 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(238, 232, 244)",
+      "borderRadius": 28,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -482,6 +488,8 @@ exports[`renders with placeholder 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
@@ -673,6 +681,8 @@ exports[`renders with placeholder 1`] = `
         style={
           Object {
             "alignSelf": undefined,
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,
@@ -820,6 +830,8 @@ exports[`renders with text 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgb(238, 232, 244)",
+      "borderRadius": 28,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -868,6 +880,8 @@ exports[`renders with text 1`] = `
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
@@ -1055,6 +1069,8 @@ exports[`renders with text 1`] = `
         style={
           Object {
             "alignSelf": undefined,
+            "backgroundColor": "transparent",
+            "borderRadius": 20,
             "bottom": undefined,
             "end": undefined,
             "flex": undefined,

--- a/src/components/__tests__/__snapshots__/Snackbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.tsx.snap
@@ -54,10 +54,17 @@ exports[`renders snackbar with Text as a child 1`] = `
     testID="surface-outer-layer"
   >
     <View
+      accessibilityLiveRegion="polite"
       collapsable={false}
+      pointerEvents="box-none"
       style={
         Object {
+          "backgroundColor": "rgba(49, 48, 51, 1)",
+          "borderRadius": 4,
           "flex": undefined,
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+          "minHeight": 48,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 1,
@@ -67,38 +74,21 @@ exports[`renders snackbar with Text as a child 1`] = `
           "shadowRadius": 2,
         }
       }
-      testID="surface-middle-layer"
+      testID="surface"
     >
       <View
-        accessibilityLiveRegion="polite"
-        collapsable={false}
-        pointerEvents="box-none"
         style={
           Object {
-            "backgroundColor": "rgba(49, 48, 51, 1)",
-            "borderRadius": 4,
-            "flex": undefined,
-            "flexDirection": "row",
-            "justifyContent": "space-between",
-            "minHeight": 48,
+            "flex": 1,
+            "marginHorizontal": 16,
+            "marginVertical": 14,
           }
         }
-        testID="surface"
       >
-        <View
-          style={
-            Object {
-              "flex": 1,
-              "marginHorizontal": 16,
-              "marginVertical": 14,
-            }
-          }
-        >
-          <View>
-            <Text>
-              Snackbar content
-            </Text>
-          </View>
+        <View>
+          <Text>
+            Snackbar content
+          </Text>
         </View>
       </View>
     </View>
@@ -158,10 +148,17 @@ exports[`renders snackbar with View & Text as a child 1`] = `
     testID="surface-outer-layer"
   >
     <View
+      accessibilityLiveRegion="polite"
       collapsable={false}
+      pointerEvents="box-none"
       style={
         Object {
+          "backgroundColor": "rgba(49, 48, 51, 1)",
+          "borderRadius": 4,
           "flex": undefined,
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+          "minHeight": 48,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 1,
@@ -171,63 +168,46 @@ exports[`renders snackbar with View & Text as a child 1`] = `
           "shadowRadius": 2,
         }
       }
-      testID="surface-middle-layer"
+      testID="surface"
     >
       <View
-        accessibilityLiveRegion="polite"
-        collapsable={false}
-        pointerEvents="box-none"
         style={
           Object {
-            "backgroundColor": "rgba(49, 48, 51, 1)",
-            "borderRadius": 4,
-            "flex": undefined,
-            "flexDirection": "row",
-            "justifyContent": "space-between",
-            "minHeight": 48,
+            "flex": 1,
+            "marginHorizontal": 16,
+            "marginVertical": 14,
           }
         }
-        testID="surface"
       >
-        <View
-          style={
-            Object {
-              "flex": 1,
-              "marginHorizontal": 16,
-              "marginVertical": 14,
+        <View>
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+              }
             }
-          }
-        >
-          <View>
+          >
             <View
               style={
                 Object {
-                  "alignItems": "center",
-                  "flexDirection": "row",
+                  "backgroundColor": "#ef9a9a",
+                  "padding": 15,
+                }
+              }
+            />
+            <Text
+              style={
+                Object {
+                  "color": "#ffffff",
+                  "flexShrink": 1,
+                  "flexWrap": "wrap",
+                  "marginLeft": 10,
                 }
               }
             >
-              <View
-                style={
-                  Object {
-                    "backgroundColor": "#ef9a9a",
-                    "padding": 15,
-                  }
-                }
-              />
-              <Text
-                style={
-                  Object {
-                    "color": "#ffffff",
-                    "flexShrink": 1,
-                    "flexWrap": "wrap",
-                    "marginLeft": 10,
-                  }
-                }
-              >
-                Error Message which is veryyyyyyyyyyyy longggggggg Error Message which is veryyyyyyyyyyyy longggggggg
-              </Text>
-            </View>
+              Error Message which is veryyyyyyyyyyyy longggggggg Error Message which is veryyyyyyyyyyyy longggggggg
+            </Text>
           </View>
         </View>
       </View>
@@ -288,10 +268,17 @@ exports[`renders snackbar with action button 1`] = `
     testID="surface-outer-layer"
   >
     <View
+      accessibilityLiveRegion="polite"
       collapsable={false}
+      pointerEvents="box-none"
       style={
         Object {
+          "backgroundColor": "rgba(49, 48, 51, 1)",
+          "borderRadius": 4,
           "flex": undefined,
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+          "minHeight": 48,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 1,
@@ -301,86 +288,96 @@ exports[`renders snackbar with action button 1`] = `
           "shadowRadius": 2,
         }
       }
-      testID="surface-middle-layer"
+      testID="surface"
     >
-      <View
-        accessibilityLiveRegion="polite"
-        collapsable={false}
-        pointerEvents="box-none"
+      <Text
         style={
-          Object {
-            "backgroundColor": "rgba(49, 48, 51, 1)",
-            "borderRadius": 4,
-            "flex": undefined,
-            "flexDirection": "row",
-            "justifyContent": "space-between",
-            "minHeight": 48,
-          }
+          Array [
+            Object {
+              "fontFamily": "System",
+              "fontSize": 14,
+              "fontWeight": "400",
+              "letterSpacing": 0.25,
+              "lineHeight": 20,
+            },
+            Object {
+              "textAlign": "left",
+            },
+            Object {
+              "color": "rgba(28, 27, 31, 1)",
+              "writingDirection": "ltr",
+            },
+            Array [
+              Object {
+                "flex": 1,
+                "marginHorizontal": 16,
+                "marginVertical": 14,
+              },
+              Object {
+                "color": "rgba(244, 239, 244, 1)",
+              },
+            ],
+          ]
         }
-        testID="surface"
       >
-        <Text
-          style={
-            Array [
-              Object {
-                "fontFamily": "System",
-                "fontSize": 14,
-                "fontWeight": "400",
-                "letterSpacing": 0.25,
-                "lineHeight": 20,
-              },
-              Object {
-                "textAlign": "left",
-              },
-              Object {
-                "color": "rgba(28, 27, 31, 1)",
-                "writingDirection": "ltr",
-              },
-              Array [
-                Object {
-                  "flex": 1,
-                  "marginHorizontal": 16,
-                  "marginVertical": 14,
-                },
-                Object {
-                  "color": "rgba(244, 239, 244, 1)",
-                },
-              ],
-            ]
-          }
-        >
-          Snackbar content
-        </Text>
+        Snackbar content
+      </Text>
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "flex-end",
+              "minHeight": 48,
+            },
+            Object {
+              "marginLeft": -12,
+            },
+          ]
+        }
+      >
         <View
+          collapsable={false}
           style={
-            Array [
-              Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "flex-end",
-                "minHeight": 48,
+            Object {
+              "alignSelf": undefined,
+              "bottom": undefined,
+              "end": undefined,
+              "flex": undefined,
+              "height": undefined,
+              "left": undefined,
+              "marginLeft": 4,
+              "marginRight": 8,
+              "opacity": undefined,
+              "position": undefined,
+              "right": undefined,
+              "shadowColor": "#000",
+              "shadowOffset": Object {
+                "height": 0,
+                "width": 0,
               },
-              Object {
-                "marginLeft": -12,
-              },
-            ]
+              "shadowOpacity": 0,
+              "shadowRadius": 0,
+              "start": undefined,
+              "top": undefined,
+              "transform": undefined,
+              "width": undefined,
+            }
           }
+          testID="button-container-outer-layer"
         >
           <View
             collapsable={false}
             style={
               Object {
-                "alignSelf": undefined,
-                "bottom": undefined,
-                "end": undefined,
+                "backgroundColor": "transparent",
+                "borderColor": "transparent",
+                "borderRadius": 20,
+                "borderStyle": "solid",
+                "borderWidth": 0,
                 "flex": undefined,
-                "height": undefined,
-                "left": undefined,
-                "marginLeft": 4,
-                "marginRight": 8,
-                "opacity": undefined,
-                "position": undefined,
-                "right": undefined,
+                "minWidth": 64,
                 "shadowColor": "#000",
                 "shadowOffset": Object {
                   "height": 0,
@@ -388,138 +385,101 @@ exports[`renders snackbar with action button 1`] = `
                 },
                 "shadowOpacity": 0,
                 "shadowRadius": 0,
-                "start": undefined,
-                "top": undefined,
-                "transform": undefined,
-                "width": undefined,
               }
             }
-            testID="button-container-outer-layer"
+            testID="button-container"
           >
             <View
-              collapsable={false}
-              style={
+              accessibilityRole="button"
+              accessibilityState={
                 Object {
-                  "flex": undefined,
-                  "shadowColor": "#000",
-                  "shadowOffset": Object {
-                    "height": 0,
-                    "width": 0,
-                  },
-                  "shadowOpacity": 0,
-                  "shadowRadius": 0,
+                  "disabled": false,
                 }
               }
-              testID="button-container-middle-layer"
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Array [
+                  Object {
+                    "overflow": "hidden",
+                  },
+                  false,
+                  Object {
+                    "borderRadius": 20,
+                  },
+                ]
+              }
+              testID="button"
             >
               <View
-                collapsable={false}
                 style={
-                  Object {
-                    "backgroundColor": "transparent",
-                    "borderColor": "transparent",
-                    "borderRadius": 20,
-                    "borderStyle": "solid",
-                    "borderWidth": 0,
-                    "flex": undefined,
-                    "minWidth": 64,
-                  }
-                }
-                testID="button-container"
-              >
-                <View
-                  accessibilityRole="button"
-                  accessibilityState={
+                  Array [
                     Object {
-                      "disabled": false,
-                    }
-                  }
-                  accessible={true}
-                  collapsable={false}
-                  focusable={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "justifyContent": "center",
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                <Text
+                  numberOfLines={1}
+                  selectable={false}
                   style={
                     Array [
                       Object {
-                        "overflow": "hidden",
+                        "fontFamily": "System",
+                        "fontSize": 14,
+                        "fontWeight": "500",
+                        "letterSpacing": 0.1,
+                        "lineHeight": 20,
                       },
-                      false,
                       Object {
-                        "borderRadius": 20,
+                        "textAlign": "left",
                       },
-                    ]
-                  }
-                  testID="button"
-                >
-                  <View
-                    style={
+                      Object {
+                        "color": "rgba(28, 27, 31, 1)",
+                        "writingDirection": "ltr",
+                      },
                       Array [
                         Object {
-                          "alignItems": "center",
-                          "flexDirection": "row",
-                          "justifyContent": "center",
+                          "marginHorizontal": 16,
+                          "marginVertical": 9,
+                          "textAlign": "center",
+                        },
+                        false,
+                        Object {
+                          "marginHorizontal": 12,
+                        },
+                        false,
+                        false,
+                        Object {
+                          "color": "rgba(208, 188, 255, 1)",
+                          "fontFamily": "System",
+                          "fontSize": 14,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.1,
+                          "lineHeight": 20,
                         },
                         undefined,
-                      ]
-                    }
-                  >
-                    <Text
-                      numberOfLines={1}
-                      selectable={false}
-                      style={
-                        Array [
-                          Object {
-                            "fontFamily": "System",
-                            "fontSize": 14,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.1,
-                            "lineHeight": 20,
-                          },
-                          Object {
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "color": "rgba(28, 27, 31, 1)",
-                            "writingDirection": "ltr",
-                          },
-                          Array [
-                            Object {
-                              "marginHorizontal": 16,
-                              "marginVertical": 9,
-                              "textAlign": "center",
-                            },
-                            false,
-                            Object {
-                              "marginHorizontal": 12,
-                            },
-                            false,
-                            false,
-                            Object {
-                              "color": "rgba(208, 188, 255, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 14,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.1,
-                              "lineHeight": 20,
-                            },
-                            undefined,
-                          ],
-                        ]
-                      }
-                      testID="button-text"
-                    >
-                      Undo
-                    </Text>
-                  </View>
-                </View>
+                      ],
+                    ]
+                  }
+                  testID="button-text"
+                >
+                  Undo
+                </Text>
               </View>
             </View>
           </View>
@@ -582,10 +542,17 @@ exports[`renders snackbar with content 1`] = `
     testID="surface-outer-layer"
   >
     <View
+      accessibilityLiveRegion="polite"
       collapsable={false}
+      pointerEvents="box-none"
       style={
         Object {
+          "backgroundColor": "rgba(49, 48, 51, 1)",
+          "borderRadius": 4,
           "flex": undefined,
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+          "minHeight": 48,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 1,
@@ -595,57 +562,40 @@ exports[`renders snackbar with content 1`] = `
           "shadowRadius": 2,
         }
       }
-      testID="surface-middle-layer"
+      testID="surface"
     >
-      <View
-        accessibilityLiveRegion="polite"
-        collapsable={false}
-        pointerEvents="box-none"
+      <Text
         style={
-          Object {
-            "backgroundColor": "rgba(49, 48, 51, 1)",
-            "borderRadius": 4,
-            "flex": undefined,
-            "flexDirection": "row",
-            "justifyContent": "space-between",
-            "minHeight": 48,
-          }
-        }
-        testID="surface"
-      >
-        <Text
-          style={
+          Array [
+            Object {
+              "fontFamily": "System",
+              "fontSize": 14,
+              "fontWeight": "400",
+              "letterSpacing": 0.25,
+              "lineHeight": 20,
+            },
+            Object {
+              "textAlign": "left",
+            },
+            Object {
+              "color": "rgba(28, 27, 31, 1)",
+              "writingDirection": "ltr",
+            },
             Array [
               Object {
-                "fontFamily": "System",
-                "fontSize": 14,
-                "fontWeight": "400",
-                "letterSpacing": 0.25,
-                "lineHeight": 20,
+                "flex": 1,
+                "marginHorizontal": 16,
+                "marginVertical": 14,
               },
               Object {
-                "textAlign": "left",
+                "color": "rgba(244, 239, 244, 1)",
               },
-              Object {
-                "color": "rgba(28, 27, 31, 1)",
-                "writingDirection": "ltr",
-              },
-              Array [
-                Object {
-                  "flex": 1,
-                  "marginHorizontal": 16,
-                  "marginVertical": 14,
-                },
-                Object {
-                  "color": "rgba(244, 239, 244, 1)",
-                },
-              ],
-            ]
-          }
-        >
-          Snackbar content
-        </Text>
-      </View>
+            ],
+          ]
+        }
+      >
+        Snackbar content
+      </Text>
     </View>
   </View>
 </View>

--- a/src/components/__tests__/__snapshots__/Snackbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.tsx.snap
@@ -28,7 +28,10 @@ exports[`renders snackbar with Text as a child 1`] = `
         "bottom": undefined,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": undefined,
+        "margin": 8,
+        "opacity": 1,
         "position": undefined,
         "right": undefined,
         "shadowColor": "#000",
@@ -40,6 +43,12 @@ exports[`renders snackbar with Text as a child 1`] = `
         "shadowRadius": 6,
         "start": undefined,
         "top": undefined,
+        "transform": Array [
+          Object {
+            "scale": 1,
+          },
+        ],
+        "width": undefined,
       }
     }
     testID="surface-outer-layer"
@@ -58,7 +67,7 @@ exports[`renders snackbar with Text as a child 1`] = `
           "shadowRadius": 2,
         }
       }
-      testID="surface-inner-layer"
+      testID="surface-middle-layer"
     >
       <View
         accessibilityLiveRegion="polite"
@@ -71,14 +80,7 @@ exports[`renders snackbar with Text as a child 1`] = `
             "flex": undefined,
             "flexDirection": "row",
             "justifyContent": "space-between",
-            "margin": 8,
             "minHeight": 48,
-            "opacity": 1,
-            "transform": Array [
-              Object {
-                "scale": 1,
-              },
-            ],
           }
         }
         testID="surface"
@@ -130,7 +132,10 @@ exports[`renders snackbar with View & Text as a child 1`] = `
         "bottom": undefined,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": undefined,
+        "margin": 8,
+        "opacity": 1,
         "position": undefined,
         "right": undefined,
         "shadowColor": "#000",
@@ -142,6 +147,12 @@ exports[`renders snackbar with View & Text as a child 1`] = `
         "shadowRadius": 6,
         "start": undefined,
         "top": undefined,
+        "transform": Array [
+          Object {
+            "scale": 1,
+          },
+        ],
+        "width": undefined,
       }
     }
     testID="surface-outer-layer"
@@ -160,7 +171,7 @@ exports[`renders snackbar with View & Text as a child 1`] = `
           "shadowRadius": 2,
         }
       }
-      testID="surface-inner-layer"
+      testID="surface-middle-layer"
     >
       <View
         accessibilityLiveRegion="polite"
@@ -173,14 +184,7 @@ exports[`renders snackbar with View & Text as a child 1`] = `
             "flex": undefined,
             "flexDirection": "row",
             "justifyContent": "space-between",
-            "margin": 8,
             "minHeight": 48,
-            "opacity": 1,
-            "transform": Array [
-              Object {
-                "scale": 1,
-              },
-            ],
           }
         }
         testID="surface"
@@ -258,7 +262,10 @@ exports[`renders snackbar with action button 1`] = `
         "bottom": undefined,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": undefined,
+        "margin": 8,
+        "opacity": 1,
         "position": undefined,
         "right": undefined,
         "shadowColor": "#000",
@@ -270,6 +277,12 @@ exports[`renders snackbar with action button 1`] = `
         "shadowRadius": 6,
         "start": undefined,
         "top": undefined,
+        "transform": Array [
+          Object {
+            "scale": 1,
+          },
+        ],
+        "width": undefined,
       }
     }
     testID="surface-outer-layer"
@@ -288,7 +301,7 @@ exports[`renders snackbar with action button 1`] = `
           "shadowRadius": 2,
         }
       }
-      testID="surface-inner-layer"
+      testID="surface-middle-layer"
     >
       <View
         accessibilityLiveRegion="polite"
@@ -301,14 +314,7 @@ exports[`renders snackbar with action button 1`] = `
             "flex": undefined,
             "flexDirection": "row",
             "justifyContent": "space-between",
-            "margin": 8,
             "minHeight": 48,
-            "opacity": 1,
-            "transform": Array [
-              Object {
-                "scale": 1,
-              },
-            ],
           }
         }
         testID="surface"
@@ -368,7 +374,11 @@ exports[`renders snackbar with action button 1`] = `
                 "bottom": undefined,
                 "end": undefined,
                 "flex": undefined,
+                "height": undefined,
                 "left": undefined,
+                "marginLeft": 4,
+                "marginRight": 8,
+                "opacity": undefined,
                 "position": undefined,
                 "right": undefined,
                 "shadowColor": "#000",
@@ -380,6 +390,8 @@ exports[`renders snackbar with action button 1`] = `
                 "shadowRadius": 0,
                 "start": undefined,
                 "top": undefined,
+                "transform": undefined,
+                "width": undefined,
               }
             }
             testID="button-container-outer-layer"
@@ -398,7 +410,7 @@ exports[`renders snackbar with action button 1`] = `
                   "shadowRadius": 0,
                 }
               }
-              testID="button-container-inner-layer"
+              testID="button-container-middle-layer"
             >
               <View
                 collapsable={false}
@@ -410,8 +422,6 @@ exports[`renders snackbar with action button 1`] = `
                     "borderStyle": "solid",
                     "borderWidth": 0,
                     "flex": undefined,
-                    "marginLeft": 4,
-                    "marginRight": 8,
                     "minWidth": 64,
                   }
                 }
@@ -546,7 +556,10 @@ exports[`renders snackbar with content 1`] = `
         "bottom": undefined,
         "end": undefined,
         "flex": undefined,
+        "height": undefined,
         "left": undefined,
+        "margin": 8,
+        "opacity": 1,
         "position": undefined,
         "right": undefined,
         "shadowColor": "#000",
@@ -558,6 +571,12 @@ exports[`renders snackbar with content 1`] = `
         "shadowRadius": 6,
         "start": undefined,
         "top": undefined,
+        "transform": Array [
+          Object {
+            "scale": 1,
+          },
+        ],
+        "width": undefined,
       }
     }
     testID="surface-outer-layer"
@@ -576,7 +595,7 @@ exports[`renders snackbar with content 1`] = `
           "shadowRadius": 2,
         }
       }
-      testID="surface-inner-layer"
+      testID="surface-middle-layer"
     >
       <View
         accessibilityLiveRegion="polite"
@@ -589,14 +608,7 @@ exports[`renders snackbar with content 1`] = `
             "flex": undefined,
             "flexDirection": "row",
             "justifyContent": "space-between",
-            "margin": 8,
             "minHeight": 48,
-            "opacity": 1,
-            "transform": Array [
-              Object {
-                "scale": 1,
-              },
-            ],
           }
         }
         testID="surface"

--- a/src/components/__tests__/__snapshots__/Snackbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.tsx.snap
@@ -25,6 +25,8 @@ exports[`renders snackbar with Text as a child 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "rgba(49, 48, 51, 1)",
+        "borderRadius": 4,
         "bottom": undefined,
         "end": undefined,
         "flex": undefined,
@@ -119,6 +121,8 @@ exports[`renders snackbar with View & Text as a child 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "rgba(49, 48, 51, 1)",
+        "borderRadius": 4,
         "bottom": undefined,
         "end": undefined,
         "flex": undefined,
@@ -239,6 +243,8 @@ exports[`renders snackbar with action button 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "rgba(49, 48, 51, 1)",
+        "borderRadius": 4,
         "bottom": undefined,
         "end": undefined,
         "flex": undefined,
@@ -342,6 +348,8 @@ exports[`renders snackbar with action button 1`] = `
           style={
             Object {
               "alignSelf": undefined,
+              "backgroundColor": "transparent",
+              "borderRadius": 20,
               "bottom": undefined,
               "end": undefined,
               "flex": undefined,
@@ -513,6 +521,8 @@ exports[`renders snackbar with content 1`] = `
     style={
       Object {
         "alignSelf": undefined,
+        "backgroundColor": "rgba(49, 48, 51, 1)",
+        "borderRadius": 4,
         "bottom": undefined,
         "end": undefined,
         "flex": undefined,

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -1296,7 +1296,13 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderColor": "rgba(121, 116, 126, 1)",
+            "borderRadius": 20,
+            "borderWidth": 0,
+            "elevation": 0,
             "flex": 1,
+            "overflow": "hidden",
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1306,110 +1312,94 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
             "shadowRadius": 0,
           }
         }
-        testID="right-icon-adornment-container-middle-layer"
+        testID="right-icon-adornment-container"
       >
         <View
-          collapsable={false}
-          style={
+          accessibilityComponentType="button"
+          accessibilityRole="button"
+          accessibilityState={
             Object {
-              "backgroundColor": "transparent",
-              "borderColor": "rgba(121, 116, 126, 1)",
-              "borderRadius": 20,
-              "borderWidth": 0,
-              "elevation": 0,
-              "flex": 1,
-              "overflow": "hidden",
+              "disabled": false,
             }
           }
-          testID="right-icon-adornment-container"
+          accessibilityTraits="button"
+          accessible={true}
+          centered={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 6,
+              "left": 6,
+              "right": 6,
+              "top": 6,
+            }
+          }
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              false,
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                Object {
+                  "borderRadius": 20,
+                },
+              ],
+            ]
+          }
+          testID="right-icon-adornment"
         >
-          <View
-            accessibilityComponentType="button"
-            accessibilityRole="button"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessibilityTraits="button"
-            accessible={true}
-            centered={true}
-            collapsable={false}
-            focusable={true}
-            hitSlop={
-              Object {
-                "bottom": 6,
-                "left": 6,
-                "right": 6,
-                "top": 6,
-              }
-            }
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
             style={
               Array [
                 Object {
-                  "overflow": "hidden",
+                  "color": "rgba(73, 69, 79, 1)",
+                  "fontSize": 24,
                 },
-                false,
                 Array [
                   Object {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
                   },
                   Object {
-                    "borderRadius": 20,
+                    "backgroundColor": "transparent",
                   },
                 ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
               ]
             }
-            testID="right-icon-adornment"
           >
-            <Text
-              accessibilityElementsHidden={true}
-              allowFontScaling={false}
-              importantForAccessibility="no-hide-descendants"
-              pointerEvents="none"
-              selectable={false}
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(73, 69, 79, 1)",
-                    "fontSize": 24,
-                  },
-                  Array [
-                    Object {
-                      "lineHeight": 24,
-                      "transform": Array [
-                        Object {
-                          "scaleX": 1,
-                        },
-                      ],
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ],
-                  Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
-              }
-            >
-              󰋑
-            </Text>
-          </View>
+            󰋑
+          </Text>
         </View>
       </View>
     </View>
@@ -1660,7 +1650,13 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
         collapsable={false}
         style={
           Object {
+            "backgroundColor": "transparent",
+            "borderColor": "rgba(121, 116, 126, 1)",
+            "borderRadius": 20,
+            "borderWidth": 0,
+            "elevation": 0,
             "flex": 1,
+            "overflow": "hidden",
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1670,110 +1666,94 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
             "shadowRadius": 0,
           }
         }
-        testID="left-icon-adornment-container-middle-layer"
+        testID="left-icon-adornment-container"
       >
         <View
-          collapsable={false}
-          style={
+          accessibilityComponentType="button"
+          accessibilityRole="button"
+          accessibilityState={
             Object {
-              "backgroundColor": "transparent",
-              "borderColor": "rgba(121, 116, 126, 1)",
-              "borderRadius": 20,
-              "borderWidth": 0,
-              "elevation": 0,
-              "flex": 1,
-              "overflow": "hidden",
+              "disabled": false,
             }
           }
-          testID="left-icon-adornment-container"
+          accessibilityTraits="button"
+          accessible={true}
+          centered={true}
+          collapsable={false}
+          focusable={true}
+          hitSlop={
+            Object {
+              "bottom": 6,
+              "left": 6,
+              "right": 6,
+              "top": 6,
+            }
+          }
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Array [
+              Object {
+                "overflow": "hidden",
+              },
+              false,
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                Object {
+                  "borderRadius": 20,
+                },
+              ],
+            ]
+          }
+          testID="left-icon-adornment"
         >
-          <View
-            accessibilityComponentType="button"
-            accessibilityRole="button"
-            accessibilityState={
-              Object {
-                "disabled": false,
-              }
-            }
-            accessibilityTraits="button"
-            accessible={true}
-            centered={true}
-            collapsable={false}
-            focusable={true}
-            hitSlop={
-              Object {
-                "bottom": 6,
-                "left": 6,
-                "right": 6,
-                "top": 6,
-              }
-            }
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
             style={
               Array [
                 Object {
-                  "overflow": "hidden",
+                  "color": "rgba(73, 69, 79, 1)",
+                  "fontSize": 24,
                 },
-                false,
                 Array [
                   Object {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
+                    "lineHeight": 24,
+                    "transform": Array [
+                      Object {
+                        "scaleX": 1,
+                      },
+                    ],
                   },
                   Object {
-                    "borderRadius": 20,
+                    "backgroundColor": "transparent",
                   },
                 ],
+                Object {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
               ]
             }
-            testID="left-icon-adornment"
           >
-            <Text
-              accessibilityElementsHidden={true}
-              allowFontScaling={false}
-              importantForAccessibility="no-hide-descendants"
-              pointerEvents="none"
-              selectable={false}
-              style={
-                Array [
-                  Object {
-                    "color": "rgba(73, 69, 79, 1)",
-                    "fontSize": 24,
-                  },
-                  Array [
-                    Object {
-                      "lineHeight": 24,
-                      "transform": Array [
-                        Object {
-                          "scaleX": 1,
-                        },
-                      ],
-                    },
-                    Object {
-                      "backgroundColor": "transparent",
-                    },
-                  ],
-                  Object {
-                    "fontFamily": "Material Design Icons",
-                    "fontStyle": "normal",
-                    "fontWeight": "normal",
-                  },
-                  Object {},
-                ]
-              }
-            >
-              󰋑
-            </Text>
-          </View>
+            󰋑
+          </Text>
         </View>
       </View>
     </View>

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -1271,7 +1271,10 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 0,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -1283,6 +1286,8 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="right-icon-adornment-container-outer-layer"
@@ -1291,7 +1296,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
         collapsable={false}
         style={
           Object {
-            "flex": undefined,
+            "flex": 1,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1301,22 +1306,19 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
             "shadowRadius": 0,
           }
         }
-        testID="right-icon-adornment-container-inner-layer"
+        testID="right-icon-adornment-container-middle-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
-              "backgroundColor": undefined,
+              "backgroundColor": "transparent",
               "borderColor": "rgba(121, 116, 126, 1)",
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
-              "flex": undefined,
-              "height": 40,
-              "margin": 0,
+              "flex": 1,
               "overflow": "hidden",
-              "width": 40,
             }
           }
           testID="right-icon-adornment-container"
@@ -1633,7 +1635,10 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
+          "height": 40,
           "left": undefined,
+          "margin": 0,
+          "opacity": undefined,
           "position": undefined,
           "right": undefined,
           "shadowColor": "#000",
@@ -1645,6 +1650,8 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
           "shadowRadius": 0,
           "start": undefined,
           "top": undefined,
+          "transform": undefined,
+          "width": 40,
         }
       }
       testID="left-icon-adornment-container-outer-layer"
@@ -1653,7 +1660,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
         collapsable={false}
         style={
           Object {
-            "flex": undefined,
+            "flex": 1,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1663,22 +1670,19 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
             "shadowRadius": 0,
           }
         }
-        testID="left-icon-adornment-container-inner-layer"
+        testID="left-icon-adornment-container-middle-layer"
       >
         <View
           collapsable={false}
           style={
             Object {
-              "backgroundColor": undefined,
+              "backgroundColor": "transparent",
               "borderColor": "rgba(121, 116, 126, 1)",
               "borderRadius": 20,
               "borderWidth": 0,
               "elevation": 0,
-              "flex": undefined,
-              "height": 40,
-              "margin": 0,
+              "flex": 1,
               "overflow": "hidden",
-              "width": 40,
             }
           }
           testID="left-icon-adornment-container"

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -1268,6 +1268,8 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,
@@ -1622,6 +1624,8 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
       style={
         Object {
           "alignSelf": undefined,
+          "backgroundColor": "transparent",
+          "borderRadius": 20,
           "bottom": undefined,
           "end": undefined,
           "flex": undefined,

--- a/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -34,7 +34,13 @@ exports[`renders disabled toggle button 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(29, 25, 43, 0.12)",
+        "borderColor": "rgba(121, 116, 126, 1)",
+        "borderRadius": 4,
+        "borderWidth": 0,
+        "elevation": 0,
         "flex": 1,
+        "overflow": "hidden",
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -44,114 +50,98 @@ exports[`renders disabled toggle button 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="icon-button-container-middle-layer"
+    testID="icon-button-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityComponentType="button"
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "rgba(29, 25, 43, 0.12)",
-          "borderColor": "rgba(121, 116, 126, 1)",
-          "borderRadius": 4,
-          "borderWidth": 0,
-          "elevation": 0,
-          "flex": 1,
-          "overflow": "hidden",
+          "disabled": true,
+          "selected": true,
         }
       }
-      testID="icon-button-container"
-    >
-      <View
-        accessibilityComponentType="button"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-            "selected": true,
-          }
+      accessibilityTraits={
+        Array [
+          "button",
+          "disabled",
+        ]
+      }
+      accessible={true}
+      centered={true}
+      collapsable={false}
+      focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 6,
+          "left": 6,
+          "right": 6,
+          "top": 6,
         }
-        accessibilityTraits={
+      }
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          false,
+          false,
           Array [
-            "button",
-            "disabled",
-          ]
-        }
-        accessible={true}
-        centered={true}
-        collapsable={false}
-        focusable={true}
-        hitSlop={
-          Object {
-            "bottom": 6,
-            "left": 6,
-            "right": 6,
-            "top": 6,
-          }
-        }
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+            Object {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            },
+            Object {
+              "borderRadius": 4,
+            },
+          ],
+        ]
+      }
+      testID="icon-button"
+    >
+      <Text
+        accessibilityElementsHidden={true}
+        allowFontScaling={false}
+        importantForAccessibility="no-hide-descendants"
+        pointerEvents="none"
+        selectable={false}
         style={
           Array [
-            false,
-            false,
+            Object {
+              "color": "rgba(28, 27, 31, 0.38)",
+              "fontSize": 24,
+            },
             Array [
               Object {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
+                "lineHeight": 24,
+                "transform": Array [
+                  Object {
+                    "scaleX": 1,
+                  },
+                ],
               },
               Object {
-                "borderRadius": 4,
+                "backgroundColor": "transparent",
               },
             ],
+            Object {
+              "fontFamily": "Material Design Icons",
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {},
           ]
         }
-        testID="icon-button"
       >
-        <Text
-          accessibilityElementsHidden={true}
-          allowFontScaling={false}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "rgba(28, 27, 31, 0.38)",
-                "fontSize": 24,
-              },
-              Array [
-                Object {
-                  "lineHeight": 24,
-                  "transform": Array [
-                    Object {
-                      "scaleX": 1,
-                    },
-                  ],
-                },
-                Object {
-                  "backgroundColor": "transparent",
-                },
-              ],
-              Object {
-                "fontFamily": "Material Design Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          󰋑
-        </Text>
-      </View>
+        󰋑
+      </Text>
     </View>
   </View>
 </View>
@@ -191,7 +181,13 @@ exports[`renders toggle button 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "rgba(29, 25, 43, 0.12)",
+        "borderColor": "rgba(121, 116, 126, 1)",
+        "borderRadius": 4,
+        "borderWidth": 0,
+        "elevation": 0,
         "flex": 1,
+        "overflow": "hidden",
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -201,109 +197,93 @@ exports[`renders toggle button 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="icon-button-container-middle-layer"
+    testID="icon-button-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityComponentType="button"
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "rgba(29, 25, 43, 0.12)",
-          "borderColor": "rgba(121, 116, 126, 1)",
-          "borderRadius": 4,
-          "borderWidth": 0,
-          "elevation": 0,
-          "flex": 1,
-          "overflow": "hidden",
+          "disabled": false,
+          "selected": true,
         }
       }
-      testID="icon-button-container"
+      accessibilityTraits="button"
+      accessible={true}
+      centered={true}
+      collapsable={false}
+      focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 6,
+          "left": 6,
+          "right": 6,
+          "top": 6,
+        }
+      }
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          false,
+          false,
+          Array [
+            Object {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            },
+            Object {
+              "borderRadius": 4,
+            },
+          ],
+        ]
+      }
+      testID="icon-button"
     >
-      <View
-        accessibilityComponentType="button"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": false,
-            "selected": true,
-          }
-        }
-        accessibilityTraits="button"
-        accessible={true}
-        centered={true}
-        collapsable={false}
-        focusable={true}
-        hitSlop={
-          Object {
-            "bottom": 6,
-            "left": 6,
-            "right": 6,
-            "top": 6,
-          }
-        }
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+      <Text
+        accessibilityElementsHidden={true}
+        allowFontScaling={false}
+        importantForAccessibility="no-hide-descendants"
+        pointerEvents="none"
+        selectable={false}
         style={
           Array [
-            false,
-            false,
+            Object {
+              "color": "rgba(73, 69, 79, 1)",
+              "fontSize": 24,
+            },
             Array [
               Object {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
+                "lineHeight": 24,
+                "transform": Array [
+                  Object {
+                    "scaleX": 1,
+                  },
+                ],
               },
               Object {
-                "borderRadius": 4,
+                "backgroundColor": "transparent",
               },
             ],
+            Object {
+              "fontFamily": "Material Design Icons",
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {},
           ]
         }
-        testID="icon-button"
       >
-        <Text
-          accessibilityElementsHidden={true}
-          allowFontScaling={false}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "rgba(73, 69, 79, 1)",
-                "fontSize": 24,
-              },
-              Array [
-                Object {
-                  "lineHeight": 24,
-                  "transform": Array [
-                    Object {
-                      "scaleX": 1,
-                    },
-                  ],
-                },
-                Object {
-                  "backgroundColor": "transparent",
-                },
-              ],
-              Object {
-                "fontFamily": "Material Design Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          󰋑
-        </Text>
-      </View>
+        󰋑
+      </Text>
     </View>
   </View>
 </View>
@@ -343,7 +323,13 @@ exports[`renders unchecked toggle button 1`] = `
     collapsable={false}
     style={
       Object {
+        "backgroundColor": "transparent",
+        "borderColor": "rgba(121, 116, 126, 1)",
+        "borderRadius": 4,
+        "borderWidth": 0,
+        "elevation": 0,
         "flex": 1,
+        "overflow": "hidden",
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -353,114 +339,98 @@ exports[`renders unchecked toggle button 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="icon-button-container-middle-layer"
+    testID="icon-button-container"
   >
     <View
-      collapsable={false}
-      style={
+      accessibilityComponentType="button"
+      accessibilityRole="button"
+      accessibilityState={
         Object {
-          "backgroundColor": "transparent",
-          "borderColor": "rgba(121, 116, 126, 1)",
-          "borderRadius": 4,
-          "borderWidth": 0,
-          "elevation": 0,
-          "flex": 1,
-          "overflow": "hidden",
+          "disabled": true,
+          "selected": false,
         }
       }
-      testID="icon-button-container"
-    >
-      <View
-        accessibilityComponentType="button"
-        accessibilityRole="button"
-        accessibilityState={
-          Object {
-            "disabled": true,
-            "selected": false,
-          }
+      accessibilityTraits={
+        Array [
+          "button",
+          "disabled",
+        ]
+      }
+      accessible={true}
+      centered={true}
+      collapsable={false}
+      focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 6,
+          "left": 6,
+          "right": 6,
+          "top": 6,
         }
-        accessibilityTraits={
+      }
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          false,
+          false,
           Array [
-            "button",
-            "disabled",
-          ]
-        }
-        accessible={true}
-        centered={true}
-        collapsable={false}
-        focusable={true}
-        hitSlop={
-          Object {
-            "bottom": 6,
-            "left": 6,
-            "right": 6,
-            "top": 6,
-          }
-        }
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
+            Object {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            },
+            Object {
+              "borderRadius": 4,
+            },
+          ],
+        ]
+      }
+      testID="icon-button"
+    >
+      <Text
+        accessibilityElementsHidden={true}
+        allowFontScaling={false}
+        importantForAccessibility="no-hide-descendants"
+        pointerEvents="none"
+        selectable={false}
         style={
           Array [
-            false,
-            false,
+            Object {
+              "color": "rgba(28, 27, 31, 0.38)",
+              "fontSize": 24,
+            },
             Array [
               Object {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
+                "lineHeight": 24,
+                "transform": Array [
+                  Object {
+                    "scaleX": 1,
+                  },
+                ],
               },
               Object {
-                "borderRadius": 4,
+                "backgroundColor": "transparent",
               },
             ],
+            Object {
+              "fontFamily": "Material Design Icons",
+              "fontStyle": "normal",
+              "fontWeight": "normal",
+            },
+            Object {},
           ]
         }
-        testID="icon-button"
       >
-        <Text
-          accessibilityElementsHidden={true}
-          allowFontScaling={false}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
-          style={
-            Array [
-              Object {
-                "color": "rgba(28, 27, 31, 0.38)",
-                "fontSize": 24,
-              },
-              Array [
-                Object {
-                  "lineHeight": 24,
-                  "transform": Array [
-                    Object {
-                      "scaleX": 1,
-                    },
-                  ],
-                },
-                Object {
-                  "backgroundColor": "transparent",
-                },
-              ],
-              Object {
-                "fontFamily": "Material Design Icons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              Object {},
-            ]
-          }
-        >
-          󰋑
-        </Text>
-      </View>
+        󰋑
+      </Text>
     </View>
   </View>
 </View>

--- a/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -9,7 +9,10 @@ exports[`renders disabled toggle button 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": 42,
       "left": undefined,
+      "margin": 0,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -21,6 +24,8 @@ exports[`renders disabled toggle button 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": 42,
     }
   }
   testID="icon-button-container-outer-layer"
@@ -29,7 +34,7 @@ exports[`renders disabled toggle button 1`] = `
     collapsable={false}
     style={
       Object {
-        "flex": undefined,
+        "flex": 1,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -39,7 +44,7 @@ exports[`renders disabled toggle button 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="icon-button-container-inner-layer"
+    testID="icon-button-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -50,11 +55,8 @@ exports[`renders disabled toggle button 1`] = `
           "borderRadius": 4,
           "borderWidth": 0,
           "elevation": 0,
-          "flex": undefined,
-          "height": 42,
-          "margin": 0,
+          "flex": 1,
           "overflow": "hidden",
-          "width": 42,
         }
       }
       testID="icon-button-container"
@@ -164,7 +166,10 @@ exports[`renders toggle button 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": 42,
       "left": undefined,
+      "margin": 0,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -176,6 +181,8 @@ exports[`renders toggle button 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": 42,
     }
   }
   testID="icon-button-container-outer-layer"
@@ -184,7 +191,7 @@ exports[`renders toggle button 1`] = `
     collapsable={false}
     style={
       Object {
-        "flex": undefined,
+        "flex": 1,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -194,7 +201,7 @@ exports[`renders toggle button 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="icon-button-container-inner-layer"
+    testID="icon-button-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -205,11 +212,8 @@ exports[`renders toggle button 1`] = `
           "borderRadius": 4,
           "borderWidth": 0,
           "elevation": 0,
-          "flex": undefined,
-          "height": 42,
-          "margin": 0,
+          "flex": 1,
           "overflow": "hidden",
-          "width": 42,
         }
       }
       testID="icon-button-container"
@@ -314,7 +318,10 @@ exports[`renders unchecked toggle button 1`] = `
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
+      "height": 42,
       "left": undefined,
+      "margin": 0,
+      "opacity": undefined,
       "position": undefined,
       "right": undefined,
       "shadowColor": "#000",
@@ -326,6 +333,8 @@ exports[`renders unchecked toggle button 1`] = `
       "shadowRadius": 0,
       "start": undefined,
       "top": undefined,
+      "transform": undefined,
+      "width": 42,
     }
   }
   testID="icon-button-container-outer-layer"
@@ -334,7 +343,7 @@ exports[`renders unchecked toggle button 1`] = `
     collapsable={false}
     style={
       Object {
-        "flex": undefined,
+        "flex": 1,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 0,
@@ -344,7 +353,7 @@ exports[`renders unchecked toggle button 1`] = `
         "shadowRadius": 0,
       }
     }
-    testID="icon-button-container-inner-layer"
+    testID="icon-button-container-middle-layer"
   >
     <View
       collapsable={false}
@@ -355,11 +364,8 @@ exports[`renders unchecked toggle button 1`] = `
           "borderRadius": 4,
           "borderWidth": 0,
           "elevation": 0,
-          "flex": undefined,
-          "height": 42,
-          "margin": 0,
+          "flex": 1,
           "overflow": "hidden",
-          "width": 42,
         }
       }
       testID="icon-button-container"

--- a/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -6,6 +6,8 @@ exports[`renders disabled toggle button 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(29, 25, 43, 0.12)",
+      "borderRadius": 4,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -153,6 +155,8 @@ exports[`renders toggle button 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "rgba(29, 25, 43, 0.12)",
+      "borderRadius": 4,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,
@@ -295,6 +299,8 @@ exports[`renders unchecked toggle button 1`] = `
   style={
     Object {
       "alignSelf": undefined,
+      "backgroundColor": "transparent",
+      "borderRadius": 4,
       "bottom": undefined,
       "end": undefined,
       "flex": undefined,

--- a/src/utils/__tests__/splitStyles.test.ts
+++ b/src/utils/__tests__/splitStyles.test.ts
@@ -1,0 +1,84 @@
+import type { ViewStyle } from 'react-native';
+
+import { splitStyles } from '../splitStyles';
+
+describe('splitStyles', () => {
+  const styles: Readonly<ViewStyle> = Object.freeze({
+    backgroundColor: 'red',
+    marginTop: 1,
+    marginBottom: 2,
+    marginLeft: 3,
+    padding: 4,
+    borderTopLeftRadius: 5,
+    borderTopRightRadius: 6,
+    right: 4,
+  });
+
+  it('splits margins, paddings, and border radiuses correctly', () => {
+    const marginPredicate = (style: string) => style.startsWith('margin');
+    const paddingPredicate = (style: string) => style.startsWith('padding');
+    const borderRadiusPredicate = (style: string) =>
+      style.startsWith('border') && style.endsWith('Radius');
+    const [filteredStyles, marginStyles, paddingStyles, borderRadiusStyles] =
+      splitStyles(
+        styles,
+        marginPredicate,
+        paddingPredicate,
+        borderRadiusPredicate
+      );
+
+    expect(keysLength(filteredStyles)).toBeGreaterThan(0);
+    expect(keysLength(filteredStyles)).toBeLessThan(keysLength(styles));
+    for (const style in filteredStyles) {
+      expect(marginPredicate(style)).toBeFalsy();
+      expect(paddingPredicate(style)).toBeFalsy();
+      expect(borderRadiusPredicate(style)).toBeFalsy();
+    }
+
+    expect(keysLength(marginStyles)).toBeGreaterThan(0);
+    for (const style in marginStyles) {
+      expect(marginPredicate(style)).toBeTruthy();
+    }
+
+    expect(keysLength(paddingStyles)).toBeGreaterThan(0);
+    for (const style in paddingStyles) {
+      expect(paddingPredicate(style)).toBeTruthy();
+    }
+
+    expect(keysLength(borderRadiusStyles)).toBeGreaterThan(0);
+    for (const style in borderRadiusStyles) {
+      expect(borderRadiusPredicate(style)).toBeTruthy();
+    }
+  });
+
+  it('filtered styles is an empty object if all styles matched some predicate', () => {
+    const styles = {
+      margin: 5,
+      padding: 6,
+    };
+    const [filteredStyles] = splitStyles(
+      styles,
+      (style) => style.startsWith('margin'),
+      (style) => style.startsWith('padding')
+    );
+
+    expect(keysLength(filteredStyles)).toBe(0);
+  });
+
+  it('processes predicates in order', () => {
+    const [, marginStyles, marginStyles2, marginStyles3] = splitStyles(
+      styles,
+      (style) => style.startsWith('margin'),
+      (style) => style.startsWith('margin'),
+      (style) => style.startsWith('margin')
+    );
+
+    expect(keysLength(marginStyles)).toBeGreaterThan(0);
+    expect(keysLength(marginStyles2)).toBe(0);
+    expect(keysLength(marginStyles3)).toBe(0);
+  });
+});
+
+function keysLength(object: object): number {
+  return Object.keys(object).length;
+}

--- a/src/utils/splitStyles.ts
+++ b/src/utils/splitStyles.ts
@@ -1,0 +1,64 @@
+import type { ViewStyle } from 'react-native';
+
+type FiltersArray = readonly ((style: string) => boolean)[];
+
+type MappedTuple<Tuple extends FiltersArray> = {
+  [Index in keyof Tuple]: ViewStyle;
+} & { length: Tuple['length'] };
+
+type Style = ViewStyle[keyof ViewStyle];
+type Entry = [string, Style];
+
+/**
+ * Utility function to extract styles in separate objects
+ *
+ * @param styles The style object you want to filter
+ * @param filters The filters by which you want to split the styles
+ * @returns An array of filtered style objects:
+ * - The first style object contains the properties that didn't match any filter
+ * - After that there will be a style object for each filter you passed in the same order as the matching filters
+ * - A style property will exist in a single style object, the first filter it matched
+ */
+export function splitStyles<Tuple extends FiltersArray>(
+  styles: ViewStyle,
+  ...filters: Tuple
+) {
+  if (process.env.NODE_ENV !== 'production' && filters.length === 0) {
+    console.error('No filters were passed when calling splitStyles');
+  }
+
+  // `Object.entries` will be used to iterate over the styles and `Object.fromEntries` will be called before returning
+  // Entries which match the given filters will be temporarily stored in `newStyles`
+  const newStyles = filters.map(returnEmptyArray<Entry>);
+
+  // Entries which match no filter
+  const rest: Entry[] = [];
+
+  // Iterate every style property
+  outer: for (const item of Object.entries(styles) as Entry[]) {
+    // Check each filter
+    for (let i = 0; i < filters.length; i++) {
+      // Check if filter matches
+      if (filters[i](item[0])) {
+        newStyles[i].push(item); // Push to temporary filtered entries array
+        continue outer; // Skip to checking next style property
+      }
+    }
+
+    // Adds to rest styles if not filtered
+    rest.push(item);
+  }
+
+  // Put unmatched styles in the beginning
+  newStyles.unshift(rest);
+
+  // Convert arrays of entries into objects
+  return newStyles.map((styles) => Object.fromEntries(styles)) as unknown as [
+    ViewStyle,
+    ...MappedTuple<Tuple>
+  ];
+}
+
+function returnEmptyArray<SomeArray>() {
+  return [] as SomeArray[];
+}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes #3733
Fixes #3593 
Closes #3681

Changes in this PR:
- Make `Surface` work fine with percentage widths and heights on iOS 
- Reduced `Surface` from 3 `Animated.View`s to 2 
- Moved `Surface` iOS logic in a separate component
- Memoized styles computation
- Applying the following styles only to the outer `Animated.View`:
  - `flex`
  - `width`
  - `height`
  - `opacity`
  - `translate`
  - `margin`s
- To fix #3593 I'm applying `borderRadius`es and `backgroundColor` to both `Animated.View`s

Affected components:
- `Appbar`
- `BottomNavigationBar`
- `Button`
- `Card`
- `Chip`
- `AnimatedFAB`
- `FAB`
- `IconButton`
- `Menu`
- `Surface`
- `Snackbar`
- `Searchbar`
- `Modal`
- `Banner`


|Before|After|
|-|-|
|![before](https://user-images.githubusercontent.com/8790386/224014299-3de5a40b-94d7-43ff-b949-dd0598ef8d33.png)|![after](https://user-images.githubusercontent.com/8790386/224014276-ac61cb43-c29a-42a6-a01d-dfaf4798adb4.png)|

<img width="543" alt="image" src="https://user-images.githubusercontent.com/8790386/224141357-4591c298-1969-444f-b825-fe2b5ecdbbba.png">

### Test plan

Percentage width and height is applied correctly. Everything else looks as before.