### PR TITLE
fix: adjust progress bar wrapper height on web

### DIFF
--- a/example/src/Examples/ProgressBarExample.tsx
+++ b/example/src/Examples/ProgressBarExample.tsx
@@ -94,9 +94,21 @@ const ProgressBarExample = () => {
       <View style={styles.row}>
         <Text variant="bodyMedium">ProgressBar with animated value</Text>
         <AnimatedProgressBar
+          visible={visible}
           style={styles.progressBar}
           animatedValue={progressBarValue}
           theme={theme}
+        />
+      </View>
+
+      <View style={[styles.row, styles.fullRow]}>
+        <Text variant="bodyMedium">
+          ProgressBar with custom percentage height
+        </Text>
+        <ProgressBar
+          style={styles.customPercentageHeight}
+          indeterminate
+          visible={visible}
         />
       </View>
     </ScreenWrapper>
@@ -112,8 +124,15 @@ const styles = StyleSheet.create({
   row: {
     marginVertical: 10,
   },
+  fullRow: {
+    height: '100%',
+    width: '100%',
+  },
   customHeight: {
     height: 20,
+  },
+  customPercentageHeight: {
+    height: '50%',
   },
   progressBar: {
     height: 15,

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -74,6 +74,7 @@ const ProgressBar = ({
   animatedValue,
   ...rest
 }: Props) => {
+  const isWeb = Platform.OS === 'web';
   const theme = useInternalTheme(themeOverrides);
   const { current: timer } = React.useRef<Animated.Value>(
     new Animated.Value(0)
@@ -123,7 +124,7 @@ const ProgressBar = ({
           duration: INDETERMINATE_DURATION,
           toValue: 1,
           // Animated.loop does not work if useNativeDriver is true on web
-          useNativeDriver: Platform.OS !== 'web',
+          useNativeDriver: !isWeb,
           isInteraction: false,
         });
       }
@@ -140,7 +141,7 @@ const ProgressBar = ({
         isInteraction: false,
       }).start();
     }
-  }, [fade, scale, indeterminate, timer, progress]);
+  }, [fade, scale, indeterminate, timer, progress, isWeb]);
 
   const stopAnimation = React.useCallback(() => {
     // Stop indeterminate animation
@@ -194,6 +195,7 @@ const ProgressBar = ({
       accessibilityValue={
         indeterminate ? {} : { min: 0, max: 100, now: progress * 100 }
       }
+      style={isWeb && styles.webContainer}
     >
       <Animated.View
         style={[
@@ -263,7 +265,10 @@ const styles = StyleSheet.create({
     height: 4,
     overflow: 'hidden',
   },
-
+  webContainer: {
+    width: '100%',
+    height: '100%',
+  },
   progressBar: {
     flex: 1,
   },

--- a/src/components/__tests__/ProgressBar.test.tsx
+++ b/src/components/__tests__/ProgressBar.test.tsx
@@ -23,6 +23,10 @@ class ClassProgressBar extends React.Component<Props> {
 
 const AnimatedProgressBar = Animated.createAnimatedComponent(ClassProgressBar);
 
+afterEach(() => {
+  Platform.OS = 'ios';
+});
+
 it('renders progress bar with animated value', async () => {
   const tree = render(<AnimatedProgressBar animatedValue={0.2} />);
   await waitFor(() => tree.getByRole(a11yRole).props.onLayout(layoutEvent));

--- a/src/components/__tests__/ProgressBar.test.tsx
+++ b/src/components/__tests__/ProgressBar.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Animated } from 'react-native';
+import { Animated, Platform } from 'react-native';
 
 import { render, waitFor } from '@testing-library/react-native';
 
@@ -58,4 +58,14 @@ it('renders indeterminate progress bar', async () => {
   await waitFor(() => tree.getByRole(a11yRole).props.onLayout(layoutEvent));
 
   expect(tree.toJSON()).toMatchSnapshot();
+});
+
+it('renders progress bar with full height on web', () => {
+  Platform.OS = 'web';
+  const tree = render(<ProgressBar progress={0.2} />);
+
+  expect(tree.getByRole(a11yRole)).toHaveStyle({
+    width: '100%',
+    height: '100%',
+  });
 });

--- a/src/components/__tests__/__snapshots__/ProgressBar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ProgressBar.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`renders colored progress bar 1`] = `
   }
   accessible={true}
   onLayout={[Function]}
+  style={false}
 >
   <View
     collapsable={false}
@@ -68,6 +69,7 @@ exports[`renders hidden progress bar 1`] = `
   }
   accessible={true}
   onLayout={[Function]}
+  style={false}
 >
   <View
     collapsable={false}
@@ -113,6 +115,7 @@ exports[`renders indeterminate progress bar 1`] = `
   accessibilityValue={Object {}}
   accessible={true}
   onLayout={[Function]}
+  style={false}
 >
   <View
     collapsable={false}
@@ -164,6 +167,7 @@ exports[`renders progress bar with specific progress 1`] = `
   }
   accessible={true}
   onLayout={[Function]}
+  style={false}
 >
   <View
     collapsable={false}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/3984

### Summary

Correct view wrapper styles for the web to properly display `ProgressBar` with the percentage height.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Added new example and unit test case.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
