### PR TITLE
fix: correct condition to accept id equal zero

### DIFF
--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -203,7 +203,7 @@ const ListAccordion = ({
   const expandedInternal = expandedProp !== undefined ? expandedProp : expanded;
 
   const groupContext = React.useContext(ListAccordionGroupContext);
-  if (groupContext !== null && !id) {
+  if (groupContext !== null && (id === undefined || id === null || id === '')) {
     throw new Error(
       'List.Accordion is used inside a List.AccordionGroup without specifying an id prop.'
     );

--- a/src/components/__tests__/ListAccordion.test.tsx
+++ b/src/components/__tests__/ListAccordion.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
 import { render } from '@testing-library/react-native';
 import color from 'color';
@@ -7,6 +7,7 @@ import color from 'color';
 import { getTheme } from '../../core/theming';
 import { red500 } from '../../styles/themes/v2/colors';
 import ListAccordion from '../List/ListAccordion';
+import ListAccordionGroup from '../List/ListAccordionGroup';
 import ListIcon from '../List/ListIcon';
 import ListItem from '../List/ListItem';
 import { getAccordionColors } from '../List/utils';
@@ -82,6 +83,36 @@ it('renders list accordion with custom title and description styles', () => {
   ).toJSON();
 
   expect(tree).toMatchSnapshot();
+});
+
+describe('ListAccordion', () => {
+  it('should not throw an error when id={0}', () => {
+    const ListAccordionTest = () => (
+      <ListAccordionGroup>
+        <ListAccordion title="Testing list" id={0}>
+          <View></View>
+        </ListAccordion>
+      </ListAccordionGroup>
+    );
+
+    expect(() => render(<ListAccordionTest />)).not.toThrow(
+      'List.Accordion is used inside a List.AccordionGroup without specifying an id prop.'
+    );
+  });
+
+  it('should throw an error when id={""}', () => {
+    const ListAccordionTest = () => (
+      <ListAccordionGroup>
+        <ListAccordion title="Testing list" id={''}>
+          <View></View>
+        </ListAccordion>
+      </ListAccordionGroup>
+    );
+
+    expect(() => render(<ListAccordionTest />)).toThrow(
+      'List.Accordion is used inside a List.AccordionGroup without specifying an id prop.'
+    );
+  });
 });
 
 describe('getAccordionColors - title color', () => {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: #3902 

### Summary

Corrects the condition to not throw an error when `id={0}` since it's typed to accept the string or number.

#### Related issue

- #3902 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Covered with unit tests.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
