### PR TITLE
Fix  "TextInput multiline text does not appear centered if only one line"  #3752

### DIFF
--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -359,7 +359,7 @@ const TextInputOutlined = ({
                 lineHeight,
                 fontWeight,
                 color: inputTextColor,
-                textAlignVertical: multiline ? 'top' : 'center',
+                textAlignVertical: multiline ? 'center' : 'center',
                 textAlign: textAlign
                   ? textAlign
                   : I18nManager.getConstants().isRTL

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -359,7 +359,7 @@ const TextInputOutlined = ({
                 lineHeight,
                 fontWeight,
                 color: inputTextColor,
-                textAlignVertical: multiline ? 'center' : 'center',
+                textAlignVertical: 'center',
                 textAlign: textAlign
                   ? textAlign
                   : I18nManager.getConstants().isRTL

--- a/src/components/__tests__/TextInput.test.tsx
+++ b/src/components/__tests__/TextInput.test.tsx
@@ -1071,5 +1071,5 @@ describe('outlineStyle - underlineStyle', () => {
       borderRadius: 16,
       borderWidth: 6,
     });
-  }); 
+  });
 });

--- a/src/components/__tests__/TextInput.test.tsx
+++ b/src/components/__tests__/TextInput.test.tsx
@@ -1071,6 +1071,5 @@ describe('outlineStyle - underlineStyle', () => {
       borderRadius: 16,
       borderWidth: 6,
     });
-  });
-  
+  }); 
 });

--- a/src/components/__tests__/TextInput.test.tsx
+++ b/src/components/__tests__/TextInput.test.tsx
@@ -22,7 +22,6 @@ const style = StyleSheet.create({
   },
   height: {
     height: 100,
-    textAlignVertical: "center",
   },
   lineHeight: {
     lineHeight: 22,
@@ -1073,4 +1072,5 @@ describe('outlineStyle - underlineStyle', () => {
       borderWidth: 6,
     });
   });
+  
 });

--- a/src/components/__tests__/TextInput.test.tsx
+++ b/src/components/__tests__/TextInput.test.tsx
@@ -22,6 +22,7 @@ const style = StyleSheet.create({
   },
   height: {
     height: 100,
+    textAlignVertical: "center",
   },
   lineHeight: {
     lineHeight: 22,

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -608,7 +608,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
               "lineHeight": undefined,
               "paddingHorizontal": 16,
               "textAlign": "left",
-              "textAlignVertical": "top",
+              "textAlignVertical": "center",
             },
             false,
             Array [


### PR DESCRIPTION
### Summary:

Fixes the Text input Outline Issue, if you pass Multiline as a prop, the first line will be adjusted to the top instead of the center. 
### Test plan:
In `src/components/TextInput/TextInputOutlined.tsx` , changes `textAlignVertical: multiline ? 'top' : 'center'` to
`textAlignVertical: 'center'`

### Screenshots and Issues fixed:
https://imgur.com/a/kK0jffs
Fixes #3752 
Fixes #3786 
