### PR TITLE
fix: unfocused TextInput label disappears on new architecture (#3776)

### DIFF
--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -216,11 +216,14 @@ const TextInputFlat = ({
   const baseLabelTranslateY =
     -labelHalfHeight - (topPosition + MINIMIZED_LABEL_Y_OFFSET);
 
+  const { current: placeholderOpacityAnims } = React.useRef([
+    new Animated.Value(0),
+    new Animated.Value(1),
+  ]);
+
   const placeholderOpacity = hasActiveOutline
     ? parentState.labeled
-    : parentState.labelLayout.measured
-    ? 1
-    : 0;
+    : placeholderOpacityAnims[parentState.labelLayout.measured ? 1 : 0];
 
   const minHeight =
     height ||

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  Animated,
   View,
   TextInput as NativeTextInput,
   StyleSheet,
@@ -173,11 +174,14 @@ const TextInputOutlined = ({
   const baseLabelTranslateY =
     -labelHalfHeight - (topPosition + OUTLINE_MINIMIZED_LABEL_Y_OFFSET);
 
+  const { current: placeholderOpacityAnims } = React.useRef([
+    new Animated.Value(0),
+    new Animated.Value(1),
+  ]);
+
   const placeholderOpacity = hasActiveOutline
     ? parentState.labeled
-    : parentState.labelLayout.measured
-    ? 1
-    : 0;
+    : placeholderOpacityAnims[parentState.labelLayout.measured ? 1 : 0];
 
   const placeholderStyle = {
     position: 'absolute',


### PR DESCRIPTION
### Summary

The `TextInput` label disappears when the input is unfocused on React Native's New Architecture (on both Android and iOS). After some digging, I noticed the root cause is switching between an `Animated.Value` and some `number`s depending on some booleans:

```ts
const placeholderOpacity = hasActiveOutline
  ? parentState.labeled // <-- `Animated.Value`
  : parentState.labelLayout.measured
  ? 1
  : 0;
```

If we switch between `Animated.Value` instances, the problem disappears:

```ts
const { current: placeholderOpacityAnims } = React.useRef([
  new Animated.Value(0),
  new Animated.Value(1),
]);

const placeholderOpacity = hasActiveOutline
  ? parentState.labeled
  : placeholderOpacityAnims[parentState.labelLayout.measured ? 1 : 0];
```

#3776 has more details about the issue and contains an example repo to reproduce it.

### Test plan

https://github.com/ChrisGadek1/react-native-paper-textinput-bug-reproduction repo from https://github.com/callstack/react-native-paper/issues/3776#issuecomment-1481136624 can be used for testing this fix.