### PR TITLE
docs: fix Appbar.Header default height

### DIFF
--- a/docs/docs/guides/10-migration-guide-to-5.0.md
+++ b/docs/docs/guides/10-migration-guide-to-5.0.md
@@ -202,10 +202,10 @@ If you want to check how to use `configureFonts` on MD3, check the [Fonts](https
 
 `Appbar` and `Appbar.Header` in the latest version can be used in four various modes due to new prop `mode`:
 
-* `small` - Appbar with default height <i>(56) (default)</i>,
+* `small` - Appbar with default height <i>(64) (default)</i>,
 * `medium` - Appbar with medium height <i>(112)</i>,
 * `large` - Appbar with large height <i>(152)</i>,
-* `center-aligned` - Appbar with default height <i>(56)</i> and center-aligned title.
+* `center-aligned` - Appbar with default height <i>(64)</i> and center-aligned title.
 
 ```js
 <Appbar mode="center-aligned">

--- a/src/components/Appbar/AppbarHeader.tsx
+++ b/src/components/Appbar/AppbarHeader.tsx
@@ -42,7 +42,7 @@ export type Props = React.ComponentProps<typeof Appbar> & {
    * @supported Available in v5.x with theme version 3
    *
    * Mode of the Appbar.
-   * - `small` - Appbar with default height (56).
+   * - `small` - Appbar with default height (64).
    * - `medium` - Appbar with medium height (112).
    * - `large` - Appbar with large height (152).
    * - `center-aligned` - Appbar with default height and center-aligned title.


### PR DESCRIPTION
Default height for Appbar.Header component was not matching the actual height (56 vs. 64).

