### PR TITLE
fix: tooltip behaviour on web

### DIFF
--- a/example/src/Examples/TooltipExample.tsx
+++ b/example/src/Examples/TooltipExample.tsx
@@ -24,6 +24,23 @@ type Props = {
 
 const MORE_ICON = Platform.OS === 'ios' ? 'dots-horizontal' : 'dots-vertical';
 
+const DURATION_MEDIUM = 1500;
+const DURATION_LONG = 3000;
+
+const formOfTransport = [
+  { title: 'Car - default delays' },
+  { title: 'Airplane - default delays' },
+  { title: 'Taxi - long enter delay', enterTouchDelay: DURATION_MEDIUM },
+  { title: 'Train - long enter delay', enterTouchDelay: DURATION_MEDIUM },
+  { title: 'Ferry - long leave delay', leaveTouchDelay: DURATION_MEDIUM },
+  { title: 'Bus - long leave delay', leaveTouchDelay: DURATION_MEDIUM },
+  {
+    title: 'Walk - long both delays',
+    enterTouchDelay: DURATION_MEDIUM,
+    leaveTouchDelay: DURATION_LONG,
+  },
+];
+
 const TooltipExample = ({ navigation }: Props) => {
   React.useLayoutEffect(() => {
     navigation.setOptions({
@@ -58,54 +75,23 @@ const TooltipExample = ({ navigation }: Props) => {
           . Continuously display the tooltip as long as the user long-presses or
           hovers over the element.
         </Banner>
-        <List.Section title="Icon Buttons" style={styles.iconButtonContainer}>
-          <Tooltip title="1st tooltip - default delays">
-            <IconButton icon="camera" size={24} onPress={() => {}} />
-          </Tooltip>
-          <Tooltip title="2nd tooltip - default delays">
-            <IconButton icon="camera" size={24} onPress={() => {}} />
-          </Tooltip>
-
-          <Tooltip
-            title="3rd tooltip - long enter delay"
-            enterTouchDelay={1800}
-          >
-            <IconButton icon="camera" size={24} onPress={() => {}} />
-          </Tooltip>
-          <Tooltip
-            title="4th tooltip - long enter delay"
-            enterTouchDelay={1800}
-          >
-            <IconButton icon="camera" size={24} onPress={() => {}} />
-          </Tooltip>
-
-          <Tooltip
-            title="5th tooltip - long leave delay"
-            leaveTouchDelay={1800}
-          >
-            <IconButton icon="camera" size={24} onPress={() => {}} />
-          </Tooltip>
-          <Tooltip
-            title="6th tooltip - long leave delay"
-            leaveTouchDelay={1800}
-          >
-            <IconButton icon="camera" size={24} onPress={() => {}} />
-          </Tooltip>
-
-          <Tooltip
-            title="7th tooltip - long both delays"
-            enterTouchDelay={1800}
-            leaveTouchDelay={2800}
-          >
-            <IconButton icon="camera" size={24} onPress={() => {}} />
-          </Tooltip>
-          <Tooltip
-            title="8th tooltip - long both delays"
-            enterTouchDelay={1800}
-            leaveTouchDelay={2800}
-          >
-            <IconButton icon="camera" size={24} onPress={() => {}} />
-          </Tooltip>
+        <List.Section title="Icon Buttons">
+          <View style={styles.iconButtonContainer}>
+            {formOfTransport.map((transport, index) => (
+              <Tooltip
+                key={index}
+                title={transport.title}
+                enterTouchDelay={transport.enterTouchDelay}
+                leaveTouchDelay={transport.leaveTouchDelay}
+              >
+                <IconButton
+                  icon={transport.title.split(' ')[0].toLowerCase()}
+                  size={24}
+                  onPress={() => {}}
+                />
+              </Tooltip>
+            ))}
+          </View>
         </List.Section>
         <List.Section title="Toggle Buttons">
           <ToggleButton.Row

--- a/example/src/Examples/TooltipExample.tsx
+++ b/example/src/Examples/TooltipExample.tsx
@@ -8,6 +8,7 @@ import {
   Banner,
   Chip,
   FAB,
+  IconButton,
   List,
   ToggleButton,
   Tooltip,
@@ -57,6 +58,55 @@ const TooltipExample = ({ navigation }: Props) => {
           . Continuously display the tooltip as long as the user long-presses or
           hovers over the element.
         </Banner>
+        <List.Section title="Icon Buttons" style={styles.iconButtonContainer}>
+          <Tooltip title="1st tooltip - default delays">
+            <IconButton icon="camera" size={24} onPress={() => {}} />
+          </Tooltip>
+          <Tooltip title="2nd tooltip - default delays">
+            <IconButton icon="camera" size={24} onPress={() => {}} />
+          </Tooltip>
+
+          <Tooltip
+            title="3rd tooltip - long enter delay"
+            enterTouchDelay={1800}
+          >
+            <IconButton icon="camera" size={24} onPress={() => {}} />
+          </Tooltip>
+          <Tooltip
+            title="4th tooltip - long enter delay"
+            enterTouchDelay={1800}
+          >
+            <IconButton icon="camera" size={24} onPress={() => {}} />
+          </Tooltip>
+
+          <Tooltip
+            title="5th tooltip - long leave delay"
+            leaveTouchDelay={1800}
+          >
+            <IconButton icon="camera" size={24} onPress={() => {}} />
+          </Tooltip>
+          <Tooltip
+            title="6th tooltip - long leave delay"
+            leaveTouchDelay={1800}
+          >
+            <IconButton icon="camera" size={24} onPress={() => {}} />
+          </Tooltip>
+
+          <Tooltip
+            title="7th tooltip - long both delays"
+            enterTouchDelay={1800}
+            leaveTouchDelay={2800}
+          >
+            <IconButton icon="camera" size={24} onPress={() => {}} />
+          </Tooltip>
+          <Tooltip
+            title="8th tooltip - long both delays"
+            enterTouchDelay={1800}
+            leaveTouchDelay={2800}
+          >
+            <IconButton icon="camera" size={24} onPress={() => {}} />
+          </Tooltip>
+        </List.Section>
         <List.Section title="Toggle Buttons">
           <ToggleButton.Row
             value="bold"
@@ -141,5 +191,9 @@ const styles = StyleSheet.create({
   },
   toggleButtonRow: {
     paddingHorizontal: 16,
+  },
+  iconButtonContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
   },
 });

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -82,19 +82,21 @@ const Tooltip = ({
     tooltip: {},
     measured: false,
   });
-  const showTooltipTimer = React.useRef<NodeJS.Timeout>();
-  const hideTooltipTimer = React.useRef<NodeJS.Timeout>();
+  const showTooltipTimer = React.useRef<NodeJS.Timeout[]>([]);
+  const hideTooltipTimer = React.useRef<NodeJS.Timeout[]>([]);
   const childrenWrapperRef = React.useRef() as React.MutableRefObject<View>;
   const touched = React.useRef(false);
 
   React.useEffect(() => {
     return () => {
-      if (showTooltipTimer.current) {
-        clearTimeout(showTooltipTimer.current);
+      if (showTooltipTimer.current.length) {
+        showTooltipTimer.current.forEach((t) => clearTimeout(t));
+        showTooltipTimer.current = [];
       }
 
-      if (hideTooltipTimer.current) {
-        clearTimeout(hideTooltipTimer.current);
+      if (hideTooltipTimer.current.length) {
+        hideTooltipTimer.current.forEach((t) => clearTimeout(t));
+        hideTooltipTimer.current = [];
       }
     };
   }, []);
@@ -120,15 +122,17 @@ const Tooltip = ({
   };
 
   const handleTouchStart = () => {
-    if (hideTooltipTimer.current) {
-      clearTimeout(hideTooltipTimer.current);
+    if (hideTooltipTimer.current.length) {
+      hideTooltipTimer.current.forEach((t) => clearTimeout(t));
+      hideTooltipTimer.current = [];
     }
 
     if (isWeb) {
-      showTooltipTimer.current = setTimeout(() => {
+      let id = setTimeout(() => {
         touched.current = true;
         setVisible(true);
       }, enterTouchDelay) as unknown as NodeJS.Timeout;
+      showTooltipTimer.current.push(id);
     } else {
       touched.current = true;
       setVisible(true);
@@ -137,14 +141,16 @@ const Tooltip = ({
 
   const handleTouchEnd = () => {
     touched.current = false;
-    if (showTooltipTimer.current) {
-      clearTimeout(showTooltipTimer.current);
+    if (showTooltipTimer.current.length) {
+      showTooltipTimer.current.forEach((t) => clearTimeout(t));
+      showTooltipTimer.current = [];
     }
 
-    hideTooltipTimer.current = setTimeout(() => {
+    let id = setTimeout(() => {
       setVisible(false);
       setMeasurement({ children: {}, tooltip: {}, measured: false });
     }, leaveTouchDelay) as unknown as NodeJS.Timeout;
+    hideTooltipTimer.current.push(id);
   };
 
   const mobilePressProps = {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Improper handling of  timeout IDs in `onHoverIn` and `onHoverOut` in `Tooltip` component, causing invalid behaviour and sometimes getting stuck with open tooltips (described in https://github.com/callstack/react-native-paper/issues/4139#issuecomment-1780617238)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### Related issue

See #4139 

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
