### PR TITLE
fix: list item row width

### DIFF
--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -262,9 +262,11 @@ const styles = StyleSheet.create({
     paddingRight: 24,
   },
   row: {
+    width: '100%',
     flexDirection: 'row',
   },
   rowV3: {
+    width: '100%',
     flexDirection: 'row',
     marginVertical: 6,
   },

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
@@ -185,6 +185,7 @@ exports[`renders expanded accordion 1`] = `
         Object {
           "flexDirection": "row",
           "marginVertical": 6,
+          "width": "100%",
         }
       }
     >

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -38,6 +38,7 @@ exports[`renders list item with custom description 1`] = `
       Object {
         "flexDirection": "row",
         "marginVertical": 6,
+        "width": "100%",
       }
     }
   >
@@ -351,6 +352,7 @@ exports[`renders list item with custom title and description styles 1`] = `
       Object {
         "flexDirection": "row",
         "marginVertical": 6,
+        "width": "100%",
       }
     }
   >
@@ -477,6 +479,7 @@ exports[`renders list item with left and right items 1`] = `
       Object {
         "flexDirection": "row",
         "marginVertical": 6,
+        "width": "100%",
       }
     }
   >
@@ -655,6 +658,7 @@ exports[`renders list item with left item 1`] = `
       Object {
         "flexDirection": "row",
         "marginVertical": 6,
+        "width": "100%",
       }
     }
   >
@@ -799,6 +803,7 @@ exports[`renders list item with right item 1`] = `
       Object {
         "flexDirection": "row",
         "marginVertical": 6,
+        "width": "100%",
       }
     }
   >
@@ -892,6 +897,7 @@ exports[`renders list item with title and description 1`] = `
       Object {
         "flexDirection": "row",
         "marginVertical": 6,
+        "width": "100%",
       }
     }
   >
@@ -1014,6 +1020,7 @@ exports[`renders with a description with typeof number 1`] = `
       Object {
         "flexDirection": "row",
         "marginVertical": 6,
+        "width": "100%",
       }
     }
   >

--- a/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
@@ -253,6 +253,7 @@ exports[`renders list section with custom title style 1`] = `
         Object {
           "flexDirection": "row",
           "marginVertical": 6,
+          "width": "100%",
         }
       }
     >
@@ -394,6 +395,7 @@ exports[`renders list section with custom title style 1`] = `
         Object {
           "flexDirection": "row",
           "marginVertical": 6,
+          "width": "100%",
         }
       }
     >
@@ -752,6 +754,7 @@ exports[`renders list section with subheader 1`] = `
         Object {
           "flexDirection": "row",
           "marginVertical": 6,
+          "width": "100%",
         }
       }
     >
@@ -893,6 +896,7 @@ exports[`renders list section with subheader 1`] = `
         Object {
           "flexDirection": "row",
           "marginVertical": 6,
+          "width": "100%",
         }
       }
     >
@@ -1213,6 +1217,7 @@ exports[`renders list section without subheader 1`] = `
         Object {
           "flexDirection": "row",
           "marginVertical": 6,
+          "width": "100%",
         }
       }
     >
@@ -1354,6 +1359,7 @@ exports[`renders list section without subheader 1`] = `
         Object {
           "flexDirection": "row",
           "marginVertical": 6,
+          "width": "100%",
         }
       }
     >


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: #3841 

### Summary

When `List.Item`s are contained within the `View` with `alignItems` then the item's row is not filling whole space – adding `width: '100%'` to the row wrapper solves the issue.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Tested manually on the apps.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
