### PR TITLE
fix: add support `PlatformColor` to unblock `react-navigation` fix

### DIFF
--- a/src/components/Appbar/AppbarAction.tsx
+++ b/src/components/Appbar/AppbarAction.tsx
@@ -4,6 +4,7 @@ import type {
   StyleProp,
   ViewStyle,
   TouchableWithoutFeedback,
+  ColorValue,
 } from 'react-native';
 import { black } from '../../styles/colors';
 import IconButton from '../IconButton';
@@ -13,7 +14,7 @@ export type Props = React.ComponentPropsWithoutRef<typeof IconButton> & {
   /**
    *  Custom color for action icon.
    */
-  color?: string;
+  color?: ColorValue;
   /**
    * Name of the icon to show.
    */

--- a/src/components/CrossFadeIcon.tsx
+++ b/src/components/CrossFadeIcon.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Animated, StyleSheet, View } from 'react-native';
+import { Animated, ColorValue, StyleSheet, View } from 'react-native';
 import Icon, { isValidIcon, IconSource, isEqualIcon } from './Icon';
 
 import { withTheme } from '../core/theming';
@@ -12,7 +12,7 @@ type Props = {
   /**
    * Color of the icon.
    */
-  color: string;
+  color: ColorValue;
   /**
    * Size of the icon.
    */

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -4,6 +4,7 @@ import {
   I18nManager,
   Platform,
   ImageSourcePropType,
+  ColorValue,
 } from 'react-native';
 import { Consumer as SettingsConsumer } from '../core/settings';
 import { accessibilityProps } from './MaterialCommunityIcon';
@@ -22,7 +23,7 @@ type IconProps = {
 };
 
 type Props = IconProps & {
-  color?: string;
+  color?: ColorValue;
   source: any;
   /**
    * @optional

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -6,6 +6,7 @@ import {
   StyleProp,
   GestureResponderEvent,
   TouchableWithoutFeedback,
+  ColorValue,
 } from 'react-native';
 import color from 'color';
 
@@ -24,7 +25,7 @@ export type Props = $RemoveChildren<typeof TouchableRipple> & {
   /**
    * Color of the icon.
    */
-  color?: string;
+  color?: ColorValue;
   /**
    * Size of the icon.
    */

--- a/src/components/MaterialCommunityIcon.tsx
+++ b/src/components/MaterialCommunityIcon.tsx
@@ -1,9 +1,16 @@
 import * as React from 'react';
-import { StyleSheet, Text, Platform, TextProps, ViewProps } from 'react-native';
+import {
+  StyleSheet,
+  Text,
+  Platform,
+  TextProps,
+  ViewProps,
+  ColorValue,
+} from 'react-native';
 
 export type IconProps = {
   name: string;
-  color: string;
+  color: ColorValue;
   size: number;
   direction: 'rtl' | 'ltr';
   allowFontScaling?: boolean;
@@ -12,7 +19,7 @@ export type IconProps = {
 let MaterialCommunityIcons: React.ComponentType<
   TextProps & {
     name: string;
-    color: string;
+    color: ColorValue;
     size: number;
     pointerEvents?: ViewProps['pointerEvents'];
   }


### PR DESCRIPTION

### Summary

Issue: https://github.com/react-navigation/react-navigation/issues/11481

I started to adding `PlatformColor` to `react-nativgation` but faced with error that `react-native-paper` also didn't support it

So I decided to apply `ColorValue` only for limited amount of commponet to unblock `react-nativgation` migration 

```tsx
<Appbar.Action
  // @ts-expect-error - no PlatformColor support :(
  color={tintColor}
/>
```

### Test plan

```
yarn tsc
```
