### PR TITLE
fix: missing react-navigation types

### DIFF
--- a/react-navigation/package.json
+++ b/react-navigation/package.json
@@ -2,5 +2,5 @@
   "main": "../lib/commonjs/react-navigation/index",
   "module": "../lib/module/react-navigation/index",
   "react-native": "../src/react-navigation/index",
-  "types": "../lib/typescript/react-navigation/index"
+  "types": "../lib/typescript/src/react-navigation/index"
 }


### PR DESCRIPTION
here is the link to the issue https://github.com/callstack/react-native-paper/issues/3959


