### PR TITLE
fix: touchable ripple overlay

### DIFF
--- a/src/components/CrossFadeIcon.tsx
+++ b/src/components/CrossFadeIcon.tsx
@@ -19,6 +19,10 @@ type Props = {
    */
   size: number;
   /**
+   * TestID used for testing purposes
+   */
+  testID?: string;
+  /**
    * @optional
    */
   theme?: ThemeProp;
@@ -29,6 +33,7 @@ const CrossFadeIcon = ({
   size,
   source,
   theme: themeOverrides,
+  testID = 'cross-fade-icon',
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
   const [currentIcon, setCurrentIcon] = React.useState<IconSource>(
@@ -97,6 +102,7 @@ const CrossFadeIcon = ({
               transform: [{ rotate: rotatePrev }],
             },
           ]}
+          testID={`${testID}-previous`}
         >
           <Icon source={previousIcon} size={size} color={color} theme={theme} />
         </Animated.View>
@@ -109,6 +115,7 @@ const CrossFadeIcon = ({
             transform: [{ rotate: rotateNext }],
           },
         ]}
+        testID={`${testID}-current`}
       >
         <Icon source={currentIcon} size={size} color={color} theme={theme} />
       </Animated.View>

--- a/src/components/TouchableRipple/TouchableRipple.native.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.native.tsx
@@ -7,6 +7,7 @@ import {
   StyleSheet,
   Pressable,
   GestureResponderEvent,
+  View,
 } from 'react-native';
 
 import { useInternalTheme } from '../../core/theming';
@@ -45,7 +46,6 @@ const TouchableRipple = ({
   ...rest
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
-  const [showUnderlay, setShowUnderlay] = React.useState<boolean>(false);
 
   const { onPress, onLongPress, onPressIn, onPressOut } = rest;
 
@@ -72,16 +72,6 @@ const TouchableRipple = ({
     Platform.Version >= ANDROID_VERSION_PIE &&
     borderless;
 
-  const handlePressIn = (e: GestureResponderEvent) => {
-    setShowUnderlay(true);
-    onPressIn?.(e);
-  };
-
-  const handlePressOut = (e: GestureResponderEvent) => {
-    setShowUnderlay(false);
-    onPressOut?.(e);
-  };
-
   if (TouchableRipple.supported) {
     return (
       <Pressable
@@ -107,15 +97,22 @@ const TouchableRipple = ({
     <Pressable
       {...rest}
       disabled={disabled}
-      style={[
-        borderless && styles.overflowHidden,
-        showUnderlay && { backgroundColor: calculatedUnderlayColor },
-        style,
-      ]}
-      onPressIn={handlePressIn}
-      onPressOut={handlePressOut}
+      style={[borderless && styles.overflowHidden, style]}
     >
-      {React.Children.only(children)}
+      {({ pressed }) => (
+        <>
+          {pressed && (
+            <View
+              testID="touchable-ripple-underlay"
+              style={[
+                styles.underlay,
+                { backgroundColor: calculatedUnderlayColor },
+              ]}
+            />
+          )}
+          {React.Children.only(children)}
+        </>
+      )}
     </Pressable>
   );
 };
@@ -126,6 +123,10 @@ TouchableRipple.supported =
 const styles = StyleSheet.create({
   overflowHidden: {
     overflow: 'hidden',
+  },
+  underlay: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 2,
   },
 });
 

--- a/src/components/__tests__/Appbar/Appbar.test.tsx
+++ b/src/components/__tests__/Appbar/Appbar.test.tsx
@@ -267,7 +267,8 @@ describe('AppbarAction', () => {
         <Appbar.Action icon="menu" testID="appbar-action" />
       </Appbar>
     );
-    const appbarActionIcon = getByTestId('appbar-action').props.children[0];
+    const appbarActionIcon = getByTestId('cross-fade-icon-current').props
+      .children;
     expect(appbarActionIcon.props.color).toBe(
       getTheme().colors.onSurfaceVariant
     );
@@ -279,7 +280,8 @@ describe('AppbarAction', () => {
         <Appbar.Action icon="menu" testID="appbar-action" isLeading />
       </Appbar>
     );
-    const appbarActionIcon = getByTestId('appbar-action').props.children[0];
+    const appbarActionIcon = getByTestId('cross-fade-icon-current').props
+      .children;
     expect(appbarActionIcon.props.color).toBe(getTheme().colors.onSurface);
   });
 
@@ -289,7 +291,8 @@ describe('AppbarAction', () => {
         <Appbar.Action icon="menu" color="purple" testID="appbar-action" />
       </Appbar>
     );
-    const appbarActionIcon = getByTestId('appbar-action').props.children[0];
+    const appbarActionIcon = getByTestId('cross-fade-icon-current').props
+      .children;
     expect(appbarActionIcon.props.color).toBe('purple');
   });
 
@@ -299,7 +302,8 @@ describe('AppbarAction', () => {
         <Appbar.BackAction color="purple" testID="appbar-action" />
       </Appbar>
     );
-    const appbarBackActionIcon = getByTestId('appbar-action').props.children[0];
+    const appbarBackActionIcon = getByTestId('cross-fade-icon-current').props
+      .children;
     expect(appbarBackActionIcon.props.color).toBe('purple');
   });
 
@@ -313,7 +317,8 @@ describe('AppbarAction', () => {
         </Appbar>
       );
 
-      const appbarActionIcon = getByTestId('appbar-action').props.children[0];
+      const appbarActionIcon = getByTestId('cross-fade-icon-current').props
+        .children;
 
       expect(appbarActionIcon.props.color).toBe('#ffffff');
     });
@@ -329,7 +334,8 @@ describe('AppbarAction', () => {
         </Provider>
       );
 
-      const appbarActionIcon = getByTestId('appbar-action').props.children[0];
+      const appbarActionIcon = getByTestId('cross-fade-icon-current').props
+        .children;
 
       expect(appbarActionIcon.props.color).toBe('#ffffff');
     });

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
@@ -193,7 +193,6 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                   Object {
                     "overflow": "hidden",
                   },
-                  false,
                   Array [
                     Object {
                       "alignItems": "center",
@@ -386,7 +385,6 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                     Object {
                       "overflow": "hidden",
                     },
-                    false,
                     Array [
                       Object {
                         "alignItems": "center",
@@ -590,7 +588,6 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
               Object {
                 "overflow": "hidden",
               },
-              false,
               Array [
                 Object {
                   "alignItems": "center",
@@ -636,6 +633,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
                   ],
                 }
               }
+              testID="cross-fade-icon-current"
             >
               <View
                 style={
@@ -830,7 +828,6 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
               Object {
                 "overflow": "hidden",
               },
-              false,
               Array [
                 Object {
                   "alignItems": "center",
@@ -876,6 +873,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
                   ],
                 }
               }
+              testID="cross-fade-icon-current"
             >
               <Text
                 accessibilityElementsHidden={true}

--- a/src/components/__tests__/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -27,7 +27,6 @@ exports[`renders Checkbox with custom testID 1`] = `
       Object {
         "overflow": "hidden",
       },
-      false,
       Object {
         "borderRadius": 18,
         "padding": 6,
@@ -111,7 +110,6 @@ exports[`renders checked Checkbox with color 1`] = `
       Object {
         "overflow": "hidden",
       },
-      false,
       Object {
         "borderRadius": 18,
         "padding": 6,
@@ -193,7 +191,6 @@ exports[`renders checked Checkbox with onPress 1`] = `
       Object {
         "overflow": "hidden",
       },
-      false,
       Object {
         "borderRadius": 18,
         "padding": 6,
@@ -275,7 +272,6 @@ exports[`renders indeterminate Checkbox 1`] = `
       Object {
         "overflow": "hidden",
       },
-      false,
       Object {
         "borderRadius": 18,
         "padding": 6,
@@ -358,7 +354,6 @@ exports[`renders indeterminate Checkbox with color 1`] = `
       Object {
         "overflow": "hidden",
       },
-      false,
       Object {
         "borderRadius": 18,
         "padding": 6,
@@ -441,7 +436,6 @@ exports[`renders unchecked Checkbox with color 1`] = `
       Object {
         "overflow": "hidden",
       },
-      false,
       Object {
         "borderRadius": 18,
         "padding": 6,
@@ -523,7 +517,6 @@ exports[`renders unchecked Checkbox with onPress 1`] = `
       Object {
         "overflow": "hidden",
       },
-      false,
       Object {
         "borderRadius": 18,
         "padding": 6,

--- a/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.tsx.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.tsx.snap
@@ -25,7 +25,6 @@ exports[`can render leading checkbox control 1`] = `
   style={
     Array [
       false,
-      false,
       undefined,
     ]
   }
@@ -72,7 +71,6 @@ exports[`can render leading checkbox control 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 18,
             "padding": 6,
@@ -190,7 +188,6 @@ exports[`can render the Android checkbox on different platforms 1`] = `
   style={
     Array [
       false,
-      false,
       undefined,
     ]
   }
@@ -273,7 +270,6 @@ exports[`can render the Android checkbox on different platforms 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 18,
             "height": 36,
@@ -391,7 +387,6 @@ exports[`can render the iOS checkbox on different platforms 1`] = `
   style={
     Array [
       false,
-      false,
       undefined,
     ]
   }
@@ -474,7 +469,6 @@ exports[`can render the iOS checkbox on different platforms 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 18,
             "padding": 6,
@@ -555,7 +549,6 @@ exports[`renders unchecked 1`] = `
   onStartShouldSetResponder={[Function]}
   style={
     Array [
-      false,
       false,
       undefined,
     ]
@@ -639,7 +632,6 @@ exports[`renders unchecked 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 18,
             "padding": 6,

--- a/src/components/__tests__/RadioButton/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/components/__tests__/RadioButton/__snapshots__/RadioButton.test.tsx.snap
@@ -27,7 +27,6 @@ exports[`RadioButton RadioButton with custom testID renders properly 1`] = `
       Object {
         "overflow": "hidden",
       },
-      false,
       Object {
         "borderRadius": 18,
         "padding": 6,
@@ -110,7 +109,6 @@ exports[`RadioButton on default platform renders properly 1`] = `
       Object {
         "overflow": "hidden",
       },
-      false,
       Object {
         "borderRadius": 18,
         "padding": 6,
@@ -192,7 +190,6 @@ exports[`RadioButton on ios platform renders properly 1`] = `
       Object {
         "overflow": "hidden",
       },
-      false,
       Object {
         "borderRadius": 18,
         "padding": 6,
@@ -274,7 +271,6 @@ exports[`RadioButton when RadioButton is wrapped by RadioButtonContext.Provider 
       Object {
         "overflow": "hidden",
       },
-      false,
       Object {
         "borderRadius": 18,
         "padding": 6,

--- a/src/components/__tests__/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/components/__tests__/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -30,7 +30,6 @@ exports[`RadioButtonGroup renders properly 1`] = `
         Object {
           "overflow": "hidden",
         },
-        false,
         Object {
           "borderRadius": 18,
           "padding": 6,

--- a/src/components/__tests__/RadioButton/__snapshots__/RadioButtonItem.test.tsx.snap
+++ b/src/components/__tests__/RadioButton/__snapshots__/RadioButtonItem.test.tsx.snap
@@ -25,7 +25,6 @@ exports[`can render leading radio button control 1`] = `
   style={
     Array [
       false,
-      false,
       undefined,
     ]
   }
@@ -71,7 +70,6 @@ exports[`can render leading radio button control 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 18,
             "padding": 6,
@@ -187,7 +185,6 @@ exports[`can render the Android radio button on different platforms 1`] = `
   style={
     Array [
       false,
-      false,
       undefined,
     ]
   }
@@ -267,7 +264,6 @@ exports[`can render the Android radio button on different platforms 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 18,
           },
@@ -316,7 +312,6 @@ exports[`can render the iOS radio button on different platforms 1`] = `
   onStartShouldSetResponder={[Function]}
   style={
     Array [
-      false,
       false,
       undefined,
     ]
@@ -397,7 +392,6 @@ exports[`can render the iOS radio button on different platforms 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 18,
             "padding": 6,
@@ -479,7 +473,6 @@ exports[`renders unchecked 1`] = `
   style={
     Array [
       false,
-      false,
       undefined,
     ]
   }
@@ -559,7 +552,6 @@ exports[`renders unchecked 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 18,
             "padding": 6,

--- a/src/components/__tests__/TouchableRipple.test.tsx
+++ b/src/components/__tests__/TouchableRipple.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Platform, Text } from 'react-native';
+
+import { render } from '@testing-library/react-native';
+
+import TouchableRipple from '../TouchableRipple/TouchableRipple';
+
+describe('TouchableRipple', () => {
+  describe('on iOS', () => {
+    Platform.OS = 'ios';
+
+    it('displays the underlay when pressed', () => {
+      const { getByTestId } = render(
+        <TouchableRipple testOnly_pressed>
+          <Text>Press me!</Text>
+        </TouchableRipple>
+      );
+
+      const underlay = getByTestId('touchable-ripple-underlay');
+      expect(underlay).toBeDefined();
+    });
+
+    it('renders custom underlay color', () => {
+      const { getByTestId } = render(
+        <TouchableRipple testOnly_pressed underlayColor="purple">
+          <Text>Press me!</Text>
+        </TouchableRipple>
+      );
+
+      const underlay = getByTestId('touchable-ripple-underlay');
+      expect(underlay).toHaveStyle({ backgroundColor: 'purple' });
+    });
+  });
+});

--- a/src/components/__tests__/__snapshots__/AnimatedFAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/AnimatedFAB.test.tsx.snap
@@ -174,7 +174,6 @@ exports[`renders animated fab 1`] = `
                 Object {
                   "overflow": "hidden",
                 },
-                false,
                 Object {
                   "borderRadius": 16,
                 },
@@ -467,7 +466,6 @@ exports[`renders animated fab with label on the left 1`] = `
                 Object {
                   "overflow": "hidden",
                 },
-                false,
                 Object {
                   "borderRadius": 16,
                 },
@@ -762,7 +760,6 @@ exports[`renders animated fab with label on the right by default 1`] = `
                 Object {
                   "overflow": "hidden",
                 },
-                false,
                 Object {
                   "borderRadius": 16,
                 },

--- a/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
@@ -202,7 +202,6 @@ exports[`render visible banner, with custom theme 1`] = `
                     Object {
                       "overflow": "hidden",
                     },
-                    false,
                     Object {
                       "borderRadius": 20,
                     },
@@ -649,7 +648,6 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                     Object {
                       "overflow": "hidden",
                     },
-                    false,
                     Object {
                       "borderRadius": 20,
                     },
@@ -931,7 +929,6 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                     Object {
                       "overflow": "hidden",
                     },
-                    false,
                     Object {
                       "borderRadius": 20,
                     },
@@ -1081,7 +1078,6 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                     Object {
                       "overflow": "hidden",
                     },
-                    false,
                     Object {
                       "borderRadius": 20,
                     },

--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -78,7 +78,6 @@ exports[`renders button with an accessibility hint 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 20,
           },
@@ -229,7 +228,6 @@ exports[`renders button with an accessibility label 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 20,
           },
@@ -379,7 +377,6 @@ exports[`renders button with button color 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 20,
           },
@@ -529,7 +526,6 @@ exports[`renders button with color 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 20,
           },
@@ -679,7 +675,6 @@ exports[`renders button with custom testID 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 20,
           },
@@ -829,7 +824,6 @@ exports[`renders button with icon 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 20,
           },
@@ -1035,7 +1029,6 @@ exports[`renders button with icon in reverse order 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 20,
           },
@@ -1243,7 +1236,6 @@ exports[`renders contained contained with mode 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 20,
           },
@@ -1394,7 +1386,6 @@ exports[`renders disabled button 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 20,
           },
@@ -1544,7 +1535,6 @@ exports[`renders loading button 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 20,
           },
@@ -1902,7 +1892,6 @@ exports[`renders outlined button with mode 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 20,
           },
@@ -2053,7 +2042,6 @@ exports[`renders text button by default 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 20,
           },
@@ -2203,7 +2191,6 @@ exports[`renders text button with mode 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 20,
           },

--- a/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -78,7 +78,6 @@ exports[`renders chip with close button 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Array [
             Object {
               "borderRadius": 8,
@@ -366,7 +365,6 @@ exports[`renders chip with custom close button 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Array [
             Object {
               "borderRadius": 8,
@@ -654,7 +652,6 @@ exports[`renders chip with icon 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Array [
             Object {
               "borderRadius": 8,
@@ -865,7 +862,6 @@ exports[`renders chip with onPress 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Array [
             Object {
               "borderRadius": 8,
@@ -1024,7 +1020,6 @@ exports[`renders outlined disabled chip 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Array [
             Object {
               "borderRadius": 8,
@@ -1183,7 +1178,6 @@ exports[`renders selected chip 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Array [
             Object {
               "borderRadius": 8,

--- a/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -22,7 +22,6 @@ exports[`renders data table cell 1`] = `
   style={
     Array [
       false,
-      false,
       Array [
         Object {
           "alignItems": "center",
@@ -352,7 +351,6 @@ exports[`renders data table pagination 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              false,
               Array [
                 Object {
                   "alignItems": "center",
@@ -495,7 +493,6 @@ exports[`renders data table pagination 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              false,
               Array [
                 Object {
                   "alignItems": "center",
@@ -696,7 +693,6 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              false,
               Array [
                 Object {
                   "alignItems": "center",
@@ -839,7 +835,6 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              false,
               Array [
                 Object {
                   "alignItems": "center",
@@ -982,7 +977,6 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              false,
               Array [
                 Object {
                   "alignItems": "center",
@@ -1125,7 +1119,6 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              false,
               Array [
                 Object {
                   "alignItems": "center",
@@ -1326,7 +1319,6 @@ exports[`renders data table pagination with label 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              false,
               Array [
                 Object {
                   "alignItems": "center",
@@ -1469,7 +1461,6 @@ exports[`renders data table pagination with label 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              false,
               Array [
                 Object {
                   "alignItems": "center",
@@ -1665,7 +1656,6 @@ exports[`renders data table pagination with options select 1`] = `
                 Object {
                   "overflow": "hidden",
                 },
-                false,
                 Object {
                   "borderRadius": 20,
                 },
@@ -1921,7 +1911,6 @@ exports[`renders data table pagination with options select 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              false,
               Array [
                 Object {
                   "alignItems": "center",
@@ -2064,7 +2053,6 @@ exports[`renders data table pagination with options select 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              false,
               Array [
                 Object {
                   "alignItems": "center",
@@ -2207,7 +2195,6 @@ exports[`renders data table pagination with options select 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              false,
               Array [
                 Object {
                   "alignItems": "center",
@@ -2350,7 +2337,6 @@ exports[`renders data table pagination with options select 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              false,
               Array [
                 Object {
                   "alignItems": "center",
@@ -2669,7 +2655,6 @@ exports[`renders right aligned data table cell 1`] = `
   onStartShouldSetResponder={[Function]}
   style={
     Array [
-      false,
       false,
       Array [
         Object {

--- a/src/components/__tests__/__snapshots__/DrawerItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DrawerItem.test.tsx.snap
@@ -27,7 +27,6 @@ exports[`renders DrawerItem with icon 1`] = `
         Object {
           "overflow": "hidden",
         },
-        false,
         Array [
           Object {
             "marginHorizontal": 10,
@@ -181,7 +180,6 @@ exports[`renders active DrawerItem 1`] = `
         Object {
           "overflow": "hidden",
         },
-        false,
         Array [
           Object {
             "marginHorizontal": 10,
@@ -335,7 +333,6 @@ exports[`renders basic DrawerItem 1`] = `
         Object {
           "overflow": "hidden",
         },
-        false,
         Array [
           Object {
             "marginHorizontal": 10,

--- a/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
@@ -78,7 +78,6 @@ exports[`renders FAB with custom size prop 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 25,
           },
@@ -135,6 +134,7 @@ exports[`renders FAB with custom size prop 1`] = `
                 ],
               }
             }
+            testID="cross-fade-icon-current"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -258,7 +258,6 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 16,
           },
@@ -315,6 +314,7 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
                 ],
               }
             }
+            testID="cross-fade-icon-current"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -438,7 +438,6 @@ exports[`renders default FAB 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 16,
           },
@@ -495,6 +494,7 @@ exports[`renders default FAB 1`] = `
                 ],
               }
             }
+            testID="cross-fade-icon-current"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -618,7 +618,6 @@ exports[`renders disabled FAB 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 16,
           },
@@ -675,6 +674,7 @@ exports[`renders disabled FAB 1`] = `
                 ],
               }
             }
+            testID="cross-fade-icon-current"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -799,7 +799,6 @@ exports[`renders extended FAB 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 16,
           },
@@ -856,6 +855,7 @@ exports[`renders extended FAB 1`] = `
                 ],
               }
             }
+            testID="cross-fade-icon-current"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -1018,7 +1018,6 @@ exports[`renders extended FAB with custom size prop 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 25,
           },
@@ -1074,6 +1073,7 @@ exports[`renders extended FAB with custom size prop 1`] = `
                 ],
               }
             }
+            testID="cross-fade-icon-current"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -1235,7 +1235,6 @@ exports[`renders large FAB 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 28,
           },
@@ -1292,6 +1291,7 @@ exports[`renders large FAB 1`] = `
                 ],
               }
             }
+            testID="cross-fade-icon-current"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -1415,7 +1415,6 @@ exports[`renders loading FAB 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 16,
           },
@@ -1720,7 +1719,6 @@ exports[`renders loading FAB with custom size prop 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 25,
           },
@@ -2025,7 +2023,6 @@ exports[`renders not visible FAB 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 16,
           },
@@ -2082,6 +2079,7 @@ exports[`renders not visible FAB 1`] = `
                 ],
               }
             }
+            testID="cross-fade-icon-current"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -2205,7 +2203,6 @@ exports[`renders small FAB 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 12,
           },
@@ -2262,6 +2259,7 @@ exports[`renders small FAB 1`] = `
                 ],
               }
             }
+            testID="cross-fade-icon-current"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -2385,7 +2383,6 @@ exports[`renders visible FAB 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderRadius": 16,
           },
@@ -2442,6 +2439,7 @@ exports[`renders visible FAB 1`] = `
                 ],
               }
             }
+            testID="cross-fade-icon-current"
           >
             <Text
               accessibilityElementsHidden={true}

--- a/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
@@ -94,7 +94,6 @@ exports[`renders disabled icon button 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Array [
             Object {
               "alignItems": "center",
@@ -239,7 +238,6 @@ exports[`renders icon button by default 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Array [
             Object {
               "alignItems": "center",
@@ -384,7 +382,6 @@ exports[`renders icon button with color 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Array [
             Object {
               "alignItems": "center",
@@ -529,7 +526,6 @@ exports[`renders icon button with size 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Array [
             Object {
               "alignItems": "center",
@@ -674,7 +670,6 @@ exports[`renders icon change animated 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Array [
             Object {
               "alignItems": "center",
@@ -720,6 +715,7 @@ exports[`renders icon change animated 1`] = `
               ],
             }
           }
+          testID="cross-fade-icon-current"
         >
           <Text
             accessibilityElementsHidden={true}

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
@@ -34,7 +34,6 @@ exports[`renders expanded accordion 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Array [
             Object {
               "padding": 8,
@@ -169,7 +168,6 @@ exports[`renders expanded accordion 1`] = `
     style={
       Array [
         false,
-        false,
         Array [
           Object {
             "paddingRight": 24,
@@ -272,7 +270,6 @@ exports[`renders list accordion with children 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Array [
             Object {
               "padding": 8,
@@ -472,7 +469,6 @@ exports[`renders list accordion with custom title and description styles 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Array [
             Object {
               "padding": 8,
@@ -662,7 +658,6 @@ exports[`renders list accordion with left items 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Array [
             Object {
               "padding": 8,
@@ -862,7 +857,6 @@ exports[`renders multiline list accordion 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Array [
             Object {
               "padding": 8,

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -22,7 +22,6 @@ exports[`renders list item with custom description 1`] = `
   style={
     Array [
       false,
-      false,
       Array [
         Object {
           "paddingRight": 24,
@@ -175,7 +174,6 @@ exports[`renders list item with custom description 1`] = `
                     Object {
                       "overflow": "hidden",
                     },
-                    false,
                     Array [
                       Object {
                         "borderRadius": 8,
@@ -335,7 +333,6 @@ exports[`renders list item with custom title and description styles 1`] = `
   style={
     Array [
       false,
-      false,
       Array [
         Object {
           "paddingRight": 24,
@@ -460,7 +457,6 @@ exports[`renders list item with left and right items 1`] = `
   onStartShouldSetResponder={[Function]}
   style={
     Array [
-      false,
       false,
       Array [
         Object {
@@ -639,7 +635,6 @@ exports[`renders list item with left item 1`] = `
   style={
     Array [
       false,
-      false,
       Array [
         Object {
           "paddingRight": 24,
@@ -783,7 +778,6 @@ exports[`renders list item with right item 1`] = `
   style={
     Array [
       false,
-      false,
       Array [
         Object {
           "paddingRight": 24,
@@ -875,7 +869,6 @@ exports[`renders list item with title and description 1`] = `
   onStartShouldSetResponder={[Function]}
   style={
     Array [
-      false,
       false,
       Array [
         Object {
@@ -997,7 +990,6 @@ exports[`renders with a description with typeof number 1`] = `
   onStartShouldSetResponder={[Function]}
   style={
     Array [
-      false,
       false,
       Array [
         Object {

--- a/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
@@ -237,7 +237,6 @@ exports[`renders list section with custom title style 1`] = `
     style={
       Array [
         false,
-        false,
         Array [
           Object {
             "paddingRight": 24,
@@ -377,7 +376,6 @@ exports[`renders list section with custom title style 1`] = `
     onStartShouldSetResponder={[Function]}
     style={
       Array [
-        false,
         false,
         Array [
           Object {
@@ -736,7 +734,6 @@ exports[`renders list section with subheader 1`] = `
     style={
       Array [
         false,
-        false,
         Array [
           Object {
             "paddingRight": 24,
@@ -876,7 +873,6 @@ exports[`renders list section with subheader 1`] = `
     onStartShouldSetResponder={[Function]}
     style={
       Array [
-        false,
         false,
         Array [
           Object {
@@ -1197,7 +1193,6 @@ exports[`renders list section without subheader 1`] = `
     style={
       Array [
         false,
-        false,
         Array [
           Object {
             "paddingRight": 24,
@@ -1337,7 +1332,6 @@ exports[`renders list section without subheader 1`] = `
     onStartShouldSetResponder={[Function]}
     style={
       Array [
-        false,
         false,
         Array [
           Object {

--- a/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -90,7 +90,6 @@ Array [
                 Object {
                   "overflow": "hidden",
                 },
-                false,
                 Object {
                   "borderRadius": 20,
                 },
@@ -315,7 +314,6 @@ Array [
               style={
                 Array [
                   false,
-                  false,
                   Array [
                     Object {
                       "height": 48,
@@ -421,7 +419,6 @@ Array [
               onStartShouldSetResponder={[Function]}
               style={
                 Array [
-                  false,
                   false,
                   Array [
                     Object {
@@ -604,7 +601,6 @@ exports[`renders not visible menu 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              false,
               Object {
                 "borderRadius": 20,
               },
@@ -770,7 +766,6 @@ Array [
                 Object {
                   "overflow": "hidden",
                 },
-                false,
                 Object {
                   "borderRadius": 20,
                 },
@@ -991,7 +986,6 @@ Array [
               style={
                 Array [
                   false,
-                  false,
                   Array [
                     Object {
                       "height": 48,
@@ -1097,7 +1091,6 @@ Array [
               onStartShouldSetResponder={[Function]}
               style={
                 Array [
-                  false,
                   false,
                   Array [
                     Object {

--- a/src/components/__tests__/__snapshots__/MenuItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/MenuItem.test.tsx.snap
@@ -24,7 +24,6 @@ Array [
     style={
       Array [
         false,
-        false,
         Array [
           Object {
             "height": 48,
@@ -178,7 +177,6 @@ Array [
     onStartShouldSetResponder={[Function]}
     style={
       Array [
-        false,
         false,
         Array [
           Object {
@@ -334,7 +332,6 @@ Array [
     style={
       Array [
         false,
-        false,
         Array [
           Object {
             "height": 48,
@@ -489,7 +486,6 @@ Array [
     style={
       Array [
         false,
-        false,
         Array [
           Object {
             "height": 48,
@@ -643,7 +639,6 @@ Array [
     onStartShouldSetResponder={[Function]}
     style={
       Array [
-        false,
         false,
         Array [
           Object {

--- a/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
@@ -140,7 +140,6 @@ exports[`activity indicator snapshot test 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              false,
               Array [
                 Object {
                   "alignItems": "center",
@@ -572,7 +571,6 @@ exports[`renders with placeholder 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              false,
               Array [
                 Object {
                   "alignItems": "center",
@@ -765,7 +763,6 @@ exports[`renders with placeholder 1`] = `
                 Object {
                   "overflow": "hidden",
                 },
-                false,
                 Array [
                   Object {
                     "alignItems": "center",
@@ -964,7 +961,6 @@ exports[`renders with text 1`] = `
               Object {
                 "overflow": "hidden",
               },
-              false,
               Array [
                 Object {
                   "alignItems": "center",
@@ -1153,7 +1149,6 @@ exports[`renders with text 1`] = `
                 Object {
                   "overflow": "hidden",
                 },
-                false,
                 Array [
                   Object {
                     "alignItems": "center",

--- a/src/components/__tests__/__snapshots__/SegmentedButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/SegmentedButton.test.tsx.snap
@@ -62,7 +62,6 @@ exports[`renders checked segmented button with selected check 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderBottomRightRadius": 0,
             "borderRadius": 20,
@@ -225,7 +224,6 @@ exports[`renders checked segmented button with selected check 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderBottomLeftRadius": 0,
             "borderRadius": 20,
@@ -353,7 +351,6 @@ exports[`renders disabled segmented button 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderBottomRightRadius": 0,
             "borderRadius": 20,
@@ -465,7 +462,6 @@ exports[`renders disabled segmented button 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderBottomLeftRadius": 0,
             "borderRadius": 20,
@@ -591,7 +587,6 @@ exports[`renders segmented button 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderBottomRightRadius": 0,
             "borderRadius": 20,
@@ -703,7 +698,6 @@ exports[`renders segmented button 1`] = `
           Object {
             "overflow": "hidden",
           },
-          false,
           Object {
             "borderBottomLeftRadius": 0,
             "borderRadius": 20,

--- a/src/components/__tests__/__snapshots__/Snackbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.tsx.snap
@@ -421,7 +421,6 @@ exports[`renders snackbar with action button 1`] = `
                   Object {
                     "overflow": "hidden",
                   },
-                  false,
                   Object {
                     "borderRadius": 20,
                   },

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -1351,7 +1351,6 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
               Object {
                 "overflow": "hidden",
               },
-              false,
               Array [
                 Object {
                   "alignItems": "center",
@@ -1707,7 +1706,6 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
               Object {
                 "overflow": "hidden",
               },
-              false,
               Array [
                 Object {
                   "alignItems": "center",

--- a/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -93,7 +93,6 @@ exports[`renders disabled toggle button 1`] = `
       style={
         Array [
           false,
-          false,
           Array [
             Object {
               "alignItems": "center",
@@ -236,7 +235,6 @@ exports[`renders toggle button 1`] = `
       onStartShouldSetResponder={[Function]}
       style={
         Array [
-          false,
           false,
           Array [
             Object {
@@ -385,7 +383,6 @@ exports[`renders unchecked toggle button 1`] = `
       onStartShouldSetResponder={[Function]}
       style={
         Array [
-          false,
           false,
           Array [
             Object {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Correct the `TouchableRipple` underlay color support, when the ripple is not supported, so the additional layer is displayed, to have a similar effect to `TouchableHighlight`.

#### Related issue

- #3871 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

- [X] - added unit tests

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
