### PR TITLE
feat: add dismissableBackButton prop to Dialog

### DIFF
--- a/example/src/Examples/DialogExample.tsx
+++ b/example/src/Examples/DialogExample.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 
 import { Button } from 'react-native-paper';
 
@@ -7,6 +7,7 @@ import { useExampleTheme } from '..';
 import ScreenWrapper from '../ScreenWrapper';
 import {
   DialogWithCustomColors,
+  DialogWithDismissableBackButton,
   DialogWithIcon,
   DialogWithLoadingIndicator,
   DialogWithLongText,
@@ -73,6 +74,15 @@ const DialogExample = () => {
           With icon
         </Button>
       )}
+      {Platform.OS === 'android' && (
+        <Button
+          mode="outlined"
+          onPress={_toggleDialog('dialog7')}
+          style={styles.button}
+        >
+          Dismissable back button
+        </Button>
+      )}
       <DialogWithLongText
         visible={_getVisible('dialog1')}
         close={_toggleDialog('dialog1')}
@@ -99,6 +109,10 @@ const DialogExample = () => {
           close={_toggleDialog('dialog6')}
         />
       )}
+      <DialogWithDismissableBackButton
+        visible={_getVisible('dialog7')}
+        close={_toggleDialog('dialog7')}
+      />
     </ScreenWrapper>
   );
 };

--- a/example/src/Examples/Dialogs/DialogWithDismissableBackButton.tsx
+++ b/example/src/Examples/Dialogs/DialogWithDismissableBackButton.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+
+import { Button, Portal, Dialog, MD2Colors } from 'react-native-paper';
+
+import { TextComponent } from './DialogTextComponent';
+
+const DialogWithDismissableBackButton = ({
+  visible,
+  close,
+}: {
+  visible: boolean;
+  close: () => void;
+}) => (
+  <Portal>
+    <Dialog
+      onDismiss={close}
+      visible={visible}
+      dismissable={false}
+      dismissableBackButton
+    >
+      <Dialog.Title>Alert</Dialog.Title>
+      <Dialog.Content>
+        <TextComponent>
+          This is an undismissable dialog, however you can use hardware back
+          button to close it!
+        </TextComponent>
+      </Dialog.Content>
+      <Dialog.Actions>
+        <Button color={MD2Colors.teal500} disabled>
+          Disagree
+        </Button>
+        <Button onPress={close}>Agree</Button>
+      </Dialog.Actions>
+    </Dialog>
+  </Portal>
+);
+
+export default DialogWithDismissableBackButton;

--- a/example/src/Examples/Dialogs/index.tsx
+++ b/example/src/Examples/Dialogs/index.tsx
@@ -4,3 +4,4 @@ export { default as DialogWithLongText } from './DialogWithLongText';
 export { default as DialogWithRadioBtns } from './DialogWithRadioBtns';
 export { default as UndismissableDialog } from './UndismissableDialog';
 export { default as DialogWithIcon } from './DialogWithIcon';
+export { default as DialogWithDismissableBackButton } from './DialogWithDismissableBackButton';

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -23,6 +23,10 @@ export type Props = {
    */
   dismissable?: boolean;
   /**
+   * Determines whether clicking Android hardware back button dismiss dialog.
+   */
+  dismissableBackButton?: boolean;
+  /**
    * Callback that is called when the user dismisses the dialog.
    */
   onDismiss?: () => void;
@@ -95,6 +99,7 @@ const DIALOG_ELEVATION: number = 24;
 const Dialog = ({
   children,
   dismissable = true,
+  dismissableBackButton = dismissable,
   onDismiss,
   visible = false,
   style,
@@ -116,6 +121,7 @@ const Dialog = ({
   return (
     <Modal
       dismissable={dismissable}
+      dismissableBackButton={dismissableBackButton}
       onDismiss={onDismiss}
       visible={visible}
       contentContainerStyle={[

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -25,6 +25,10 @@ export type Props = {
    */
   dismissable?: boolean;
   /**
+   * Determines whether clicking Android hardware back button dismiss dialog.
+   */
+  dismissableBackButton?: boolean;
+  /**
    * Callback that is called when the user dismisses the modal.
    */
   onDismiss?: () => void;
@@ -102,6 +106,7 @@ const DEFAULT_DURATION = 220;
  */
 function Modal({
   dismissable = true,
+  dismissableBackButton = dismissable,
   visible = false,
   overlayAccessibilityLabel = 'Close modal',
   onDismiss = () => {},
@@ -170,7 +175,7 @@ function Modal({
     }
 
     const onHardwareBackPress = () => {
-      if (dismissable) {
+      if (dismissable || dismissableBackButton) {
         hideModal();
       }
 
@@ -183,7 +188,7 @@ function Modal({
       onHardwareBackPress
     );
     return () => subscription.remove();
-  }, [dismissable, hideModal, visible]);
+  }, [dismissable, dismissableBackButton, hideModal, visible]);
 
   const prevVisible = React.useRef<boolean | null>(null);
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Solves: #3810 

Introducing new prop:

```
  /**
   * Determines whether clicking Android hardware back button dismiss dialog.
   */
  dismissableBackButton?: boolean;
```

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

- [X] - added unit test case
- [X] - added new example

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
