### PR TITLE
fix: set default pointer events on web Surface

### DIFF
--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -307,9 +307,11 @@ const Surface = forwardRef<View, Props>(
     const isElevated = mode === 'elevated';
 
     if (Platform.OS === 'web') {
+      const { pointerEvents = 'auto' } = props;
       return (
         <Animated.View
           {...props}
+          pointerEvents={pointerEvents}
           ref={ref}
           testID={testID}
           style={[

--- a/src/components/__tests__/ListItem.test.tsx
+++ b/src/components/__tests__/ListItem.test.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 import { Text, View } from 'react-native';
 
-import { render } from '@testing-library/react-native';
+import { fireEvent, render } from '@testing-library/react-native';
 
 import { red500 } from '../../styles/themes/v2/colors';
 import Chip from '../Chip/Chip';
+import IconButton from '../IconButton/IconButton';
 import ListIcon from '../List/ListIcon';
 import ListItem from '../List/ListItem';
 
@@ -109,4 +110,20 @@ it('renders with a description with typeof number', () => {
   ).toJSON();
 
   expect(tree).toMatchSnapshot();
+});
+
+it('calling onPress on ListItem right component', () => {
+  Platform.OS = 'web';
+  const onPress = jest.fn();
+
+  const { getByTestId } = render(
+    <ListItem
+      title="First Item"
+      description="Item description"
+      right={() => <IconButton icon="pencil" onPress={onPress} />}
+    />
+  );
+
+  fireEvent(getByTestId('icon-button'), 'onPress');
+  expect(onPress).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/3898

### Summary

Sets the default value for `pointerEvents` in web `Surface` component, to avoid the case where it's overwritten by `none !important` when it's not specified, which in results makes nested touchable within `TouchableRipple` not pressable.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Covered

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
