### PR TITLE
docs: render cell react element without text container

### DIFF
--- a/src/components/DataTable/DataTableCell.tsx
+++ b/src/components/DataTable/DataTableCell.tsx
@@ -62,17 +62,35 @@ const DataTableCell = ({
   textStyle,
   style,
   numeric,
+  testID,
   ...rest
-}: Props) => (
-  <TouchableRipple
-    {...rest}
-    style={[styles.container, numeric && styles.right, style]}
-  >
-    <Text style={textStyle} numberOfLines={1}>
-      {children}
-    </Text>
-  </TouchableRipple>
-);
+}: Props) => {
+  const renderChildren = () => {
+    if (React.isValidElement(children)) {
+      return children;
+    }
+
+    return (
+      <Text
+        style={textStyle}
+        numberOfLines={1}
+        testID={`${testID}-text-container`}
+      >
+        {children}
+      </Text>
+    );
+  };
+
+  return (
+    <TouchableRipple
+      {...rest}
+      testID={testID}
+      style={[styles.container, numeric && styles.right, style]}
+    >
+      {renderChildren()}
+    </TouchableRipple>
+  );
+};
 
 DataTableCell.displayName = 'DataTable.Cell';
 

--- a/src/components/DataTable/DataTableCell.tsx
+++ b/src/components/DataTable/DataTableCell.tsx
@@ -29,6 +29,10 @@ export type Props = $RemoveChildren<typeof TouchableRipple> & {
    * Text content style of the `DataTableCell`.
    */
   textStyle?: StyleProp<TextStyle>;
+  /**
+   * testID to be used on tests.
+   */
+  testID?: string;
 };
 
 /**
@@ -56,7 +60,6 @@ export type Props = $RemoveChildren<typeof TouchableRipple> & {
  *
  * @extends TouchableRipple props https://callstack.github.io/react-native-paper/docs/components/TouchableRipple
  */
-
 const DataTableCell = ({
   children,
   textStyle,
@@ -65,30 +68,36 @@ const DataTableCell = ({
   testID,
   ...rest
 }: Props) => {
-  const renderChildren = () => {
-    if (React.isValidElement(children)) {
-      return children;
-    }
-
-    return (
-      <Text
-        style={textStyle}
-        numberOfLines={1}
-        testID={`${testID}-text-container`}
-      >
-        {children}
-      </Text>
-    );
-  };
-
   return (
     <TouchableRipple
       {...rest}
       testID={testID}
       style={[styles.container, numeric && styles.right, style]}
     >
-      {renderChildren()}
+      <CellContent textStyle={textStyle} testID={testID}>
+        {children}
+      </CellContent>
     </TouchableRipple>
+  );
+};
+
+const CellContent = ({
+  children,
+  textStyle,
+  testID,
+}: Pick<Props, 'children' | 'textStyle' | 'testID'>) => {
+  if (React.isValidElement(children)) {
+    return children;
+  }
+
+  return (
+    <Text
+      style={textStyle}
+      numberOfLines={1}
+      testID={`${testID}-text-container`}
+    >
+      {children}
+    </Text>
   );
 };
 

--- a/src/components/__tests__/DataTable.test.tsx
+++ b/src/components/__tests__/DataTable.test.tsx
@@ -2,125 +2,153 @@ import * as React from 'react';
 
 import { render } from '@testing-library/react-native';
 
+import Checkbox from '../Checkbox';
 import DataTable from '../DataTable/DataTable';
 
-it('renders data table header', () => {
-  const tree = render(
-    <DataTable.Header>
-      <DataTable.Title>Dessert</DataTable.Title>
-      <DataTable.Title>Calories</DataTable.Title>
-    </DataTable.Header>
-  ).toJSON();
+describe('DataTable.Header', () => {
+  it('renders data table header', () => {
+    const tree = render(
+      <DataTable.Header>
+        <DataTable.Title>Dessert</DataTable.Title>
+        <DataTable.Title>Calories</DataTable.Title>
+      </DataTable.Header>
+    ).toJSON();
 
-  expect(tree).toMatchSnapshot();
+    expect(tree).toMatchSnapshot();
+  });
 });
 
-it('renders data table title with sort icon', () => {
-  const tree = render(
-    <DataTable.Title sortDirection="descending">Dessert</DataTable.Title>
-  ).toJSON();
+describe('DataTable.Title', () => {
+  it('renders data table title with sort icon', () => {
+    const tree = render(
+      <DataTable.Title sortDirection="descending">Dessert</DataTable.Title>
+    ).toJSON();
 
-  expect(tree).toMatchSnapshot();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders right aligned data table title', () => {
+    const tree = render(
+      <DataTable.Title numeric>Calories</DataTable.Title>
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders data table title with press handler', () => {
+    const tree = render(
+      <DataTable.Title sortDirection="descending" onPress={() => {}}>
+        Dessert
+      </DataTable.Title>
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
 });
 
-it('renders right aligned data table title', () => {
-  const tree = render(
-    <DataTable.Title numeric>Calories</DataTable.Title>
-  ).toJSON();
+describe('DataTable.Cell', () => {
+  it('renders data table cell', () => {
+    const tree = render(<DataTable.Cell>Cupcake</DataTable.Cell>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-  expect(tree).toMatchSnapshot();
+  it('renders right aligned data table cell', () => {
+    const tree = render(<DataTable.Cell numeric>356</DataTable.Cell>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders data table cell with text container', () => {
+    const { getByText, getByTestId } = render(
+      <DataTable.Cell testID="table-cell">Table cell</DataTable.Cell>
+    );
+
+    expect(getByText('Table cell')).toBeOnTheScreen();
+    expect(getByTestId('table-cell-text-container')).toBeOnTheScreen();
+  });
+
+  it('renders data table cell children without text container', () => {
+    const { queryByTestId } = render(
+      <DataTable.Cell testID="table-cell">
+        <Checkbox status="checked" testID="table-cell-checkbox" />
+      </DataTable.Cell>
+    );
+
+    expect(queryByTestId('table-cell-text-container')).not.toBeOnTheScreen();
+  });
 });
 
-it('renders data table title with press handler', () => {
-  const tree = render(
-    <DataTable.Title sortDirection="descending" onPress={() => {}}>
-      Dessert
-    </DataTable.Title>
-  ).toJSON();
+describe('DataTable.Pagination', () => {
+  it('renders data table pagination', () => {
+    const tree = render(
+      <DataTable.Pagination
+        page={3}
+        numberOfPages={15}
+        onPageChange={() => {}}
+      />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-  expect(tree).toMatchSnapshot();
-});
+  it('renders data table pagination with label', () => {
+    const tree = render(
+      <DataTable.Pagination
+        page={3}
+        numberOfPages={15}
+        onPageChange={() => {}}
+        label="11-20 of 150"
+      />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-it('renders data table cell', () => {
-  const tree = render(<DataTable.Cell>Cupcake</DataTable.Cell>).toJSON();
+  it('renders data table pagination with fast-forward buttons', () => {
+    const { getByLabelText, toJSON } = render(
+      <DataTable.Pagination
+        page={3}
+        numberOfPages={15}
+        onPageChange={() => {}}
+        label="11-20 of 150"
+        showFastPaginationControls
+      />
+    );
 
-  expect(tree).toMatchSnapshot();
-});
+    expect(getByLabelText('page-first')).toBeTruthy();
+    expect(getByLabelText('page-last')).toBeTruthy();
+    expect(toJSON()).toMatchSnapshot();
+  });
 
-it('renders right aligned data table cell', () => {
-  const tree = render(<DataTable.Cell numeric>356</DataTable.Cell>).toJSON();
+  it('renders data table pagination without options select', () => {
+    const { queryByLabelText } = render(
+      <DataTable.Pagination
+        page={3}
+        numberOfPages={15}
+        onPageChange={() => {}}
+        label="11-20 of 150"
+        showFastPaginationControls
+      />
+    );
 
-  expect(tree).toMatchSnapshot();
-});
+    expect(queryByLabelText('Options Select')).toBeFalsy();
+  });
 
-it('renders data table pagination', () => {
-  const tree = render(
-    <DataTable.Pagination page={3} numberOfPages={15} onPageChange={() => {}} />
-  ).toJSON();
+  it('renders data table pagination with options select', () => {
+    const { getByLabelText, toJSON } = render(
+      <DataTable.Pagination
+        page={3}
+        numberOfPages={15}
+        onPageChange={() => {}}
+        label="11-20 of 150"
+        showFastPaginationControls
+        numberOfItemsPerPageList={[2, 4, 6]}
+        numberOfItemsPerPage={2}
+        onItemsPerPageChange={() => {}}
+        selectPageDropdownLabel={'Rows per page'}
+      />
+    );
 
-  expect(tree).toMatchSnapshot();
-});
+    expect(getByLabelText('Options Select')).toBeTruthy();
+    expect(getByLabelText('selectPageDropdownLabel')).toBeTruthy();
 
-it('renders data table pagination with label', () => {
-  const tree = render(
-    <DataTable.Pagination
-      page={3}
-      numberOfPages={15}
-      onPageChange={() => {}}
-      label="11-20 of 150"
-    />
-  ).toJSON();
-
-  expect(tree).toMatchSnapshot();
-});
-
-it('renders data table pagination with fast-forward buttons', () => {
-  const { getByLabelText, toJSON } = render(
-    <DataTable.Pagination
-      page={3}
-      numberOfPages={15}
-      onPageChange={() => {}}
-      label="11-20 of 150"
-      showFastPaginationControls
-    />
-  );
-
-  expect(getByLabelText('page-first')).toBeTruthy();
-  expect(getByLabelText('page-last')).toBeTruthy();
-  expect(toJSON()).toMatchSnapshot();
-});
-
-it('renders data table pagination without options select', () => {
-  const { queryByLabelText } = render(
-    <DataTable.Pagination
-      page={3}
-      numberOfPages={15}
-      onPageChange={() => {}}
-      label="11-20 of 150"
-      showFastPaginationControls
-    />
-  );
-
-  expect(queryByLabelText('Options Select')).toBeFalsy();
-});
-
-it('renders data table pagination with options select', () => {
-  const { getByLabelText, toJSON } = render(
-    <DataTable.Pagination
-      page={3}
-      numberOfPages={15}
-      onPageChange={() => {}}
-      label="11-20 of 150"
-      showFastPaginationControls
-      numberOfItemsPerPageList={[2, 4, 6]}
-      numberOfItemsPerPage={2}
-      onItemsPerPageChange={() => {}}
-      selectPageDropdownLabel={'Rows per page'}
-    />
-  );
-
-  expect(getByLabelText('Options Select')).toBeTruthy();
-  expect(getByLabelText('selectPageDropdownLabel')).toBeTruthy();
-
-  expect(toJSON()).toMatchSnapshot();
+    expect(toJSON()).toMatchSnapshot();
+  });
 });

--- a/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders data table cell 1`] = `
+exports[`DataTable.Cell renders data table cell 1`] = `
 <View
   accessibilityState={
     {
@@ -65,13 +65,88 @@ exports[`renders data table cell 1`] = `
         undefined,
       ]
     }
+    testID="undefined-text-container"
   >
     Cupcake
   </Text>
 </View>
 `;
 
-exports[`renders data table header 1`] = `
+exports[`DataTable.Cell renders right aligned data table cell 1`] = `
+<View
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": true,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    [
+      false,
+      [
+        {
+          "alignItems": "center",
+          "flex": 1,
+          "flexDirection": "row",
+        },
+        {
+          "justifyContent": "flex-end",
+        },
+        undefined,
+      ],
+    ]
+  }
+>
+  <Text
+    numberOfLines={1}
+    style={
+      [
+        {
+          "textAlign": "left",
+        },
+        {
+          "color": "rgba(28, 27, 31, 1)",
+          "fontFamily": "System",
+          "fontWeight": "400",
+          "letterSpacing": 0,
+        },
+        {
+          "writingDirection": "ltr",
+        },
+        undefined,
+      ]
+    }
+    testID="undefined-text-container"
+  >
+    356
+  </Text>
+</View>
+`;
+
+exports[`DataTable.Header renders data table header 1`] = `
 <View
   style={
     [
@@ -230,7 +305,7 @@ exports[`renders data table header 1`] = `
 </View>
 `;
 
-exports[`renders data table pagination 1`] = `
+exports[`DataTable.Pagination renders data table pagination 1`] = `
 <View
   accessibilityLabel="pagination-container"
   style={
@@ -572,7 +647,7 @@ exports[`renders data table pagination 1`] = `
 </View>
 `;
 
-exports[`renders data table pagination with fast-forward buttons 1`] = `
+exports[`DataTable.Pagination renders data table pagination with fast-forward buttons 1`] = `
 <View
   accessibilityLabel="pagination-container"
   style={
@@ -1202,7 +1277,7 @@ exports[`renders data table pagination with fast-forward buttons 1`] = `
 </View>
 `;
 
-exports[`renders data table pagination with label 1`] = `
+exports[`DataTable.Pagination renders data table pagination with label 1`] = `
 <View
   accessibilityLabel="pagination-container"
   style={
@@ -1546,7 +1621,7 @@ exports[`renders data table pagination with label 1`] = `
 </View>
 `;
 
-exports[`renders data table pagination with options select 1`] = `
+exports[`DataTable.Pagination renders data table pagination with options select 1`] = `
 <View
   accessibilityLabel="pagination-container"
   style={
@@ -2427,7 +2502,7 @@ exports[`renders data table pagination with options select 1`] = `
 </View>
 `;
 
-exports[`renders data table title with press handler 1`] = `
+exports[`DataTable.Title renders data table title with press handler 1`] = `
 <View
   accessibilityState={
     {
@@ -2551,7 +2626,7 @@ exports[`renders data table title with press handler 1`] = `
 </View>
 `;
 
-exports[`renders data table title with sort icon 1`] = `
+exports[`DataTable.Title renders data table title with sort icon 1`] = `
 <View
   accessibilityState={
     {
@@ -2675,80 +2750,7 @@ exports[`renders data table title with sort icon 1`] = `
 </View>
 `;
 
-exports[`renders right aligned data table cell 1`] = `
-<View
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": undefined,
-      "disabled": true,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
-  accessible={true}
-  collapsable={false}
-  focusable={true}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  style={
-    [
-      false,
-      [
-        {
-          "alignItems": "center",
-          "flex": 1,
-          "flexDirection": "row",
-        },
-        {
-          "justifyContent": "flex-end",
-        },
-        undefined,
-      ],
-    ]
-  }
->
-  <Text
-    numberOfLines={1}
-    style={
-      [
-        {
-          "textAlign": "left",
-        },
-        {
-          "color": "rgba(28, 27, 31, 1)",
-          "fontFamily": "System",
-          "fontWeight": "400",
-          "letterSpacing": 0,
-        },
-        {
-          "writingDirection": "ltr",
-        },
-        undefined,
-      ]
-    }
-  >
-    356
-  </Text>
-</View>
-`;
-
-exports[`renders right aligned data table title 1`] = `
+exports[`DataTable.Title renders right aligned data table title 1`] = `
 <View
   accessibilityState={
     {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Avoid wrapping React Element passed into the `DataTable.Cell` as a children into `Text` container.

#### Related issue

- #4119  

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

* added unit tests

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
