### PR TITLE
feat: add overlayAccessibilityLabel prop to Dialog

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -31,6 +31,10 @@ export type Props = {
    */
   onDismiss?: () => void;
   /**
+   * Accessibility label for the overlay. This is read by the screen reader when the user taps outside the dialog.
+   */
+  overlayAccessibilityLabel?: string;
+  /**
    * Determines Whether the dialog is visible.
    */
   visible: boolean;
@@ -101,6 +105,7 @@ const Dialog = ({
   dismissable = true,
   dismissableBackButton = dismissable,
   onDismiss,
+  overlayAccessibilityLabel,
   visible = false,
   style,
   theme: themeOverrides,
@@ -124,6 +129,7 @@ const Dialog = ({
       dismissableBackButton={dismissableBackButton}
       onDismiss={onDismiss}
       visible={visible}
+      overlayAccessibilityLabel={overlayAccessibilityLabel}
       contentContainerStyle={[
         {
           borderRadius,

--- a/src/components/__tests__/Dialog.test.tsx
+++ b/src/components/__tests__/Dialog.test.tsx
@@ -38,6 +38,22 @@ describe('Dialog', () => {
     expect(getByTestId('dialog')).toHaveTextContent('This is simple dialog');
   });
 
+  it('should apply overlayAccessibilityLabel to the backdrop', () => {
+    const { getByTestId } = render(
+      <Dialog
+        visible
+        overlayAccessibilityLabel="Close dialog"
+        testID="dialog"
+      >
+        <Text>This is simple dialog</Text>
+      </Dialog>
+    );
+
+    expect(getByTestId('dialog-backdrop').props.accessibilityLabel).toBe(
+      'Close dialog'
+    );
+  });
+
   it('should call onDismiss when dismissable', () => {
     const onDismiss = jest.fn();
     const { getByTestId } = render(


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Forward `overlayAccessibilityLabel` on Dialog component to be able to change the accessible label on the modal.

Addresses #3911 

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
