### PR TITLE
fix: configureFonts should be deterministic

### DIFF
--- a/src/styles/__tests__/fonts.test.js
+++ b/src/styles/__tests__/fonts.test.js
@@ -271,4 +271,20 @@ describe('configureFonts', () => {
       },
     });
   });
+
+  it('should be deterministic', () => {
+    // first call that should not mutate the original config
+    configureFonts({
+      config: {
+        labelMedium: {
+          color: 'coral',
+        },
+      },
+    });
+
+    // second call that should return the original config without modification
+    const fontsB = configureFonts({ config: {} });
+
+    expect(fontsB.labelMedium.color).toBeUndefined();
+  });
 });

--- a/src/styles/fonts.tsx
+++ b/src/styles/fonts.tsx
@@ -99,6 +99,7 @@ function configureV3Fonts(
   }
 
   return Object.assign(
+    {},
     typescale,
     ...Object.entries(config).map(([variantName, variantProperties]) => ({
       [variantName]: {


### PR DESCRIPTION
Fixes #4094 

Every call to `configureFonts` should always return the same result for a given configuration.

### Summary

Previous calls to `configureFonts` mutated the base typescale object, resulting in a corrupted fonts object.
Each call to `configureFonts` should be the result of a fixed default config plus a custom config passed as argument.

### Test plan

If you call `configureFonts` multiple times with different configs, you should not find custom config from previous calls in your resulting object.
