### PR TITLE
feat: add cursorColor to TextInput RenderProps types

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -62,6 +62,10 @@ export type Props = React.ComponentPropsWithRef<typeof NativeTextInput> & {
    */
   selectionColor?: string;
   /**
+   * Cursor (or "caret") color of the input - Android.
+   */
+  cursorColor?: string;
+  /**
    * Inactive underline color of the input.
    */
   underlineColor?: string;

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -52,6 +52,7 @@ const TextInputFlat = ({
   label,
   error = false,
   selectionColor,
+  cursorColor,
   underlineColor,
   underlineStyle,
   activeUnderlineColor,
@@ -382,6 +383,8 @@ const TextInputFlat = ({
             typeof selectionColor === 'undefined'
               ? activeColor
               : selectionColor,
+          cursorColor:
+            typeof cursorColor === 'undefined' ? activeColor : cursorColor,
           onFocus,
           onBlur,
           underlineColorAndroid: 'transparent',

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -47,6 +47,7 @@ const TextInputOutlined = ({
   label,
   error = false,
   selectionColor,
+  cursorColor,
   underlineColor: _underlineColor,
   outlineColor: customOutlineColor,
   activeOutlineColor,
@@ -343,6 +344,8 @@ const TextInputOutlined = ({
               typeof selectionColor === 'undefined'
                 ? activeColor
                 : selectionColor,
+            cursorColor:
+              typeof cursorColor === 'undefined' ? activeColor : cursorColor,
             onFocus,
             onBlur,
             underlineColorAndroid: 'transparent',

--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -20,6 +20,7 @@ export type RenderProps = {
   placeholderTextColor?: ColorValue;
   editable?: boolean;
   selectionColor?: string;
+  cursorColor?: string;
   onFocus?: (args: any) => void;
   onBlur?: (args: any) => void;
   underlineColorAndroid?: string;

--- a/src/components/__tests__/TextInput.test.tsx
+++ b/src/components/__tests__/TextInput.test.tsx
@@ -107,6 +107,19 @@ it('correctly applies textAlign center', () => {
   expect(toJSON()).toMatchSnapshot();
 });
 
+it('correctly applies cursorColor prop', () => {
+  const { toJSON } = render(
+    <TextInput
+      label="Flat input"
+      placeholder="Type something"
+      value={'Some test value'}
+      cursorColor={red500 as string}
+    />
+  );
+
+  expect(toJSON()).toMatchSnapshot();
+});
+
 it('correctly applies height to multiline Outline TextInput', () => {
   const { toJSON } = render(
     <TextInput

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -159,6 +159,201 @@ exports[`correctly applies a component as the text label 1`] = `
       </Text>
     </View>
     <TextInput
+      cursorColor="rgba(103, 80, 164, 1)"
+      editable={true}
+      maxFontSizeMultiplier={1.5}
+      multiline={false}
+      onBlur={[Function]}
+      onChangeText={[Function]}
+      onFocus={[Function]}
+      placeholder=" "
+      placeholderTextColor="rgba(73, 69, 79, 1)"
+      selectionColor="rgba(103, 80, 164, 1)"
+      style={
+        Array [
+          Object {
+            "margin": 0,
+          },
+          Object {
+            "paddingLeft": 16,
+            "paddingRight": 16,
+          },
+          Object {
+            "height": 56,
+          },
+          Object {
+            "paddingBottom": 4,
+            "paddingTop": 24,
+          },
+          Object {
+            "color": "rgba(73, 69, 79, 1)",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": undefined,
+            "letterSpacing": 0.15,
+            "lineHeight": undefined,
+            "textAlign": "left",
+            "textAlignVertical": "center",
+          },
+          false,
+          Array [
+            Object {},
+          ],
+          undefined,
+        ]
+      }
+      testID="text-input-flat"
+      underlineColorAndroid="transparent"
+      value="Some test value"
+    />
+  </View>
+</View>
+`;
+
+exports[`correctly applies cursorColor prop 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "rgba(231, 224, 236, 1)",
+        "borderTopLeftRadius": 4,
+        "borderTopRightRadius": 4,
+      },
+      Object {},
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      Object {
+        "backgroundColor": "rgba(28, 27, 31, 1)",
+        "bottom": 0,
+        "height": 1,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "transform": Array [
+          Object {
+            "scaleY": 0.5,
+          },
+        ],
+        "zIndex": 1,
+      }
+    }
+    testID="text-input-underline"
+  />
+  <View
+    style={
+      Array [
+        Object {
+          "paddingBottom": 0,
+          "paddingTop": 0,
+        },
+        Object {
+          "minHeight": 56,
+        },
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      pointerEvents="none"
+      style={
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "transform": Array [
+            Object {
+              "translateX": 4,
+            },
+          ],
+          "zIndex": 3,
+        }
+      }
+    >
+      <Text
+        collapsable={false}
+        maxFontSizeMultiplier={1.5}
+        numberOfLines={1}
+        onLayout={[Function]}
+        style={
+          Object {
+            "color": "rgba(103, 80, 164, 1)",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": undefined,
+            "left": 0,
+            "letterSpacing": 0.15,
+            "lineHeight": undefined,
+            "opacity": 0,
+            "paddingLeft": 16,
+            "paddingRight": 16,
+            "position": "absolute",
+            "textAlign": "left",
+            "top": 30,
+            "transform": Array [
+              Object {
+                "translateX": 0,
+              },
+              Object {
+                "translateY": -12,
+              },
+              Object {
+                "scale": 0.75,
+              },
+            ],
+            "writingDirection": "ltr",
+          }
+        }
+        testID="text-input-flat-label-active"
+      >
+        Flat input
+      </Text>
+      <Text
+        collapsable={false}
+        maxFontSizeMultiplier={1.5}
+        numberOfLines={1}
+        style={
+          Object {
+            "color": "rgba(73, 69, 79, 1)",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": undefined,
+            "left": 0,
+            "letterSpacing": 0.15,
+            "lineHeight": undefined,
+            "opacity": 0,
+            "paddingLeft": 16,
+            "paddingRight": 16,
+            "position": "absolute",
+            "textAlign": "left",
+            "top": 30,
+            "transform": Array [
+              Object {
+                "translateX": 0,
+              },
+              Object {
+                "translateY": -12,
+              },
+              Object {
+                "scale": 0.75,
+              },
+            ],
+            "writingDirection": "ltr",
+          }
+        }
+        testID="text-input-flat-label-inactive"
+      >
+        Flat input
+      </Text>
+    </View>
+    <TextInput
+      cursorColor="#f44336"
       editable={true}
       maxFontSizeMultiplier={1.5}
       multiline={false}
@@ -352,6 +547,7 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
       </Text>
     </View>
     <TextInput
+      cursorColor="rgba(103, 80, 164, 1)"
       editable={true}
       maxFontSizeMultiplier={1.5}
       multiline={false}
@@ -577,6 +773,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
         </Text>
       </View>
       <TextInput
+        cursorColor="rgba(103, 80, 164, 1)"
         editable={true}
         maxFontSizeMultiplier={1.5}
         multiline={true}
@@ -769,6 +966,7 @@ exports[`correctly applies paddingLeft from contentStyleProp 1`] = `
       </Text>
     </View>
     <TextInput
+      cursorColor="rgba(103, 80, 164, 1)"
       editable={true}
       maxFontSizeMultiplier={1.5}
       multiline={false}
@@ -964,6 +1162,7 @@ exports[`correctly applies textAlign center 1`] = `
       </Text>
     </View>
     <TextInput
+      cursorColor="rgba(103, 80, 164, 1)"
       editable={true}
       maxFontSizeMultiplier={1.5}
       multiline={false}
@@ -1157,6 +1356,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
       </Text>
     </View>
     <TextInput
+      cursorColor="rgba(103, 80, 164, 1)"
       editable={true}
       maxFontSizeMultiplier={1.5}
       multiline={false}
@@ -1540,6 +1740,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
       </Text>
     </View>
     <TextInput
+      cursorColor="rgba(103, 80, 164, 1)"
       editable={true}
       maxFontSizeMultiplier={1.5}
       multiline={false}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
This PR adds support for the recently introduced cursorColor feature https://reactnative.dev/docs/0.70/textinput#cursorcolor-android

###  Fixes https://github.com/callstack/react-native-paper/issues/3611

### Continued from https://github.com/callstack/react-native-paper/pull/3612
