### PR TITLE
feat: add Link component

### DIFF
--- a/example/src/ExampleList.tsx
+++ b/example/src/ExampleList.tsx
@@ -23,6 +23,7 @@ import DialogExample from './Examples/DialogExample';
 import DividerExample from './Examples/DividerExample';
 import FABExample from './Examples/FABExample';
 import IconButtonExample from './Examples/IconButtonExample';
+import LinkExample from './Examples/LinkExample';
 import ListAccordionExample from './Examples/ListAccordionExample';
 import ListAccordionExampleGroup from './Examples/ListAccordionGroupExample';
 import ListItemExample from './Examples/ListItemExample';
@@ -74,6 +75,7 @@ export const mainExamples: Record<
   divider: DividerExample,
   fab: FABExample,
   iconButton: IconButtonExample,
+  link: LinkExample,
   listAccordion: ListAccordionExample,
   listAccordionGroup: ListAccordionExampleGroup,
   listSection: ListSectionExample,

--- a/example/src/Examples/LinkExample.tsx
+++ b/example/src/Examples/LinkExample.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import Link from '../../../src/components/Link';
+import ScreenWrapper from '../ScreenWrapper';
+
+const LinkExample = () => {
+  return (
+    <ScreenWrapper>
+      <View style={styles.container}>
+        <Link
+          href="https://callstack.github.io/react-native-paper"
+          underline
+          style={styles.link}
+        >
+          React native paper
+        </Link>
+        <Link
+          href="https://google.com"
+          size="titleLarge"
+          position="center"
+          style={styles.link}
+        >
+          Google
+        </Link>
+        <Link
+          href="https://facebook.com"
+          size="bodyLarge"
+          position="right"
+          style={styles.link}
+        >
+          Facebook
+        </Link>
+        <Link
+          href="https://callstack.github.io"
+          size="headlineLarge"
+          style={styles.link}
+        >
+          Instagram
+        </Link>
+      </View>
+    </ScreenWrapper>
+  );
+};
+
+LinkExample.title = 'Link';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+  },
+  link: {
+    marginVertical: 10,
+  },
+});
+
+export default LinkExample;

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,0 +1,135 @@
+import * as React from 'react';
+import {
+  Linking,
+  Pressable,
+  StyleProp,
+  StyleSheet,
+  ViewStyle,
+} from 'react-native';
+
+import Text from './Typography/Text';
+import type { VariantProp } from './Typography/types';
+
+const URLRegex = /^(?:http:\/\/|www\.|https:\/\/)([^/]+)/;
+
+type Props<T> = React.ComponentProps<typeof Pressable> & {
+  /**
+   * URL to open
+   */
+  href: string;
+  /**
+   * @supported Available in v5.x with theme version 3
+   *
+   * Variant defines appropriate text styles for size.
+   * Available variants:
+   *
+   *  Display: `displayLarge`, `displayMedium`, `displaySmall`
+   *
+   *  Headline: `headlineLarge`, `headlineMedium`, `headlineSmall`
+   *
+   *  Title: `titleLarge`, `titleMedium`, `titleSmall`
+   *
+   *  Label:  `labelLarge`, `labelMedium`, `labelSmall`
+   *
+   *  Body: `bodyLarge`, `bodyMedium`, `bodySmall`
+   */
+  size?: VariantProp<T>;
+  /**
+   * Content of the `Linking`.
+   */
+  children: string;
+  /**
+   * where to position the link in the view.
+   */
+  position?: string;
+  /**
+   * add a underline on the link
+   */
+  underline?: boolean;
+  /**
+   * @optional
+   */
+  style?: StyleProp<ViewStyle>;
+};
+
+/**
+ * Link is a simple component where users can use to open external link.
+ * `http://` and `https://` protocols are supported.
+ * Note: Only valid https and http link are show.
+ *
+ * ## Usage
+ * ```js
+ * import * as React from 'react';
+ * import { Link } from 'react-native-paper';
+ *
+ * const MyComponent = () => {
+ *
+ *   return (
+ *     <Link
+ *       href="https://callstack.github.io/react-native-paper/"
+ *     >
+ *     React native paper
+ *     </Link>
+ *   );
+ * };
+ *
+ * export default MyComponent;
+ * ```
+ */
+const Link = ({
+  href,
+  size = 'bodyMedium',
+  children,
+  position = 'left',
+  underline = false,
+  style,
+}: Props<never>) => {
+  const linkStyle = (StyleSheet.flatten(style) || {}) as ViewStyle;
+  const textStyle = underline && styles.underline;
+
+  const openLink = async () => {
+    try {
+      await Linking.openURL(href);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return URLRegex.test(href) ? (
+    <Pressable
+      onPress={openLink}
+      style={[
+        styles.container,
+        position === 'center'
+          ? styles.center
+          : position === 'right'
+          ? styles.right
+          : styles.left,
+      ]}
+    >
+      <Text variant={size} style={[textStyle, linkStyle]}>
+        {children}
+      </Text>
+    </Pressable>
+  ) : null;
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  left: {
+    alignSelf: 'flex-start',
+  },
+  right: {
+    alignSelf: 'flex-end',
+  },
+  center: {
+    alignSelf: 'center',
+  },
+  underline: {
+    textDecorationLine: 'underline',
+  },
+});
+
+export default Link;

--- a/src/components/__tests__/Link.test.tsx
+++ b/src/components/__tests__/Link.test.tsx
@@ -1,0 +1,149 @@
+import * as React from 'react';
+
+import { render } from '@testing-library/react-native';
+
+import Link from '../Link';
+
+it('renders link', () => {
+  const tree = render(
+    <Link href="https://callstack.github.io/react-native-paper/">
+      React native paper
+    </Link>
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders link with underline', () => {
+  const tree = render(
+    <Link href="https://callstack.github.io/react-native-paper/" underline>
+      React native paper
+    </Link>
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders link to the right', () => {
+  const tree = render(
+    <Link
+      href="https://callstack.github.io/react-native-paper/"
+      position="right"
+    >
+      React native paper
+    </Link>
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders link to the center', () => {
+  const tree = render(
+    <Link
+      href="https://callstack.github.io/react-native-paper/"
+      position="center"
+    >
+      React native paper
+    </Link>
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders link in different size (displayLarge)', () => {
+  const tree = render(
+    <Link
+      href="https://callstack.github.io/react-native-paper/"
+      size="displayLarge"
+    >
+      React native paper
+    </Link>
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+it('renders link in different size (displayMedium)', () => {
+  const tree = render(
+    <Link
+      href="https://callstack.github.io/react-native-paper/"
+      size="displayMedium"
+    >
+      React native paper
+    </Link>
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+it('renders link in different size (displaySmall)', () => {
+  const tree = render(
+    <Link
+      href="https://callstack.github.io/react-native-paper/"
+      size="displaySmall"
+    >
+      React native paper
+    </Link>
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders link in different size (titleLarge)', () => {
+  const tree = render(
+    <Link
+      href="https://callstack.github.io/react-native-paper/"
+      size="titleLarge"
+    >
+      React native paper
+    </Link>
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+it('renders link in different size (titleMedium)', () => {
+  const tree = render(
+    <Link
+      href="https://callstack.github.io/react-native-paper/"
+      size="titleMedium"
+    >
+      React native paper
+    </Link>
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+it('renders link in different size (titleSmall)', () => {
+  const tree = render(
+    <Link
+      href="https://callstack.github.io/react-native-paper/"
+      size="titleSmall"
+    >
+      React native paper
+    </Link>
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders link in different size (bodyLarge)', () => {
+  const tree = render(
+    <Link
+      href="https://callstack.github.io/react-native-paper/"
+      size="bodyLarge"
+    >
+      React native paper
+    </Link>
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+it('renders link in different size (bodyMedium)', () => {
+  const tree = render(
+    <Link
+      href="https://callstack.github.io/react-native-paper/"
+      size="bodyMedium"
+    >
+      React native paper
+    </Link>
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+it('renders link in different size (bodySmall)', () => {
+  const tree = render(
+    <Link
+      href="https://callstack.github.io/react-native-paper/"
+      size="bodySmall"
+    >
+      React native paper
+    </Link>
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/__tests__/__snapshots__/Link.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Link.test.tsx.snap
@@ -1,0 +1,705 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders link 1`] = `
+<View
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "flex": 1,
+      },
+      Object {
+        "alignSelf": "flex-start",
+      },
+    ]
+  }
+>
+  <Text
+    style={
+      Array [
+        Object {
+          "fontFamily": "System",
+          "fontSize": 14,
+          "fontWeight": "400",
+          "letterSpacing": 0.25,
+          "lineHeight": 20,
+        },
+        Object {
+          "textAlign": "left",
+        },
+        Object {
+          "color": "rgba(28, 27, 31, 1)",
+          "writingDirection": "ltr",
+        },
+        Array [
+          false,
+          Object {},
+        ],
+      ]
+    }
+  >
+    React native paper
+  </Text>
+</View>
+`;
+
+exports[`renders link in different size (bodyLarge) 1`] = `
+<View
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "flex": 1,
+      },
+      Object {
+        "alignSelf": "flex-start",
+      },
+    ]
+  }
+>
+  <Text
+    style={
+      Array [
+        Object {
+          "fontFamily": "System",
+          "fontSize": 16,
+          "fontWeight": "400",
+          "letterSpacing": 0.15,
+          "lineHeight": 24,
+        },
+        Object {
+          "textAlign": "left",
+        },
+        Object {
+          "color": "rgba(28, 27, 31, 1)",
+          "writingDirection": "ltr",
+        },
+        Array [
+          false,
+          Object {},
+        ],
+      ]
+    }
+  >
+    React native paper
+  </Text>
+</View>
+`;
+
+exports[`renders link in different size (bodyMedium) 1`] = `
+<View
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "flex": 1,
+      },
+      Object {
+        "alignSelf": "flex-start",
+      },
+    ]
+  }
+>
+  <Text
+    style={
+      Array [
+        Object {
+          "fontFamily": "System",
+          "fontSize": 14,
+          "fontWeight": "400",
+          "letterSpacing": 0.25,
+          "lineHeight": 20,
+        },
+        Object {
+          "textAlign": "left",
+        },
+        Object {
+          "color": "rgba(28, 27, 31, 1)",
+          "writingDirection": "ltr",
+        },
+        Array [
+          false,
+          Object {},
+        ],
+      ]
+    }
+  >
+    React native paper
+  </Text>
+</View>
+`;
+
+exports[`renders link in different size (bodySmall) 1`] = `
+<View
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "flex": 1,
+      },
+      Object {
+        "alignSelf": "flex-start",
+      },
+    ]
+  }
+>
+  <Text
+    style={
+      Array [
+        Object {
+          "fontFamily": "System",
+          "fontSize": 12,
+          "fontWeight": "400",
+          "letterSpacing": 0.4,
+          "lineHeight": 16,
+        },
+        Object {
+          "textAlign": "left",
+        },
+        Object {
+          "color": "rgba(28, 27, 31, 1)",
+          "writingDirection": "ltr",
+        },
+        Array [
+          false,
+          Object {},
+        ],
+      ]
+    }
+  >
+    React native paper
+  </Text>
+</View>
+`;
+
+exports[`renders link in different size (displayLarge) 1`] = `
+<View
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "flex": 1,
+      },
+      Object {
+        "alignSelf": "flex-start",
+      },
+    ]
+  }
+>
+  <Text
+    style={
+      Array [
+        Object {
+          "fontFamily": "System",
+          "fontSize": 57,
+          "fontWeight": "400",
+          "letterSpacing": 0,
+          "lineHeight": 64,
+        },
+        Object {
+          "textAlign": "left",
+        },
+        Object {
+          "color": "rgba(28, 27, 31, 1)",
+          "writingDirection": "ltr",
+        },
+        Array [
+          false,
+          Object {},
+        ],
+      ]
+    }
+  >
+    React native paper
+  </Text>
+</View>
+`;
+
+exports[`renders link in different size (displayMedium) 1`] = `
+<View
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "flex": 1,
+      },
+      Object {
+        "alignSelf": "flex-start",
+      },
+    ]
+  }
+>
+  <Text
+    style={
+      Array [
+        Object {
+          "fontFamily": "System",
+          "fontSize": 45,
+          "fontWeight": "400",
+          "letterSpacing": 0,
+          "lineHeight": 52,
+        },
+        Object {
+          "textAlign": "left",
+        },
+        Object {
+          "color": "rgba(28, 27, 31, 1)",
+          "writingDirection": "ltr",
+        },
+        Array [
+          false,
+          Object {},
+        ],
+      ]
+    }
+  >
+    React native paper
+  </Text>
+</View>
+`;
+
+exports[`renders link in different size (displaySmall) 1`] = `
+<View
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "flex": 1,
+      },
+      Object {
+        "alignSelf": "flex-start",
+      },
+    ]
+  }
+>
+  <Text
+    style={
+      Array [
+        Object {
+          "fontFamily": "System",
+          "fontSize": 36,
+          "fontWeight": "400",
+          "letterSpacing": 0,
+          "lineHeight": 44,
+        },
+        Object {
+          "textAlign": "left",
+        },
+        Object {
+          "color": "rgba(28, 27, 31, 1)",
+          "writingDirection": "ltr",
+        },
+        Array [
+          false,
+          Object {},
+        ],
+      ]
+    }
+  >
+    React native paper
+  </Text>
+</View>
+`;
+
+exports[`renders link in different size (titleLarge) 1`] = `
+<View
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "flex": 1,
+      },
+      Object {
+        "alignSelf": "flex-start",
+      },
+    ]
+  }
+>
+  <Text
+    style={
+      Array [
+        Object {
+          "fontFamily": "System",
+          "fontSize": 22,
+          "fontWeight": "400",
+          "letterSpacing": 0,
+          "lineHeight": 28,
+        },
+        Object {
+          "textAlign": "left",
+        },
+        Object {
+          "color": "rgba(28, 27, 31, 1)",
+          "writingDirection": "ltr",
+        },
+        Array [
+          false,
+          Object {},
+        ],
+      ]
+    }
+  >
+    React native paper
+  </Text>
+</View>
+`;
+
+exports[`renders link in different size (titleMedium) 1`] = `
+<View
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "flex": 1,
+      },
+      Object {
+        "alignSelf": "flex-start",
+      },
+    ]
+  }
+>
+  <Text
+    style={
+      Array [
+        Object {
+          "fontFamily": "System",
+          "fontSize": 16,
+          "fontWeight": "500",
+          "letterSpacing": 0.15,
+          "lineHeight": 24,
+        },
+        Object {
+          "textAlign": "left",
+        },
+        Object {
+          "color": "rgba(28, 27, 31, 1)",
+          "writingDirection": "ltr",
+        },
+        Array [
+          false,
+          Object {},
+        ],
+      ]
+    }
+  >
+    React native paper
+  </Text>
+</View>
+`;
+
+exports[`renders link in different size (titleSmall) 1`] = `
+<View
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "flex": 1,
+      },
+      Object {
+        "alignSelf": "flex-start",
+      },
+    ]
+  }
+>
+  <Text
+    style={
+      Array [
+        Object {
+          "fontFamily": "System",
+          "fontSize": 14,
+          "fontWeight": "500",
+          "letterSpacing": 0.1,
+          "lineHeight": 20,
+        },
+        Object {
+          "textAlign": "left",
+        },
+        Object {
+          "color": "rgba(28, 27, 31, 1)",
+          "writingDirection": "ltr",
+        },
+        Array [
+          false,
+          Object {},
+        ],
+      ]
+    }
+  >
+    React native paper
+  </Text>
+</View>
+`;
+
+exports[`renders link to the center 1`] = `
+<View
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "flex": 1,
+      },
+      Object {
+        "alignSelf": "center",
+      },
+    ]
+  }
+>
+  <Text
+    style={
+      Array [
+        Object {
+          "fontFamily": "System",
+          "fontSize": 14,
+          "fontWeight": "400",
+          "letterSpacing": 0.25,
+          "lineHeight": 20,
+        },
+        Object {
+          "textAlign": "left",
+        },
+        Object {
+          "color": "rgba(28, 27, 31, 1)",
+          "writingDirection": "ltr",
+        },
+        Array [
+          false,
+          Object {},
+        ],
+      ]
+    }
+  >
+    React native paper
+  </Text>
+</View>
+`;
+
+exports[`renders link to the right 1`] = `
+<View
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "flex": 1,
+      },
+      Object {
+        "alignSelf": "flex-end",
+      },
+    ]
+  }
+>
+  <Text
+    style={
+      Array [
+        Object {
+          "fontFamily": "System",
+          "fontSize": 14,
+          "fontWeight": "400",
+          "letterSpacing": 0.25,
+          "lineHeight": 20,
+        },
+        Object {
+          "textAlign": "left",
+        },
+        Object {
+          "color": "rgba(28, 27, 31, 1)",
+          "writingDirection": "ltr",
+        },
+        Array [
+          false,
+          Object {},
+        ],
+      ]
+    }
+  >
+    React native paper
+  </Text>
+</View>
+`;
+
+exports[`renders link with underline 1`] = `
+<View
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "flex": 1,
+      },
+      Object {
+        "alignSelf": "flex-start",
+      },
+    ]
+  }
+>
+  <Text
+    style={
+      Array [
+        Object {
+          "fontFamily": "System",
+          "fontSize": 14,
+          "fontWeight": "400",
+          "letterSpacing": 0.25,
+          "lineHeight": 20,
+        },
+        Object {
+          "textAlign": "left",
+        },
+        Object {
+          "color": "rgba(28, 27, 31, 1)",
+          "writingDirection": "ltr",
+        },
+        Array [
+          Object {
+            "textDecorationLine": "underline",
+          },
+          Object {},
+        ],
+      ]
+    }
+  >
+    React native paper
+  </Text>
+</View>
+`;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -56,6 +56,7 @@ export { default as TextInput } from './components/TextInput/TextInput';
 export { default as ToggleButton } from './components/ToggleButton';
 export { default as SegmentedButtons } from './components/SegmentedButtons/SegmentedButtons';
 export { default as Tooltip } from './components/Tooltip/Tooltip';
+export { default as Link } from './components/Link';
 
 export {
   Caption,


### PR DESCRIPTION
### Summary

This PR introduces the `Link` component which allow user to open external link with a provides valid URL. Only `https://` and `http://` protocol are supported
We have a couple of supported props:
```jsx
underline(boolean) is optional
href(url to open) is required
position('left', 'center', 'right'. the default position is 'left') is optional
size(used the variant size from Typography component. the default size is 'bodyMedium') is optional
```

### Test plan

You can use it by call it like this:
```jsx
<Link href="https://callstack.github.io">CallStack</Link>
```
