### PR TITLE
fix: create internal back handler to avoid errors on web

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
   Animated,
-  BackHandler,
   Dimensions,
   Easing,
   EmitterSubscription,
@@ -16,9 +15,9 @@ import {
   ScrollViewProps,
   StyleProp,
   StyleSheet,
-  TouchableWithoutFeedback,
   View,
   ViewStyle,
+  Pressable,
 } from 'react-native';
 
 import MenuItem from './MenuItem';
@@ -26,6 +25,7 @@ import { APPROX_STATUSBAR_HEIGHT } from '../../constants';
 import { withInternalTheme } from '../../core/theming';
 import type { $Omit, InternalTheme } from '../../types';
 import { addEventListener } from '../../utils/addEventListener';
+import { BackHandler } from '../../utils/BackHandler/BackHandler';
 import Portal from '../Portal/Portal';
 import Surface from '../Surface';
 
@@ -610,13 +610,12 @@ class Menu extends React.Component<Props, State> {
         {this.isCoordinate(anchor) ? null : anchor}
         {rendered ? (
           <Portal>
-            <TouchableWithoutFeedback
+            <Pressable
               accessibilityLabel={overlayAccessibilityLabel}
               accessibilityRole="button"
               onPress={onDismiss}
-            >
-              <View style={StyleSheet.absoluteFill} />
-            </TouchableWithoutFeedback>
+              style={styles.pressableOverlay}
+            />
             <View
               ref={(ref) => {
                 this.menu = ref;
@@ -672,6 +671,10 @@ const styles = StyleSheet.create({
   shadowMenuContainer: {
     opacity: 0,
     paddingVertical: 8,
+  },
+  pressableOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    width: '100%',
   },
 });
 

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
   Animated,
-  BackHandler,
   Easing,
   StyleProp,
   StyleSheet,
@@ -17,6 +16,7 @@ import Surface from './Surface';
 import { useInternalTheme } from '../core/theming';
 import type { ThemeProp } from '../types';
 import { addEventListener } from '../utils/addEventListener';
+import { BackHandler } from '../utils/BackHandler/BackHandler';
 import useAnimatedValue from '../utils/useAnimatedValue';
 
 export type Props = {

--- a/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -189,9 +189,20 @@ exports[`renders menu with content styles 1`] = `
           "selected": undefined,
         }
       }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
       accessible={true}
+      collapsable={false}
       focusable={true}
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -205,6 +216,7 @@ exports[`renders menu with content styles 1`] = `
           "position": "absolute",
           "right": 0,
           "top": 0,
+          "width": "100%",
         }
       }
     />
@@ -895,9 +907,20 @@ exports[`renders visible menu 1`] = `
           "selected": undefined,
         }
       }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
       accessible={true}
+      collapsable={false}
       focusable={true}
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -911,6 +934,7 @@ exports[`renders visible menu 1`] = `
           "position": "absolute",
           "right": 0,
           "top": 0,
+          "width": "100%",
         }
       }
     />

--- a/src/utils/BackHandler/BackHandler.native.tsx
+++ b/src/utils/BackHandler/BackHandler.native.tsx
@@ -1,0 +1,3 @@
+import { BackHandler } from 'react-native';
+
+export { BackHandler };

--- a/src/utils/BackHandler/BackHandler.tsx
+++ b/src/utils/BackHandler/BackHandler.tsx
@@ -1,0 +1,11 @@
+function emptyFunction() {}
+
+export const BackHandler = {
+  exitApp: emptyFunction,
+  addEventListener(): { remove: () => void } {
+    return {
+      remove: emptyFunction,
+    };
+  },
+  removeEventListener: emptyFunction,
+};


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

In `react-native-web` version `0.19.x` the `BackHandler` was removed. To avoid errors on the `web` when `BackHandler` is imported and used, we are introducing the internal `BackHandler`, which for `web` returns empty functions. 

#### Related issue

- #4079 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

- [X] tested on the expo sdk 49, on the repo attached in the issue

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
