### PR TITLE
fix: use theme background for transparent text inputs

### DIFF
--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -122,6 +122,7 @@ const InputLabel = (props: InputLabelProps) => {
         backgroundColor,
         roundness,
         maxFontSizeMultiplier: maxFontSizeMultiplier,
+        testID,
       })}
       <AnimatedText
         variant="bodySmall"

--- a/src/components/TextInput/Label/LabelBackground.tsx
+++ b/src/components/TextInput/Label/LabelBackground.tsx
@@ -15,6 +15,7 @@ const LabelBackground = ({
   roundness,
   labelStyle,
   maxFontSizeMultiplier,
+  testID,
 }: LabelBackgroundProps) => {
   const opacity = labeled.interpolate({
     inputRange: [0, 0.6],
@@ -60,6 +61,7 @@ const LabelBackground = ({
     roundedEdgeCover,
     <AnimatedText
       key="labelBackground-text"
+      testID={`${testID}-label-background`}
       style={[
         placeholderStyle,
         labelStyle,

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -186,6 +186,11 @@ const TextInputOutlined = ({
     paddingHorizontal: INPUT_PADDING_HORIZONTAL,
   };
 
+  const labelBackgroundColor: ColorValue =
+    backgroundColor === 'transparent'
+      ? theme.colors.background
+      : backgroundColor;
+
   const labelProps = {
     label,
     onLayoutAnimatedText,
@@ -204,7 +209,7 @@ const TextInputOutlined = ({
     hasActiveOutline,
     activeColor,
     placeholderColor,
-    backgroundColor: backgroundColor as ColorValue,
+    backgroundColor: labelBackgroundColor,
     errorColor,
     labelTranslationXOffset,
     roundness,

--- a/src/components/__tests__/TextInput.test.tsx
+++ b/src/components/__tests__/TextInput.test.tsx
@@ -5,7 +5,7 @@ import { StyleSheet, Text, Platform, I18nManager } from 'react-native';
 import { fireEvent, render } from '@testing-library/react-native';
 import color from 'color';
 
-import { getTheme } from '../../core/theming';
+import { DefaultTheme, getTheme, ThemeProvider } from '../../core/theming';
 import { red500 } from '../../styles/themes/v2/colors';
 import {
   getFlatInputColors,
@@ -354,6 +354,33 @@ it('calls onLayout on right-side affix adornment', () => {
     });
   })
 );
+
+it("correctly applies theme background to label when input's background is transparent", () => {
+  const backgroundColor = 'transparent';
+  const theme = {
+    ...DefaultTheme,
+    colors: {
+      ...DefaultTheme.colors,
+      background: 'pink',
+    },
+  };
+
+  const { getByTestId } = render(
+    <ThemeProvider theme={theme}>
+      <TextInput
+        mode="outlined"
+        label="Transparent input"
+        value={'Some test value'}
+        style={{ backgroundColor }}
+        testID={'transparent-example'}
+      />
+    </ThemeProvider>
+  );
+
+  expect(getByTestId('transparent-example-label-background')).toHaveStyle({
+    backgroundColor: 'pink',
+  });
+});
 
 describe('maxFontSizeMultiplier', () => {
   const createInput = (

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -695,6 +695,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
               "writingDirection": "ltr",
             }
           }
+          testID="text-input-outlined-label-background"
         >
           Outline Input
         </Text>


### PR DESCRIPTION
### Summary

In `outlined` mode, the background color of the label is derived from `colors?.background` in theme or the `backgroundColor` style. When `backgroundColor` style is passed as `transparent` that would affect the border cover as well, resulting in border & label overlapping in active state.

This PR switches background of the cover from `transparent` back to theme's background as a last resort.

Closes: https://github.com/callstack/react-native-paper/issues/3759

### Test plan

Tested on the example app + simple unit test added.

<img width="1235" alt="image" src="https://github.com/callstack/react-native-paper/assets/7429558/346442a7-898a-4c93-9b21-a15daa35026e">

