### PR TITLE
feat: add label style to segmented buttons

### DIFF
--- a/src/components/SegmentedButtons/SegmentedButtonItem.tsx
+++ b/src/components/SegmentedButtons/SegmentedButtonItem.tsx
@@ -224,7 +224,7 @@ const SegmentedButtonItem = ({
             style={[styles.label, labelTextStyle, labelStyle]}
             selectable={false}
             numberOfLines={1}
-            testID={testID ? `${testID}-label` : undefined}
+            testID={`${testID}-label`}
           >
             {label}
           </Text>

--- a/src/components/SegmentedButtons/SegmentedButtonItem.tsx
+++ b/src/components/SegmentedButtons/SegmentedButtonItem.tsx
@@ -81,6 +81,10 @@ export type Props = {
   density?: 'regular' | 'small' | 'medium' | 'high';
   style?: StyleProp<ViewStyle>;
   /**
+   * Allows you to customize the style of the label associated with a SegmentedButton.
+   */
+  labelStyle?: StyleProp<TextStyle>;
+  /**
    * testID to be used on tests.
    */
   testID?: string;
@@ -95,6 +99,7 @@ const SegmentedButtonItem = ({
   accessibilityLabel,
   disabled,
   style,
+  labelStyle,
   showSelectedCheck,
   checkedColor,
   uncheckedColor,
@@ -216,9 +221,10 @@ const SegmentedButtonItem = ({
           ) : null}
           <Text
             variant="labelLarge"
-            style={[styles.label, labelTextStyle]}
+            style={[styles.label, labelTextStyle, labelStyle]}
             selectable={false}
             numberOfLines={1}
+            testID={testID ? `${testID}-label` : undefined}
           >
             {label}
           </Text>

--- a/src/components/SegmentedButtons/SegmentedButtonItem.tsx
+++ b/src/components/SegmentedButtons/SegmentedButtonItem.tsx
@@ -81,7 +81,7 @@ export type Props = {
   density?: 'regular' | 'small' | 'medium' | 'high';
   style?: StyleProp<ViewStyle>;
   /**
-   * Allows you to customize the style of the label associated with a SegmentedButton.
+   * Style for the button label.
    */
   labelStyle?: StyleProp<TextStyle>;
   /**

--- a/src/components/SegmentedButtons/SegmentedButtons.tsx
+++ b/src/components/SegmentedButtons/SegmentedButtons.tsx
@@ -3,6 +3,7 @@ import {
   GestureResponderEvent,
   StyleProp,
   StyleSheet,
+  TextStyle,
   View,
   ViewStyle,
 } from 'react-native';
@@ -71,6 +72,7 @@ export type Props = {
     label?: string;
     showSelectedCheck?: boolean;
     style?: StyleProp<ViewStyle>;
+    labelStyle?: StyleProp<TextStyle>;
     testID?: string;
   }[];
   /**
@@ -178,6 +180,7 @@ const SegmentedButtons = ({
             density={density}
             onPress={onPress}
             style={[item.style, disabledChildStyle]}
+            labelStyle={item.labelStyle}
             theme={theme}
           />
         );

--- a/src/components/__tests__/SegmentedButton.test.tsx
+++ b/src/components/__tests__/SegmentedButton.test.tsx
@@ -439,3 +439,49 @@ describe('should have `accessibilityState={ checked: true }` when selected', () 
     expect(getByTestId('walking-check-icon')).toBeDefined();
   });
 });
+
+describe('labelStyle is handled', () => {
+  it('when labelStyle is given', () => {
+    const { getByTestId } = render(
+      <SegmentedButtons
+        value={'walk'}
+        buttons={[
+          {
+            label: 'Walking',
+            value: 'walk',
+            testID: 'walking-button',
+            labelStyle: { fontSize: 10 },
+          },
+          {
+            label: 'Driving',
+            value: 'drive',
+            testID: 'driving-button',
+            labelStyle: { fontSize: 12 },
+          },
+        ]}
+        onValueChange={() => {}}
+      />
+    );
+
+    expect(getByTestId('walking-button-label')).toHaveStyle({ fontSize: 10 });
+    expect(getByTestId('driving-button-label')).toHaveStyle({ fontSize: 12 });
+  });
+
+  it('when labelStyle is omitted', () => {
+    const { getByTestId } = render(
+      <SegmentedButtons
+        value={'walk'}
+        buttons={[
+          {
+            label: 'Walking',
+            value: 'walk',
+            testID: 'walking-button',
+          },
+        ]}
+        onValueChange={() => {}}
+      />
+    );
+
+    expect(getByTestId('walking-button-label')).toHaveStyle({ fontSize: 14 });
+  });
+});

--- a/src/components/__tests__/__snapshots__/SegmentedButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/SegmentedButton.test.tsx.snap
@@ -169,6 +169,7 @@ exports[`renders checked segmented button with selected check 1`] = `
                   "letterSpacing": 0.1,
                   "lineHeight": 20,
                 },
+                undefined,
               ],
             ]
           }
@@ -279,6 +280,7 @@ exports[`renders checked segmented button with selected check 1`] = `
                   "letterSpacing": 0.1,
                   "lineHeight": 20,
                 },
+                undefined,
               ],
             ]
           }
@@ -407,6 +409,7 @@ exports[`renders disabled segmented button 1`] = `
                   "letterSpacing": 0.1,
                   "lineHeight": 20,
                 },
+                undefined,
               ],
             ]
           }
@@ -517,6 +520,7 @@ exports[`renders disabled segmented button 1`] = `
                   "letterSpacing": 0.1,
                   "lineHeight": 20,
                 },
+                undefined,
               ],
             ]
           }
@@ -643,6 +647,7 @@ exports[`renders segmented button 1`] = `
                   "letterSpacing": 0.1,
                   "lineHeight": 20,
                 },
+                undefined,
               ],
             ]
           }
@@ -753,6 +758,7 @@ exports[`renders segmented button 1`] = `
                   "letterSpacing": 0.1,
                   "lineHeight": 20,
                 },
+                undefined,
               ],
             ]
           }


### PR DESCRIPTION
### Summary

Currently there is no way to change the style of the label of a `SegmentedButton`. This PR introduces the ability to give each element of the `buttons`-list an individual style.

```tsx
{
    value: 'test',
    label: 'Test',
    style: {
        // Some wrapper style
    },
    labelStyle: {
        fontSize: 5,
    },
}
```

### Test plan

Like in the example above, just apply some label style to a specific `SegementedButton` item.
