### PR TITLE
docs: correct typo in code snippet for combining themes with React Navigation

### DIFF
--- a/docs/docs/guides/08-theming-with-react-navigation.md
+++ b/docs/docs/guides/08-theming-with-react-navigation.md
@@ -140,8 +140,8 @@ import {
 } from 'react-native-paper';
 import merge from 'deepmerge';
 
-const CombinedDefaultTheme = merge(MD2DarkTheme, NavigationDefaultTheme);
-const CombinedDarkTheme = merge(MD2LightTheme, NavigationDarkTheme);
+const CombinedDefaultTheme = merge(MD2LightTheme, NavigationDefaultTheme);
+const CombinedDarkTheme = merge(MD2DarkTheme, NavigationDarkTheme);
 ```
 
 ### Material Design 3
@@ -163,8 +163,8 @@ const { LightTheme, DarkTheme } = adaptNavigationTheme({
   reactNavigationDark: NavigationDarkTheme,
 });
 
-const CombinedDefaultTheme = merge(MD3DarkTheme, LightTheme);
-const CombinedDarkTheme = merge(MD3LightTheme, DarkTheme);
+const CombinedDefaultTheme = merge(MD3LightTheme, LightTheme);
+const CombinedDarkTheme = merge(MD3DarkTheme, DarkTheme);
 ```
 
 Alternatively, we could merge those themes using vanilla JavaScript:


### PR DESCRIPTION
### Summary

Corrected a typo in the documentation page [Theming with React Navigation](https://callstack.github.io/react-native-paper/docs/guides/theming-with-react-navigation/#material-design-2-1), where in the code snippet it incorrectly merged the React Native Paper "MD3DarkTheme" with the React Navigation "LightTheme" into "CombinedDefaultTheme". Same typo with "CombinedDarkTheme".

### Test plan

(N/A)
