### PR TITLE
fix: add onTabLongPress for Bottom Navigation

### DIFF
--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -474,12 +474,6 @@ const BottomNavigation = ({
     }
   );
 
-  const handleTabLongPress = useLatestCallback(
-    (event: { route: Route } & TabPressEvent) => {
-      onTabLongPress?.(event);
-    }
-  );
-
   const jumpTo = useLatestCallback((key: string) => {
     const index = navigationState.routes.findIndex(
       (route) => route.key === key
@@ -591,7 +585,7 @@ const BottomNavigation = ({
         labeled={labeled}
         animationEasing={sceneAnimationEasing}
         onTabPress={handleTabPress}
-        onTabLongPress={handleTabLongPress}
+        onTabLongPress={onTabLongPress}
         shifting={shifting}
         safeAreaInsets={safeAreaInsets}
         labelMaxFontSizeMultiplier={labelMaxFontSizeMultiplier}

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -196,6 +196,10 @@ export type Props = {
    */
   onTabPress?: (props: { route: Route } & TabPressEvent) => void;
   /**
+   * Function to execute on tab long press. It receives the route for the pressed tab, useful for things like custom action when longed pressed.
+   */
+  onTabLongPress?: (props: { route: Route } & TabPressEvent) => void;
+  /**
    * Custom color for icon and label in the active tab.
    */
   activeColor?: string;
@@ -335,6 +339,7 @@ const BottomNavigation = ({
   sceneAnimationType = 'opacity',
   sceneAnimationEasing,
   onTabPress,
+  onTabLongPress,
   onIndexChange,
   shifting: shiftingProp,
   safeAreaInsets,
@@ -469,6 +474,12 @@ const BottomNavigation = ({
     }
   );
 
+  const handleTabLongPress = useLatestCallback(
+    (event: { route: Route } & TabPressEvent) => {
+      onTabLongPress?.(event);
+    }
+  );
+
   const jumpTo = useLatestCallback((key: string) => {
     const index = navigationState.routes.findIndex(
       (route) => route.key === key
@@ -580,6 +591,7 @@ const BottomNavigation = ({
         labeled={labeled}
         animationEasing={sceneAnimationEasing}
         onTabPress={handleTabPress}
+        onTabLongPress={handleTabLongPress}
         shifting={shifting}
         safeAreaInsets={safeAreaInsets}
         labelMaxFontSizeMultiplier={labelMaxFontSizeMultiplier}

--- a/src/components/BottomNavigation/BottomNavigationBar.tsx
+++ b/src/components/BottomNavigation/BottomNavigationBar.tsx
@@ -163,6 +163,10 @@ export type Props = {
    */
   onTabPress: (props: { route: Route } & TabPressEvent) => void;
   /**
+   * Function to execute on tab long press. It receives the route for the pressed tab
+   */
+  onTabLongPress?: (props: { route: Route } & TabPressEvent) => void;
+  /**
    * Custom color for icon and label in the active tab.
    */
   activeColor?: string;
@@ -366,6 +370,7 @@ const BottomNavigationBar = ({
   labeled = true,
   animationEasing,
   onTabPress,
+  onTabLongPress,
   shifting: shiftingProp,
   safeAreaInsets,
   labelMaxFontSizeMultiplier = 1,
@@ -508,6 +513,18 @@ const BottomNavigationBar = ({
     };
 
     onTabPress(event);
+  };
+
+  const handleTabLongPress = (index: number) => {
+    const event = {
+      route: navigationState.routes[index],
+      defaultPrevented: false,
+      preventDefault: () => {
+        event.defaultPrevented = true;
+      },
+    };
+
+    onTabLongPress?.(event);
   };
 
   const { routes } = navigationState;
@@ -746,6 +763,7 @@ const BottomNavigationBar = ({
               centered: true,
               rippleColor: isV3 ? 'transparent' : touchColor,
               onPress: () => handleTabPress(index),
+              onLongPress: () => handleTabLongPress(index),
               testID: getTestID({ route }),
               accessibilityLabel: getAccessibilityLabel({ route }),
               accessibilityRole: Platform.OS === 'ios' ? 'button' : 'tab',

--- a/src/components/BottomNavigation/BottomNavigationBar.tsx
+++ b/src/components/BottomNavigation/BottomNavigationBar.tsx
@@ -503,7 +503,7 @@ const BottomNavigationBar = ({
     animateToIndex(navigationState.index);
   }, [navigationState.index, animateToIndex]);
 
-  const handleTabPress = (index: number) => {
+  const eventForIndex = (index: number) => {
     const event = {
       route: navigationState.routes[index],
       defaultPrevented: false,
@@ -512,19 +512,7 @@ const BottomNavigationBar = ({
       },
     };
 
-    onTabPress(event);
-  };
-
-  const handleTabLongPress = (index: number) => {
-    const event = {
-      route: navigationState.routes[index],
-      defaultPrevented: false,
-      preventDefault: () => {
-        event.defaultPrevented = true;
-      },
-    };
-
-    onTabLongPress?.(event);
+    return event;
   };
 
   const { routes } = navigationState;
@@ -762,8 +750,8 @@ const BottomNavigationBar = ({
               borderless: true,
               centered: true,
               rippleColor: isV3 ? 'transparent' : touchColor,
-              onPress: () => handleTabPress(index),
-              onLongPress: () => handleTabLongPress(index),
+              onPress: () => onTabPress(eventForIndex(index)),
+              onLongPress: () => onTabLongPress?.(eventForIndex(index)),
               testID: getTestID({ route }),
               accessibilityLabel: getAccessibilityLabel({ route }),
               accessibilityRole: Platform.OS === 'ios' ? 'button' : 'tab',

--- a/src/components/__tests__/BottomNavigation.test.tsx
+++ b/src/components/__tests__/BottomNavigation.test.tsx
@@ -190,6 +190,24 @@ it('calls onIndexChange', () => {
   expect(onIndexChange).toHaveBeenCalledTimes(1);
 });
 
+it('calls onTabLongPress', () => {
+  const onTabLongPress = jest.fn();
+  const onIndexChange = jest.fn();
+
+  const tree = render(
+    <BottomNavigation
+      shifting
+      onIndexChange={onIndexChange}
+      onTabLongPress={onTabLongPress}
+      navigationState={createState(0, 5)}
+      renderScene={({ route }) => route.title}
+    />
+  );
+  fireEvent(tree.getByText('Route: 1'), 'onLongPress');
+  expect(onTabLongPress).toHaveBeenCalled();
+  expect(onTabLongPress).toHaveBeenCalledTimes(1);
+});
+
 it('renders non-shifting bottom navigation', () => {
   const tree = renderer
     .create(

--- a/src/components/__tests__/BottomNavigation.test.tsx
+++ b/src/components/__tests__/BottomNavigation.test.tsx
@@ -190,6 +190,33 @@ it('calls onIndexChange', () => {
   expect(onIndexChange).toHaveBeenCalledTimes(1);
 });
 
+it('calls onTabPress', () => {
+  const onTabPress = jest.fn();
+  const onIndexChange = jest.fn();
+
+  const tree = render(
+    <BottomNavigation
+      shifting
+      onTabPress={onTabPress}
+      onIndexChange={onIndexChange}
+      navigationState={createState(0, 5)}
+      renderScene={({ route }) => route.title}
+    />
+  );
+  fireEvent(tree.getByText('Route: 1'), 'onPress');
+  expect(onTabPress).toHaveBeenCalled();
+  expect(onTabPress).toHaveBeenCalledTimes(1);
+  expect(onTabPress).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      route: expect.objectContaining({
+        key: 'key-1',
+      }),
+      defaultPrevented: expect.any(Boolean),
+      preventDefault: expect.any(Function),
+    })
+  );
+});
+
 it('calls onTabLongPress', () => {
   const onTabLongPress = jest.fn();
   const onIndexChange = jest.fn();
@@ -203,9 +230,18 @@ it('calls onTabLongPress', () => {
       renderScene={({ route }) => route.title}
     />
   );
-  fireEvent(tree.getByText('Route: 1'), 'onLongPress');
+  fireEvent(tree.getByText('Route: 2'), 'onLongPress');
   expect(onTabLongPress).toHaveBeenCalled();
   expect(onTabLongPress).toHaveBeenCalledTimes(1);
+  expect(onTabLongPress).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      route: expect.objectContaining({
+        key: 'key-2',
+      }),
+      defaultPrevented: expect.any(Boolean),
+      preventDefault: expect.any(Function),
+    })
+  );
 });
 
 it('renders non-shifting bottom navigation', () => {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
This fix Implements: https://github.com/callstack/react-native-paper/issues/3690

Add long press action on the bottom navigation tabs
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

1. Start the example app 
2. Click on the Bottom Navigation
3. Click and hold any of the bottom tabs for at least 370 milliseconds.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

https://user-images.githubusercontent.com/33870502/225570574-dd95eba1-afc7-4a26-9666-b80d141dfc1b.mp4

