### PR TITLE
fix: input icon custom color

### DIFF
--- a/src/components/TextInput/Adornment/TextInputIcon.tsx
+++ b/src/components/TextInput/Adornment/TextInputIcon.tsx
@@ -131,7 +131,7 @@ const TextInputIcon = ({
   icon,
   onPress,
   forceTextInputFocus,
-  color,
+  color: customColor,
   theme: themeOverrides,
   ...rest
 }: Props) => {
@@ -151,7 +151,12 @@ const TextInputIcon = ({
 
   const theme = useInternalTheme(themeOverrides);
 
-  const iconColor = getIconColor({ theme, disabled });
+  const iconColor = getIconColor({
+    theme,
+    disabled,
+    isTextInputFocused,
+    customColor,
+  });
 
   return (
     <View style={[styles.container, style]}>
@@ -160,9 +165,7 @@ const TextInputIcon = ({
         style={styles.iconButton}
         size={ICON_SIZE}
         onPress={onPressWithFocusControl}
-        iconColor={
-          typeof color === 'function' ? color(isTextInputFocused) : iconColor
-        }
+        iconColor={iconColor}
         testID={testID}
         theme={themeOverrides}
         {...rest}

--- a/src/components/TextInput/Adornment/TextInputIcon.tsx
+++ b/src/components/TextInput/Adornment/TextInputIcon.tsx
@@ -17,7 +17,7 @@ import { getIconColor } from './utils';
 
 export type Props = $Omit<
   React.ComponentProps<typeof IconButton>,
-  'icon' | 'theme' | 'color'
+  'icon' | 'theme' | 'color' | 'iconColor'
 > & {
   /**
    * @renamed Renamed from 'name' to 'icon` in v5.x

--- a/src/components/TextInput/Adornment/utils.ts
+++ b/src/components/TextInput/Adornment/utils.ts
@@ -20,7 +20,22 @@ export function getTextColor({ theme, disabled }: BaseProps) {
     .string();
 }
 
-export function getIconColor({ theme, disabled }: BaseProps) {
+export function getIconColor({
+  theme,
+  isTextInputFocused,
+  disabled,
+  customColor,
+}: BaseProps & {
+  isTextInputFocused: boolean;
+  customColor?: ((isTextInputFocused: boolean) => string | undefined) | string;
+}) {
+  if (typeof customColor === 'function') {
+    return customColor(isTextInputFocused);
+  }
+  if (customColor) {
+    return customColor;
+  }
+
   if (!theme.isV3) {
     return theme.colors.text;
   }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/3901

### Summary

Corrects using the custom color in to `TextInput.Icon`.

#### Related issue

- #3901 

### Test plan

Tested manually in the app on the second example.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
