### PR TITLE
fix(docs): `SegementedButton` theme docs

### DIFF
--- a/docs/src/data/themeColors.js
+++ b/docs/src/data/themeColors.js
@@ -302,7 +302,7 @@ const themeColors = {
     },
     unchecked: {
       '-': {
-        backgroundColor: 'theme.colors.primary + 12% transparency',
+        backgroundColor: 'transparent',
         textColor: 'theme.colors.onSurface',
         borderColor: 'theme.colors.outline',
       },


### PR DESCRIPTION
change docs to accurately reflect the color used for the `backgroundColor` of the `SegementedButton` component when it is unchecked.



### Summary

[Docs](https://callstack.github.io/react-native-paper/docs/components/SegmentedButtons/#theme-colors) for the SegmentedButton incorrectly list the background color when it is unchecked as "theme.colors.primary + 12% transparency" when it is in fact `'transparent'`.  The incorrect value is for when the theme is *MD2*, but the docs specifically call out being for MD3.

### Test plan

Code for the `backgroundColor` is [here](https://github.com/callstack/react-native-paper/blob/015e418c600b8c39334d65138decb46787def3c7/src/components/SegmentedButtons/utils.ts#L87C12-L87C12) and it clearly returns `transparent` when the button is not checked.
