### PR TITLE
fix: data table header title number of lines not working

### DIFF
--- a/example/src/Examples/DataTableExample.tsx
+++ b/example/src/Examples/DataTableExample.tsx
@@ -83,7 +83,9 @@ const DataTableExample = () => {
             >
               Dessert
             </DataTable.Title>
-            <DataTable.Title numeric>Calories</DataTable.Title>
+            <DataTable.Title numberOfLines={2} numeric>
+              Calories per piece
+            </DataTable.Title>
             <DataTable.Title numeric>Fat (g)</DataTable.Title>
           </DataTable.Header>
 

--- a/example/src/Examples/DataTableExample.tsx
+++ b/example/src/Examples/DataTableExample.tsx
@@ -60,9 +60,9 @@ const DataTableExample = () => {
   const sortedItems = items
     .slice()
     .sort((item1, item2) =>
-      (sortAscending ? item1.name < item2.name : item2.name < item1.name)
-        ? 1
-        : -1
+      sortAscending
+        ? item1.name.localeCompare(item2.name)
+        : item2.name.localeCompare(item1.name)
     );
   const from = page * itemsPerPage;
   const to = Math.min((page + 1) * itemsPerPage, items.length);

--- a/src/components/DataTable/DataTableHeader.tsx
+++ b/src/components/DataTable/DataTableHeader.tsx
@@ -78,7 +78,6 @@ DataTableHeader.displayName = 'DataTable.Header';
 const styles = StyleSheet.create({
   header: {
     flexDirection: 'row',
-    height: 48,
     paddingHorizontal: 16,
     borderBottomWidth: StyleSheet.hairlineWidth * 2,
   },

--- a/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -67,7 +67,6 @@ exports[`renders data table header 1`] = `
       Object {
         "borderBottomWidth": 1,
         "flexDirection": "row",
-        "height": 48,
         "paddingHorizontal": 16,
       },
       Object {


### PR DESCRIPTION
### Summary

Data table column titles were stuck on one line, even if numberOfLines > 1.

The problem was that data table header had a fixed height of 48 px.

I updated the data table in the example app to include a column title with two lines.

### Test plan

You can use the data table sample on the example app and tweak the numberOfLines and title text.

Right now, the second column is set to show the column title in 2 lines as you can see below:

![Screenshot 2023-03-21 at 16 23 40](https://user-images.githubusercontent.com/48553277/226679746-2083f062-f820-43ce-bddc-79446c53f898.png)

