### PR TITLE
Draft: fix: conditionally import react navigation

### DIFF
--- a/src/react-navigation/adapter.ts
+++ b/src/react-navigation/adapter.ts
@@ -1,19 +1,14 @@
-import {
-  // @ts-ignore: this hook is not available in React Navigation v7
-  useLinkBuilder,
-  // @ts-ignore: this hook is not available in React Navigation v6
-  useLinkTools,
-} from '@react-navigation/native';
-
-function useV7LinkBuilder() {
-  const tools = useLinkTools();
-  return tools.buildHref;
-}
+const module = require('@react-navigation/native');
 
 type NavigationLink = () => (
   name: string,
   params?: object
 ) => string | undefined;
+
+function useV7LinkBuilder() {
+  const tools = module.useLinkTools();
+  return tools.buildHref;
+}
 
 /**
  * In React Navigation 7 `useLinkBuilder` was superseded by `useLinkTools`
@@ -21,4 +16,4 @@ type NavigationLink = () => (
  **/
 
 export const useNavigationLink: NavigationLink =
-  typeof useLinkTools !== 'undefined' ? useV7LinkBuilder : useLinkBuilder;
+  'useLinkTools' in module ? useV7LinkBuilder : module.useLinkBuilder;


### PR DESCRIPTION
Fixes https://github.com/callstack/react-native-paper/issues/3952

### Summary

Unfortunately Webpack won't allows us to import missing export via ES6. Dynamic imports are a no-go as well. They're async and since we want to import hook we end up with `Promise<useLinkTools>`. This would break rules of hooks since we'd have a conditional hook rendered (before and after async import).

The only solution I found is to import the whole package as `CommonJS`. This won't break the rules since it's sync. It will import once and then only one hook will be returned. 

### Test plan

Example app does not throw an error anymore on either v6 or v7
