### PR TITLE
fix(snackbar,view): make snackbar width fit to screen

### DIFF
--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -20,6 +20,7 @@ import IconButton from './IconButton/IconButton';
 import MaterialCommunityIcon from './MaterialCommunityIcon';
 import Surface from './Surface';
 import Text from './Typography/Text';
+const {width} = Dimensions.get('window');
 
 export type Props = React.ComponentProps<typeof Surface> & {
   /**
@@ -362,7 +363,8 @@ const styles = StyleSheet.create({
   wrapper: {
     position: 'absolute',
     bottom: 0,
-    width: '100%',
+    width: width,
+    paddingHorizontal: 16,
   },
   container: {
     flexDirection: 'row',


### PR DESCRIPTION
in some case the snackbar not fit to device screen because still use `%` instead of use  device width

<img width="429" alt="Screenshot 2023-03-21 at 23 35 51" src="https://user-images.githubusercontent.com/29495223/226679019-94072c41-534f-4e12-b35b-9b03e0bd6d2d.png">


### Summary

so in this fix i just change to use device width and add padding for the content
<img width="422" alt="Screenshot 2023-03-21 at 23 36 10" src="https://user-images.githubusercontent.com/29495223/226679142-fa7db8bb-50d7-4d1e-bc5c-0bdc0bcdbe0b.png">

