### PR TITLE
feat: support flat and elevated mode

### DIFF
--- a/example/src/Examples/SurfaceExample.tsx
+++ b/example/src/Examples/SurfaceExample.tsx
@@ -1,53 +1,74 @@
 import * as React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
 
-import { MD3Elevation, Surface, Text, MD3Colors } from 'react-native-paper';
+import {
+  MD3Elevation,
+  Surface,
+  Text,
+  MD3Colors,
+  List,
+} from 'react-native-paper';
 
 import { useExampleTheme } from '..';
-import { isWeb } from '../../utils';
 import ScreenWrapper from '../ScreenWrapper';
 
 const SurfaceExample = () => {
   const { isV3 } = useExampleTheme();
-
   const v2Elevation = [1, 2, 4, 8, 12];
-  const baseElevation = isV3 ? Array.from({ length: 6 }) : v2Elevation;
+  const elevationValues = isV3 ? Array.from({ length: 6 }) : v2Elevation;
+
+  const renderSurface = (index: number, mode: 'flat' | 'elevated') => (
+    <Surface
+      key={index}
+      style={[
+        styles.surface,
+        isV3 ? styles.v3Surface : { elevation: v2Elevation[index] },
+      ]}
+      mode={mode}
+      {...(isV3 && { elevation: index as MD3Elevation })}
+    >
+      <Text variant="bodyLarge">
+        {isV3
+          ? `Elevation ${index === 1 ? '(default)' : ''} ${index}`
+          : `${elevationValues[index]}`}
+      </Text>
+    </Surface>
+  );
 
   return (
-    <ScreenWrapper
-      contentContainerStyle={[styles.content, isWeb && styles.webContent]}
-    >
-      {baseElevation.map((e, i) => (
-        <Surface
-          key={i}
-          style={[
-            styles.surface,
-            isV3 ? styles.v3Surface : { elevation: v2Elevation[i] },
-          ]}
-          {...(isV3 && { elevation: i as MD3Elevation })}
-        >
-          <Text variant="bodyLarge">
-            {isV3 ? `Elevation ${i === 1 ? '(default)' : ''} ${i}` : `${e}`}
-          </Text>
-        </Surface>
-      ))}
+    <ScreenWrapper>
+      <List.Section title="Elevated surface">
+        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+          {elevationValues.map((_, index) => renderSurface(index, 'elevated'))}
+        </ScrollView>
+      </List.Section>
 
-      <View style={styles.horizontalSurfacesContainer}>
-        <Surface style={styles.horizontalSurface}>
-          <Text style={styles.centerText}>Left</Text>
-        </Surface>
-        <Surface style={styles.horizontalSurface}>
-          <Text style={styles.centerText}>Right</Text>
-        </Surface>
-      </View>
-      <View style={styles.verticalSurfacesContainer}>
-        <Surface style={styles.verticalSurface}>
-          <Text style={styles.centerText}>Top</Text>
-        </Surface>
-        <Surface style={styles.verticalSurface}>
-          <Text style={styles.centerText}>Bottom</Text>
-        </Surface>
-      </View>
+      <List.Section title="Flat surface">
+        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+          {elevationValues.map((_, index) => renderSurface(index, 'flat'))}
+        </ScrollView>
+      </List.Section>
+
+      <List.Section title="Layout">
+        <View style={styles.content}>
+          <View style={styles.horizontalSurfacesContainer}>
+            <Surface style={styles.horizontalSurface}>
+              <Text style={styles.centerText}>Left</Text>
+            </Surface>
+            <Surface style={styles.horizontalSurface}>
+              <Text style={styles.centerText}>Right</Text>
+            </Surface>
+          </View>
+          <View style={styles.verticalSurfacesContainer}>
+            <Surface style={styles.verticalSurface}>
+              <Text style={styles.centerText}>Top</Text>
+            </Surface>
+            <Surface style={styles.verticalSurface}>
+              <Text style={styles.centerText}>Bottom</Text>
+            </Surface>
+          </View>
+        </View>
+      </List.Section>
     </ScreenWrapper>
   );
 };
@@ -58,11 +79,6 @@ const styles = StyleSheet.create({
   content: {
     padding: 24,
     alignItems: 'center',
-  },
-  webContent: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    padding: 0,
   },
   surface: {
     margin: 24,

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -4,7 +4,7 @@ import { Animated, StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 import useLatestCallback from 'use-latest-callback';
 
 import { useInternalTheme } from '../core/theming';
-import type { $RemoveChildren, ThemeProp } from '../types';
+import type { $Omit, $RemoveChildren, ThemeProp } from '../types';
 import Button from './Button/Button';
 import Icon, { IconSource } from './Icon';
 import Surface from './Surface';
@@ -12,7 +12,7 @@ import Text from './Typography/Text';
 
 const DEFAULT_MAX_WIDTH = 960;
 
-export type Props = $RemoveChildren<typeof Surface> & {
+export type Props = $Omit<$RemoveChildren<typeof Surface>, 'mode'> & {
   /**
    * Whether banner is currently visible.
    */

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -12,7 +12,7 @@ import {
 import color from 'color';
 
 import { useInternalTheme } from '../../core/theming';
-import type { ThemeProp } from '../../types';
+import type { $Omit, ThemeProp } from '../../types';
 import ActivityIndicator from '../ActivityIndicator';
 import Icon, { IconSource } from '../Icon';
 import Surface from '../Surface';
@@ -20,7 +20,7 @@ import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import Text from '../Typography/Text';
 import { ButtonMode, getButtonColors } from './utils';
 
-export type Props = React.ComponentProps<typeof Surface> & {
+export type Props = $Omit<React.ComponentProps<typeof Surface>, 'mode'> & {
   /**
    * Mode of the button. You can change the mode to adjust the styling to give it desired emphasis.
    * - `text` - flat button without background or outline, used for the lowest priority actions, especially when presenting multiple options.

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 
 import { useInternalTheme } from '../../core/theming';
-import type { ThemeProp } from '../../types';
+import type { $Omit, ThemeProp } from '../../types';
 import Surface from '../Surface';
 import CardActions from './CardActions';
 import CardContent from './CardContent';
@@ -39,7 +39,7 @@ type HandlePressType = 'in' | 'out';
 
 type Mode = 'elevated' | 'outlined' | 'contained';
 
-export type Props = React.ComponentProps<typeof Surface> & {
+export type Props = $Omit<React.ComponentProps<typeof Surface>, 'mode'> & {
   /**
    * Mode of the Card.
    * - `elevated` - Card with elevation.

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -14,7 +14,7 @@ import {
 
 import { useInternalTheme } from '../../core/theming';
 import { white } from '../../styles/themes/v2/colors';
-import type { EllipsizeProp, ThemeProp } from '../../types';
+import type { $Omit, EllipsizeProp, ThemeProp } from '../../types';
 import type { IconSource } from '../Icon';
 import Icon from '../Icon';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
@@ -23,7 +23,7 @@ import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import Text from '../Typography/Text';
 import { getChipColors } from './helpers';
 
-export type Props = React.ComponentProps<typeof Surface> & {
+export type Props = $Omit<React.ComponentProps<typeof Surface>, 'mode'> & {
   /**
    * Mode of the chip.
    * - `flat` - flat chip without outline.

--- a/src/components/FAB/AnimatedFAB.tsx
+++ b/src/components/FAB/AnimatedFAB.tsx
@@ -21,7 +21,7 @@ import {
 import color from 'color';
 
 import { useInternalTheme } from '../../core/theming';
-import type { $RemoveChildren, ThemeProp } from '../../types';
+import type { $Omit, $RemoveChildren, ThemeProp } from '../../types';
 import type { IconSource } from '../Icon';
 import Icon from '../Icon';
 import Surface from '../Surface';
@@ -32,7 +32,7 @@ import { getCombinedStyles, getFABColors } from './utils';
 export type AnimatedFABIconMode = 'static' | 'dynamic';
 export type AnimatedFABAnimateFrom = 'left' | 'right';
 
-export type Props = $RemoveChildren<typeof Surface> & {
+export type Props = $Omit<$RemoveChildren<typeof Surface>, 'mode'> & {
   /**
    * Icon to display for the `FAB`.
    */

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 
 import { useInternalTheme } from '../../core/theming';
-import type { $RemoveChildren, ThemeProp } from '../../types';
+import type { $Omit, $RemoveChildren, ThemeProp } from '../../types';
 import { forwardRef } from '../../utils/forwardRef';
 import ActivityIndicator from '../ActivityIndicator';
 import CrossFadeIcon from '../CrossFadeIcon';
@@ -34,7 +34,7 @@ type IconOrLabel =
       label: string;
     };
 
-export type Props = $RemoveChildren<typeof Surface> & {
+export type Props = $Omit<$RemoveChildren<typeof Surface>, 'mode'> & {
   // For `icon` and `label` props their types are duplicated due to the generation of documentation.
   // Appropriate type for them is `IconOrLabel` contains the both union and intersection types.
   /**

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -13,7 +13,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import useLatestCallback from 'use-latest-callback';
 
 import { useInternalTheme } from '../core/theming';
-import type { $RemoveChildren, ThemeProp } from '../types';
+import type { $Omit, $RemoveChildren, ThemeProp } from '../types';
 import Button from './Button/Button';
 import type { IconSource } from './Icon';
 import IconButton from './IconButton/IconButton';
@@ -21,7 +21,7 @@ import MaterialCommunityIcon from './MaterialCommunityIcon';
 import Surface from './Surface';
 import Text from './Typography/Text';
 
-export type Props = React.ComponentProps<typeof Surface> & {
+export type Props = $Omit<React.ComponentProps<typeof Surface>, 'mode'> & {
   /**
    * Whether the Snackbar is currently visible.
    */

--- a/src/components/__tests__/Surface.test.tsx
+++ b/src/components/__tests__/Surface.test.tsx
@@ -4,6 +4,7 @@ import { Platform } from 'react-native';
 
 import { render } from '@testing-library/react-native';
 
+import { getTheme } from '../../core/theming';
 import Surface from '../Surface';
 
 describe('Surface', () => {
@@ -37,6 +38,35 @@ describe('Surface', () => {
         flexDirection: 'row',
         alignContent: 'center',
       },
+    });
+
+    it('should render Surface with appropriate bg color but without shadow, if mode is set to "flat"', () => {
+      const { getByTestId } = render(
+        <Surface
+          mode="flat"
+          elevation={5}
+          pointerEvents="box-none"
+          testID={'surface-test'}
+        >
+          {null}
+        </Surface>
+      );
+
+      expect(getByTestId('surface-test')).not.toHaveStyle({
+        shadowColor: '#000',
+        shadowOpacity: 0.3,
+        shadowOffset: { width: 0, height: 4 },
+        shadowRadius: 4,
+      });
+      expect(getByTestId('surface-test-outer-layer')).not.toHaveStyle({
+        shadowColor: '#000',
+        shadowOpacity: 0.15,
+        shadowOffset: { width: 0, height: 8 },
+        shadowRadius: 12,
+      });
+      expect(getByTestId('surface-test')).toHaveStyle({
+        backgroundColor: getTheme().colors.elevation.level5,
+      });
     });
 
     it.each`
@@ -205,6 +235,28 @@ describe('Surface', () => {
         );
 
         expect(getByTestId(testID)).toHaveStyle(combinedStyles);
+      });
+    });
+  });
+
+  describe('on Android', () => {
+    it('should render Surface with appropriate bg color but without shadow, if mode is set to "flat"', () => {
+      Platform.OS = 'android';
+      const testID = 'surface-container';
+      const { getByTestId } = render(
+        <Surface
+          mode="flat"
+          elevation={5}
+          pointerEvents="box-none"
+          testID={testID}
+        >
+          {null}
+        </Surface>
+      );
+
+      expect(getByTestId(testID)).not.toHaveStyle({ elevation: 5 });
+      expect(getByTestId(testID)).toHaveStyle({
+        backgroundColor: getTheme().colors.elevation.level5,
       });
     });
   });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: #3790 

### Summary

#### Related issue

- #3790 

Introducing prop `mode` to the `Surface` component with two possible options `elevated` (default) and `flat`.

The `flat` mode indicates the `Surface` component will have the background color appropriate to the set level, however, it will not have a `shadow`.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

ios | android | web
-- | --- | ---
<img width="526" alt="Zrzut ekranu 2023-04-3 o 12 58 38" src="https://user-images.githubusercontent.com/22746080/229490657-e1a4dc53-c7a2-4f4d-bf3f-3facd95c8fd0.png"> | <img width="449" alt="Zrzut ekranu 2023-04-3 o 12 57 27" src="https://user-images.githubusercontent.com/22746080/229490682-260c758c-4c26-44a7-99ea-1d3a2c0b9285.png"> | <img width="1726" alt="Zrzut ekranu 2023-04-3 o 12 57 43" src="https://user-images.githubusercontent.com/22746080/229490717-61909f3b-0b71-48e2-af4b-c7e56f494b1f.png">


### Test plan

New prop `mode` covered by unit tests.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
