### PR TITLE
fix: remove abstraction function from event emitter

### DIFF
--- a/src/react-navigation/types.tsx
+++ b/src/react-navigation/types.tsx
@@ -106,6 +106,7 @@ export type MaterialBottomTabNavigationConfig = Partial<
     | 'navigationState'
     | 'onIndexChange'
     | 'onTabPress'
+    | 'onTabLongPress'
     | 'renderScene'
     | 'renderLabel'
     | 'renderIcon'

--- a/src/react-navigation/types.tsx
+++ b/src/react-navigation/types.tsx
@@ -17,7 +17,7 @@ export type MaterialBottomTabNavigationEventMap = {
   /**
    * Event which fires on long pressing on the tab in the tab bar.
    */
-  onTabLongPress: { data: undefined; canPreventDefault: true };
+  tabLongPress: {};
 };
 
 export type MaterialBottomTabNavigationHelpers = NavigationHelpers<


### PR DESCRIPTION
### Summary

Remove abstraction function for event emitter https://github.com/callstack/react-native-paper/pull/3769

### Test plan

`yarn bootstrap` works
