### PR TITLE
docs: comment for TypeScript users

### DIFF
--- a/docs/docs/guides/04-fonts.md
+++ b/docs/docs/guides/04-fonts.md
@@ -138,6 +138,10 @@ export default function Main() {
 }
 ```
 
+:::tip
+If you're using TypeScript use `as const` when defining `fontConfig`.
+:::
+
 ### Material Design 3
 
 #### Variants


### PR DESCRIPTION
### Summary

#3763

TypeScript infers `fontWeight` as `string` and cannot pick the correct overload. The expected `fontWeight` is a union:
https://github.com/callstack/react-native-paper/blob/844a2b192cc223ed3d024b01d17ea5773776078c/src/types.tsx#L7-L18

### Test plan

Nothing, docs only change