### PR TITLE
docs: create correct prop header to be displayed in TOC

### DIFF
--- a/docs/src/components/PropTable.tsx
+++ b/docs/src/components/PropTable.tsx
@@ -17,8 +17,6 @@ const typeDefinitions = {
   'StyleProp<TextStyle>': 'https://reactnative.dev/docs/text-style-props',
 };
 
-const ANNOTATION_OPTIONAL = '@optional';
-const ANNOTATION_INTERNAL = '@internal';
 const ANNOTATION_EXTENDS = '@extends';
 
 const renderBadge = (annotation: string) => {
@@ -60,8 +58,14 @@ const renderExtendsLink = (description: string) => {
   ));
 };
 
-export default function PropTable({ link }: { link: string }) {
-  const doc = useDoc(link);
+export default function PropTable({
+  componentLink,
+  prop,
+}: {
+  componentLink: string;
+  prop: string;
+}) {
+  const doc = useDoc(componentLink);
 
   if (!doc || !doc.data || !doc.data.props) {
     return null;
@@ -69,33 +73,16 @@ export default function PropTable({ link }: { link: string }) {
 
   const props = doc.data.props;
 
-  for (const prop in props) {
-    if (!props[prop].description) {
-      props[prop].description = '';
-    }
-
-    // Remove @optional annotations from descriptions.
-    if (props[prop].description.includes(ANNOTATION_OPTIONAL)) {
-      props[prop].description = props[prop].description.replace(
-        ANNOTATION_OPTIONAL,
-        ''
-      );
-    }
-    // Hide props with @internal annotations.
-    if (props[prop].description.includes(ANNOTATION_INTERNAL)) {
-      delete props[prop];
-    }
-  }
-
   return (
     <div>
       {Object.keys(props).map((key) => {
-        let leadingBadge = '';
+        if (key !== prop) {
+          return null;
+        }
         let descriptionByLines = props[key].description.split('\n');
 
-        // Find leading badge and put it next after prop name.
+        // Slice leading badge - it's handled in `generatePageMDX`
         if (descriptionByLines[0].includes('@')) {
-          leadingBadge = descriptionByLines[0];
           descriptionByLines = descriptionByLines.slice(1);
         }
         descriptionByLines = descriptionByLines.map((line: string) => {
@@ -116,16 +103,6 @@ export default function PropTable({ link }: { link: string }) {
 
         return (
           <div key={key}>
-            <h3>
-              {key} {props[key].required ? '(required)' : ''}
-              {leadingBadge && (
-                <span
-                  dangerouslySetInnerHTML={{
-                    __html: renderBadge(leadingBadge),
-                  }}
-                />
-              )}
-            </h3>
             <p>
               Type:{' '}
               {tsTypeLink ? (

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -187,6 +187,17 @@ html[data-theme='light'] .gallery-dark {
   src: url('../../node_modules/react-native-vector-icons/Fonts/MaterialCommunityIcons.ttf') format('truetype');
 }
 
+.badge:is(a .badge) {
+  padding: 0px;
+  height: 8px;
+  width: 8px;
+  border-radius: 4px;
+}
+
+a .badge .badge-text {
+  display: none;
+}
+
 .badge {
   background-color: black;
   color: white;
@@ -215,7 +226,6 @@ html[data-theme='light'] .gallery-dark {
   color: rgba(176, 0, 32, 1);
   background-color: rgba(176, 0, 32, 0.2);
   border-color: rgba(176, 0, 32, 1);
-
 }
 
 .badge-renamed {

--- a/src/components/Card/CardTitle.tsx
+++ b/src/components/Card/CardTitle.tsx
@@ -108,10 +108,6 @@ const LEFT_SIZE = 40;
 /**
  * A component to show a title, subtitle and an avatar inside a Card.
  *
- * <div class="screenshots">
- *   <img class="small" src="screenshots/card-title-1.png" />
- * </div>
- *
  * ## Usage
  * ```js
  * import * as React from 'react';

--- a/src/components/FAB/AnimatedFAB.tsx
+++ b/src/components/FAB/AnimatedFAB.tsx
@@ -105,6 +105,9 @@ export type Props = $Omit<$RemoveChildren<typeof Surface>, 'mode'> & {
    * @optional
    */
   theme?: ThemeProp;
+  /**
+   * TestID used for testing purposes
+   */
   testID?: string;
 };
 

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -133,6 +133,9 @@ export type Props = $Omit<$RemoveChildren<typeof Surface>, 'mode'> & {
    * @optional
    */
   theme?: ThemeProp;
+  /**
+   * TestID used for testing purposes
+   */
   testID?: string;
   ref?: React.RefObject<View>;
 } & IconOrLabel;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

* creating TOC with props on the right side
* updating annotation badge to be displayed next to the header prop, and just the dot badge within TOC

<img width="1227" alt="image" src="https://github.com/callstack/react-native-paper/assets/22746080/2270ceeb-ccd1-4af4-b25f-ba1dbc9acfb4">


<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Manual testing and checking

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
