### PR TITLE
chore: remove disabled accessibility trait for `AppbarContent` and `Card`

### DIFF
--- a/example/src/Examples/AppbarExample.tsx
+++ b/example/src/Examples/AppbarExample.tsx
@@ -8,6 +8,7 @@ import {
   List,
   Paragraph,
   RadioButton,
+  Snackbar,
   Switch,
   Text,
 } from 'react-native-paper';
@@ -36,6 +37,7 @@ const AppbarExample = ({ navigation }: Props) => {
   const [appbarMode, setAppbarMode] = React.useState<AppbarModes>('small');
   const [showCalendarIcon, setShowCalendarIcon] = React.useState(false);
   const [showElevated, setShowElevated] = React.useState(false);
+  const [showSnackbar, setShowSnackbar] = React.useState(false);
 
   const theme = useExampleTheme();
   const { bottom, left, right } = useSafeAreaInsets();
@@ -60,6 +62,7 @@ const AppbarExample = ({ navigation }: Props) => {
           <Appbar.Content
             title="Title"
             subtitle={showSubtitle ? 'Subtitle' : null}
+            onPress={() => setShowSnackbar(true)}
           />
           {isCenterAlignedMode
             ? false
@@ -216,6 +219,13 @@ const AppbarExample = ({ navigation }: Props) => {
         {theme.isV3 && renderFAB()}
       </Appbar>
       {!theme.isV3 && renderFAB()}
+      <Snackbar
+        visible={showSnackbar}
+        onDismiss={() => setShowSnackbar(false)}
+        duration={Snackbar.DURATION_SHORT}
+      >
+        Heading pressed
+      </Snackbar>
     </>
   );
 };

--- a/src/components/Card/CardTitle.tsx
+++ b/src/components/Card/CardTitle.tsx
@@ -146,15 +146,9 @@ const CardTitle = ({
   theme: themeOverrides,
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
-  const titleComponent = (props: any) =>
-    theme.isV3 ? <Text {...props} /> : <Title {...props} />;
+  const TitleComponent = theme.isV3 ? Text : Title;
+  const SubtitleComponent = theme.isV3 ? Text : Caption;
 
-  const subtitleComponent = (props: any) =>
-    theme.isV3 ? <Text {...props} /> : <Caption {...props} />;
-
-  const TextComponent = React.memo(({ component, ...rest }: any) =>
-    React.createElement(component, rest)
-  );
   const minHeight = subtitle || left || right ? 72 : 50;
   const marginBottom = subtitle ? 0 : 2;
 
@@ -170,24 +164,22 @@ const CardTitle = ({
 
       <View style={[styles.titles]}>
         {title && (
-          <TextComponent
-            component={titleComponent}
+          <TitleComponent
             style={[styles.title, { marginBottom }, titleStyle]}
             numberOfLines={titleNumberOfLines}
             variant={titleVariant}
           >
             {title}
-          </TextComponent>
+          </TitleComponent>
         )}
         {subtitle && (
-          <TextComponent
-            component={subtitleComponent}
+          <SubtitleComponent
             style={[styles.subtitle, subtitleStyle]}
             numberOfLines={subtitleNumberOfLines}
             variant={subtitleVariant}
           >
             {subtitle}
-          </TextComponent>
+          </SubtitleComponent>
         )}
       </View>
       <View style={rightStyle}>{right ? right({ size: 24 }) : null}</View>

--- a/src/components/__tests__/Appbar/Appbar.test.tsx
+++ b/src/components/__tests__/Appbar/Appbar.test.tsx
@@ -220,10 +220,10 @@ describe('renderAppbarContent', () => {
       </mockSafeAreaContext.SafeAreaProvider>
     );
 
-    expect(getByRole('text')).toBeTruthy();
+    expect(getByRole('header')).toBeTruthy();
   });
-  it('Is recognized as a button when onPress callback has been pressed', () => {
-    const { getByRole } = render(
+  it('is recognized as a button when onPress callback has been passed', () => {
+    const { getByTestId } = render(
       <mockSafeAreaContext.SafeAreaProvider>
         <Appbar.Header>
           <Appbar.Content title="Accessible test" onPress={() => {}} />
@@ -231,7 +231,36 @@ describe('renderAppbarContent', () => {
       </mockSafeAreaContext.SafeAreaProvider>
     );
 
-    expect(getByRole('button')).toBeTruthy();
+    expect(getByTestId('appbar-content').props.accessibilityRole).toEqual([
+      'button',
+      'header',
+    ]);
+    expect(
+      getByTestId('appbar-content').props.accessibilityState || {}
+    ).not.toMatchObject({ disabled: true });
+    expect(
+      getByTestId('appbar-content-title-text').props.accessibilityRole
+    ).toEqual('none');
+  });
+  it('is recognized as a disabled button when onPress and disabled is passed', () => {
+    const { getByTestId } = render(
+      <mockSafeAreaContext.SafeAreaProvider>
+        <Appbar.Header>
+          <Appbar.Content title="Accessible test" onPress={() => {}} disabled />
+        </Appbar.Header>
+      </mockSafeAreaContext.SafeAreaProvider>
+    );
+
+    expect(getByTestId('appbar-content').props.accessibilityRole).toEqual([
+      'button',
+      'header',
+    ]);
+    expect(
+      getByTestId('appbar-content').props.accessibilityState
+    ).toMatchObject({ disabled: true });
+    expect(
+      getByTestId('appbar-content-title-text').props.accessibilityRole
+    ).toEqual('none');
   });
 });
 

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
@@ -683,21 +683,6 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
       </View>
     </View>
     <View
-      accessibilityRole="text"
-      accessibilityState={
-        Object {
-          "disabled": true,
-        }
-      }
-      accessible={true}
-      focusable={false}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       pointerEvents="box-none"
       style={
         Array [
@@ -719,6 +704,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
     >
       <Text
         accessibilityRole="header"
+        accessibilityTraits="header"
         accessible={true}
         numberOfLines={1}
         style={

--- a/src/components/__tests__/Card/Card.test.tsx
+++ b/src/components/__tests__/Card/Card.test.tsx
@@ -86,6 +86,27 @@ describe('Card', () => {
 
     expect(getByTestId('card')).toHaveStyle(styles.contentStyle);
   });
+
+  it('does not render a disabled accessibility state', () => {
+    const { getByTestId } = render(<Card>{null}</Card>);
+
+    expect(
+      getByTestId('card').props.accessibilityState || {}
+    ).not.toMatchObject({
+      disabled: true,
+    });
+  });
+  it('does render a disabled accessibility state', () => {
+    const { getByTestId } = render(
+      <Card onPress={() => {}} disabled>
+        {null}
+      </Card>
+    );
+
+    expect(getByTestId('card').props.accessibilityState).toMatchObject({
+      disabled: true,
+    });
+  });
 });
 
 describe('CardActions', () => {

--- a/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
@@ -70,20 +70,6 @@ exports[`Card renders an outlined card 1`] = `
       testID="card-outline"
     />
     <View
-      accessibilityState={
-        Object {
-          "disabled": true,
-        }
-      }
-      accessible={true}
-      focusable={false}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
         Array [
           Object {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

It's kinda weird to hear "not enabled" for elements of the UI that will never become interactable.

I tried messing around with the `accessibilityState` prop but I couldn't figure out a way without removing the element: https://snack.expo.dev/@dimitarnestorov/touchablewithoutfeedback-can-not-remove-disabled-trait

|Before|After|
|-|-|
|<img width="881" alt="Showcasing traits for AppbarContent before changes in PR" src="https://user-images.githubusercontent.com/8790386/229113325-2d5a3318-56cf-4f69-8c66-dc5e2153818b.png">|<img width="887" alt="Showcasing traits for AppbarContent after changes in PR" src="https://user-images.githubusercontent.com/8790386/229113611-f52b1f62-ddb0-465b-97a1-6a6632f10f25.png">|
|<img width="862" alt="Showcasing traits for Card before changes in PR" src="https://user-images.githubusercontent.com/8790386/229113172-5e5a045b-d945-410d-92e7-a847b9626662.png">|<img width="874" alt="Showcasing traits for Card after changes in PR" src="https://user-images.githubusercontent.com/8790386/229113680-45931d89-e8c3-4d72-87a4-1221630deecf.png">|

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Tests pass
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
