### PR TITLE
docs: Added missing tooltip for 'bold' icon

### DIFF
--- a/example/src/Examples/TooltipExample.tsx
+++ b/example/src/Examples/TooltipExample.tsx
@@ -63,7 +63,9 @@ const TooltipExample = ({ navigation }: Props) => {
             style={styles.toggleButtonRow}
             onValueChange={() => {}}
           >
-            <ToggleButton icon="format-bold" value="bold" />
+            <Tooltip title="Bold">
+              <ToggleButton icon="format-bold" value="bold" />
+            </Tooltip>
             <Tooltip title="Align center">
               <ToggleButton icon="format-align-center" value="align-center" />
             </Tooltip>


### PR DESCRIPTION
In this PR, missing tooltips for the 'bold' icon have been documented in the `TooltipExample.tsx` file. This ensures that all icons are adequately explained, contributing to a more comprehensive and user-friendly documentation.

### Related issue
- Tooltip is missing for bold icon

Uploading Simulator Screen Recording - iPhone 13 - 2023-11-08 at 14.55.11.mp4…


