### PR TITLE
docs: Update FAB description in docs

### DIFF
--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -133,7 +133,7 @@ export type Props = $Omit<$RemoveChildren<typeof Surface>, 'mode'> & {
 } & IconOrLabel;
 
 /**
- * A floating action button represents the primary action in an application.
+ * A floating action button represents the primary action in an application. It appears in front of all screen content.
  * <div class="screenshots">
  *   <img class="small" src="screenshots/fab-1.png" />
  *   <img class="small" src="screenshots/fab-2.png" />

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -133,7 +133,7 @@ export type Props = $Omit<$RemoveChildren<typeof Surface>, 'mode'> & {
 } & IconOrLabel;
 
 /**
- * A floating action button represents the primary action in an application. It appears in front of all screen content.
+ * A floating action button represents the primary action on a screen. It appears in front of all screen content.
  * <div class="screenshots">
  *   <img class="small" src="screenshots/fab-1.png" />
  *   <img class="small" src="screenshots/fab-2.png" />


### PR DESCRIPTION
### Summary

Trying to make the FAB description a little more comprehensive and precise. 

I think noting what distinguishes an FAB from a normal button is helpful to someone not familiar with Material-UI. 

I also changed "application" to "screen," as an FAB represents the most important action on *a screen* - not necessarily the most important application in the entire application.

### Test plan

Load the docs for FAB, verify that they make sense.