### PR TITLE
fix: adjust top padding for outlined input without label

### DIFF
--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -656,6 +656,9 @@ const TextInputExample = () => {
               />
             </View>
             <View style={styles.inputContainerStyle}>
+              <TextInput mode="outlined" placeholder="Outlined without label" />
+            </View>
+            <View style={styles.inputContainerStyle}>
               <TextInput
                 mode="outlined"
                 label="Outlined input with custom cursor and selection colors"

--- a/src/components/TextInput/Addons/Outline.tsx
+++ b/src/components/TextInput/Addons/Outline.tsx
@@ -7,6 +7,8 @@ import {
   ViewStyle,
 } from 'react-native';
 
+import { TextInputLabelProp } from '../types';
+
 type OutlineProps = {
   isV3: boolean;
   activeColor: string;
@@ -15,11 +17,13 @@ type OutlineProps = {
   focused?: boolean;
   outlineColor?: string;
   roundness?: number;
+  label?: TextInputLabelProp;
   style?: StyleProp<ViewStyle>;
 };
 
 export const Outline = ({
   isV3,
+  label,
   activeColor,
   backgroundColor,
   hasActiveOutline,
@@ -33,6 +37,7 @@ export const Outline = ({
     pointerEvents="none"
     style={[
       styles.outline,
+      !label && styles.noLabelOutline,
       // eslint-disable-next-line react-native/no-inline-styles
       {
         backgroundColor,
@@ -52,5 +57,8 @@ const styles = StyleSheet.create({
     right: 0,
     top: 6,
     bottom: 0,
+  },
+  noLabelOutline: {
+    top: 0,
   },
 });

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -110,6 +110,8 @@ const TextInputOutlined = ({
     theme,
   });
 
+  const paddingTop = label ? LABEL_PADDING_TOP : 0;
+
   const labelScale = MINIMIZED_LABEL_FONT_SIZE / fontSize;
   const fontScale = MAXIMIZED_LABEL_FONT_SIZE / fontSize;
 
@@ -136,7 +138,7 @@ const TextInputOutlined = ({
   }
 
   const minInputHeight =
-    (dense ? MIN_DENSE_HEIGHT_OUTLINED : MIN_HEIGHT) - LABEL_PADDING_TOP;
+    (dense ? MIN_DENSE_HEIGHT_OUTLINED : MIN_HEIGHT) - paddingTop;
 
   const inputHeight = calculateInputHeight(labelHeight, height, minInputHeight);
 
@@ -308,6 +310,7 @@ const TextInputOutlined = ({
       <Outline
         isV3={isV3}
         style={outlineStyle}
+        label={label}
         roundness={roundness}
         hasActiveOutline={hasActiveOutline}
         focused={parentState.focused}
@@ -320,7 +323,7 @@ const TextInputOutlined = ({
           style={[
             styles.labelContainer,
             {
-              paddingTop: LABEL_PADDING_TOP,
+              paddingTop,
               minHeight,
             },
           ]}

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -607,6 +607,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
           "right": 0,
           "top": 6,
         },
+        false,
         {
           "backgroundColor": "rgba(255, 251, 254, 1)",
           "borderColor": "rgba(121, 116, 126, 1)",


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Fixes: https://github.com/callstack/react-native-paper/issues/3669

### Summary

Sets the `paddingTop` value according to the `label` visibility.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Updated snapshot.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
