### PR TITLE
feat: add long press support for fab group

### DIFF
--- a/example/src/Examples/FABExample.tsx
+++ b/example/src/Examples/FABExample.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Alert, StyleSheet, View } from 'react-native';
 
 import { FAB, Portal, Text } from 'react-native-paper';
 
 import { useExampleTheme } from '..';
+import { isWeb } from '../../utils';
 import ScreenWrapper from '../ScreenWrapper';
 
 type FABVariant = 'primary' | 'secondary' | 'tertiary' | 'surface';
@@ -12,6 +13,8 @@ type FABMode = 'flat' | 'elevated';
 
 const FABExample = () => {
   const [visible, setVisible] = React.useState<boolean>(true);
+  const [toggleStackOnLongPress, setToggleStackOnLongPress] =
+    React.useState<boolean>(false);
   const [open, setOpen] = React.useState<boolean>(false);
   const { isV3 } = useExampleTheme();
 
@@ -142,6 +145,7 @@ const FABExample = () => {
           <FAB.Group
             open={open}
             icon={open ? 'calendar-today' : 'plus'}
+            toggleStackOnLongPress={toggleStackOnLongPress}
             actions={[
               { icon: 'plus', onPress: () => {} },
               { icon: 'star', label: 'Star', onPress: () => {} },
@@ -152,10 +156,33 @@ const FABExample = () => {
                 onPress: () => {},
                 size: isV3 ? 'small' : 'medium',
               },
+              {
+                icon: toggleStackOnLongPress
+                  ? 'gesture-tap'
+                  : 'gesture-tap-hold',
+                label: toggleStackOnLongPress
+                  ? 'Toggle on Press'
+                  : 'Toggle on Long Press',
+                onPress: () => {
+                  setToggleStackOnLongPress(!toggleStackOnLongPress);
+                },
+              },
             ]}
             onStateChange={({ open }: { open: boolean }) => setOpen(open)}
             onPress={() => {
-              if (open) {
+              if (toggleStackOnLongPress) {
+                isWeb ? alert('Fab is Pressed') : Alert.alert('Fab is Pressed');
+                // do something on press when the speed dial is closed
+              } else if (open) {
+                isWeb ? alert('Fab is Pressed') : Alert.alert('Fab is Pressed');
+                // do something if the speed dial is open
+              }
+            }}
+            onLongPress={() => {
+              if (!toggleStackOnLongPress) {
+                isWeb
+                  ? alert('Fab is Long Pressed')
+                  : Alert.alert('Fab is Long Pressed');
                 // do something if the speed dial is open
               }
             }}

--- a/example/src/Examples/FABExample.tsx
+++ b/example/src/Examples/FABExample.tsx
@@ -168,6 +168,7 @@ const FABExample = () => {
                 },
               },
             ]}
+            enableLongPressWhenStackOpened
             onStateChange={({ open }: { open: boolean }) => setOpen(open)}
             onPress={() => {
               if (toggleStackOnLongPress) {
@@ -179,7 +180,7 @@ const FABExample = () => {
               }
             }}
             onLongPress={() => {
-              if (!toggleStackOnLongPress) {
+              if (!toggleStackOnLongPress || open) {
                 isWeb
                   ? alert('Fab is Long Pressed')
                   : Alert.alert('Fab is Long Pressed');

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -83,6 +83,14 @@ export type Props = {
    */
   toggleStackOnLongPress?: boolean;
   /**
+   * Changes the delay for long press reaction.
+   */
+  delayLongPress?: number;
+  /**
+   * Allows for onLongPress when stack is opened.
+   */
+  enableLongPressWhenStackOpened?: boolean;
+  /**
    * Whether the speed dial is open.
    */
   open: boolean;
@@ -200,7 +208,9 @@ const FABGroup = ({
   testID,
   onStateChange,
   color: colorProp,
+  delayLongPress = 200,
   variant = 'primary',
+  enableLongPressWhenStackOpened = false,
   backdropColor: customBackdropColor,
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
@@ -433,14 +443,14 @@ const FABGroup = ({
             }
           }}
           onLongPress={() => {
-            if (!open) {
+            if (!open || enableLongPressWhenStackOpened) {
               onLongPress?.();
               if (toggleStackOnLongPress) {
                 toggle();
               }
             }
           }}
-          delayLongPress={200}
+          delayLongPress={delayLongPress}
           icon={icon}
           color={colorProp}
           accessibilityLabel={accessibilityLabel}

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -34,6 +34,8 @@ export type Props = {
    * - `containerStyle`: pass additional styles for the fab item label container, for example, `backgroundColor` @supported Available in 5.x
    * - `labelStyle`: pass additional styles for the fab item label, for example, `fontSize`
    * - `onPress`: callback that is called when `FAB` is pressed (required)
+   * - `onLongPress`: callback that is called when `FAB` is long pressed
+   * - `toggleStackOnLongPress`: callback that is called when `FAB` is long pressed
    * - `size`: size of action item. Defaults to `small`. @supported Available in v5.x
    * - `testID`: testID to be used on tests
    */
@@ -72,6 +74,14 @@ export type Props = {
    * Function to execute on pressing the `FAB`.
    */
   onPress?: (e: GestureResponderEvent) => void;
+  /**
+   * Function to execute on long pressing the `FAB`.
+   */
+  onLongPress?: () => void;
+  /**
+   * Makes actions stack appear on long press instead of on press.
+   */
+  toggleStackOnLongPress?: boolean;
   /**
    * Whether the speed dial is open.
    */
@@ -179,6 +189,8 @@ const FABGroup = ({
   icon,
   open,
   onPress,
+  onLongPress,
+  toggleStackOnLongPress,
   accessibilityLabel,
   theme: themeOverrides,
   style,
@@ -416,8 +428,19 @@ const FABGroup = ({
         <FAB
           onPress={(e) => {
             onPress?.(e);
-            toggle();
+            if (!toggleStackOnLongPress || open) {
+              toggle();
+            }
           }}
+          onLongPress={() => {
+            if (!open) {
+              onLongPress?.();
+              if (toggleStackOnLongPress) {
+                toggle();
+              }
+            }
+          }}
+          delayLongPress={200}
           icon={icon}
           color={colorProp}
           accessibilityLabel={accessibilityLabel}

--- a/src/components/__tests__/FABGroup.test.tsx
+++ b/src/components/__tests__/FABGroup.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Animated } from 'react-native';
 
-import { render } from '@testing-library/react-native';
+import { act, fireEvent, render } from '@testing-library/react-native';
 import color from 'color';
 
 import { getTheme } from '../../core/theming';
@@ -218,5 +218,113 @@ it('animated value changes correctly', () => {
 
   expect(getByTestId('my-fab-container-outer-layer')).toHaveStyle({
     transform: [{ scale: 1.5 }],
+  });
+});
+
+describe('Toggle Stack visibility', () => {
+  it('toggles stack visibility on press', () => {
+    const onStateChange = jest.fn();
+    const { getByText } = render(
+      <FAB.Group
+        visible
+        open={false}
+        label="Stack test"
+        icon=""
+        onStateChange={onStateChange}
+        actions={[
+          {
+            label: 'testing',
+            onPress() {},
+            icon: '',
+          },
+        ]}
+      />
+    );
+
+    act(() => {
+      fireEvent(getByText('Stack test'), 'onPress');
+    });
+
+    expect(onStateChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not toggle stack visibility on long press', () => {
+    const onStateChange = jest.fn();
+    const { getByText } = render(
+      <FAB.Group
+        visible
+        open={false}
+        label="Stack test"
+        icon=""
+        onStateChange={onStateChange}
+        actions={[
+          {
+            label: 'testing',
+            onPress() {},
+            icon: '',
+          },
+        ]}
+      />
+    );
+
+    act(() => {
+      fireEvent(getByText('Stack test'), 'onLongPress');
+    });
+
+    expect(onStateChange).toHaveBeenCalledTimes(0);
+  });
+
+  it('toggles stack visibility on long press with toggleStackOnLongPress prop', () => {
+    const onStateChange = jest.fn();
+    const { getByText } = render(
+      <FAB.Group
+        visible
+        open={false}
+        toggleStackOnLongPress
+        label="Stack test"
+        icon=""
+        onStateChange={onStateChange}
+        actions={[
+          {
+            label: 'testing',
+            onPress() {},
+            icon: '',
+          },
+        ]}
+      />
+    );
+
+    act(() => {
+      fireEvent(getByText('Stack test'), 'onLongPress');
+    });
+
+    expect(onStateChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not toggle stack visibility on press with toggleStackOnLongPress prop', () => {
+    const onStateChange = jest.fn();
+    const { getByText } = render(
+      <FAB.Group
+        visible
+        open={false}
+        toggleStackOnLongPress
+        label="Stack test"
+        icon=""
+        onStateChange={onStateChange}
+        actions={[
+          {
+            label: 'testing',
+            onPress() {},
+            icon: '',
+          },
+        ]}
+      />
+    );
+
+    act(() => {
+      fireEvent(getByText('Stack test'), 'onPress');
+    });
+
+    expect(onStateChange).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/components/__tests__/FABGroup.test.tsx
+++ b/src/components/__tests__/FABGroup.test.tsx
@@ -327,4 +327,61 @@ describe('Toggle Stack visibility', () => {
 
     expect(onStateChange).toHaveBeenCalledTimes(0);
   });
+
+  it('does not trigger onLongPress when stack is opened', () => {
+    const onStateChange = jest.fn();
+    const onLongPress = jest.fn();
+    const { getByText } = render(
+      <FAB.Group
+        visible
+        open={true}
+        label="Stack test"
+        icon=""
+        onStateChange={onStateChange}
+        onLongPress={onLongPress}
+        actions={[
+          {
+            label: 'testing',
+            onPress() {},
+            icon: '',
+          },
+        ]}
+      />
+    );
+
+    act(() => {
+      fireEvent(getByText('Stack test'), 'onLongPress');
+    });
+
+    expect(onLongPress).toHaveBeenCalledTimes(0);
+  });
+
+  it('does trigger onLongPress when stack is opened and enableLongPressWhenStackOpened is true', () => {
+    const onStateChange = jest.fn();
+    const onLongPress = jest.fn();
+    const { getByText } = render(
+      <FAB.Group
+        visible
+        open={true}
+        enableLongPressWhenStackOpened
+        label="Stack test"
+        icon=""
+        onStateChange={onStateChange}
+        onLongPress={onLongPress}
+        actions={[
+          {
+            label: 'testing',
+            onPress() {},
+            icon: '',
+          },
+        ]}
+      />
+    );
+
+    act(() => {
+      fireEvent(getByText('Stack test'), 'onLongPress');
+    });
+
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
### Summary

Added `onLongPress` support. Allows to revert the logic of displaying actions stack from `onPress` to `onLongPress`.

## Related issue:
https://github.com/callstack/react-native-paper/issues/3180

### Test plan
- [ ] Check if long press triggers action, and single press toggles stack.
- [ ] Open actions stack by press.
- [ ] Click "Toggle on Long Press" action.
- [ ] Check if logic got reverted, and now single press triggers action, and long press toggles stack.
