### PR TITLE
docs: fix DataTableHeader.tsx screenshot preview

### DIFF
--- a/src/components/DataTable/DataTableHeader.tsx
+++ b/src/components/DataTable/DataTableHeader.tsx
@@ -22,7 +22,7 @@ export type Props = React.ComponentPropsWithRef<typeof View> & {
 /**
  * A component to display title in table header.
  *
- * <div class="screenshots">
+ * <div class="screenshots-full-width">
  *   <figure>
  *     <img class="medium" src="screenshots/data-table-header.png" />
  *   </figure>


### PR DESCRIPTION
As a dev
I can see the preview of a component
So that I can use it 

### Summary

**Expected**

![image](https://github.com/callstack/react-native-paper/assets/360936/347ac980-8523-483a-bb9a-c16b6ddde3c3)

**Actual**

![image](https://github.com/callstack/react-native-paper/assets/360936/5c58ad77-fdd9-4564-8386-cfe063301514)

right now the CSS for `screenshots figure` shrinks the image to 25% —wich is good for fullscreen shots.
The problem is, with part of component we can't see anything.

### Test plan

go to https://callstack.github.io/react-native-paper/docs/components/DataTable/DataTableTitle

I just changed this particular example, because I don't know what is the "design strategy for the CSS".

1. I am happy to dig on with your feedback an tackle all the issues like [here](https://callstack.github.io/react-native-paper/docs/components/Divider) or [here](https://callstack.github.io/react-native-paper/docs/components/DataTable/DataTablePagination)
2. or you can just merge this and follow up others components with a biggest PR
