### PR TITLE
docs: correct type links, add admonitions, support extends annotation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ The core team works directly on GitHub and all work is public.
 
 ### Development workflow
 
-> **Working on your first pull request?** You can learn how from this *free* series: [How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github).
+> **Working on your first pull request?** You can learn how from this *free* series: [How to Contribute to an Open Source Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github).
 
 1. Fork the repo and create your branch from `main` (a guide on [how to fork a repository](https://help.github.com/articles/fork-a-repo/)).
 2. Run `yarn bootstrap` on the root level, to setup the development environment.

--- a/docs/component-docs-plugin/generatePageMDX.js
+++ b/docs/component-docs-plugin/generatePageMDX.js
@@ -34,7 +34,8 @@ function generatePageMDX(doc, link) {
   const description = doc.description
     .replace(/<\/br>/g, '')
     .replace(/style="[a-zA-Z0-9:;.\s()\-,]*"/gi, '')
-    .replace(/src="screenshots/g, `src="${baseUrl}screenshots`);
+    .replace(/src="screenshots/g, `src="${baseUrl}screenshots`)
+    .replace(/@extends.+$/, '');
 
   const mdx = `
 ---

--- a/docs/docs/guides/01-getting-started.md
+++ b/docs/docs/guides/01-getting-started.md
@@ -69,7 +69,9 @@ module.exports = function(api) {
 
 The plugin only works if you are importing the library using ES2015 import statements and not with `require`.
 
-**Note:** The above examples are for the latest `react-native` using Babel 7. If you have `react-native <= 0.55`, you'll have a `.babelrc` file instead of a `babel.config.js` file and the content of the file will be different.
+:::note
+The above examples are for the latest `react-native` using Babel 7. If you have `react-native <= 0.55`, you'll have a `.babelrc` file instead of a `babel.config.js` file and the content of the file will be different.
+:::
 
 If you're using Flow for typechecking your code, you need to add the following under the `[options]` section in your `.flowconfig`:
 
@@ -155,4 +157,6 @@ export default function Main() {
 }
 ```
 
-<i>Note: For MD2 check the following [Material Design 2 default theme](https://github.com/callstack/react-native-paper/blob/main/src/styles/themes/v2/LightTheme.tsx).</i>
+:::note
+For MD2 check the following [Material Design 2 default theme](https://github.com/callstack/react-native-paper/blob/main/src/styles/themes/v2/LightTheme.tsx).
+:::

--- a/docs/docs/guides/02-theming.mdx
+++ b/docs/docs/guides/02-theming.mdx
@@ -6,7 +6,9 @@ import DynamicColorTheme from '@site/src/components/DynamicColorTheme.tsx'
 
 # Theming
 
-<b>Note:</b> To observe changes related to switching between light and dark mode in the app, ensure that the <i>"Override force-dark"</i> feature in the <i>"developer options"</i> settings on your Android device is <b>not overridden</b>.
+:::note
+To observe changes related to switching between light and dark mode in the app, ensure that the <i>"Override force-dark"</i> feature in the <i>"developer options"</i> settings on your Android device is <b>not overridden</b>.
+:::
 
 ## Applying a theme to the whole app
 
@@ -275,8 +277,10 @@ There are two supported ways of overriding the theme:
 1. <b>Simple built-in theme overrides</b> - when you only customize the values and the whole theme schema remains the same
 2. <b>Advanced theme overrides</b> - when you <i>add new properties</i> or <i>change the built-in schema shape</i>
 
-📍<b>Warning</b>: TypeScript support for withTheme is currently limited to <b>Material You (MD3)</b> theme only. 
+:::caution
+TypeScript support for `withTheme` is currently limited to <b>Material You (MD3)</b> theme only. 
 <i>We are planning to provide a better support of handling custom theme overrides in future releases.</i>
+:::
 
 ### Simple built-in theme overrides
 

--- a/docs/docs/guides/04-fonts.md
+++ b/docs/docs/guides/04-fonts.md
@@ -20,7 +20,9 @@ The easiest way to install custom fonts to your RN project is do as follows:
       ],
   ```
 
-  Note: `fonts` is a folder with `.ttf` files
+:::note
+`fonts` is a folder with `.ttf` files
+:::
 
   2. Place your font files in your assets directory.
 
@@ -56,7 +58,9 @@ To create a custom font, prepare a `fontConfig` object where fonts are divided b
 
 The `fontConfig` object accepts `ios`, `android`, `macos`, `windows`, `web`, and `native`. Use these to override fonts on particular platforms.
 
-Note: At a minimum, you need to explicitly pass fonts for `android`, `ios`, and `web`.
+:::info
+At a minimum, you need to explicitly pass fonts for `android`, `ios`, and `web`.
+:::
 
 ```js
 import * as React from 'react';
@@ -140,7 +144,8 @@ export default function Main() {
 
 In the latest version fonts in theme are structured based on the `variant` keys e.g. `displayLarge` or `bodyMedium` which are then used in `Text`'s component throughout the whole library.
 
-Note: The default `fontFamily` is different per particular platfrom:
+:::info
+The default `fontFamily` is different per particular platfrom:
 
 ```js
 Platform.select({
@@ -149,7 +154,7 @@ Platform.select({
   default: 'sans-serif', // and 'sans-serif-medium' for `fontWeight:"500"`
 }),
 ```
-
+:::
 
 * #### Display
 
@@ -381,7 +386,8 @@ Platform.select({
   </div>
 </div>
 
-<i>Note:</i> If any component uses Paper's `Text` component, without specified <b>variant</b>, then `default` variant is applied:
+:::info
+If any component uses Paper's `Text` component, without specified <b>variant</b>, then `default` variant is applied:
 
 ```json
 "default": {
@@ -390,6 +396,7 @@ Platform.select({
   "letterSpacing": 0,
 },
 ```
+:::
 
 #### Using `configureFonts` helper
 

--- a/docs/docs/guides/10-migration-guide-to-5.0.md
+++ b/docs/docs/guides/10-migration-guide-to-5.0.md
@@ -56,7 +56,9 @@ New theme introduces a new color palette along with new namings reflecting desig
 
 Each accent and error colors has a group of related tones. The tones are mapped to roles that create contrast and visual interest when applied to elements in the UI.
 
-📍<i>Note: Dynamic colors are not supported yet.</i>
+:::note
+Dynamic colors are not supported yet
+:::
 
 ![color-palette](../../static/migration/color-palette.png)
 
@@ -114,7 +116,9 @@ theme: {
 
 A new way of approaching typography introduces one component `<Text>` which accepts prop `variant`. Variant defines appropriate text styles for type role and its size. The updated type scale organizes styles into five roles that are named to describe their purposes: <b>Display</b>, <b>Headline</b>, <b>Title</b>, <b>Label</b> and <b>Body</b> along with three display styles <i>large</i>, <i>medium</i>, and <i>small</i>. In total, there are fifteen variants that are MD3 compliant and are reflecting design typography tokens written in camel case. 
 
-Note: If any component uses Paper's `Text` component, without specified <b>variant</b>, then `default` variant is applied.
+:::info
+If any component uses Paper's `Text` component, without specified <b>variant</b>, then `default` variant is applied.
+:::
 
 ```js
 <Text variant="displayLarge">Display Large</Text>
@@ -188,7 +192,9 @@ To use your current font config from <b>v2</b> and migrate to <b>v3</b> there ar
 + configureFonts({config: fontConfig, isV3: false})
 ```
 
-📍Note: If you want to check how to use `configureFonts` on MD3, check the [Fonts](https://callstack.github.io/react-native-paper/docs/guides/fonts.html) guide.
+:::tip
+If you want to check how to use `configureFonts` on MD3, check the [Fonts](https://callstack.github.io/react-native-paper/docs/guides/fonts.html) guide.
+:::
 
 ## Components
 
@@ -257,7 +263,9 @@ For the sake of new animation of pill shape, indicating active destination, and 
 * `icon` is renamed to `focusedIcon`, as the name implies, with theme version 3 it's the outline icon used as focused tab icon and with theme version 2 it's a default icon,
 * `unfocusedIcon` <i>(optional)</i> is the filled icon used as the unfocused tab icon, compatible with theme version 3.
 
-📍<i>Note: `unfocusedIcon` is optional, if you can't find outline icon equivalent, omit that prop, so `focusedIcon` will be displayed in both active and inactive state</i>
+:::info
+`unfocusedIcon` is optional, if you can't find outline icon equivalent, omit that prop, so `focusedIcon` will be displayed in both active and inactive state.
+:::
 
 ```diff
 routes: [
@@ -376,7 +384,9 @@ To properly compose `Chip` component and adjust into required type, there are th
 
 `Dialog.Icon` is another freshly added component presenting an icon within a `Dialog`, placed at the top of the content.
 
-📍<i>Note: It's working only with theme version 3.</i>
+:::caution
+It's working only with theme version 3.
+:::
 
 ```js
 <Portal>
@@ -404,7 +414,9 @@ Additionally prop `inset` was renamed to `leftInset`.
 
 `Drawer.CollapsedItem` is a newly created side navigation component that can be used within `Drawer`, representing a destination in the form of an action item with an icon and optionally label.
 
-📍<i>Note: It's working only with theme version 3.</i>
+:::caution
+It's working only with theme version 3.
+:::
 
 ```js
 <Drawer.Section>

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -192,11 +192,15 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: (params) =>
-            `https://github.com/callstack/react-native-paper/tree/main/src/${params.docPath.replace(
-              'mdx',
-              'tsx'
-            )}`,
+          editUrl: (params) => {
+            const urlToMain =
+              'https://github.com/callstack/react-native-paper/tree/main';
+            if (params.docPath.includes('guides')) {
+              return `${urlToMain}/docs/docs/${params.docPath}`;
+            }
+            return `${urlToMain}/src/${params.docPath.replace('mdx', 'tsx')}`;
+          },
+
           remarkPlugins: [
             [require('@docusaurus/remark-plugin-npm2yarn'), { sync: true }],
           ],

--- a/docs/src/components/PropTable.tsx
+++ b/docs/src/components/PropTable.tsx
@@ -7,8 +7,10 @@ import useDoc from '@site/component-docs-plugin/useDocs';
 import Markdown from './Markdown';
 
 const typeDefinitions = {
-  IconSource: '/docs/icons',
-  Theme: '/docs/theming#theme-properties',
+  IconSource:
+    'https://github.com/callstack/react-native-paper/blob/main/src/components/Icon.tsx#L16',
+  ThemeProp:
+    'https://callstack.github.io/react-native-paper/docs/guides/theming#theme-properties',
   AccessibilityState:
     'https://reactnative.dev/docs/accessibility#accessibilitystate',
   'StyleProp<ViewStyle>': 'https://reactnative.dev/docs/view-style-props',
@@ -17,12 +19,45 @@ const typeDefinitions = {
 
 const ANNOTATION_OPTIONAL = '@optional';
 const ANNOTATION_INTERNAL = '@internal';
+const ANNOTATION_EXTENDS = '@extends';
 
 const renderBadge = (annotation: string) => {
   const [annotType, ...annotLabel] = annotation.split(' ');
 
   // eslint-disable-next-line prettier/prettier
   return `<span class="badge badge-${annotType.replace('@', '')} ">${annotLabel.join(' ')}</span>`;
+};
+
+const renderExtendsLink = (description: string) => {
+  const extendsAttributes: { name: string; link?: string }[] = [];
+  description
+    .split('\n')
+    .filter((line: string) => {
+      if (line.startsWith(ANNOTATION_EXTENDS)) {
+        const parts = line.split(' ').slice(1);
+        const link = parts.pop();
+        extendsAttributes.push({
+          name: parts.join(' '),
+          link,
+        });
+        return false;
+      }
+      return true;
+    })
+    .join('\n');
+
+  if (extendsAttributes.length === 0) {
+    return null;
+  }
+
+  return extendsAttributes.map((prop) => (
+    <a key={prop.name} href={prop.link}>
+      <code>
+        ...
+        {prop.name}
+      </code>
+    </a>
+  ));
 };
 
 export default function PropTable({ link }: { link: string }) {
@@ -96,7 +131,13 @@ export default function PropTable({ link }: { link: string }) {
               {tsTypeLink ? (
                 <a
                   href={tsTypeLink}
-                  target={tsTypeLink.startsWith('/') ? '_self' : '_blank'}
+                  target={
+                    tsTypeLink.startsWith(
+                      'https://callstack.github.io/react-native-paper'
+                    )
+                      ? '_self'
+                      : '_blank'
+                  }
                   rel="noreferrer"
                 >
                   <code>{tsType}</code>
@@ -114,6 +155,7 @@ export default function PropTable({ link }: { link: string }) {
           </div>
         );
       })}
+      {renderExtendsLink(doc.description)}
     </div>
   );
 }

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -267,7 +267,7 @@ const SceneComponent = React.memo(({ component, ...rest }: any) =>
  * It is primarily designed for use on mobile. If you want to use the navigation bar only see [`BottomNavigation.Bar`](BottomNavigationBar).
  *
  * By default Bottom navigation uses primary color as a background, in dark theme with `adaptive` mode it will use surface colour instead.
- * See [Dark InternalTheme](https://callstack.github.io/react-native-paper/docs/guides/theming#dark-theme) for more information.
+ * See [Dark Theme](https://callstack.github.io/react-native-paper/docs/guides/theming#dark-theme) for more information.
  *
  * <div class="screenshots">
  *   <img class="small" src="screenshots/bottom-navigation.gif" />

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -45,7 +45,7 @@ const DIALOG_ELEVATION: number = 24;
 
 /**
  * Dialogs inform users about a specific task and may contain critical information, require decisions, or involve multiple tasks.
- * To render the `Dialog` above other components, you'll need to wrap it with the [`Portal`](portal.html) component.
+ * To render the `Dialog` above other components, you'll need to wrap it with the [`Portal`](../../Portal) component.
  *
  *  <div class="screenshots">
  *   <img class="small" src="screenshots/dialog-1.png" />

--- a/src/components/Drawer/DrawerCollapsedItem.tsx
+++ b/src/components/Drawer/DrawerCollapsedItem.tsx
@@ -67,7 +67,8 @@ const itemSize = 56;
 const outlineHeight = 32;
 
 /**
- * @supported Available in v5.x with theme version 3
+ * Note: Available in v5.x with theme version 3
+ *
  * Collapsed component used to show an action item with an icon and optionally label in a navigation drawer.
  *
  * <div class="screenshots">

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -116,7 +116,7 @@ export type Props = {
 
 /**
  * A component to display a stack of FABs with related actions in a speed dial.
- * To render the group above other components, you'll need to wrap it with the [`Portal`](portal.html) component.
+ * To render the group above other components, you'll need to wrap it with the [`Portal`](../Portal) component.
  *
  * <div class="screenshots">
  *   <img class="small" src="screenshots/fab-group.gif" />

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -68,6 +68,10 @@ export type Props = $RemoveChildren<typeof TouchableRipple> & {
   style?: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
   ref?: React.RefObject<View>;
   /**
+   * TestID used for testing purposes
+   */
+  testID?: string;
+  /**
    * @optional
    */
   theme?: ThemeProp;

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -63,7 +63,7 @@ const DEFAULT_DURATION = 220;
 
 /**
  * The Modal component is a simple way to present content above an enclosing view.
- * To render the `Modal` above other components, you'll need to wrap it with the [`Portal`](portal.html) component.
+ * To render the `Modal` above other components, you'll need to wrap it with the [`Portal`](./Portal) component.
  *
  * <div class="screenshots">
  *   <figure>

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -24,7 +24,7 @@ export type Props = {
 /**
  * Portal allows rendering a component at a different place in the parent tree.
  * You can use it to render content which should appear above other elements, similar to `Modal`.
- * It requires a [`Portal.Host`](portal-host.html) component to be rendered somewhere in the parent tree.
+ * It requires a [`Portal.Host`](PortalHost) component to be rendered somewhere in the parent tree.
  * Note that if you're using the `Provider` component, this already includes a `Portal.Host`.
  *
  * ## Usage

--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -67,7 +67,7 @@ const MD2Surface = forwardRef<View, Props>(
 /**
  * Surface is a basic container that can give depth to an element with elevation shadow.
  * On dark theme with `adaptive` mode, surface is constructed by also placing a semi-transparent white overlay over a component surface.
- * See [Dark InternalTheme](https://callstack.github.io/react-native-paper/docs/guides/theming#dark-theme) for more information.
+ * See [Dark Theme](https://callstack.github.io/react-native-paper/docs/guides/theming#dark-theme) for more information.
  * Overlay and shadow can be applied by specifying the `elevation` property both on Android and iOS.
  *
  * <div class="screenshots">

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -177,6 +177,8 @@ type TextInputHandles = Pick<
   'focus' | 'clear' | 'blur' | 'isFocused' | 'setNativeProps'
 >;
 
+const DefaultRenderer = (props: RenderProps) => <NativeTextInput {...props} />;
+
 /**
  * A component to allow users to input text.
  *
@@ -221,9 +223,6 @@ type TextInputHandles = Pick<
  *
  * @extends TextInput props https://reactnative.dev/docs/textinput#props
  */
-
-const DefaultRenderer = (props: RenderProps) => <NativeTextInput {...props} />;
-
 const TextInput = forwardRef<TextInputHandles, Props>(
   (
     {

--- a/src/components/ToggleButton/ToggleButtonGroup.tsx
+++ b/src/components/ToggleButton/ToggleButtonGroup.tsx
@@ -26,7 +26,7 @@ export const ToggleButtonGroupContext =
 
 /**
  * Toggle group allows to control a group of toggle buttons.</br>
- * It doesn't change the appearance of the toggle buttons. If you want to group them in a row, check out <a href="toggle-button-row.html">`ToggleButton.Row`</a>.
+ * It doesn't change the appearance of the toggle buttons. If you want to group them in a row, check out [ToggleButton.Row](ToggleButtonRow).
  *
  * <div class="screenshots">
  *   <figure>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/3731

### Summary

Addressing leftovers from the list within the [issue](#3731):

* corrects link to the egghead on the contribution guide
* adding admonitions in several places: 

<img width="979" alt="image" src="https://user-images.githubusercontent.com/22746080/225249292-e1db960c-fc3b-480a-bcfa-dc3d0c35c1d0.png">

* add support for `@extends` annotation, for prop extension:

<img width="350" alt="image" src="https://user-images.githubusercontent.com/22746080/225249819-4c086399-e5ec-4955-a9ae-fb262ec3131d.png">

* correct links for `Edit this page` in `guides`
* correct links for types such as `IconSource` and `ThemeProp`

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
