### PR TITLE
fix: ignore onTabLongPress in MaterialBottomTabNavigationConfig

### DIFF
--- a/src/react-navigation/types.tsx
+++ b/src/react-navigation/types.tsx
@@ -106,6 +106,7 @@ export type MaterialBottomTabNavigationConfig = Partial<
     | 'navigationState'
     | 'onIndexChange'
     | 'onTabPress'
+    | 'onTabLongPress'
     | 'renderScene'
     | 'renderLabel'
     | 'renderIcon'


### PR DESCRIPTION
### Summary

Fixes conflict between https://github.com/callstack/react-native-paper/pull/3758 and https://github.com/callstack/react-native-paper/pull/3741

### Test plan

`yarn bootstrap` works
