### PR TITLE
docs: Added missing tooltip for 'bold' icon

### DIFF
--- a/example/src/Examples/TooltipExample.tsx
+++ b/example/src/Examples/TooltipExample.tsx
@@ -63,7 +63,9 @@ const TooltipExample = ({ navigation }: Props) => {
             style={styles.toggleButtonRow}
             onValueChange={() => {}}
           >
-            <ToggleButton icon="format-bold" value="bold" />
+            <Tooltip title="Bold">
+              <ToggleButton icon="format-bold" value="bold" />
+            </Tooltip>
             <Tooltip title="Align center">
               <ToggleButton icon="format-align-center" value="align-center" />
             </Tooltip>


### PR DESCRIPTION
In this PR, missing tooltips for the 'bold' icon have been documented in the TooltipExample.tsx file. This ensures that all icons are adequately explained, contributing to a more comprehensive and user-friendly documentation.

Related issue
Tooltip is missing for bold icon

https://github.com/qburst/react-native-paper-qb-1/assets/134603758/8bd6b3d7-dd77-470e-8ea6-2cbeb7ba35e5

