### PR TITLE
docs: Fixed images linking to incorrect path

### DIFF
--- a/docs/docs/guides/9-react-navigation.md
+++ b/docs/docs/guides/9-react-navigation.md
@@ -75,7 +75,7 @@ const style = StyleSheet.create({
 
 Once we have finished implementing the components, we can run the app and check how Stack looks like.
 
-<img src="../../screenshots/react-navigation-appBar1.png" width="300" />
+<img src="/react-native-paper/screenshots/react-navigation-appBar1.png" width="300" />
 
 To navigate from `HomeScreen` to `DetailsScreen` we can use the navigation object provided by `Stack.Screen` component. Every component rendered by `Stack.Screen` has an access to the navigation object via props. Let's modify our `HomeScreen` component:
 
@@ -104,7 +104,7 @@ const style = StyleSheet.create({
 
 Our result:
 
-<img src="../../screenshots/react-navigation-appBar2.gif" width="300" />
+<img src="/react-native-paper/screenshots/react-navigation-appBar2.gif" width="300" />
 
 As you can see, we can already navigate between two screens. In the next steps, we will show you how to use Paper's `AppBar` instead of the default header.
 
@@ -181,7 +181,7 @@ export default function CustomNavigationBar({ navigation, route, options, back }
 }
 ```
 
-<img src="../../screenshots/react-navigation-appBar3.gif" width="300" />
+<img src="/react-native-paper/screenshots/react-navigation-appBar3.gif" width="300" />
 
 ### Adding more items to `Appbar`
 
@@ -274,7 +274,7 @@ export default function CustomNavigationBar({
 
 Final result:
 
-<img src="../../screenshots/react-navigation-appBar4.gif" width="300" />
+<img src="/react-native-paper/screenshots/react-navigation-appBar4.gif" width="300" />
 
 That's all we need! We have app bar that contains everything we need to navigate through screens and access an additional menu on the main screen. As you can see, with Material design `Appbar` provided by `react-native-paper` used together with `react-navigation` we can easily create an app that looks and works great. 
 


### PR DESCRIPTION
Path to images didn't link to anything, now it should link correctly, at least according to the docs at https://callstack.github.io/react-native-paper/docs/guides/react-navigation/

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixed images linking to incorrect path

### Test plan

Tested directly on https://callstack.github.io, changing the links from `../../` to `/react-native-paper/` makes them show up
