### PR TITLE
docs: Update Chip.tsx description

### DIFF
--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -125,7 +125,15 @@ export type Props = $Omit<React.ComponentProps<typeof Surface>, 'mode'> & {
 };
 
 /**
- * Chips can be used to display entities in small blocks.
+ * Chips are compact elements that can represent inputs, attributes, or actions.
+ * They can have an icon or avatar on the left, and a close button icon on the right.
+ * They are typically used to:
+ * <ul>
+ *  <li>Present multiple options </li>
+ *  <li>Represent attributes active or chosen </li>
+ *  <li>Present filter options </li>
+ *  <li>Trigger actions related to primary content </li>
+ * </ul>
  *
  * <div class="screenshots">
  *   <figure>


### PR DESCRIPTION
Update description

Small expansion of the Chip documentation.

### Summary

The current Chip documentation doesn't give much info as to how the Chip element is intended to be used in Material UI. While the user can certainly look it up, most Material UI libraries give at least a brief summary of [the usage guidelines](https://m2.material.io/components/chips) in their own documentation, and I think it's helpful. 

So this PR adds some brief guidance as to how the Chip component is used in the Material UI system. (I thought a link to the [official guidelines](https://m2.material.io/components/chips) might also be nice, but wasn't sure if that might be against policy, since it's not already being done...? If not, and you think it's a good idea, I can include one.)

### Test plan

Check the description for the Chip component, see if it makes sense and feels sufficiently informative.
