### PR TITLE
docs: correctly spread default theme colors

### DIFF
--- a/docs/docs/guides/02-theming.mdx
+++ b/docs/docs/guides/02-theming.mdx
@@ -170,9 +170,9 @@ const theme = {
   ...DefaultTheme,
   // Specify custom property
   myOwnProperty: true,
-     ...DefaultTheme.colors,
   // Specify custom property in nested object
   colors: {
+    ...DefaultTheme.colors,
     myOwnColor: '#BADA55',
   },
 };


### PR DESCRIPTION
The example of providing a custom color is incorrect. `DefaultTheme.colors` should be spread inside the `colors` object, not in the root theme object.
