### PR TITLE
fix: added style to component used for text measurement on Android

### DIFF
--- a/src/components/FAB/AnimatedFAB.tsx
+++ b/src/components/FAB/AnimatedFAB.tsx
@@ -13,7 +13,6 @@ import {
   ScrollView,
   StyleProp,
   StyleSheet,
-  Text,
   View,
   ViewStyle,
 } from 'react-native';
@@ -496,12 +495,20 @@ const AnimatedFAB = ({
         // proper text measurements there is a need to additionaly render that text, but
         // wrapped in absolutely positioned `ScrollView` which height is 0.
         <ScrollView style={styles.textPlaceholderContainer}>
-          <Text
+          <AnimatedText
+            variant="labelLarge"
+            numberOfLines={1}
             onTextLayout={onTextLayout}
-            style={[uppercase && styles.uppercaseLabel, textStyle]}
+            ellipsizeMode={'tail'}
+            style={[
+              styles.label,
+              uppercase && styles.uppercaseLabel,
+              textStyle,
+            ]}
+            theme={theme}
           >
             {label}
-          </Text>
+          </AnimatedText>
         </ScrollView>
       )}
     </Surface>

--- a/src/components/FAB/AnimatedFAB.tsx
+++ b/src/components/FAB/AnimatedFAB.tsx
@@ -496,7 +496,12 @@ const AnimatedFAB = ({
         // proper text measurements there is a need to additionaly render that text, but
         // wrapped in absolutely positioned `ScrollView` which height is 0.
         <ScrollView style={styles.textPlaceholderContainer}>
-          <Text onTextLayout={onTextLayout}>{label}</Text>
+          <Text
+            onTextLayout={onTextLayout}
+            style={[uppercase && styles.uppercaseLabel, textStyle]}
+          >
+            {label}
+          </Text>
         </ScrollView>
       )}
     </Surface>


### PR DESCRIPTION
### Summary
On Android, the text on AnimatedFAB is calculated using a 2nd component, but this component doesn't take the text style into account. This leads to incorrect text measurement.

### Test plan
This issue is easy to see on Android if you're using the MD2 theme. Depending on the length of your label, the spacing between the icon and the text will look different because the width of the label is wrong.
