### PR TITLE
fix: incorrect List.Item a11y announcement

### DIFF
--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -206,11 +206,12 @@ const ListItem = ({
   return (
     <TouchableRipple
       {...rest}
+      accessible={false}
       style={[theme.isV3 ? styles.containerV3 : styles.container, style]}
       onPress={onPress}
       theme={theme}
     >
-      <View style={theme.isV3 ? styles.rowV3 : styles.row}>
+      <View accessible style={theme.isV3 ? styles.rowV3 : styles.row}>
         {left
           ? left({
               color: descriptionColor,


### PR DESCRIPTION
### Summary

On VoiceOver screen reader, `List.Item`s announce as "dimmed", signalling that they are disabled, even when the item is not disabled. This is because the item is wrapped in `<TouchableRipple>`, which appends a "dimmed" announcement to any content within it. (This in itself may be an issue, but when implementing `<TouchableRipple>` directly, adding `accessible={false}` to the `<TouchableRipple>` wrapper is an easy fix.)

This PR adds `accessible={false}` to the `<TouchableRipple>` wrapper, so that `<List.Item>`s are not incorrectly announced as "dimmed," and adds `accessible` to the `<View>` element within it, so that the list element is still grouped for screen-reader announcement. 

### Test plan

1. Test a `List.Item` on VoiceOver iOS screen reader and check that it is correctly announced.
2. 1. Test a `List.Item` on Talkback Android screen reader and check that it is correctly announced.

