### PR TITLE
refactor: fix `splitStyles` for Expo Snack

### DIFF
--- a/src/utils/splitStyles.ts
+++ b/src/utils/splitStyles.ts
@@ -29,7 +29,7 @@ export function splitStyles<Tuple extends FiltersArray>(
 
   // `Object.entries` will be used to iterate over the styles and `Object.fromEntries` will be called before returning
   // Entries which match the given filters will be temporarily stored in `newStyles`
-  const newStyles = filters.map(returnEmptyArray<Entry>);
+  const newStyles = filters.map(() => [] as Entry[]);
 
   // Entries which match no filter
   const rest: Entry[] = [];
@@ -57,8 +57,4 @@ export function splitStyles<Tuple extends FiltersArray>(
     ViewStyle,
     ...MappedTuple<Tuple>
   ];
-}
-
-function returnEmptyArray<SomeArray>() {
-  return [] as SomeArray[];
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Paper 5.5.0 cannot be used in Expo Snack.

![image](https://user-images.githubusercontent.com/8790386/227256288-37dc39b7-ea26-442d-b3b7-00bd3c349b13.png)

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Tested the changes in this Snack: https://snack.expo.dev/@dimitarnestorov/mad-tortilla

