### PR TITLE
fix: iOS Surface flex styles moved to outer layer

### DIFF
--- a/example/src/Examples/ButtonExample.tsx
+++ b/example/src/Examples/ButtonExample.tsx
@@ -284,6 +284,25 @@ const ButtonExample = () => {
             Custom Font
           </Button>
         </View>
+
+        <View style={styles.row}>
+          <Button
+            mode="contained"
+            onPress={() => {}}
+            style={styles.flexGrow1Button}
+          >
+            flex-grow: 1
+          </Button>
+        </View>
+        <View style={styles.row}>
+          <Button
+            mode="contained"
+            onPress={() => {}}
+            style={styles.width100PercentButton}
+          >
+            width: 100%
+          </Button>
+        </View>
       </List.Section>
       <List.Section title="Compact">
         <View style={styles.row}>
@@ -336,6 +355,14 @@ const styles = StyleSheet.create({
   fontStyles: {
     fontWeight: '800',
     fontSize: 24,
+  },
+  flexGrow1Button: {
+    flexGrow: 1,
+    marginTop: 10,
+  },
+  width100PercentButton: {
+    width: '100%',
+    marginTop: 10,
   },
 });
 

--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -77,7 +77,23 @@ const MD2Surface = forwardRef<View, Props>(
   }
 );
 
-const flexProperties = ['flex', 'flexShrink', 'flexGrow'];
+const outerLayerStyleProperties: (keyof ViewStyle)[] = [
+  'position',
+  'alignSelf',
+  'top',
+  'right',
+  'bottom',
+  'left',
+  'start',
+  'end',
+  'flex',
+  'flexShrink',
+  'flexGrow',
+  'width',
+  'height',
+  'transform',
+  'opacity',
+];
 
 const shadowColor = '#000';
 const iOSShadowOutputRanges = [
@@ -150,29 +166,14 @@ const SurfaceIOS = forwardRef<
     ref
   ) => {
     const [outerLayerViewStyles, innerLayerViewStyles] = React.useMemo(() => {
-      const {
-        position,
-        alignSelf,
-        top,
-        left,
-        right,
-        bottom,
-        start,
-        end,
-        flex,
-        backgroundColor: backgroundColorStyle,
-        width,
-        height,
-        transform,
-        opacity,
-        ...restStyle
-      } = (StyleSheet.flatten(style) || {}) as ViewStyle;
+      const flattenedStyles = (StyleSheet.flatten(style) || {}) as ViewStyle;
 
       const [filteredStyles, outerLayerStyles, borderRadiusStyles] =
         splitStyles(
-          restStyle,
+          flattenedStyles,
           (style) =>
-            flexProperties.includes(style) || style.startsWith('margin'),
+            outerLayerStyleProperties.includes(style) ||
+            style.startsWith('margin'),
           (style) => style.startsWith('border') && style.endsWith('Radius')
         );
 
@@ -186,7 +187,7 @@ const SurfaceIOS = forwardRef<
         );
       }
 
-      const bgColor = backgroundColorStyle || backgroundColor;
+      const bgColor = flattenedStyles.backgroundColor || backgroundColor;
 
       const isElevated = mode === 'elevated';
 
@@ -194,19 +195,6 @@ const SurfaceIOS = forwardRef<
         ...(isElevated && getStyleForShadowLayer(elevation, 0)),
         ...outerLayerStyles,
         ...borderRadiusStyles,
-        position,
-        alignSelf,
-        top,
-        right,
-        bottom,
-        left,
-        start,
-        end,
-        flex,
-        width,
-        height,
-        transform,
-        opacity,
         backgroundColor: bgColor,
       };
 
@@ -214,7 +202,7 @@ const SurfaceIOS = forwardRef<
         ...(isElevated && getStyleForShadowLayer(elevation, 1)),
         ...filteredStyles,
         ...borderRadiusStyles,
-        flex: height ? 1 : undefined,
+        flex: flattenedStyles.height ? 1 : undefined,
         backgroundColor: bgColor,
       };
 

--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -77,6 +77,8 @@ const MD2Surface = forwardRef<View, Props>(
   }
 );
 
+const flexProperties = ['flex', 'flexShrink', 'flexGrow'];
+
 const shadowColor = '#000';
 const iOSShadowOutputRanges = [
   {
@@ -166,11 +168,13 @@ const SurfaceIOS = forwardRef<
         ...restStyle
       } = (StyleSheet.flatten(style) || {}) as ViewStyle;
 
-      const [filteredStyles, marginStyles, borderRadiusStyles] = splitStyles(
-        restStyle,
-        (style) => style.startsWith('margin'),
-        (style) => style.startsWith('border') && style.endsWith('Radius')
-      );
+      const [filteredStyles, outerLayerStyles, borderRadiusStyles] =
+        splitStyles(
+          restStyle,
+          (style) =>
+            flexProperties.includes(style) || style.startsWith('margin'),
+          (style) => style.startsWith('border') && style.endsWith('Radius')
+        );
 
       if (
         process.env.NODE_ENV !== 'production' &&
@@ -188,7 +192,7 @@ const SurfaceIOS = forwardRef<
 
       const outerLayerViewStyles = {
         ...(isElevated && getStyleForShadowLayer(elevation, 0)),
-        ...marginStyles,
+        ...outerLayerStyles,
         ...borderRadiusStyles,
         position,
         alignSelf,

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
@@ -5,16 +5,8 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(255, 251, 254, 1)",
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
       "height": 64,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -22,10 +14,6 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -58,17 +46,8 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
       collapsable={false}
       style={
         Object {
-          "alignSelf": undefined,
           "backgroundColor": "rgb(238, 232, 244)",
           "borderRadius": 28,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
-          "height": undefined,
-          "left": undefined,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -76,10 +55,6 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
-          "width": undefined,
         }
       }
       testID="search-bar-container-outer-layer"
@@ -108,18 +83,10 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
           collapsable={false}
           style={
             Object {
-              "alignSelf": undefined,
               "backgroundColor": "transparent",
               "borderRadius": 20,
-              "bottom": undefined,
-              "end": undefined,
-              "flex": undefined,
               "height": 40,
-              "left": undefined,
               "margin": 6,
-              "opacity": undefined,
-              "position": undefined,
-              "right": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -127,9 +94,6 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
               },
               "shadowOpacity": 0,
               "shadowRadius": 0,
-              "start": undefined,
-              "top": undefined,
-              "transform": undefined,
               "width": 40,
             }
           }
@@ -301,18 +265,10 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
             collapsable={false}
             style={
               Object {
-                "alignSelf": undefined,
                 "backgroundColor": "transparent",
                 "borderRadius": 20,
-                "bottom": undefined,
-                "end": undefined,
-                "flex": undefined,
                 "height": 40,
-                "left": undefined,
                 "margin": 6,
-                "opacity": undefined,
-                "position": undefined,
-                "right": undefined,
                 "shadowColor": "#000",
                 "shadowOffset": Object {
                   "height": 0,
@@ -320,9 +276,6 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                 },
                 "shadowOpacity": 0,
                 "shadowRadius": 0,
-                "start": undefined,
-                "top": undefined,
-                "transform": undefined,
                 "width": 40,
               }
             }
@@ -452,16 +405,8 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(255, 251, 254, 1)",
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
       "height": 64,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -469,10 +414,6 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -505,18 +446,10 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
       collapsable={false}
       style={
         Object {
-          "alignSelf": undefined,
           "backgroundColor": "transparent",
           "borderRadius": 20,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
           "height": 40,
-          "left": undefined,
           "margin": 6,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -524,9 +457,6 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
           "width": 40,
         }
       }
@@ -746,18 +676,10 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
       collapsable={false}
       style={
         Object {
-          "alignSelf": undefined,
           "backgroundColor": "transparent",
           "borderRadius": 20,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
           "height": 40,
-          "left": undefined,
           "margin": 6,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -765,9 +687,6 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
           "width": 40,
         }
       }

--- a/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
@@ -5,17 +5,8 @@ exports[`Card renders an outlined card 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(255, 251, 254, 1)",
       "borderRadius": 12,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -23,10 +14,6 @@ exports[`Card renders an outlined card 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="card-container-outer-layer"

--- a/src/components/__tests__/__snapshots__/AnimatedFAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/AnimatedFAB.test.tsx.snap
@@ -5,17 +5,10 @@ exports[`renders animated fab 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "transparent",
       "borderRadius": 16,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
       "opacity": 1,
       "position": "absolute",
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -23,14 +16,11 @@ exports[`renders animated fab 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
-      "start": undefined,
-      "top": undefined,
       "transform": Array [
         Object {
           "scale": 1,
         },
       ],
-      "width": undefined,
     }
   }
   testID="animated-fab-container-outer-layer"
@@ -298,17 +288,10 @@ exports[`renders animated fab with label on the left 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "transparent",
       "borderRadius": 16,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
       "opacity": 1,
       "position": "absolute",
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -316,14 +299,11 @@ exports[`renders animated fab with label on the left 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
-      "start": undefined,
-      "top": undefined,
       "transform": Array [
         Object {
           "scale": 1,
         },
       ],
-      "width": undefined,
     }
   }
   testID="animated-fab-container-outer-layer"
@@ -593,17 +573,10 @@ exports[`renders animated fab with label on the right by default 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "transparent",
       "borderRadius": 16,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
       "opacity": 1,
       "position": "absolute",
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -611,14 +584,11 @@ exports[`renders animated fab with label on the right by default 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
-      "start": undefined,
-      "top": undefined,
       "transform": Array [
         Object {
           "scale": 1,
         },
       ],
-      "width": undefined,
     }
   }
   testID="animated-fab-container-outer-layer"

--- a/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
@@ -5,16 +5,8 @@ exports[`render visible banner, with custom theme 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgb(247, 243, 249)",
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
       "opacity": 1,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 1,
@@ -22,10 +14,6 @@ exports[`render visible banner, with custom theme 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -129,18 +117,9 @@ exports[`render visible banner, with custom theme 1`] = `
             collapsable={false}
             style={
               Object {
-                "alignSelf": undefined,
                 "backgroundColor": "transparent",
                 "borderRadius": 20,
-                "bottom": undefined,
-                "end": undefined,
-                "flex": undefined,
-                "height": undefined,
-                "left": undefined,
                 "margin": 4,
-                "opacity": undefined,
-                "position": undefined,
-                "right": undefined,
                 "shadowColor": "#000",
                 "shadowOffset": Object {
                   "height": 0,
@@ -148,10 +127,6 @@ exports[`render visible banner, with custom theme 1`] = `
                 },
                 "shadowOpacity": 0,
                 "shadowRadius": 0,
-                "start": undefined,
-                "top": undefined,
-                "transform": undefined,
-                "width": undefined,
               }
             }
             testID="button-container-outer-layer"
@@ -287,16 +262,8 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgb(247, 243, 249)",
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
       "opacity": 0,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 1,
@@ -304,10 +271,6 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -430,16 +393,8 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgb(247, 243, 249)",
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
       "opacity": 1,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 1,
@@ -447,10 +402,6 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -576,18 +527,9 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
             collapsable={false}
             style={
               Object {
-                "alignSelf": undefined,
                 "backgroundColor": "transparent",
                 "borderRadius": 20,
-                "bottom": undefined,
-                "end": undefined,
-                "flex": undefined,
-                "height": undefined,
-                "left": undefined,
                 "margin": 4,
-                "opacity": undefined,
-                "position": undefined,
-                "right": undefined,
                 "shadowColor": "#000",
                 "shadowOffset": Object {
                   "height": 0,
@@ -595,10 +537,6 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                 },
                 "shadowOpacity": 0,
                 "shadowRadius": 0,
-                "start": undefined,
-                "top": undefined,
-                "transform": undefined,
-                "width": undefined,
               }
             }
             testID="button-container-outer-layer"
@@ -734,16 +672,8 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgb(247, 243, 249)",
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
       "opacity": 1,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 1,
@@ -751,10 +681,6 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -858,18 +784,9 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
             collapsable={false}
             style={
               Object {
-                "alignSelf": undefined,
                 "backgroundColor": "transparent",
                 "borderRadius": 20,
-                "bottom": undefined,
-                "end": undefined,
-                "flex": undefined,
-                "height": undefined,
-                "left": undefined,
                 "margin": 4,
-                "opacity": undefined,
-                "position": undefined,
-                "right": undefined,
                 "shadowColor": "#000",
                 "shadowOffset": Object {
                   "height": 0,
@@ -877,10 +794,6 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                 },
                 "shadowOpacity": 0,
                 "shadowRadius": 0,
-                "start": undefined,
-                "top": undefined,
-                "transform": undefined,
-                "width": undefined,
               }
             }
             testID="button-container-outer-layer"
@@ -1008,18 +921,9 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
             collapsable={false}
             style={
               Object {
-                "alignSelf": undefined,
                 "backgroundColor": "transparent",
                 "borderRadius": 20,
-                "bottom": undefined,
-                "end": undefined,
-                "flex": undefined,
-                "height": undefined,
-                "left": undefined,
                 "margin": 4,
-                "opacity": undefined,
-                "position": undefined,
-                "right": undefined,
                 "shadowColor": "#000",
                 "shadowOffset": Object {
                   "height": 0,
@@ -1027,10 +931,6 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                 },
                 "shadowOpacity": 0,
                 "shadowRadius": 0,
-                "start": undefined,
-                "top": undefined,
-                "transform": undefined,
-                "width": undefined,
               }
             }
             testID="button-container-outer-layer"
@@ -1166,16 +1066,8 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgb(247, 243, 249)",
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
       "opacity": 1,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 1,
@@ -1183,10 +1075,6 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="surface-outer-layer"
@@ -1319,16 +1207,8 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgb(247, 243, 249)",
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
       "opacity": 1,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 1,
@@ -1336,10 +1216,6 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 3,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="surface-outer-layer"

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
@@ -74,15 +74,9 @@ exports[`allows customizing Route's type via generics 1`] = `
     collapsable={false}
     style={
       Object {
-        "alignSelf": undefined,
         "backgroundColor": "transparent",
         "bottom": 0,
-        "end": undefined,
-        "flex": undefined,
-        "height": undefined,
         "left": 0,
-        "opacity": undefined,
-        "position": undefined,
         "right": 0,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -91,10 +85,6 @@ exports[`allows customizing Route's type via generics 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
-        "start": undefined,
-        "top": undefined,
-        "transform": undefined,
-        "width": undefined,
       }
     }
     testID="bottom-navigation-bar-outer-layer"
@@ -711,15 +701,9 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
     collapsable={false}
     style={
       Object {
-        "alignSelf": undefined,
         "backgroundColor": "transparent",
         "bottom": 0,
-        "end": undefined,
-        "flex": undefined,
-        "height": undefined,
         "left": 0,
-        "opacity": undefined,
-        "position": undefined,
         "right": 0,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -728,10 +712,6 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
-        "start": undefined,
-        "top": undefined,
-        "transform": undefined,
-        "width": undefined,
       }
     }
     testID="bottom-navigation-bar-outer-layer"
@@ -1459,15 +1439,9 @@ exports[`hides labels in shifting bottom navigation 1`] = `
     collapsable={false}
     style={
       Object {
-        "alignSelf": undefined,
         "backgroundColor": "transparent",
         "bottom": 0,
-        "end": undefined,
-        "flex": undefined,
-        "height": undefined,
         "left": 0,
-        "opacity": undefined,
-        "position": undefined,
         "right": 0,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -1476,10 +1450,6 @@ exports[`hides labels in shifting bottom navigation 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
-        "start": undefined,
-        "top": undefined,
-        "transform": undefined,
-        "width": undefined,
       }
     }
     testID="bottom-navigation-bar-outer-layer"
@@ -2339,15 +2309,9 @@ exports[`renders bottom navigation with getLazy 1`] = `
     collapsable={false}
     style={
       Object {
-        "alignSelf": undefined,
         "backgroundColor": "transparent",
         "bottom": 0,
-        "end": undefined,
-        "flex": undefined,
-        "height": undefined,
         "left": 0,
-        "opacity": undefined,
-        "position": undefined,
         "right": 0,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -2356,10 +2320,6 @@ exports[`renders bottom navigation with getLazy 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
-        "start": undefined,
-        "top": undefined,
-        "transform": undefined,
-        "width": undefined,
       }
     }
     testID="bottom-navigation-bar-outer-layer"
@@ -4048,15 +4008,9 @@ exports[`renders bottom navigation with scene animation 1`] = `
     collapsable={false}
     style={
       Object {
-        "alignSelf": undefined,
         "backgroundColor": "transparent",
         "bottom": 0,
-        "end": undefined,
-        "flex": undefined,
-        "height": undefined,
         "left": 0,
-        "opacity": undefined,
-        "position": undefined,
         "right": 0,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -4065,10 +4019,6 @@ exports[`renders bottom navigation with scene animation 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
-        "start": undefined,
-        "top": undefined,
-        "transform": undefined,
-        "width": undefined,
       }
     }
     testID="bottom-navigation-bar-outer-layer"
@@ -5517,15 +5467,9 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
     collapsable={false}
     style={
       Object {
-        "alignSelf": undefined,
         "backgroundColor": "transparent",
         "bottom": 0,
-        "end": undefined,
-        "flex": undefined,
-        "height": undefined,
         "left": 0,
-        "opacity": undefined,
-        "position": undefined,
         "right": 0,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -5534,10 +5478,6 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
-        "start": undefined,
-        "top": undefined,
-        "transform": undefined,
-        "width": undefined,
       }
     }
     testID="bottom-navigation-bar-outer-layer"
@@ -6205,15 +6145,9 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
     collapsable={false}
     style={
       Object {
-        "alignSelf": undefined,
         "backgroundColor": "transparent",
         "bottom": 0,
-        "end": undefined,
-        "flex": undefined,
-        "height": undefined,
         "left": 0,
-        "opacity": undefined,
-        "position": undefined,
         "right": 0,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -6222,10 +6156,6 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
-        "start": undefined,
-        "top": undefined,
-        "transform": undefined,
-        "width": undefined,
       }
     }
     testID="bottom-navigation-bar-outer-layer"
@@ -7174,15 +7104,9 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
     collapsable={false}
     style={
       Object {
-        "alignSelf": undefined,
         "backgroundColor": "transparent",
         "bottom": 0,
-        "end": undefined,
-        "flex": undefined,
-        "height": undefined,
         "left": 0,
-        "opacity": undefined,
-        "position": undefined,
         "right": 0,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -7191,10 +7115,6 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
-        "start": undefined,
-        "top": undefined,
-        "transform": undefined,
-        "width": undefined,
       }
     }
     testID="bottom-navigation-bar-outer-layer"
@@ -8267,15 +8187,9 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
     collapsable={false}
     style={
       Object {
-        "alignSelf": undefined,
         "backgroundColor": "transparent",
         "bottom": 0,
-        "end": undefined,
-        "flex": undefined,
-        "height": undefined,
         "left": 0,
-        "opacity": undefined,
-        "position": undefined,
         "right": 0,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -8284,10 +8198,6 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
-        "start": undefined,
-        "top": undefined,
-        "transform": undefined,
-        "width": undefined,
       }
     }
     testID="bottom-navigation-bar-outer-layer"
@@ -9216,15 +9126,9 @@ exports[`renders non-shifting bottom navigation 1`] = `
     collapsable={false}
     style={
       Object {
-        "alignSelf": undefined,
         "backgroundColor": "transparent",
         "bottom": 0,
-        "end": undefined,
-        "flex": undefined,
-        "height": undefined,
         "left": 0,
-        "opacity": undefined,
-        "position": undefined,
         "right": 0,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -9233,10 +9137,6 @@ exports[`renders non-shifting bottom navigation 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
-        "start": undefined,
-        "top": undefined,
-        "transform": undefined,
-        "width": undefined,
       }
     }
     testID="bottom-navigation-bar-outer-layer"
@@ -10309,15 +10209,9 @@ exports[`renders shifting bottom navigation 1`] = `
     collapsable={false}
     style={
       Object {
-        "alignSelf": undefined,
         "backgroundColor": "transparent",
         "bottom": 0,
-        "end": undefined,
-        "flex": undefined,
-        "height": undefined,
         "left": 0,
-        "opacity": undefined,
-        "position": undefined,
         "right": 0,
         "shadowColor": "#000",
         "shadowOffset": Object {
@@ -10326,10 +10220,6 @@ exports[`renders shifting bottom navigation 1`] = `
         },
         "shadowOpacity": 0,
         "shadowRadius": 0,
-        "start": undefined,
-        "top": undefined,
-        "transform": undefined,
-        "width": undefined,
       }
     }
     testID="bottom-navigation-bar-outer-layer"

--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -5,17 +5,8 @@ exports[`renders button with an accessibility hint 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "transparent",
       "borderRadius": 20,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -23,10 +14,6 @@ exports[`renders button with an accessibility hint 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -156,17 +143,8 @@ exports[`renders button with an accessibility label 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "transparent",
       "borderRadius": 20,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -174,10 +152,6 @@ exports[`renders button with an accessibility label 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -307,17 +281,8 @@ exports[`renders button with button color 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "#e91e63",
       "borderRadius": 20,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -325,10 +290,6 @@ exports[`renders button with button color 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -457,17 +418,8 @@ exports[`renders button with color 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "transparent",
       "borderRadius": 20,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -475,10 +427,6 @@ exports[`renders button with color 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -607,17 +555,8 @@ exports[`renders button with custom testID 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "transparent",
       "borderRadius": 20,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -625,10 +564,6 @@ exports[`renders button with custom testID 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="custom:testID-container-outer-layer"
@@ -757,17 +692,8 @@ exports[`renders button with icon 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "transparent",
       "borderRadius": 20,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -775,10 +701,6 @@ exports[`renders button with icon 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -963,17 +885,8 @@ exports[`renders button with icon in reverse order 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "transparent",
       "borderRadius": 20,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -981,10 +894,6 @@ exports[`renders button with icon in reverse order 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -1171,17 +1080,8 @@ exports[`renders contained contained with mode 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(103, 80, 164, 1)",
       "borderRadius": 20,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -1189,10 +1089,6 @@ exports[`renders contained contained with mode 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -1322,17 +1218,8 @@ exports[`renders disabled button 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "transparent",
       "borderRadius": 20,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -1340,10 +1227,6 @@ exports[`renders disabled button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -1472,17 +1355,8 @@ exports[`renders loading button 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "transparent",
       "borderRadius": 20,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -1490,10 +1364,6 @@ exports[`renders loading button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -1830,17 +1700,8 @@ exports[`renders outlined button with mode 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "transparent",
       "borderRadius": 20,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -1848,10 +1709,6 @@ exports[`renders outlined button with mode 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -1981,17 +1838,8 @@ exports[`renders text button by default 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "transparent",
       "borderRadius": 20,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -1999,10 +1847,6 @@ exports[`renders text button by default 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="button-container-outer-layer"
@@ -2131,17 +1975,8 @@ exports[`renders text button with mode 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "transparent",
       "borderRadius": 20,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -2149,10 +1984,6 @@ exports[`renders text button with mode 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="button-container-outer-layer"

--- a/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -5,17 +5,8 @@ exports[`renders chip with close button 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(232, 222, 248, 1)",
       "borderRadius": 8,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -23,10 +14,6 @@ exports[`renders chip with close button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="chip-container-outer-layer"
@@ -293,17 +280,8 @@ exports[`renders chip with custom close button 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(232, 222, 248, 1)",
       "borderRadius": 8,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -311,10 +289,6 @@ exports[`renders chip with custom close button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="chip-container-outer-layer"
@@ -581,17 +555,8 @@ exports[`renders chip with icon 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(232, 222, 248, 1)",
       "borderRadius": 8,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -599,10 +564,6 @@ exports[`renders chip with icon 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="chip-container-outer-layer"
@@ -792,17 +753,8 @@ exports[`renders chip with onPress 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(232, 222, 248, 1)",
       "borderRadius": 8,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -810,10 +762,6 @@ exports[`renders chip with onPress 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="chip-container-outer-layer"
@@ -951,17 +899,8 @@ exports[`renders outlined disabled chip 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "transparent",
       "borderRadius": 8,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -969,10 +908,6 @@ exports[`renders outlined disabled chip 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="chip-container-outer-layer"
@@ -1110,17 +1045,8 @@ exports[`renders selected chip 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgb(232, 222, 248)",
       "borderRadius": 8,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -1128,10 +1054,6 @@ exports[`renders selected chip 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="chip-container-outer-layer"

--- a/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -267,18 +267,10 @@ exports[`renders data table pagination 1`] = `
       collapsable={false}
       style={
         Object {
-          "alignSelf": undefined,
           "backgroundColor": "transparent",
           "borderRadius": 20,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
           "height": 40,
-          "left": undefined,
           "margin": 6,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -286,9 +278,6 @@ exports[`renders data table pagination 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
           "width": 40,
         }
       }
@@ -410,18 +399,10 @@ exports[`renders data table pagination 1`] = `
       collapsable={false}
       style={
         Object {
-          "alignSelf": undefined,
           "backgroundColor": "transparent",
           "borderRadius": 20,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
           "height": 40,
-          "left": undefined,
           "margin": 6,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -429,9 +410,6 @@ exports[`renders data table pagination 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
           "width": 40,
         }
       }
@@ -611,18 +589,10 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
       collapsable={false}
       style={
         Object {
-          "alignSelf": undefined,
           "backgroundColor": "transparent",
           "borderRadius": 20,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
           "height": 40,
-          "left": undefined,
           "margin": 6,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -630,9 +600,6 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
           "width": 40,
         }
       }
@@ -754,18 +721,10 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
       collapsable={false}
       style={
         Object {
-          "alignSelf": undefined,
           "backgroundColor": "transparent",
           "borderRadius": 20,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
           "height": 40,
-          "left": undefined,
           "margin": 6,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -773,9 +732,6 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
           "width": 40,
         }
       }
@@ -897,18 +853,10 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
       collapsable={false}
       style={
         Object {
-          "alignSelf": undefined,
           "backgroundColor": "transparent",
           "borderRadius": 20,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
           "height": 40,
-          "left": undefined,
           "margin": 6,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -916,9 +864,6 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
           "width": 40,
         }
       }
@@ -1040,18 +985,10 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
       collapsable={false}
       style={
         Object {
-          "alignSelf": undefined,
           "backgroundColor": "transparent",
           "borderRadius": 20,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
           "height": 40,
-          "left": undefined,
           "margin": 6,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -1059,9 +996,6 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
           "width": 40,
         }
       }
@@ -1241,18 +1175,10 @@ exports[`renders data table pagination with label 1`] = `
       collapsable={false}
       style={
         Object {
-          "alignSelf": undefined,
           "backgroundColor": "transparent",
           "borderRadius": 20,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
           "height": 40,
-          "left": undefined,
           "margin": 6,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -1260,9 +1186,6 @@ exports[`renders data table pagination with label 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
           "width": 40,
         }
       }
@@ -1384,18 +1307,10 @@ exports[`renders data table pagination with label 1`] = `
       collapsable={false}
       style={
         Object {
-          "alignSelf": undefined,
           "backgroundColor": "transparent",
           "borderRadius": 20,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
           "height": 40,
-          "left": undefined,
           "margin": 6,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -1403,9 +1318,6 @@ exports[`renders data table pagination with label 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
           "width": 40,
         }
       }
@@ -1591,18 +1503,9 @@ exports[`renders data table pagination with options select 1`] = `
         collapsable={false}
         style={
           Object {
-            "alignSelf": undefined,
             "backgroundColor": "transparent",
             "borderRadius": 20,
-            "bottom": undefined,
-            "end": undefined,
-            "flex": undefined,
-            "height": undefined,
-            "left": undefined,
             "marginRight": 16,
-            "opacity": undefined,
-            "position": undefined,
-            "right": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1610,10 +1513,6 @@ exports[`renders data table pagination with options select 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
-            "start": undefined,
-            "top": undefined,
-            "transform": undefined,
-            "width": undefined,
           }
         }
         testID="button-container-outer-layer"
@@ -1836,18 +1735,10 @@ exports[`renders data table pagination with options select 1`] = `
       collapsable={false}
       style={
         Object {
-          "alignSelf": undefined,
           "backgroundColor": "transparent",
           "borderRadius": 20,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
           "height": 40,
-          "left": undefined,
           "margin": 6,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -1855,9 +1746,6 @@ exports[`renders data table pagination with options select 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
           "width": 40,
         }
       }
@@ -1979,18 +1867,10 @@ exports[`renders data table pagination with options select 1`] = `
       collapsable={false}
       style={
         Object {
-          "alignSelf": undefined,
           "backgroundColor": "transparent",
           "borderRadius": 20,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
           "height": 40,
-          "left": undefined,
           "margin": 6,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -1998,9 +1878,6 @@ exports[`renders data table pagination with options select 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
           "width": 40,
         }
       }
@@ -2122,18 +1999,10 @@ exports[`renders data table pagination with options select 1`] = `
       collapsable={false}
       style={
         Object {
-          "alignSelf": undefined,
           "backgroundColor": "transparent",
           "borderRadius": 20,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
           "height": 40,
-          "left": undefined,
           "margin": 6,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -2141,9 +2010,6 @@ exports[`renders data table pagination with options select 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
           "width": 40,
         }
       }
@@ -2265,18 +2131,10 @@ exports[`renders data table pagination with options select 1`] = `
       collapsable={false}
       style={
         Object {
-          "alignSelf": undefined,
           "backgroundColor": "transparent",
           "borderRadius": 20,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
           "height": 40,
-          "left": undefined,
           "margin": 6,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -2284,9 +2142,6 @@ exports[`renders data table pagination with options select 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
           "width": 40,
         }
       }

--- a/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
@@ -5,17 +5,9 @@ exports[`renders FAB with custom size prop 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(234, 221, 255, 1)",
       "borderRadius": 25,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
       "opacity": 1,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -23,14 +15,11 @@ exports[`renders FAB with custom size prop 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
-      "start": undefined,
-      "top": undefined,
       "transform": Array [
         Object {
           "scale": 1,
         },
       ],
-      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -185,17 +174,9 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(234, 221, 255, 1)",
       "borderRadius": 16,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
       "opacity": 1,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -203,14 +184,11 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
-      "start": undefined,
-      "top": undefined,
       "transform": Array [
         Object {
           "scale": 1,
         },
       ],
-      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -365,17 +343,9 @@ exports[`renders default FAB 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(234, 221, 255, 1)",
       "borderRadius": 16,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
       "opacity": 1,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -383,14 +353,11 @@ exports[`renders default FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
-      "start": undefined,
-      "top": undefined,
       "transform": Array [
         Object {
           "scale": 1,
         },
       ],
-      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -545,17 +512,9 @@ exports[`renders disabled FAB 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(28, 27, 31, 0.12)",
       "borderRadius": 16,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
       "opacity": 1,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -563,14 +522,11 @@ exports[`renders disabled FAB 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
       "transform": Array [
         Object {
           "scale": 1,
         },
       ],
-      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -725,17 +681,9 @@ exports[`renders extended FAB 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(234, 221, 255, 1)",
       "borderRadius": 16,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
       "opacity": 1,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -743,14 +691,11 @@ exports[`renders extended FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
-      "start": undefined,
-      "top": undefined,
       "transform": Array [
         Object {
           "scale": 1,
         },
       ],
-      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -944,17 +889,9 @@ exports[`renders extended FAB with custom size prop 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(234, 221, 255, 1)",
       "borderRadius": 25,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
       "opacity": 1,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -962,14 +899,11 @@ exports[`renders extended FAB with custom size prop 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
-      "start": undefined,
-      "top": undefined,
       "transform": Array [
         Object {
           "scale": 1,
         },
       ],
-      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -1162,17 +1096,9 @@ exports[`renders large FAB 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(234, 221, 255, 1)",
       "borderRadius": 28,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
       "opacity": 1,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -1180,14 +1106,11 @@ exports[`renders large FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
-      "start": undefined,
-      "top": undefined,
       "transform": Array [
         Object {
           "scale": 1,
         },
       ],
-      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -1342,17 +1265,9 @@ exports[`renders loading FAB 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(234, 221, 255, 1)",
       "borderRadius": 16,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
       "opacity": 1,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -1360,14 +1275,11 @@ exports[`renders loading FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
-      "start": undefined,
-      "top": undefined,
       "transform": Array [
         Object {
           "scale": 1,
         },
       ],
-      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -1647,17 +1559,9 @@ exports[`renders loading FAB with custom size prop 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(234, 221, 255, 1)",
       "borderRadius": 25,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
       "opacity": 1,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -1665,14 +1569,11 @@ exports[`renders loading FAB with custom size prop 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
-      "start": undefined,
-      "top": undefined,
       "transform": Array [
         Object {
           "scale": 1,
         },
       ],
-      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -1952,17 +1853,9 @@ exports[`renders not visible FAB 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(234, 221, 255, 1)",
       "borderRadius": 16,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
       "opacity": 1,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -1970,14 +1863,11 @@ exports[`renders not visible FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
-      "start": undefined,
-      "top": undefined,
       "transform": Array [
         Object {
           "scale": 1,
         },
       ],
-      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -2132,17 +2022,9 @@ exports[`renders small FAB 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(234, 221, 255, 1)",
       "borderRadius": 12,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
       "opacity": 1,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -2150,14 +2032,11 @@ exports[`renders small FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
-      "start": undefined,
-      "top": undefined,
       "transform": Array [
         Object {
           "scale": 1,
         },
       ],
-      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"
@@ -2312,17 +2191,9 @@ exports[`renders visible FAB 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(234, 221, 255, 1)",
       "borderRadius": 16,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
       "opacity": 0,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 4,
@@ -2330,14 +2201,11 @@ exports[`renders visible FAB 1`] = `
       },
       "shadowOpacity": 0.15,
       "shadowRadius": 8,
-      "start": undefined,
-      "top": undefined,
       "transform": Array [
         Object {
           "scale": 0,
         },
       ],
-      "width": undefined,
     }
   }
   testID="fab-container-outer-layer"

--- a/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
@@ -5,18 +5,10 @@ exports[`renders disabled icon button 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "transparent",
       "borderRadius": 20,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
       "height": 40,
-      "left": undefined,
       "margin": 6,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -24,9 +16,6 @@ exports[`renders disabled icon button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
       "width": 40,
     }
   }
@@ -155,18 +144,10 @@ exports[`renders icon button by default 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "transparent",
       "borderRadius": 20,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
       "height": 40,
-      "left": undefined,
       "margin": 6,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -174,9 +155,6 @@ exports[`renders icon button by default 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
       "width": 40,
     }
   }
@@ -300,18 +278,10 @@ exports[`renders icon button with color 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "transparent",
       "borderRadius": 20,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
       "height": 40,
-      "left": undefined,
       "margin": 6,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -319,9 +289,6 @@ exports[`renders icon button with color 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
       "width": 40,
     }
   }
@@ -445,18 +412,10 @@ exports[`renders icon button with size 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "transparent",
       "borderRadius": 23,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
       "height": 46,
-      "left": undefined,
       "margin": 6,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -464,9 +423,6 @@ exports[`renders icon button with size 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
       "width": 46,
     }
   }
@@ -590,18 +546,10 @@ exports[`renders icon change animated 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "transparent",
       "borderRadius": 20,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
       "height": 40,
-      "left": undefined,
       "margin": 6,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -609,9 +557,6 @@ exports[`renders icon change animated 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
       "width": 40,
     }
   }

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -102,17 +102,8 @@ exports[`renders list item with custom description 1`] = `
             collapsable={false}
             style={
               Object {
-                "alignSelf": undefined,
                 "backgroundColor": "rgba(232, 222, 248, 1)",
                 "borderRadius": 8,
-                "bottom": undefined,
-                "end": undefined,
-                "flex": undefined,
-                "height": undefined,
-                "left": undefined,
-                "opacity": undefined,
-                "position": undefined,
-                "right": undefined,
                 "shadowColor": "#000",
                 "shadowOffset": Object {
                   "height": 0,
@@ -120,10 +111,6 @@ exports[`renders list item with custom description 1`] = `
                 },
                 "shadowOpacity": 0,
                 "shadowRadius": 0,
-                "start": undefined,
-                "top": undefined,
-                "transform": undefined,
-                "width": undefined,
               }
             }
             testID="chip-container-outer-layer"

--- a/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -18,17 +18,8 @@ Array [
         collapsable={false}
         style={
           Object {
-            "alignSelf": undefined,
             "backgroundColor": "transparent",
             "borderRadius": 20,
-            "bottom": undefined,
-            "end": undefined,
-            "flex": undefined,
-            "height": undefined,
-            "left": undefined,
-            "opacity": undefined,
-            "position": undefined,
-            "right": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -36,10 +27,6 @@ Array [
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
-            "start": undefined,
-            "top": undefined,
-            "transform": undefined,
-            "width": undefined,
           }
         }
         testID="button-container-outer-layer"
@@ -237,19 +224,11 @@ Array [
           collapsable={false}
           style={
             Object {
-              "alignSelf": undefined,
               "backgroundColor": "rgb(243, 237, 246)",
               "borderRadius": 4,
               "borderTopLeftRadius": 0,
               "borderTopRightRadius": 0,
-              "bottom": undefined,
-              "end": undefined,
-              "flex": undefined,
-              "height": undefined,
-              "left": undefined,
               "opacity": 0,
-              "position": undefined,
-              "right": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 2,
@@ -257,8 +236,6 @@ Array [
               },
               "shadowOpacity": 0.15,
               "shadowRadius": 6,
-              "start": undefined,
-              "top": undefined,
               "transform": Array [
                 Object {
                   "scaleX": 0,
@@ -267,7 +244,6 @@ Array [
                   "scaleY": 0,
                 },
               ],
-              "width": undefined,
             }
           }
           testID="menu-surface-outer-layer"
@@ -532,17 +508,8 @@ exports[`renders not visible menu 1`] = `
       collapsable={false}
       style={
         Object {
-          "alignSelf": undefined,
           "backgroundColor": "transparent",
           "borderRadius": 20,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
-          "height": undefined,
-          "left": undefined,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -550,10 +517,6 @@ exports[`renders not visible menu 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
-          "width": undefined,
         }
       }
       testID="button-container-outer-layer"
@@ -698,17 +661,8 @@ Array [
         collapsable={false}
         style={
           Object {
-            "alignSelf": undefined,
             "backgroundColor": "transparent",
             "borderRadius": 20,
-            "bottom": undefined,
-            "end": undefined,
-            "flex": undefined,
-            "height": undefined,
-            "left": undefined,
-            "opacity": undefined,
-            "position": undefined,
-            "right": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -716,10 +670,6 @@ Array [
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
-            "start": undefined,
-            "top": undefined,
-            "transform": undefined,
-            "width": undefined,
           }
         }
         testID="button-container-outer-layer"
@@ -917,17 +867,9 @@ Array [
           collapsable={false}
           style={
             Object {
-              "alignSelf": undefined,
               "backgroundColor": "rgb(243, 237, 246)",
               "borderRadius": 4,
-              "bottom": undefined,
-              "end": undefined,
-              "flex": undefined,
-              "height": undefined,
-              "left": undefined,
               "opacity": 0,
-              "position": undefined,
-              "right": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 2,
@@ -935,8 +877,6 @@ Array [
               },
               "shadowOpacity": 0.15,
               "shadowRadius": 6,
-              "start": undefined,
-              "top": undefined,
               "transform": Array [
                 Object {
                   "scaleX": 0,
@@ -945,7 +885,6 @@ Array [
                   "scaleY": 0,
                 },
               ],
-              "width": undefined,
             }
           }
           testID="menu-surface-outer-layer"

--- a/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
@@ -5,17 +5,8 @@ exports[`activity indicator snapshot test 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgb(238, 232, 244)",
       "borderRadius": 28,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -23,10 +14,6 @@ exports[`activity indicator snapshot test 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="search-bar-container-outer-layer"
@@ -55,18 +42,10 @@ exports[`activity indicator snapshot test 1`] = `
       collapsable={false}
       style={
         Object {
-          "alignSelf": undefined,
           "backgroundColor": "transparent",
           "borderRadius": 20,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
           "height": 40,
-          "left": undefined,
           "margin": 6,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -74,9 +53,6 @@ exports[`activity indicator snapshot test 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
           "width": 40,
         }
       }
@@ -437,17 +413,8 @@ exports[`renders with placeholder 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgb(238, 232, 244)",
       "borderRadius": 28,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -455,10 +422,6 @@ exports[`renders with placeholder 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="search-bar-container-outer-layer"
@@ -487,18 +450,10 @@ exports[`renders with placeholder 1`] = `
       collapsable={false}
       style={
         Object {
-          "alignSelf": undefined,
           "backgroundColor": "transparent",
           "borderRadius": 20,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
           "height": 40,
-          "left": undefined,
           "margin": 6,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -506,9 +461,6 @@ exports[`renders with placeholder 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
           "width": 40,
         }
       }
@@ -680,18 +632,10 @@ exports[`renders with placeholder 1`] = `
         collapsable={false}
         style={
           Object {
-            "alignSelf": undefined,
             "backgroundColor": "transparent",
             "borderRadius": 20,
-            "bottom": undefined,
-            "end": undefined,
-            "flex": undefined,
             "height": 40,
-            "left": undefined,
             "margin": 6,
-            "opacity": undefined,
-            "position": undefined,
-            "right": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -699,9 +643,6 @@ exports[`renders with placeholder 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
-            "start": undefined,
-            "top": undefined,
-            "transform": undefined,
             "width": 40,
           }
         }
@@ -829,17 +770,8 @@ exports[`renders with text 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgb(238, 232, 244)",
       "borderRadius": 28,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
-      "height": undefined,
-      "left": undefined,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -847,10 +779,6 @@ exports[`renders with text 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
-      "width": undefined,
     }
   }
   testID="search-bar-container-outer-layer"
@@ -879,18 +807,10 @@ exports[`renders with text 1`] = `
       collapsable={false}
       style={
         Object {
-          "alignSelf": undefined,
           "backgroundColor": "transparent",
           "borderRadius": 20,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
           "height": 40,
-          "left": undefined,
           "margin": 6,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -898,9 +818,6 @@ exports[`renders with text 1`] = `
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
           "width": 40,
         }
       }
@@ -1068,18 +985,10 @@ exports[`renders with text 1`] = `
         collapsable={false}
         style={
           Object {
-            "alignSelf": undefined,
             "backgroundColor": "transparent",
             "borderRadius": 20,
-            "bottom": undefined,
-            "end": undefined,
-            "flex": undefined,
             "height": 40,
-            "left": undefined,
             "margin": 6,
-            "opacity": undefined,
-            "position": undefined,
-            "right": undefined,
             "shadowColor": "#000",
             "shadowOffset": Object {
               "height": 0,
@@ -1087,9 +996,6 @@ exports[`renders with text 1`] = `
             },
             "shadowOpacity": 0,
             "shadowRadius": 0,
-            "start": undefined,
-            "top": undefined,
-            "transform": undefined,
             "width": 40,
           }
         }

--- a/src/components/__tests__/__snapshots__/Snackbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.tsx.snap
@@ -24,18 +24,10 @@ exports[`renders snackbar with Text as a child 1`] = `
     collapsable={false}
     style={
       Object {
-        "alignSelf": undefined,
         "backgroundColor": "rgba(49, 48, 51, 1)",
         "borderRadius": 4,
-        "bottom": undefined,
-        "end": undefined,
-        "flex": undefined,
-        "height": undefined,
-        "left": undefined,
         "margin": 8,
         "opacity": 1,
-        "position": undefined,
-        "right": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 2,
@@ -43,14 +35,11 @@ exports[`renders snackbar with Text as a child 1`] = `
         },
         "shadowOpacity": 0.15,
         "shadowRadius": 6,
-        "start": undefined,
-        "top": undefined,
         "transform": Array [
           Object {
             "scale": 1,
           },
         ],
-        "width": undefined,
       }
     }
     testID="surface-outer-layer"
@@ -120,18 +109,10 @@ exports[`renders snackbar with View & Text as a child 1`] = `
     collapsable={false}
     style={
       Object {
-        "alignSelf": undefined,
         "backgroundColor": "rgba(49, 48, 51, 1)",
         "borderRadius": 4,
-        "bottom": undefined,
-        "end": undefined,
-        "flex": undefined,
-        "height": undefined,
-        "left": undefined,
         "margin": 8,
         "opacity": 1,
-        "position": undefined,
-        "right": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 2,
@@ -139,14 +120,11 @@ exports[`renders snackbar with View & Text as a child 1`] = `
         },
         "shadowOpacity": 0.15,
         "shadowRadius": 6,
-        "start": undefined,
-        "top": undefined,
         "transform": Array [
           Object {
             "scale": 1,
           },
         ],
-        "width": undefined,
       }
     }
     testID="surface-outer-layer"
@@ -242,18 +220,10 @@ exports[`renders snackbar with action button 1`] = `
     collapsable={false}
     style={
       Object {
-        "alignSelf": undefined,
         "backgroundColor": "rgba(49, 48, 51, 1)",
         "borderRadius": 4,
-        "bottom": undefined,
-        "end": undefined,
-        "flex": undefined,
-        "height": undefined,
-        "left": undefined,
         "margin": 8,
         "opacity": 1,
-        "position": undefined,
-        "right": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 2,
@@ -261,14 +231,11 @@ exports[`renders snackbar with action button 1`] = `
         },
         "shadowOpacity": 0.15,
         "shadowRadius": 6,
-        "start": undefined,
-        "top": undefined,
         "transform": Array [
           Object {
             "scale": 1,
           },
         ],
-        "width": undefined,
       }
     }
     testID="surface-outer-layer"
@@ -347,19 +314,10 @@ exports[`renders snackbar with action button 1`] = `
           collapsable={false}
           style={
             Object {
-              "alignSelf": undefined,
               "backgroundColor": "transparent",
               "borderRadius": 20,
-              "bottom": undefined,
-              "end": undefined,
-              "flex": undefined,
-              "height": undefined,
-              "left": undefined,
               "marginLeft": 4,
               "marginRight": 8,
-              "opacity": undefined,
-              "position": undefined,
-              "right": undefined,
               "shadowColor": "#000",
               "shadowOffset": Object {
                 "height": 0,
@@ -367,10 +325,6 @@ exports[`renders snackbar with action button 1`] = `
               },
               "shadowOpacity": 0,
               "shadowRadius": 0,
-              "start": undefined,
-              "top": undefined,
-              "transform": undefined,
-              "width": undefined,
             }
           }
           testID="button-container-outer-layer"
@@ -520,18 +474,10 @@ exports[`renders snackbar with content 1`] = `
     collapsable={false}
     style={
       Object {
-        "alignSelf": undefined,
         "backgroundColor": "rgba(49, 48, 51, 1)",
         "borderRadius": 4,
-        "bottom": undefined,
-        "end": undefined,
-        "flex": undefined,
-        "height": undefined,
-        "left": undefined,
         "margin": 8,
         "opacity": 1,
-        "position": undefined,
-        "right": undefined,
         "shadowColor": "#000",
         "shadowOffset": Object {
           "height": 2,
@@ -539,14 +485,11 @@ exports[`renders snackbar with content 1`] = `
         },
         "shadowOpacity": 0.15,
         "shadowRadius": 6,
-        "start": undefined,
-        "top": undefined,
         "transform": Array [
           Object {
             "scale": 1,
           },
         ],
-        "width": undefined,
       }
     }
     testID="surface-outer-layer"

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -1267,18 +1267,10 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
       collapsable={false}
       style={
         Object {
-          "alignSelf": undefined,
           "backgroundColor": "transparent",
           "borderRadius": 20,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
           "height": 40,
-          "left": undefined,
           "margin": 0,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -1286,9 +1278,6 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
           "width": 40,
         }
       }
@@ -1623,18 +1612,10 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
       collapsable={false}
       style={
         Object {
-          "alignSelf": undefined,
           "backgroundColor": "transparent",
           "borderRadius": 20,
-          "bottom": undefined,
-          "end": undefined,
-          "flex": undefined,
           "height": 40,
-          "left": undefined,
           "margin": 0,
-          "opacity": undefined,
-          "position": undefined,
-          "right": undefined,
           "shadowColor": "#000",
           "shadowOffset": Object {
             "height": 0,
@@ -1642,9 +1623,6 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
           },
           "shadowOpacity": 0,
           "shadowRadius": 0,
-          "start": undefined,
-          "top": undefined,
-          "transform": undefined,
           "width": 40,
         }
       }

--- a/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -5,18 +5,10 @@ exports[`renders disabled toggle button 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(29, 25, 43, 0.12)",
       "borderRadius": 4,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
       "height": 42,
-      "left": undefined,
       "margin": 0,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -24,9 +16,6 @@ exports[`renders disabled toggle button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
       "width": 42,
     }
   }
@@ -154,18 +143,10 @@ exports[`renders toggle button 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "rgba(29, 25, 43, 0.12)",
       "borderRadius": 4,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
       "height": 42,
-      "left": undefined,
       "margin": 0,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -173,9 +154,6 @@ exports[`renders toggle button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
       "width": 42,
     }
   }
@@ -298,18 +276,10 @@ exports[`renders unchecked toggle button 1`] = `
   collapsable={false}
   style={
     Object {
-      "alignSelf": undefined,
       "backgroundColor": "transparent",
       "borderRadius": 4,
-      "bottom": undefined,
-      "end": undefined,
-      "flex": undefined,
       "height": 42,
-      "left": undefined,
       "margin": 0,
-      "opacity": undefined,
-      "position": undefined,
-      "right": undefined,
       "shadowColor": "#000",
       "shadowOffset": Object {
         "height": 0,
@@ -317,9 +287,6 @@ exports[`renders unchecked toggle button 1`] = `
       },
       "shadowOpacity": 0,
       "shadowRadius": 0,
-      "start": undefined,
-      "top": undefined,
-      "transform": undefined,
       "width": 42,
     }
   }

--- a/src/utils/splitStyles.ts
+++ b/src/utils/splitStyles.ts
@@ -1,13 +1,13 @@
 import type { ViewStyle } from 'react-native';
 
-type FiltersArray = readonly ((style: string) => boolean)[];
+type FiltersArray = readonly ((style: keyof ViewStyle) => boolean)[];
 
 type MappedTuple<Tuple extends FiltersArray> = {
   [Index in keyof Tuple]: ViewStyle;
 } & { length: Tuple['length'] };
 
 type Style = ViewStyle[keyof ViewStyle];
-type Entry = [string, Style];
+type Entry = [keyof ViewStyle, Style];
 
 /**
  * Utility function to extract styles in separate objects


### PR DESCRIPTION

### Summary

Fixes #3882 

![IMG_930C2C835FB5-1](https://github.com/callstack/react-native-paper/assets/8790386/7191e93b-2d94-4fe3-a612-ec778a9c3a95)

### Test plan

Added examples in example app. They should work fine.