### PR TITLE
docs: create known issues section per component

### DIFF
--- a/docs/component-docs-plugin/generatePageMDX.js
+++ b/docs/component-docs-plugin/generatePageMDX.js
@@ -2,6 +2,34 @@ const config = require('../docusaurus.config');
 
 const { baseUrl, customFields } = config;
 
+function generateKnownIssues(componentName) {
+  const componentKnownIssues = customFields.knownIssues[componentName];
+
+  if (!componentKnownIssues) {
+    return `<span />`;
+  }
+
+  const issues = Object.entries(componentKnownIssues)
+    .map(([key, value]) => {
+      return `
+        <li key="${key}">
+          <a href="${value}">${key}</a>
+        </li>
+    `;
+    })
+    .join('');
+
+  return `
+  ## Known Issues
+
+  <details>
+    <ul>
+      ${issues}
+    </ul>
+  </details>
+  `;
+}
+
 function generateMoreExamples(componentName) {
   const componentMoreExamples = customFields.moreExamples[componentName];
 
@@ -12,9 +40,9 @@ function generateMoreExamples(componentName) {
   const links = Object.entries(componentMoreExamples)
     .map(([key, value]) => {
       return `
-    <li key="${key}">
-      <a href="${value}">${key}</a>
-    </li>
+        <li key="${key}">
+          <a href="${value}">${key}</a>
+        </li>
     `;
     })
     .join('');
@@ -67,6 +95,8 @@ ${generateMoreExamples(doc.title)}
 <PropTable link="${link}" />
 
 ${generateThemeColors(doc.title, data)}
+
+${generateKnownIssues(doc.title)}
 `;
 
   return mdx.slice(1);

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -326,6 +326,14 @@ const config = {
           'https://snack.expo.dev/@react-native-paper/more-examples---snackbar-rendered-regardless-of-the-parent-positioning',
       },
     },
+    knownIssues: {
+      TextInput: {
+        'Outline overlaps label':
+          'https://github.com/callstack/react-native-paper/issues/3759#issuecomment-1601235262',
+        'Long text wraps to a second line':
+          'https://github.com/callstack/react-native-paper/issues/2581#issuecomment-790251987',
+      },
+    },
     themeColors,
   },
 };


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes: https://github.com/callstack/react-native-paper/issues/3855

Created a section called `Known Issues` per component, to pin issues/limtations affecting the component, but currently cannot be solved due to the component constraints or the root cause is located in `react-native` itself.

In order to add the issue, there is a need to edit the section `knownIssues` in `docusaurus.config` and fill the component object with the new item.

#### Related issue

- #3855 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Check if the `Known Issues` exists in the `TextInput` ✅ 

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
