### PR TITLE
fix: chip style 

### DIFF
--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -280,7 +280,7 @@ const Chip = ({
     >
       <TouchableRipple
         borderless
-        style={[{ borderRadius }, styles.touchable]}
+        style={[{ borderRadius }]}
         onPress={onPress}
         onLongPress={onLongPress}
         onPressIn={hasPassedTouchHandler ? handlePressIn : undefined}
@@ -414,7 +414,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingLeft: 4,
     position: 'relative',
-    flexGrow: 1,
   },
   md3Content: {
     paddingLeft: 0,
@@ -472,9 +471,6 @@ const styles = StyleSheet.create({
     height: '100%',
     justifyContent: 'center',
     alignItems: 'center',
-  },
-  touchable: {
-    flexGrow: 1,
   },
 });
 

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -280,7 +280,7 @@ const Chip = ({
     >
       <TouchableRipple
         borderless
-        style={[{ borderRadius }]}
+        style={[{ borderRadius }, styles.touchable]}
         onPress={onPress}
         onLongPress={onLongPress}
         onPressIn={hasPassedTouchHandler ? handlePressIn : undefined}
@@ -471,6 +471,9 @@ const styles = StyleSheet.create({
     height: '100%',
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  touchable: {
+    width: '100%',
   },
 });
 

--- a/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -69,9 +69,6 @@ exports[`renders chip with close button 1`] = `
             Object {
               "borderRadius": 8,
             },
-            Object {
-              "flexGrow": 1,
-            },
           ],
         ]
       }
@@ -83,7 +80,6 @@ exports[`renders chip with close button 1`] = `
             Object {
               "alignItems": "center",
               "flexDirection": "row",
-              "flexGrow": 1,
               "paddingLeft": 4,
               "position": "relative",
             },
@@ -345,9 +341,6 @@ exports[`renders chip with custom close button 1`] = `
             Object {
               "borderRadius": 8,
             },
-            Object {
-              "flexGrow": 1,
-            },
           ],
         ]
       }
@@ -359,7 +352,6 @@ exports[`renders chip with custom close button 1`] = `
             Object {
               "alignItems": "center",
               "flexDirection": "row",
-              "flexGrow": 1,
               "paddingLeft": 4,
               "position": "relative",
             },
@@ -621,9 +613,6 @@ exports[`renders chip with icon 1`] = `
             Object {
               "borderRadius": 8,
             },
-            Object {
-              "flexGrow": 1,
-            },
           ],
         ]
       }
@@ -635,7 +624,6 @@ exports[`renders chip with icon 1`] = `
             Object {
               "alignItems": "center",
               "flexDirection": "row",
-              "flexGrow": 1,
               "paddingLeft": 4,
               "position": "relative",
             },
@@ -820,9 +808,6 @@ exports[`renders chip with onPress 1`] = `
             Object {
               "borderRadius": 8,
             },
-            Object {
-              "flexGrow": 1,
-            },
           ],
         ]
       }
@@ -834,7 +819,6 @@ exports[`renders chip with onPress 1`] = `
             Object {
               "alignItems": "center",
               "flexDirection": "row",
-              "flexGrow": 1,
               "paddingLeft": 4,
               "position": "relative",
             },
@@ -967,9 +951,6 @@ exports[`renders outlined disabled chip 1`] = `
             Object {
               "borderRadius": 8,
             },
-            Object {
-              "flexGrow": 1,
-            },
           ],
         ]
       }
@@ -981,7 +962,6 @@ exports[`renders outlined disabled chip 1`] = `
             Object {
               "alignItems": "center",
               "flexDirection": "row",
-              "flexGrow": 1,
               "paddingLeft": 4,
               "position": "relative",
             },
@@ -1114,9 +1094,6 @@ exports[`renders selected chip 1`] = `
             Object {
               "borderRadius": 8,
             },
-            Object {
-              "flexGrow": 1,
-            },
           ],
         ]
       }
@@ -1128,7 +1105,6 @@ exports[`renders selected chip 1`] = `
             Object {
               "alignItems": "center",
               "flexDirection": "row",
-              "flexGrow": 1,
               "paddingLeft": 4,
               "position": "relative",
             },

--- a/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -69,6 +69,9 @@ exports[`renders chip with close button 1`] = `
             Object {
               "borderRadius": 8,
             },
+            Object {
+              "width": "100%",
+            },
           ],
         ]
       }
@@ -340,6 +343,9 @@ exports[`renders chip with custom close button 1`] = `
           Array [
             Object {
               "borderRadius": 8,
+            },
+            Object {
+              "width": "100%",
             },
           ],
         ]
@@ -613,6 +619,9 @@ exports[`renders chip with icon 1`] = `
             Object {
               "borderRadius": 8,
             },
+            Object {
+              "width": "100%",
+            },
           ],
         ]
       }
@@ -808,6 +817,9 @@ exports[`renders chip with onPress 1`] = `
             Object {
               "borderRadius": 8,
             },
+            Object {
+              "width": "100%",
+            },
           ],
         ]
       }
@@ -951,6 +963,9 @@ exports[`renders outlined disabled chip 1`] = `
             Object {
               "borderRadius": 8,
             },
+            Object {
+              "width": "100%",
+            },
           ],
         ]
       }
@@ -1093,6 +1108,9 @@ exports[`renders selected chip 1`] = `
           Array [
             Object {
               "borderRadius": 8,
+            },
+            Object {
+              "width": "100%",
             },
           ],
         ]

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -166,9 +166,6 @@ exports[`renders list item with custom description 1`] = `
                       Object {
                         "borderRadius": 8,
                       },
-                      Object {
-                        "flexGrow": 1,
-                      },
                     ],
                   ]
                 }
@@ -180,7 +177,6 @@ exports[`renders list item with custom description 1`] = `
                       Object {
                         "alignItems": "center",
                         "flexDirection": "row",
-                        "flexGrow": 1,
                         "paddingLeft": 4,
                         "position": "relative",
                       },

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -166,6 +166,9 @@ exports[`renders list item with custom description 1`] = `
                       Object {
                         "borderRadius": 8,
                       },
+                      Object {
+                        "width": "100%",
+                      },
                     ],
                   ]
                 }


### PR DESCRIPTION
Fixes: https://github.com/callstack/react-native-paper/issues/3916

Chip component was having `"flexGrow": 1,` style because of which it was taking the entire parent size when a parent has aligned item style. 

### Summary

I have removed `flexGrow`. 

### Test plan

I simulated and tested the example given in the [issue](https://github.com/callstack/react-native-paper/issues/3916)