### PR TITLE
chore: install use-latest-callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@callstack/react-theme-provider": "^3.0.8",
     "color": "^3.1.2",
-    "use-event-callback": "^0.1.0"
+    "use-latest-callback": "^0.1.5"
   },
   "devDependencies": {
     "@babel/core": "^7.20.7",

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Animated, StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 
-import useEventCallback from 'use-event-callback';
+import useLatestCallback from 'use-latest-callback';
 
 import { useInternalTheme } from '../core/theming';
 import type { $RemoveChildren, ThemeProp } from '../types';
@@ -151,8 +151,8 @@ const Banner = ({
     measured: false,
   });
 
-  const showCallback = useEventCallback(onShowAnimationFinished);
-  const hideCallback = useEventCallback(onHideAnimationFinished);
+  const showCallback = useLatestCallback(onShowAnimationFinished);
+  const hideCallback = useLatestCallback(onHideAnimationFinished);
 
   const { scale } = theme.animation;
 

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -10,7 +10,7 @@ import {
   ViewStyle,
 } from 'react-native';
 
-import useEventCallback from 'use-event-callback';
+import useLatestCallback from 'use-latest-callback';
 
 import { useInternalTheme } from '../../core/theming';
 import type { ThemeProp } from '../../types';
@@ -450,7 +450,7 @@ const BottomNavigation = ({
     animateToIndex(navigationState.index);
   }, [navigationState.index, animateToIndex, offsetsAnims]);
 
-  const handleTabPress = useEventCallback(
+  const handleTabPress = useLatestCallback(
     (event: { route: Route } & TabPressEvent) => {
       onTabPress?.(event);
 
@@ -469,7 +469,7 @@ const BottomNavigation = ({
     }
   );
 
-  const jumpTo = useEventCallback((key: string) => {
+  const jumpTo = useLatestCallback((key: string) => {
     const index = navigationState.routes.findIndex(
       (route) => route.key === key
     );

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import useEventCallback from 'use-event-callback';
+import useLatestCallback from 'use-latest-callback';
 
 import { useInternalTheme } from '../core/theming';
 import type { ThemeProp } from '../types';
@@ -118,7 +118,7 @@ function Modal({
     visibleRef.current = visible;
   });
 
-  const onDismissCallback = useEventCallback(onDismiss);
+  const onDismissCallback = useLatestCallback(onDismiss);
 
   const { scale } = theme.animation;
 

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import useEventCallback from 'use-event-callback';
+import useLatestCallback from 'use-latest-callback';
 
 import { useInternalTheme } from '../core/theming';
 import type { $RemoveChildren, ThemeProp } from '../types';
@@ -157,7 +157,7 @@ const Snackbar = ({
 
   const { scale } = theme.animation;
 
-  const handleOnVisible = useEventCallback(() => {
+  const handleOnVisible = useLatestCallback(() => {
     // show
     if (hideTimeout.current) clearTimeout(hideTimeout.current);
     setHidden(false);
@@ -182,7 +182,7 @@ const Snackbar = ({
     });
   });
 
-  const handleOnHidden = useEventCallback(() => {
+  const handleOnHidden = useLatestCallback(() => {
     // hide
     if (hideTimeout.current) {
       clearTimeout(hideTimeout.current);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11358,11 +11358,6 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
-use-event-callback@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/use-event-callback/-/use-event-callback-0.1.0.tgz#29d7ce996802935c5387e7d3b606cf316da3457f"
-  integrity sha512-5fTzY5UEXHMK5UR0NRkUz6TPfWmmX9fO8Tx3SnHrfMPdrQ7Rna0gDBy0r56SP68TwsP9DgwSBzeysCu3A/Z2NA==
-
 use-latest-callback@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/use-latest-callback/-/use-latest-callback-0.1.5.tgz#a4a836c08fa72f6608730b5b8f4bbd9c57c04f51"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/3737

### Summary

Replace the `use-event-callback` with `use-latest-callback` to avoid warnings.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Following steps from the issue:

Create a new Expo project:
`yarn create expo-app folder-to-install-app-in`
`yarn add react-native-web react-dom @expo/webpack-config`

Run yarn web and it will start fine without any warning.
Add React Native Paper with `yarn react-native-safe-area-context react-native-paper`
Wrap App.js with <Provider>...</Provider>.

Run `yarn web`.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
