### PR TITLE
docs: add annotation for bottom navigation tab bar color prop

### DIFF
--- a/docs/docs/guides/09-bottom-navigation.md
+++ b/docs/docs/guides/09-bottom-navigation.md
@@ -125,7 +125,7 @@ Generic title that can be used as a fallback for `headerTitle` and `tabBarLabel`
 
 Function that given `{ focused: boolean, color: string }` returns a React.Node, to display in the tab bar.
 
-#### `tabBarColor`
+#### `tabBarColor` <div class="badge badge-deprecated">In v5.x works only with theme version 2.</div>
 
 Color for the tab bar when the tab corresponding to the screen is active. Used for the ripple effect. This is only supported when `shifting` is `true`.
 

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -80,7 +80,7 @@ export type Props<Route extends BaseRoute> = {
    * - `title`: title of the route to use as the tab label
    * - `focusedIcon`:  icon to use as the focused tab icon, can be a string, an image source or a react component @renamed Renamed from 'icon' to 'focusedIcon' in v5.x
    * - `unfocusedIcon`:  icon to use as the unfocused tab icon, can be a string, an image source or a react component @supported Available in v5.x with theme version 3
-   * - `color`: color to use as background color for shifting bottom navigation @deprecated Deprecated in v5.x
+   * - `color`: color to use as background color for shifting bottom navigation @deprecated In v5.x works only with theme version 2.
    * - `badge`: badge to show on the tab icon, can be `true` to show a dot, `string` or `number` to show text.
    * - `accessibilityLabel`: accessibility label for the tab button
    * - `testID`: test id for the tab button

--- a/src/react-navigation/types.tsx
+++ b/src/react-navigation/types.tsx
@@ -61,6 +61,7 @@ export type MaterialBottomTabNavigationOptions = {
   title?: string;
 
   /**
+   * @deprecated In v5.x works only with theme version 2.
    * Color of the tab bar when this tab is active. Only used when `shifting` is `true`.
    */
   tabBarColor?: string;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Adds annotation about `tabBarColor` working only with theme version 2.

#### Related issue

- #4129 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<img width="1592" alt="Zrzut ekranu 2023-10-14 o 17 43 36" src="https://github.com/callstack/react-native-paper/assets/22746080/afa4ce4f-90fd-4da0-a7f5-de2db8113def">


<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
