### PR TITLE
docs: add configuration for component's more examples

### DIFF
--- a/docs/component-docs-plugin/generatePageMDX.js
+++ b/docs/component-docs-plugin/generatePageMDX.js
@@ -1,6 +1,34 @@
 const config = require('../docusaurus.config');
 
-const { baseUrl } = config;
+const { baseUrl, customFields } = config;
+
+function generateMoreExamples(componentName) {
+  const componentMoreExamples = customFields.moreExamples[componentName];
+
+  if (!componentMoreExamples) {
+    return `<span />`;
+  }
+
+  const links = Object.entries(componentMoreExamples)
+    .map(([key, value]) => {
+      return `
+    <li key="${key}">
+      <a href="${value}">${key}</a>
+    </li>
+    `;
+    })
+    .join('');
+
+  return `
+  ## More Examples
+  <details>
+    <summary>Toggle to grab more examples</summary>
+    <ul>
+      ${links}
+    </ul>
+  </details>
+  `;
+}
 
 function generatePageMDX(doc, link) {
   const description = doc.description
@@ -16,6 +44,8 @@ title: ${doc.title}
 import PropTable from '@site/src/components/PropTable.tsx';
 
 ${description}
+
+${generateMoreExamples(doc.title)}
 
 ## Props
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -289,6 +289,15 @@ const config = {
         indexName: 'crawler_React Native Paper Docs',
       },
     }),
+
+  customFields: {
+    moreExamples: {
+      Portal: {
+        'Comprehensive Portal example':
+          'https://snack.expo.dev/@react-native-paper/comprehensive-portal-example',
+      },
+    },
+  },
 };
 
 module.exports = config;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Solves: #3682 

### Summary

Extends docusaurus config **customFields** with the property `moreExamples` which can be supplemented with links to the snack / github repositories containing additional component's examples.

Based on the linked issue, added the first additional user's example for `Portal` component 
_(provided snack in the issue was copied into `react-native-paper` expo account with credits to the author)_

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

#### Related issue

- #3682 

### Test plan

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/22746080/224573229-9d536f25-853d-47ff-81e2-64c4ee20f5d0.png">


<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
