### PR TITLE
fix: custom theme property for RadioButtonItem component

### DIFF
--- a/src/components/RadioButton/RadioButtonItem.tsx
+++ b/src/components/RadioButton/RadioButtonItem.tsx
@@ -135,7 +135,14 @@ const RadioButtonItem = ({
   labelVariant = 'bodyLarge',
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
-  const radioButtonProps = { value, disabled, status, color, uncheckedColor };
+  const radioButtonProps = {
+    value,
+    disabled,
+    status,
+    color,
+    theme,
+    uncheckedColor,
+  };
   const isLeading = position === 'leading';
   let radioButton: any;
 

--- a/src/components/RadioButton/RadioButtonItem.tsx
+++ b/src/components/RadioButton/RadioButtonItem.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-native';
 
 import { useInternalTheme } from '../../core/theming';
-import type { InternalTheme, MD3TypescaleKey } from '../../types';
+import type { ThemeProp, MD3TypescaleKey } from '../../types';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import Text from '../Typography/Text';
 import RadioButton from './RadioButton';
@@ -79,7 +79,7 @@ export type Props = {
   /**
    * @optional
    */
-  theme?: InternalTheme;
+  theme?: ThemeProp;
   /**
    * testID to be used on tests.
    */


### PR DESCRIPTION
This PR contains two fixes for RadioButtonItem when passing custom colors through `theme` property:
```
theme={{
  colors: {
     onSurface: ....,
     onSurfaceDisabled: ...,
  },
}}
```

1. Fix for type error:
```
error TS2740: Type '{ onSurface: string; onSurfaceDisabled: string; }' is missing the following properties from type 'MD3Colors': primary, primaryContainer, secondary, secondaryContainer, and 27 more.
```
Solution: Change `theme` type to `ThemeProp`.

2. Radio button icon does not apply disabled color from custom `onSurfaceDisabled` theme color.

Solution: pass `theme` down to the components handling icon colors.
