### PR TITLE
refactor: create in example dir separate entry files per platform

### DIFF
--- a/example/src/DrawerItems.tsx
+++ b/example/src/DrawerItems.tsx
@@ -190,14 +190,16 @@ function DrawerItems() {
               </View>
             </TouchableRipple>
 
-            <TouchableRipple onPress={_handleToggleRTL}>
-              <View style={[styles.preference, isV3 && styles.v3Preference]}>
-                <Text variant="labelLarge">RTL</Text>
-                <View pointerEvents="none">
-                  <Switch value={isRTL} />
+            {!isWeb && (
+              <TouchableRipple onPress={_handleToggleRTL}>
+                <View style={[styles.preference, isV3 && styles.v3Preference]}>
+                  <Text variant="labelLarge">RTL</Text>
+                  <View pointerEvents="none">
+                    <Switch value={isRTL} />
+                  </View>
                 </View>
-              </View>
-            </TouchableRipple>
+              </TouchableRipple>
+            )}
 
             <TouchableRipple onPress={toggleThemeVersion}>
               <View style={[styles.preference, isV3 && styles.v3Preference]}>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

After [merging](https://github.com/callstack/react-native-paper/pull/3809) the support for using device colors, on the Android platform, there was introduced the library allowing to handle that. It's not supported by the web platform, so there were issues with running the web example locally. In order to unblock it, there are introduced separated entry files, per platform, since the web doesn't require the feature with device colors and importing the library.

Additionally, unblocked the `Drawer` for the web example, where removed the `rtl` example, which is currently not available.
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
