### PR TITLE
docs: add section for component theme colors

### DIFF
--- a/docs/.eslintrc
+++ b/docs/.eslintrc
@@ -9,7 +9,7 @@
     "react/prop-types": "off",
     "import/no-unresolved": [
       2,
-      {"ignore": ["^@docusaurus"]}
+      {"ignore": ["^@docusaurus", "^@theme", "@^site"]}
     ]
   }
 }

--- a/docs/component-docs-plugin/generatePageMDX.js
+++ b/docs/component-docs-plugin/generatePageMDX.js
@@ -37,12 +37,19 @@ function generatePageMDX(doc, link) {
     .replace(/src="screenshots/g, `src="${baseUrl}screenshots`)
     .replace(/@extends.+$/, '');
 
+  const data = JSON.stringify(customFields.themeColors[doc.title]);
+
   const mdx = `
 ---
 title: ${doc.title}
 ---
 
 import PropTable from '@site/src/components/PropTable.tsx';
+import ThemeColorsTable from '@site/src/components/ThemeColorsTable.tsx';
+
+## Theme colors
+
+<ThemeColorsTable data={${data}} componentName="${doc.title}" />
 
 ${description}
 

--- a/docs/component-docs-plugin/generatePageMDX.js
+++ b/docs/component-docs-plugin/generatePageMDX.js
@@ -47,10 +47,6 @@ title: ${doc.title}
 import PropTable from '@site/src/components/PropTable.tsx';
 import ThemeColorsTable from '@site/src/components/ThemeColorsTable.tsx';
 
-## Theme colors
-
-<ThemeColorsTable data={${data}} componentName="${doc.title}" />
-
 ${description}
 
 ${generateMoreExamples(doc.title)}
@@ -58,6 +54,10 @@ ${generateMoreExamples(doc.title)}
 ## Props
 
 <PropTable link="${link}" />
+
+## Theme colors
+
+<ThemeColorsTable data={${data}} componentName="${doc.title}" />
 `;
 
   return mdx.slice(1);

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -301,6 +301,115 @@ const config = {
           'https://snack.expo.dev/@react-native-paper/comprehensive-portal-example',
       },
     },
+    themeColors: {
+      IconButton: {
+        unselected: {
+          default: {
+            iconColor: 'theme.colors.onSurfaceVariant',
+          },
+          outlined: {
+            iconColor: 'theme.colors.onSurfaceVariant',
+            borderColor: 'theme.colors.outline',
+          },
+          contained: {
+            backgroundColor: 'theme.colors.surfaceVariant',
+            iconColor: 'theme.colors.primary',
+          },
+          'contained-tonal': {
+            backgroundColor: 'theme.colors.surfaceVariant',
+            iconColor: 'theme.colors.onSurfaceVariant',
+          },
+        },
+        selected: {
+          default: {
+            iconColor: 'theme.colors.primary',
+          },
+          outlined: {
+            backgroundColor: 'theme.colors.inverseSurface',
+            iconColor: 'theme.colors.inverseOnSurface',
+          },
+          contained: {
+            backgroundColor: 'theme.colors.primary',
+            iconColor: 'theme.colors.onPrimary',
+          },
+          'contained-tonal': {
+            backgroundColor: 'theme.colors.secondaryContainer',
+            iconColor: 'theme.colors.onSecondaryContainer',
+          },
+        },
+        disabled: {
+          default: {
+            iconColor: 'theme.colors.onSurfaceDisabled',
+          },
+          outlined: {
+            backgroundColor: 'theme.colors.surfaceDisabled',
+            iconColor: 'theme.colors.onSurfaceDisabled',
+            borderColor: 'theme.colors.surfaceDisabled',
+          },
+          contained: {
+            backgroundColor: 'theme.colors.surfaceDisabled',
+            iconColor: 'theme.colors.onSurfaceDisabled',
+          },
+          'contained-tonal': {
+            backgroundColor: 'theme.colors.surfaceDisabled',
+            iconColor: 'theme.colors.onSurfaceDisabled',
+          },
+        },
+      },
+      Button: {
+        active: {
+          elevated: {
+            backgroundColor: 'theme.colors.elevation.level1',
+            color: 'theme.colors.primary',
+          },
+          contained: {
+            backgroundColor: 'theme.colors.primary',
+            color: 'theme.colors.onPrimary',
+          },
+          'contained-tonal': {
+            backgroundColor: 'theme.colors.secondaryContainer',
+            color: 'theme.colors.onSecondaryContainer',
+          },
+          outlined: {
+            color: 'theme.colors.primary',
+            borderColor: 'theme.colors.outline',
+          },
+          text: {
+            color: 'theme.colors.primary',
+          },
+        },
+        disabled: {
+          elevated: {
+            backgroundColor: 'theme.colors.surfaceDisabled',
+            color: 'theme.colors.onSurfaceDisabled',
+          },
+          contained: {
+            backgroundColor: 'theme.colors.surfaceDisabled',
+            color: 'theme.colors.onSurfaceDisabled',
+          },
+          'contained-tonal': {
+            backgroundColor: 'theme.colors.surfaceDisabled',
+            color: 'theme.colors.onSurfaceDisabled',
+          },
+          outlined: {
+            color: 'theme.colors.onSurfaceDisabled',
+            borderColor: 'theme.colors.surfaceDisabled',
+          },
+          text: {
+            color: 'theme.colors.onSurfaceDisabled',
+          },
+        },
+      },
+      Card: {
+        contained: {
+          backgroundColor: 'theme.colors.surfaceVariant',
+        },
+        outlined: {
+          backgroundColor: 'theme.colors.surface',
+          borderColor: 'theme.colors.outline',
+        },
+      },
+    },
   },
 };
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -5,6 +5,8 @@ const path = require('path');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const lightCodeTheme = require('prism-react-renderer/themes/github');
 
+const { themeColors } = require('./src/data/themeColors.js');
+
 const { NODE_ENV, DOCUSAURUS_BASE_URL } = process.env;
 
 const title = 'React Native Paper';
@@ -301,115 +303,7 @@ const config = {
           'https://snack.expo.dev/@react-native-paper/comprehensive-portal-example',
       },
     },
-    themeColors: {
-      IconButton: {
-        unselected: {
-          default: {
-            iconColor: 'theme.colors.onSurfaceVariant',
-          },
-          outlined: {
-            iconColor: 'theme.colors.onSurfaceVariant',
-            borderColor: 'theme.colors.outline',
-          },
-          contained: {
-            backgroundColor: 'theme.colors.surfaceVariant',
-            iconColor: 'theme.colors.primary',
-          },
-          'contained-tonal': {
-            backgroundColor: 'theme.colors.surfaceVariant',
-            iconColor: 'theme.colors.onSurfaceVariant',
-          },
-        },
-        selected: {
-          default: {
-            iconColor: 'theme.colors.primary',
-          },
-          outlined: {
-            backgroundColor: 'theme.colors.inverseSurface',
-            iconColor: 'theme.colors.inverseOnSurface',
-          },
-          contained: {
-            backgroundColor: 'theme.colors.primary',
-            iconColor: 'theme.colors.onPrimary',
-          },
-          'contained-tonal': {
-            backgroundColor: 'theme.colors.secondaryContainer',
-            iconColor: 'theme.colors.onSecondaryContainer',
-          },
-        },
-        disabled: {
-          default: {
-            iconColor: 'theme.colors.onSurfaceDisabled',
-          },
-          outlined: {
-            backgroundColor: 'theme.colors.surfaceDisabled',
-            iconColor: 'theme.colors.onSurfaceDisabled',
-            borderColor: 'theme.colors.surfaceDisabled',
-          },
-          contained: {
-            backgroundColor: 'theme.colors.surfaceDisabled',
-            iconColor: 'theme.colors.onSurfaceDisabled',
-          },
-          'contained-tonal': {
-            backgroundColor: 'theme.colors.surfaceDisabled',
-            iconColor: 'theme.colors.onSurfaceDisabled',
-          },
-        },
-      },
-      Button: {
-        active: {
-          elevated: {
-            backgroundColor: 'theme.colors.elevation.level1',
-            color: 'theme.colors.primary',
-          },
-          contained: {
-            backgroundColor: 'theme.colors.primary',
-            color: 'theme.colors.onPrimary',
-          },
-          'contained-tonal': {
-            backgroundColor: 'theme.colors.secondaryContainer',
-            color: 'theme.colors.onSecondaryContainer',
-          },
-          outlined: {
-            color: 'theme.colors.primary',
-            borderColor: 'theme.colors.outline',
-          },
-          text: {
-            color: 'theme.colors.primary',
-          },
-        },
-        disabled: {
-          elevated: {
-            backgroundColor: 'theme.colors.surfaceDisabled',
-            color: 'theme.colors.onSurfaceDisabled',
-          },
-          contained: {
-            backgroundColor: 'theme.colors.surfaceDisabled',
-            color: 'theme.colors.onSurfaceDisabled',
-          },
-          'contained-tonal': {
-            backgroundColor: 'theme.colors.surfaceDisabled',
-            color: 'theme.colors.onSurfaceDisabled',
-          },
-          outlined: {
-            color: 'theme.colors.onSurfaceDisabled',
-            borderColor: 'theme.colors.surfaceDisabled',
-          },
-          text: {
-            color: 'theme.colors.onSurfaceDisabled',
-          },
-        },
-      },
-      Card: {
-        contained: {
-          backgroundColor: 'theme.colors.surfaceVariant',
-        },
-        outlined: {
-          backgroundColor: 'theme.colors.surface',
-          borderColor: 'theme.colors.outline',
-        },
-      },
-    },
+    themeColors,
   },
 };
 

--- a/docs/src/components/ThemeColorsTable.tsx
+++ b/docs/src/components/ThemeColorsTable.tsx
@@ -27,44 +27,43 @@ const getTableCell = (keys: string[], modes: DataObject): JSX.Element[] => {
   });
 };
 
-const ThemeColorsTable = ({
+const FlatTable = ({
   data,
-  componentName,
+  uniqueKeys,
 }: {
-  data?: DataObject;
-  componentName: string;
-}): JSX.Element | null => {
-  if (!data) {
-    return null;
-  }
-
-  const uniqueKeys = getUniqueNestedKeys(data);
-  const nestingLevel = getMaxNestedLevel(data);
-
-  if (nestingLevel === 1) {
-    const rows = Object.keys(data).map((mode) => {
-      return (
-        <tr key={`${mode}`}>
-          <td>{mode}</td>
-          {getTableCell(uniqueKeys, data[mode] as DataObject)}
-        </tr>
-      );
-    });
-
+  data: DataObject;
+  uniqueKeys: string[];
+}): JSX.Element => {
+  const rows = Object.keys(data).map((mode) => {
     return (
-      <table>
-        <thead>
-          <tr>
-            <th>mode</th>
-            {getTableHeader(uniqueKeys)}
-          </tr>
-        </thead>
-        <tbody>{rows}</tbody>
-      </table>
+      <tr key={`${mode}`}>
+        <td>{mode}</td>
+        {getTableCell(uniqueKeys, data[mode] as DataObject)}
+      </tr>
     );
-  }
+  });
 
-  const tableElements = Object.keys(data).map((key) => {
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>mode</th>
+          {getTableHeader(uniqueKeys)}
+        </tr>
+      </thead>
+      <tbody>{rows}</tbody>
+    </table>
+  );
+};
+
+const TabbedTable = ({
+  data,
+  uniqueKeys,
+}: {
+  data: DataObject;
+  uniqueKeys: string[];
+}): JSX.Element => {
+  const tabTableContent = Object.keys(data).map((key) => {
     const modes = data[key] as DataObject;
     const rows = Object.keys(modes).map((mode) => {
       return (
@@ -89,9 +88,29 @@ const ThemeColorsTable = ({
     );
   });
 
+  return <Tabs>{tabTableContent}</Tabs>;
+};
+
+const ThemeColorsTable = ({
+  data,
+  componentName,
+}: {
+  data?: DataObject;
+  componentName: string;
+}): JSX.Element | null => {
+  if (!data) {
+    return null;
+  }
+
+  const uniqueKeys = getUniqueNestedKeys(data);
+  const nestingLevel = getMaxNestedLevel(data);
+  const isFlatTable = nestingLevel === 1;
+
+  const Table = isFlatTable ? FlatTable : TabbedTable;
+
   return (
     <>
-      <Tabs>{tableElements}</Tabs>
+      <Table data={data} uniqueKeys={uniqueKeys} />
       <Admonition type="tip">
         <p>
           If a dedicated prop for a specific color is not available or the{' '}

--- a/docs/src/components/ThemeColorsTable.tsx
+++ b/docs/src/components/ThemeColorsTable.tsx
@@ -7,40 +7,11 @@ import TabItem from '@theme/TabItem';
 //@ts-ignore
 import Tabs from '@theme/Tabs';
 
-type DataObject = {
-  [key: string]: string | DataObject;
-};
-
-const getUniqueNestedKeys = (data: DataObject): string[] => {
-  const keys: string[] = [];
-
-  const traverseObject = (obj: DataObject) => {
-    for (const [key, value] of Object.entries(obj)) {
-      if (typeof value === 'object') {
-        traverseObject(value);
-      } else {
-        keys.push(key);
-      }
-    }
-  };
-
-  traverseObject(data);
-
-  return [...new Set(keys)];
-};
-
-const getNestingLevel = (obj: DataObject): number => {
-  let maxNestedLevel = 0;
-
-  for (const key in obj) {
-    if (typeof obj[key] === 'object') {
-      const nestedLevel = getNestingLevel(obj[key] as DataObject) + 1;
-      maxNestedLevel = Math.max(maxNestedLevel, nestedLevel);
-    }
-  }
-
-  return maxNestedLevel;
-};
+import {
+  DataObject,
+  getMaxNestedLevel,
+  getUniqueNestedKeys,
+} from '../utils/themeColors';
 
 const getTableHeader = (keys: string[]): JSX.Element[] => {
   return keys.map((key) => <th key={key}>{key}</th>);
@@ -68,7 +39,7 @@ const ThemeColorsTable = ({
   }
 
   const uniqueKeys = getUniqueNestedKeys(data);
-  const nestingLevel = getNestingLevel(data);
+  const nestingLevel = getMaxNestedLevel(data);
 
   if (nestingLevel === 1) {
     const rows = Object.keys(data).map((mode) => {

--- a/docs/src/components/ThemeColorsTable.tsx
+++ b/docs/src/components/ThemeColorsTable.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+
+//@ts-ignore
+import Admonition from '@theme/Admonition';
+//@ts-ignore
+import TabItem from '@theme/TabItem';
+//@ts-ignore
+import Tabs from '@theme/Tabs';
+
+type DataObject = {
+  [key: string]: string | DataObject;
+};
+
+const getUniqueNestedKeys = (data: DataObject) => {
+  let keys: string[] = [];
+
+  const traverseObject = (obj: DataObject) => {
+    for (let [key, value] of Object.entries(obj)) {
+      if (typeof value === 'object') {
+        traverseObject(value);
+      } else {
+        keys.push(key);
+      }
+    }
+  };
+
+  traverseObject(data);
+
+  return [...new Set(keys)];
+};
+
+function getNestingLevel(obj: DataObject) {
+  let maxNestedLevel = 0;
+  for (const key in obj) {
+    if (typeof obj[key] === 'object') {
+      const nestedLevel = getNestingLevel(obj[key] as DataObject) + 1;
+      if (nestedLevel > maxNestedLevel) {
+        maxNestedLevel = nestedLevel;
+      }
+    }
+  }
+  return maxNestedLevel;
+}
+
+export default function ThemeColorsTable({
+  data,
+  componentName,
+}: {
+  data: DataObject | undefined;
+  componentName: string;
+}) {
+  if (!data) {
+    return null;
+  }
+  const uniqueKeys = getUniqueNestedKeys(data);
+
+  if (getNestingLevel(data) === 1) {
+    const rows = Object.keys(data).map((mode) => {
+      return (
+        <tr key={`${mode}`}>
+          <td>{mode}</td>
+          {uniqueKeys.map((key) => {
+            return <td key={key}>{data[mode][key] || ''}</td>;
+          })}
+        </tr>
+      );
+    });
+
+    return (
+      <table>
+        <thead>
+          <tr>
+            <th>mode</th>
+            {uniqueKeys.map((key) => (
+              <th key={key}>{key}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>{rows}</tbody>
+      </table>
+    );
+  }
+
+  const tableElements = Object.keys(data).map((key) => {
+    const modes = data[key];
+    const rows = Object.keys(modes).map((mode) => {
+      return (
+        <tr key={`${key}-${mode}`}>
+          <td>{mode}</td>
+          {uniqueKeys.map((key) => {
+            return <td key={key}>{modes[mode][key] || ''}</td>;
+          })}
+        </tr>
+      );
+    });
+
+    return (
+      <TabItem label={key} value={key} key={key}>
+        <table>
+          <thead>
+            <tr>
+              <th>mode</th>
+              {uniqueKeys.map((key) => (
+                <th key={key}>{key}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>{rows}</tbody>
+        </table>
+      </TabItem>
+    );
+  });
+
+  return (
+    <>
+      <Tabs>{tableElements}</Tabs>
+      <Admonition type="tip">
+        <p>
+          If a dedicated prop for a specific color is not available or the{' '}
+          <code>style</code> prop does not allow color modification, you can
+          customize it using the <code>theme</code> prop. It allows to override
+          any color, within the component, based on the table above.
+        </p>
+        <p>
+          <i>Example of overriding </i>
+          <code>primary</code>
+          <i> color:</i>
+        </p>
+        <code>{`<${componentName} theme={{ colors: { primary: 'green' } }} />`}</code>
+      </Admonition>
+    </>
+  );
+}

--- a/docs/src/data/themeColors.js
+++ b/docs/src/data/themeColors.js
@@ -1,0 +1,116 @@
+const themeColors = {
+  IconButton: {
+    selected: {
+      default: {
+        iconColor: 'theme.colors.primary',
+      },
+      outlined: {
+        backgroundColor: 'theme.colors.inverseSurface',
+        iconColor: 'theme.colors.inverseOnSurface',
+      },
+      contained: {
+        backgroundColor: 'theme.colors.primary',
+        iconColor: 'theme.colors.onPrimary',
+      },
+      'contained-tonal': {
+        backgroundColor: 'theme.colors.secondaryContainer',
+        iconColor: 'theme.colors.onSecondaryContainer',
+      },
+    },
+    unselected: {
+      default: {
+        iconColor: 'theme.colors.onSurfaceVariant',
+      },
+      outlined: {
+        iconColor: 'theme.colors.onSurfaceVariant',
+        borderColor: 'theme.colors.outline',
+      },
+      contained: {
+        backgroundColor: 'theme.colors.surfaceVariant',
+        iconColor: 'theme.colors.primary',
+      },
+      'contained-tonal': {
+        backgroundColor: 'theme.colors.surfaceVariant',
+        iconColor: 'theme.colors.onSurfaceVariant',
+      },
+    },
+    disabled: {
+      default: {
+        iconColor: 'theme.colors.onSurfaceDisabled',
+      },
+      outlined: {
+        backgroundColor: 'theme.colors.surfaceDisabled',
+        iconColor: 'theme.colors.onSurfaceDisabled',
+        borderColor: 'theme.colors.surfaceDisabled',
+      },
+      contained: {
+        backgroundColor: 'theme.colors.surfaceDisabled',
+        iconColor: 'theme.colors.onSurfaceDisabled',
+      },
+      'contained-tonal': {
+        backgroundColor: 'theme.colors.surfaceDisabled',
+        iconColor: 'theme.colors.onSurfaceDisabled',
+      },
+    },
+  },
+  Button: {
+    active: {
+      elevated: {
+        backgroundColor: 'theme.colors.elevation.level1',
+        color: 'theme.colors.primary',
+      },
+      contained: {
+        backgroundColor: 'theme.colors.primary',
+        color: 'theme.colors.onPrimary',
+      },
+      'contained-tonal': {
+        backgroundColor: 'theme.colors.secondaryContainer',
+        color: 'theme.colors.onSecondaryContainer',
+      },
+      outlined: {
+        color: 'theme.colors.primary',
+        borderColor: 'theme.colors.outline',
+      },
+      text: {
+        color: 'theme.colors.primary',
+      },
+    },
+    disabled: {
+      elevated: {
+        backgroundColor: 'theme.colors.surfaceDisabled',
+        color: 'theme.colors.onSurfaceDisabled',
+      },
+      contained: {
+        backgroundColor: 'theme.colors.surfaceDisabled',
+        color: 'theme.colors.onSurfaceDisabled',
+      },
+      'contained-tonal': {
+        backgroundColor: 'theme.colors.surfaceDisabled',
+        color: 'theme.colors.onSurfaceDisabled',
+      },
+      outlined: {
+        color: 'theme.colors.onSurfaceDisabled',
+        borderColor: 'theme.colors.surfaceDisabled',
+      },
+      text: {
+        color: 'theme.colors.onSurfaceDisabled',
+      },
+    },
+  },
+  Card: {
+    contained: {
+      backgroundColor: 'theme.colors.surfaceVariant',
+    },
+    elevated: {
+      backgroundColor: 'theme.colors.elevation.level1',
+    },
+    outlined: {
+      backgroundColor: 'theme.colors.surface',
+      borderColor: 'theme.colors.outline',
+    },
+  },
+};
+
+module.exports = {
+  themeColors,
+};

--- a/docs/src/utils/__tests__/themeColors.test.tsx
+++ b/docs/src/utils/__tests__/themeColors.test.tsx
@@ -1,0 +1,112 @@
+import { getMaxNestedLevel, getUniqueNestedKeys } from '../themeColors';
+
+const Button = {
+  active: {
+    elevated: {
+      backgroundColor: 'theme.colors.elevation.level1',
+      color: 'theme.colors.primary',
+    },
+    contained: {
+      backgroundColor: 'theme.colors.primary',
+      color: 'theme.colors.onPrimary',
+    },
+    'contained-tonal': {
+      backgroundColor: 'theme.colors.secondaryContainer',
+      color: 'theme.colors.onSecondaryContainer',
+    },
+    outlined: {
+      color: 'theme.colors.primary',
+      borderColor: 'theme.colors.outline',
+    },
+    text: {
+      color: 'theme.colors.primary',
+    },
+  },
+  disabled: {
+    elevated: {
+      backgroundColor: 'theme.colors.surfaceDisabled',
+      color: 'theme.colors.onSurfaceDisabled',
+    },
+    contained: {
+      backgroundColor: 'theme.colors.surfaceDisabled',
+      color: 'theme.colors.onSurfaceDisabled',
+    },
+    'contained-tonal': {
+      backgroundColor: 'theme.colors.surfaceDisabled',
+      color: 'theme.colors.onSurfaceDisabled',
+    },
+    outlined: {
+      color: 'theme.colors.onSurfaceDisabled',
+      borderColor: 'theme.colors.surfaceDisabled',
+    },
+    text: {
+      color: 'theme.colors.onSurfaceDisabled',
+    },
+  },
+};
+
+const Card = {
+  contained: {
+    backgroundColor: 'theme.colors.surfaceVariant',
+  },
+  outlined: {
+    backgroundColor: 'theme.colors.surface',
+    borderColor: 'theme.colors.outline',
+  },
+};
+
+const Custom = {
+  active: {
+    contained: {
+      pressed: {
+        backgroundColor: 'theme.colors.primary',
+      },
+    },
+    outlined: {
+      backgroundColor: 'theme.colors.surface',
+    },
+  },
+};
+
+describe('getUniqueNestedKeys', () => {
+  it('should return an array of unique keys for flat structure', () => {
+    expect(getUniqueNestedKeys(Card)).toEqual([
+      'backgroundColor',
+      'borderColor',
+    ]);
+  });
+
+  it('should return an array of unique keys for nested structure', () => {
+    expect(getUniqueNestedKeys(Button)).toEqual([
+      'backgroundColor',
+      'color',
+      'borderColor',
+    ]);
+  });
+
+  it('should return an empty array if data object is empty', () => {
+    expect(getUniqueNestedKeys({})).toEqual([]);
+  });
+});
+
+describe('getMaxNestedLevel', () => {
+  it('should return the correct nesting level', () => {
+    const buttonLevel = getMaxNestedLevel(Button);
+    const cardLevel = getMaxNestedLevel(Card);
+
+    expect(buttonLevel).toEqual(2);
+    expect(cardLevel).toEqual(1);
+  });
+
+  it('should return 0 if the object is not nested', () => {
+    const level = getMaxNestedLevel({
+      foo: 'bar',
+    });
+    expect(level).toEqual(0);
+  });
+
+  it('should handle nested objects at different levels', () => {
+    const level = getMaxNestedLevel(Custom);
+    expect(level).toEqual(3);
+  });
+});

--- a/docs/src/utils/themeColors.tsx
+++ b/docs/src/utils/themeColors.tsx
@@ -1,0 +1,34 @@
+export type DataObject = {
+  [key: string]: string | DataObject;
+};
+
+export const getUniqueNestedKeys = (data: DataObject): string[] => {
+  const keys: string[] = [];
+
+  const traverseObject = (obj: DataObject) => {
+    for (const [key, value] of Object.entries(obj)) {
+      if (typeof value === 'object') {
+        traverseObject(value);
+      } else {
+        keys.push(key);
+      }
+    }
+  };
+
+  traverseObject(data);
+
+  return [...new Set(keys)];
+};
+
+export const getMaxNestedLevel = (obj: DataObject): number => {
+  let maxNestedLevel = 0;
+
+  for (const key in obj) {
+    if (typeof obj[key] === 'object') {
+      const nestedLevel = getMaxNestedLevel(obj[key] as DataObject) + 1;
+      maxNestedLevel = Math.max(maxNestedLevel, nestedLevel);
+    }
+  }
+
+  return maxNestedLevel;
+};


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

We're adding a "Theme colors" section to each component's doc to simplify the process of identifying theme color names and their corresponding roles without diving into the source code

* Colors are manually collected within the file `docs/src/data/themeColors` for each component
* Colors are defined for possible component's:
	* states such as `active` or `selected`
	* modes such as `flat` or `outlined`
	
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

- [X] - added tests for utils
- [X] - tested manually on the build

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
