### PR TITLE
[draft] fix(require-cycles): remove require cycle between Appbar and AppbarHeader

### DIFF
--- a/src/components/Appbar/Appbar.props.ts
+++ b/src/components/Appbar/Appbar.props.ts
@@ -1,4 +1,4 @@
-import type { ReactNode, ComponentPropsWithRef, ComponentType } from 'react';
+import type { ReactNode, ComponentPropsWithRef } from 'react';
 import type { Animated, StyleProp, View, ViewStyle } from 'react-native';
 
 import type { ThemeProp } from '../../types';

--- a/src/components/Appbar/Appbar.props.ts
+++ b/src/components/Appbar/Appbar.props.ts
@@ -1,0 +1,47 @@
+import type { ReactNode, ComponentPropsWithRef, ComponentType } from 'react';
+import type { Animated, StyleProp, View, ViewStyle } from 'react-native';
+
+import type { ThemeProp } from '../../types';
+
+export type AppbarProps = Omit<
+  Partial<ComponentPropsWithRef<typeof View>>,
+  'style'
+> & {
+  /**
+   * Whether the background color is a dark color. A dark appbar will render light text and vice-versa.
+   */
+  dark?: boolean;
+  /**
+   * Content of the `Appbar`.
+   */
+  children: ReactNode;
+  /**
+   * @supported Available in v5.x with theme version 3
+   *
+   * Mode of the Appbar.
+   * - `small` - Appbar with default height (64).
+   * - `medium` - Appbar with medium height (112).
+   * - `large` - Appbar with large height (152).
+   * - `center-aligned` - Appbar with default height and center-aligned title.
+   */
+  mode?: 'small' | 'medium' | 'large' | 'center-aligned';
+  /**
+   * @supported Available in v5.x with theme version 3
+   * Whether Appbar background should have the elevation along with primary color pigment.
+   */
+  elevated?: boolean;
+  /**
+   * Safe area insets for the Appbar. This can be used to avoid elements like the navigation bar on Android and bottom safe area on iOS.
+   */
+  safeAreaInsets?: {
+    bottom?: number;
+    top?: number;
+    left?: number;
+    right?: number;
+  };
+  /**
+   * @optional
+   */
+  theme?: ThemeProp;
+  style?: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
+};

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -1,23 +1,15 @@
 import * as React from 'react';
-import {
-  Animated,
-  Platform,
-  StyleProp,
-  StyleSheet,
-  View,
-  ViewStyle,
-  ColorValue,
-} from 'react-native';
+import { Platform, StyleSheet, View, ColorValue } from 'react-native';
 
 import color from 'color';
 
 import { useInternalTheme } from '../../core/theming';
-import type { MD3Elevation, ThemeProp } from '../../types';
+import type { MD3Elevation } from '../../types';
 import Surface from '../Surface';
+import type { AppbarProps } from './Appbar.props';
 import AppbarAction from './AppbarAction';
 import AppbarBackAction from './AppbarBackAction';
 import AppbarContent from './AppbarContent';
-import AppbarHeader from './AppbarHeader';
 import {
   AppbarModes,
   DEFAULT_APPBAR_HEIGHT,
@@ -25,49 +17,6 @@ import {
   modeAppbarHeight,
   renderAppbarContent,
 } from './utils';
-
-export type Props = Omit<
-  Partial<React.ComponentPropsWithRef<typeof View>>,
-  'style'
-> & {
-  /**
-   * Whether the background color is a dark color. A dark appbar will render light text and vice-versa.
-   */
-  dark?: boolean;
-  /**
-   * Content of the `Appbar`.
-   */
-  children: React.ReactNode;
-  /**
-   * @supported Available in v5.x with theme version 3
-   *
-   * Mode of the Appbar.
-   * - `small` - Appbar with default height (64).
-   * - `medium` - Appbar with medium height (112).
-   * - `large` - Appbar with large height (152).
-   * - `center-aligned` - Appbar with default height and center-aligned title.
-   */
-  mode?: 'small' | 'medium' | 'large' | 'center-aligned';
-  /**
-   * @supported Available in v5.x with theme version 3
-   * Whether Appbar background should have the elevation along with primary color pigment.
-   */
-  elevated?: boolean;
-  /**
-   * Safe area insets for the Appbar. This can be used to avoid elements like the navigation bar on Android and bottom safe area on iOS.
-   */
-  safeAreaInsets?: {
-    bottom?: number;
-    top?: number;
-    left?: number;
-    right?: number;
-  };
-  /**
-   * @optional
-   */
-  theme?: ThemeProp;
-  style?: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
-};
 
 /**
  * A component to display action items in a bar. It can be placed at the top or bottom.
@@ -167,8 +116,9 @@ const Appbar = ({
   elevated,
   safeAreaInsets,
   theme: themeOverrides,
+  renderExcept,
   ...rest
-}: Props) => {
+}: AppbarProps) => {
   const theme = useInternalTheme(themeOverrides);
   const { isV3 } = theme;
   const flattenedStyle = StyleSheet.flatten(style);
@@ -307,12 +257,8 @@ const Appbar = ({
                 children: filterAppbarActions(false),
                 isDark,
                 isV3,
-                renderExcept: [
-                  Appbar,
-                  AppbarBackAction,
-                  AppbarContent,
-                  AppbarHeader,
-                ],
+                renderExcept: [Appbar, AppbarBackAction, AppbarContent],
+                renderExceptDisplayName: ['Appbar.Header'],
                 mode,
               })}
             </View>

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -116,7 +116,6 @@ const Appbar = ({
   elevated,
   safeAreaInsets,
   theme: themeOverrides,
-  renderExcept,
   ...rest
 }: AppbarProps) => {
   const theme = useInternalTheme(themeOverrides);

--- a/src/components/Appbar/AppbarHeader.tsx
+++ b/src/components/Appbar/AppbarHeader.tsx
@@ -14,14 +14,15 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useInternalTheme } from '../../core/theming';
 import shadow from '../../styles/shadow';
 import type { ThemeProp } from '../../types';
-import { Appbar } from './Appbar';
+import Appbar from './Appbar';
+import type { AppbarProps } from './Appbar.props';
 import {
   DEFAULT_APPBAR_HEIGHT,
   getAppbarColor,
   modeAppbarHeight,
 } from './utils';
 
-export type Props = React.ComponentProps<typeof Appbar> & {
+export type Props = AppbarProps & {
   /**
    * Whether the background color is a dark color. A dark header will render light text and vice-versa.
    */

--- a/src/components/Appbar/utils.ts
+++ b/src/components/Appbar/utils.ts
@@ -46,6 +46,7 @@ type RenderAppbarContentProps = {
   isV3: boolean;
   renderOnly?: (React.ComponentType<any> | false)[];
   renderExcept?: React.ComponentType<any>[];
+  renderExceptDisplayName?: string[]; // same as renderExcept but only applies to displayName (helping avoid require cycles)
   mode?: AppbarModes;
   theme?: ThemeProp;
 };
@@ -74,6 +75,7 @@ export const renderAppbarContent = ({
   isV3,
   renderOnly,
   renderExcept,
+  renderExceptDisplayName,
   mode = 'small',
   theme,
 }: RenderAppbarContentProps) => {
@@ -83,6 +85,12 @@ export const renderAppbarContent = ({
       .filter((child) =>
         // @ts-expect-error: TypeScript complains about the type of type but it doesn't matter
         renderExcept ? !renderExcept.includes(child.type) : child
+      )
+      .filter((child) =>
+        renderExceptDisplayName
+          ? // @ts-expect-error: TypeScript complains about the type of type but it doesn't matter
+            !renderExceptDisplayName?.includes(child.type.displayName)
+          : child
       )
       // @ts-expect-error: TypeScript complains about the type of type but it doesn't matter
       .filter((child) => (renderOnly ? renderOnly.includes(child.type) : child))

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -68,7 +68,7 @@ export { default as Text, customText } from './components/Typography/Text';
 // Types
 export type { Props as ActivityIndicatorProps } from './components/ActivityIndicator';
 export type { Props as AnimatedFABProps } from './components/FAB/AnimatedFAB';
-export type { Props as AppbarProps } from './components/Appbar/Appbar';
+export type { AppbarProps } from './components/Appbar/Appbar.props';
 export type { Props as AppbarActionProps } from './components/Appbar/AppbarAction';
 export type { Props as AppbarBackActionProps } from './components/Appbar/AppbarBackAction';
 export type { Props as AppbarContentProps } from './components/Appbar/AppbarContent';


### PR DESCRIPTION
### Summary

Fixes require cycle Appbar -> AppbarHeader -> Appbar.

FYI there are a few more remaining items:
`npx dpdm ./src/index.tsx --tree false`

Outputs this:
```
  1) src/components/Appbar/AppbarContent.tsx -> src/components/Appbar/utils.ts
  2) src/components/TextInput/TextInput.tsx -> src/components/TextInput/Adornment/TextInputAffix.tsx -> src/components/TextInput/helpers.tsx -> src/components/TextInput/types.tsx
```

This issue exists on release [5.3.1](https://github.com/callstack/react-native-paper/tree/v5.3.1)

### Test plan
1. Did not test this. This is a draft PR. Hoping to have some feedback.