### PR TITLE
feat(text-input): add onPress to affix adornment

### DIFF
--- a/src/components/TextInput/Adornment/TextInputAffix.tsx
+++ b/src/components/TextInput/Adornment/TextInputAffix.tsx
@@ -144,8 +144,10 @@ const TextInputAffix = ({
 
   const textColor = getTextColor({ theme, disabled });
 
+  const Wrapper = typeof onPress === 'function' ? Pressable : React.Fragment;
+
   return (
-    <Pressable accessibilityRole="button" onPress={onPress}>
+    <Wrapper accessibilityRole="button" onPress={onPress}>
       <Animated.View
         style={[
           styles.container,
@@ -170,7 +172,7 @@ const TextInputAffix = ({
           {text}
         </Text>
       </Animated.View>
-    </Pressable>
+    </Wrapper>
   );
 };
 TextInputAffix.displayName = 'TextInput.Affix';

--- a/src/components/TextInput/Adornment/TextInputAffix.tsx
+++ b/src/components/TextInput/Adornment/TextInputAffix.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   Animated,
   LayoutChangeEvent,
+  Pressable,
   StyleProp,
   StyleSheet,
   Text,
@@ -21,6 +22,7 @@ export type Props = {
    */
   text: string;
   onLayout?: (event: LayoutChangeEvent) => void;
+  onPress?: () => void;
   /**
    * Style that is passed to the Text element.
    */
@@ -115,6 +117,7 @@ const TextInputAffix = ({
   textStyle: labelStyle,
   theme: themeOverrides,
   onLayout: onTextLayout,
+  onPress,
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
   const { AFFIX_OFFSET } = getConstants(theme.isV3);
@@ -142,30 +145,32 @@ const TextInputAffix = ({
   const textColor = getTextColor({ theme, disabled });
 
   return (
-    <Animated.View
-      style={[
-        styles.container,
-        style,
-        {
-          opacity:
-            visible?.interpolate({
-              inputRange: [0, 1],
-              outputRange: [1, 0],
-            }) || 1,
-        },
-      ]}
-      onLayout={onLayout}
-      testID={testID}
-    >
-      <Text
-        maxFontSizeMultiplier={maxFontSizeMultiplier}
-        style={[{ color: textColor }, textStyle, labelStyle]}
-        onLayout={onTextLayout}
-        testID={`${testID}-text`}
+    <Pressable accessibilityRole="button" onPress={onPress}>
+      <Animated.View
+        style={[
+          styles.container,
+          style,
+          {
+            opacity:
+              visible?.interpolate({
+                inputRange: [0, 1],
+                outputRange: [1, 0],
+              }) || 1,
+          },
+        ]}
+        onLayout={onLayout}
+        testID={testID}
       >
-        {text}
-      </Text>
-    </Animated.View>
+        <Text
+          maxFontSizeMultiplier={maxFontSizeMultiplier}
+          style={[{ color: textColor }, textStyle, labelStyle]}
+          onLayout={onTextLayout}
+          testID={`${testID}-text`}
+        >
+          {text}
+        </Text>
+      </Animated.View>
+    </Pressable>
   );
 };
 TextInputAffix.displayName = 'TextInput.Affix';

--- a/src/components/TextInput/Adornment/TextInputAffix.tsx
+++ b/src/components/TextInput/Adornment/TextInputAffix.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   Animated,
+  GestureResponderEvent,
   LayoutChangeEvent,
   Pressable,
   StyleProp,
@@ -22,7 +23,14 @@ export type Props = {
    */
   text: string;
   onLayout?: (event: LayoutChangeEvent) => void;
-  onPress?: () => void;
+  /**
+   * Function to execute on press.
+   */
+  onPress?: (e: GestureResponderEvent) => void;
+  /**
+   * Accessibility label for the affix. This is read by the screen reader when the user taps the affix.
+   */
+  accessibilityLabel?: string;
   /**
    * Style that is passed to the Text element.
    */
@@ -118,6 +126,7 @@ const TextInputAffix = ({
   theme: themeOverrides,
   onLayout: onTextLayout,
   onPress,
+  accessibilityLabel = text,
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
   const { AFFIX_OFFSET } = getConstants(theme.isV3);
@@ -144,37 +153,47 @@ const TextInputAffix = ({
 
   const textColor = getTextColor({ theme, disabled });
 
-  const Wrapper = typeof onPress === 'function' ? Pressable : React.Fragment;
-
-  return (
-    <Wrapper accessibilityRole="button" onPress={onPress}>
-      <Animated.View
-        style={[
-          styles.container,
-          style,
-          {
-            opacity:
-              visible?.interpolate({
-                inputRange: [0, 1],
-                outputRange: [1, 0],
-              }) || 1,
-          },
-        ]}
-        onLayout={onLayout}
-        testID={testID}
+  const affix = (
+    <Animated.View
+      style={[
+        styles.container,
+        style,
+        {
+          opacity:
+            visible?.interpolate({
+              inputRange: [0, 1],
+              outputRange: [1, 0],
+            }) || 1,
+        },
+      ]}
+      onLayout={onLayout}
+      testID={testID}
+    >
+      <Text
+        maxFontSizeMultiplier={maxFontSizeMultiplier}
+        style={[{ color: textColor }, textStyle, labelStyle]}
+        onLayout={onTextLayout}
+        testID={`${testID}-text`}
       >
-        <Text
-          maxFontSizeMultiplier={maxFontSizeMultiplier}
-          style={[{ color: textColor }, textStyle, labelStyle]}
-          onLayout={onTextLayout}
-          testID={`${testID}-text`}
-        >
-          {text}
-        </Text>
-      </Animated.View>
-    </Wrapper>
+        {text}
+      </Text>
+    </Animated.View>
   );
+
+  if (onPress) {
+    return (
+      <Pressable
+        onPress={onPress}
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel}
+      >
+        {affix}
+      </Pressable>
+    );
+  }
+  return affix;
 };
+
 TextInputAffix.displayName = 'TextInput.Affix';
 
 const styles = StyleSheet.create({

--- a/src/components/__tests__/TextInput.test.tsx
+++ b/src/components/__tests__/TextInput.test.tsx
@@ -452,6 +452,25 @@ it('always applies line height, even if not specified', () => {
   });
 });
 
+it('call onPress when affix adornment pressed', () => {
+  const affixOnPress = jest.fn();
+  const affixTextValue = '+39';
+  const { getByText, toJSON } = render(
+    <TextInput
+      label="Flat input"
+      placeholder="Enter your phone number"
+      value={''}
+      left={<TextInput.Affix text="+39" onPress={affixOnPress} />}
+    />
+  );
+
+  fireEvent.press(getByText(affixTextValue));
+
+  expect(getByText(affixTextValue)).toBeTruthy();
+  expect(toJSON()).toMatchSnapshot();
+  expect(affixOnPress).toHaveBeenCalledTimes(1);
+});
+
 describe('maxFontSizeMultiplier', () => {
   const createInput = (
     type: Exclude<Props['mode'], undefined>,

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -194,6 +194,7 @@ exports[`call onPress when affix adornment pressed 1`] = `
     />
   </View>
   <View
+    accessibilityLabel="+39"
     accessibilityRole="button"
     accessibilityState={
       {

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -1684,76 +1684,43 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
     />
   </View>
   <View
-    accessibilityRole="button"
-    accessibilityState={
-      {
-        "busy": undefined,
-        "checked": undefined,
-        "disabled": undefined,
-        "expanded": undefined,
-        "selected": undefined,
-      }
-    }
-    accessibilityValue={
-      {
-        "max": undefined,
-        "min": undefined,
-        "now": undefined,
-        "text": undefined,
-      }
-    }
-    accessible={true}
     collapsable={false}
-    focusable={true}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-  >
-    <View
-      collapsable={false}
-      onLayout={[Function]}
-      style={
-        {
-          "alignItems": "center",
-          "justifyContent": "center",
-          "left": 16,
-          "opacity": 1,
-          "position": "absolute",
-          "top": null,
-        }
+    onLayout={[Function]}
+    style={
+      {
+        "alignItems": "center",
+        "justifyContent": "center",
+        "left": 16,
+        "opacity": 1,
+        "position": "absolute",
+        "top": null,
       }
-      testID="left-affix-adornment"
+    }
+    testID="left-affix-adornment"
+  >
+    <Text
+      maxFontSizeMultiplier={1.5}
+      style={
+        [
+          {
+            "color": "rgba(73, 69, 79, 1)",
+          },
+          {
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": undefined,
+            "letterSpacing": 0.15,
+            "lineHeight": 19.2,
+          },
+          {
+            "color": "#f44336",
+          },
+        ]
+      }
+      testID="left-affix-adornment-text"
     >
-      <Text
-        maxFontSizeMultiplier={1.5}
-        style={
-          [
-            {
-              "color": "rgba(73, 69, 79, 1)",
-            },
-            {
-              "fontFamily": "System",
-              "fontSize": 16,
-              "fontWeight": undefined,
-              "letterSpacing": 0.15,
-              "lineHeight": 19.2,
-            },
-            {
-              "color": "#f44336",
-            },
-          ]
-        }
-        testID="left-affix-adornment-text"
-      >
-        /100
-      </Text>
-    </View>
+      /100
+    </Text>
   </View>
   <View
     style={
@@ -2274,76 +2241,43 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
     </View>
   </View>
   <View
-    accessibilityRole="button"
-    accessibilityState={
-      {
-        "busy": undefined,
-        "checked": undefined,
-        "disabled": undefined,
-        "expanded": undefined,
-        "selected": undefined,
-      }
-    }
-    accessibilityValue={
-      {
-        "max": undefined,
-        "min": undefined,
-        "now": undefined,
-        "text": undefined,
-      }
-    }
-    accessible={true}
     collapsable={false}
-    focusable={true}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-  >
-    <View
-      collapsable={false}
-      onLayout={[Function]}
-      style={
-        {
-          "alignItems": "center",
-          "justifyContent": "center",
-          "opacity": 1,
-          "position": "absolute",
-          "right": 16,
-          "top": null,
-        }
+    onLayout={[Function]}
+    style={
+      {
+        "alignItems": "center",
+        "justifyContent": "center",
+        "opacity": 1,
+        "position": "absolute",
+        "right": 16,
+        "top": null,
       }
-      testID="right-affix-adornment"
+    }
+    testID="right-affix-adornment"
+  >
+    <Text
+      maxFontSizeMultiplier={1.5}
+      style={
+        [
+          {
+            "color": "rgba(73, 69, 79, 1)",
+          },
+          {
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": undefined,
+            "letterSpacing": 0.15,
+            "lineHeight": 19.2,
+          },
+          {
+            "color": "#f44336",
+          },
+        ]
+      }
+      testID="right-affix-adornment-text"
     >
-      <Text
-        maxFontSizeMultiplier={1.5}
-        style={
-          [
-            {
-              "color": "rgba(73, 69, 79, 1)",
-            },
-            {
-              "fontFamily": "System",
-              "fontSize": 16,
-              "fontWeight": undefined,
-              "letterSpacing": 0.15,
-              "lineHeight": 19.2,
-            },
-            {
-              "color": "#f44336",
-            },
-          ]
-        }
-        testID="right-affix-adornment-text"
-      >
-        /100
-      </Text>
-    </View>
+      /100
+    </Text>
   </View>
 </View>
 `;

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -1,5 +1,271 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`call onPress when affix adornment pressed 1`] = `
+<View
+  style={
+    [
+      {
+        "backgroundColor": "rgba(231, 224, 236, 1)",
+        "borderTopLeftRadius": 4,
+        "borderTopRightRadius": 4,
+      },
+      {},
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      {
+        "backgroundColor": "rgba(28, 27, 31, 1)",
+        "bottom": 0,
+        "height": 1,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "transform": [
+          {
+            "scaleY": 0.5,
+          },
+        ],
+        "zIndex": 1,
+      }
+    }
+    testID="text-input-underline"
+  />
+  <View
+    style={
+      [
+        {
+          "paddingBottom": 0,
+          "paddingTop": 0,
+        },
+        {
+          "minHeight": 56,
+        },
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      pointerEvents="none"
+      style={
+        {
+          "bottom": 0,
+          "left": 0,
+          "opacity": 1,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "transform": [
+            {
+              "translateX": 0,
+            },
+          ],
+          "width": 750,
+          "zIndex": 3,
+        }
+      }
+    >
+      <Text
+        collapsable={false}
+        maxFontSizeMultiplier={1.5}
+        numberOfLines={1}
+        onLayout={[Function]}
+        onTextLayout={[Function]}
+        style={
+          {
+            "color": "rgba(103, 80, 164, 1)",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": undefined,
+            "left": 0,
+            "letterSpacing": 0.15,
+            "lineHeight": 19.2,
+            "opacity": 0,
+            "paddingLeft": 16,
+            "paddingRight": 16,
+            "position": "absolute",
+            "textAlign": "left",
+            "top": 30,
+            "transform": [
+              {
+                "translateX": 0,
+              },
+              {
+                "translateY": 0,
+              },
+              {
+                "scale": 1,
+              },
+            ],
+            "writingDirection": "ltr",
+          }
+        }
+        testID="text-input-flat-label-active"
+      >
+        Flat input
+      </Text>
+      <Text
+        collapsable={false}
+        maxFontSizeMultiplier={1.5}
+        numberOfLines={1}
+        style={
+          {
+            "color": "rgba(73, 69, 79, 1)",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": undefined,
+            "left": 0,
+            "letterSpacing": 0.15,
+            "lineHeight": 19.2,
+            "opacity": 0,
+            "paddingLeft": 16,
+            "paddingRight": 16,
+            "position": "absolute",
+            "textAlign": "left",
+            "top": 30,
+            "transform": [
+              {
+                "translateX": 0,
+              },
+              {
+                "translateY": 0,
+              },
+              {
+                "scale": 1,
+              },
+            ],
+            "writingDirection": "ltr",
+          }
+        }
+        testID="text-input-flat-label-inactive"
+      >
+        Flat input
+      </Text>
+    </View>
+    <TextInput
+      cursorColor="rgba(103, 80, 164, 1)"
+      editable={true}
+      maxFontSizeMultiplier={1.5}
+      multiline={false}
+      onBlur={[Function]}
+      onChangeText={[Function]}
+      onFocus={[Function]}
+      placeholder=" "
+      placeholderTextColor="rgba(73, 69, 79, 1)"
+      selectionColor="rgba(103, 80, 164, 0.54)"
+      style={
+        [
+          {
+            "margin": 0,
+          },
+          {
+            "height": 56,
+          },
+          {
+            "paddingBottom": 4,
+            "paddingTop": 24,
+          },
+          {
+            "color": "rgba(73, 69, 79, 1)",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": undefined,
+            "letterSpacing": 0.15,
+            "lineHeight": 19.2,
+            "minWidth": 65,
+            "paddingLeft": 16,
+            "paddingRight": 16,
+            "textAlign": "left",
+            "textAlignVertical": "center",
+          },
+          false,
+          {
+            "marginLeft": 0,
+            "paddingLeft": 40,
+          },
+          undefined,
+        ]
+      }
+      testID="text-input-flat"
+      underlineColorAndroid="transparent"
+      value=""
+    />
+  </View>
+  <View
+    accessibilityRole="button"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+  >
+    <View
+      collapsable={false}
+      onLayout={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "justifyContent": "center",
+          "left": 16,
+          "opacity": 0,
+          "position": "absolute",
+          "top": null,
+        }
+      }
+      testID="left-affix-adornment"
+    >
+      <Text
+        maxFontSizeMultiplier={1.5}
+        style={
+          [
+            {
+              "color": "rgba(73, 69, 79, 1)",
+            },
+            {
+              "fontFamily": "System",
+              "fontSize": 16,
+              "fontWeight": undefined,
+              "letterSpacing": 0.15,
+              "lineHeight": 19.2,
+            },
+            undefined,
+          ]
+        }
+        testID="left-affix-adornment-text"
+      >
+        +39
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
 exports[`correctly applies a component as the text label 1`] = `
 <View
   style={
@@ -1418,43 +1684,76 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
     />
   </View>
   <View
-    collapsable={false}
-    onLayout={[Function]}
-    style={
+    accessibilityRole="button"
+    accessibilityState={
       {
-        "alignItems": "center",
-        "justifyContent": "center",
-        "left": 16,
-        "opacity": 1,
-        "position": "absolute",
-        "top": null,
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
       }
     }
-    testID="left-affix-adornment"
-  >
-    <Text
-      maxFontSizeMultiplier={1.5}
-      style={
-        [
-          {
-            "color": "rgba(73, 69, 79, 1)",
-          },
-          {
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
-            "letterSpacing": 0.15,
-            "lineHeight": 19.2,
-          },
-          {
-            "color": "#f44336",
-          },
-        ]
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
       }
-      testID="left-affix-adornment-text"
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+  >
+    <View
+      collapsable={false}
+      onLayout={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "justifyContent": "center",
+          "left": 16,
+          "opacity": 1,
+          "position": "absolute",
+          "top": null,
+        }
+      }
+      testID="left-affix-adornment"
     >
-      /100
-    </Text>
+      <Text
+        maxFontSizeMultiplier={1.5}
+        style={
+          [
+            {
+              "color": "rgba(73, 69, 79, 1)",
+            },
+            {
+              "fontFamily": "System",
+              "fontSize": 16,
+              "fontWeight": undefined,
+              "letterSpacing": 0.15,
+              "lineHeight": 19.2,
+            },
+            {
+              "color": "#f44336",
+            },
+          ]
+        }
+        testID="left-affix-adornment-text"
+      >
+        /100
+      </Text>
+    </View>
   </View>
   <View
     style={
@@ -1975,43 +2274,76 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
     </View>
   </View>
   <View
-    collapsable={false}
-    onLayout={[Function]}
-    style={
+    accessibilityRole="button"
+    accessibilityState={
       {
-        "alignItems": "center",
-        "justifyContent": "center",
-        "opacity": 1,
-        "position": "absolute",
-        "right": 16,
-        "top": null,
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
       }
     }
-    testID="right-affix-adornment"
-  >
-    <Text
-      maxFontSizeMultiplier={1.5}
-      style={
-        [
-          {
-            "color": "rgba(73, 69, 79, 1)",
-          },
-          {
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
-            "letterSpacing": 0.15,
-            "lineHeight": 19.2,
-          },
-          {
-            "color": "#f44336",
-          },
-        ]
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
       }
-      testID="right-affix-adornment-text"
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+  >
+    <View
+      collapsable={false}
+      onLayout={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "justifyContent": "center",
+          "opacity": 1,
+          "position": "absolute",
+          "right": 16,
+          "top": null,
+        }
+      }
+      testID="right-affix-adornment"
     >
-      /100
-    </Text>
+      <Text
+        maxFontSizeMultiplier={1.5}
+        style={
+          [
+            {
+              "color": "rgba(73, 69, 79, 1)",
+            },
+            {
+              "fontFamily": "System",
+              "fontSize": 16,
+              "fontWeight": undefined,
+              "letterSpacing": 0.15,
+              "lineHeight": 19.2,
+            },
+            {
+              "color": "#f44336",
+            },
+          ]
+        }
+        testID="right-affix-adornment-text"
+      >
+        /100
+      </Text>
+    </View>
   </View>
 </View>
 `;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Add `Pressable` to [`TextInput.Affix`](https://callstack.github.io/react-native-paper/docs/components/TextInput/TextInputAffix) text input adornment and `onPress` prop.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Related issue #3968 

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
`yarn test`
