### PR TITLE
fix: correct toggle button icon color prop

### DIFF
--- a/example/src/Examples/ToggleButtonExample.tsx
+++ b/example/src/Examples/ToggleButtonExample.tsx
@@ -73,14 +73,14 @@ const ToggleButtonExample = () => {
             <ImageBackground
               style={styles.customImage}
               source={{
-                uri: 'https://images.pexels.com/photos/1068534/pexels-photo-1068534.jpeg?auto=compress&cs=tinysrgb&h=750&w=1260',
+                uri: 'https://images.pexels.com/photos/5946081/pexels-photo-5946081.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
               }}
             >
               <ToggleButton
                 value="watermelon"
                 size={24}
                 style={styles.customButton}
-                color="white"
+                iconColor="white"
                 icon={fruit === 'watermelon' ? 'heart' : 'heart-outline'}
               />
             </ImageBackground>
@@ -94,7 +94,7 @@ const ToggleButtonExample = () => {
                 value="strawberries"
                 size={24}
                 style={styles.customButton}
-                color="white"
+                iconColor="white"
                 icon={fruit === 'strawberries' ? 'heart' : 'heart-outline'}
               />
             </ImageBackground>

--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -31,7 +31,7 @@ export type Props = {
   /**
    * Custom text color for button.
    */
-  color?: string;
+  iconColor?: string;
   /**
    * Whether the button is disabled.
    */


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: #3819 

### Summary

#### Related issue

- #3819 

Correct `ToggleButton`'s property name for icon color, which was introduced in v5 and renamed from `color` to `iconColor` according to the [migration guide](https://callstack.github.io/react-native-paper/docs/guides/migration-guide-to-5.0#iconbutton)

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan



<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
