### PR TITLE
fix: fixed if not loaded backgroundColor to prevent render error on SearchBar

### DIFF
--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -284,7 +284,7 @@ const Searchbar = forwardRef<TextInputHandles, Props>(
           { borderRadius: roundness },
           !isV3 && styles.elevation,
           isV3 && {
-            backgroundColor: theme.colors.elevation.level3,
+            backgroundColor: theme?.colors?.elevation?.level3,
             borderRadius: roundness * (isBarMode ? 7 : 0),
           },
           styles.container,


### PR DESCRIPTION
Summary

SearchBar when used get the hint error on render:
<br />

Error on IOS
<img src="https://github.com/callstack/react-native-paper/assets/25457238/969e0a51-8842-46c8-81d5-6de4ead2b4e8" width="300" />
<br />

Error on Android
<img src="https://github.com/callstack/react-native-paper/assets/25457238/0a477349-fbb3-4e8b-b77e-fdb146adb0e6" width="300" />
### Motivation

This implementation suggest to add a optional chaining operator to avoid this error.

### Test plan

1- try use the search bar with actual version(_version: "react-native-paper": "^5.11.1"_ )
Suggestion:
```
import { Searchbar } from "react-native-paper";
<Searchbar
 style={{ backgroundColor: "white"}}
  value={search}
  onChange={handleSearch}
/>
```

2- Try using with this fix:
Suggestion:
```
import { Searchbar } from "react-native-paper";
<Searchbar
 style={{ backgroundColor: "white"}}
  value={search}
  onChange={handleSearch}
/>
```
