### PR TITLE
fix: MD2 Checkbox.Android disabled color

### DIFF
--- a/src/components/Checkbox/utils.ts
+++ b/src/components/Checkbox/utils.ts
@@ -78,7 +78,7 @@ const getAndroidControlColor = ({
     if (theme.isV3) {
       return theme.colors.onSurfaceDisabled;
     }
-    return theme.colors.text;
+    return theme.colors.disabled;
   }
 
   if (checked) {

--- a/src/components/__tests__/Checkbox/utils.test.tsx
+++ b/src/components/__tests__/Checkbox/utils.test.tsx
@@ -96,7 +96,7 @@ describe('getAndroidSelectionControlColor - checkbox color', () => {
         checked: false,
       })
     ).toMatchObject({
-      selectionControlColor: getTheme(false, false).colors.text,
+      selectionControlColor: getTheme(false, false).colors.disabled,
     });
   });
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This fixes an issue where on MD2 themes, the Android Checkbox component did not use the correct color when disabled.


### Test plan
The issue can be reproduced in this expo snack: https://snack.expo.dev/@jvsalas/restless-bagel


<img width="400" alt="Screenshot 2023-06-15 at 4 19 07 PM" src="https://github.com/callstack/react-native-paper/assets/12005979/ce333fbb-123b-4a65-9677-cbdb5aa4427c">

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
