### PR TITLE
fix: correct content style type

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -149,7 +149,7 @@ export type Props = React.ComponentPropsWithRef<typeof NativeTextInput> & {
    * Overrides input style
    * Example: `paddingLeft`, `backgroundColor`
    */
-  contentStyle?: StyleProp<ViewStyle>;
+  contentStyle?: StyleProp<TextStyle>;
   /**
    * Pass style to override the default style of outlined wrapper.
    * Overrides style when mode is set to `outlined`


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Correct the type of `contentStyle` prop passed to the `styles` of the `TextInput` from `react-native `which means, the type should be the same as in the source – `StyleProp<TextStyle>`

#### Related issue

- #3814 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

N/A

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
