### PR TITLE
fix(text): variant loss with child component

### DIFF
--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -7,7 +7,9 @@ import {
   TextStyle,
 } from 'react-native';
 
+import AnimatedText from './AnimatedText';
 import type { VariantProp } from './types';
+import StyledText from './v2/StyledText';
 import { useInternalTheme } from '../../core/theming';
 import type { ThemeProp } from '../../types';
 import { forwardRef } from '../../utils/forwardRef';
@@ -96,9 +98,10 @@ const Text = (
     let textStyle = [font, style];
 
     if (
-      rest.children &&
-      typeof rest.children === 'object' &&
-      'props' in rest.children
+      React.isValidElement(rest.children) &&
+      (rest.children.type === Component ||
+        rest.children.type === AnimatedText ||
+        rest.children.type === StyledText)
     ) {
       const { props } = rest.children;
 

--- a/src/components/__tests__/Typography/Text.test.tsx
+++ b/src/components/__tests__/Typography/Text.test.tsx
@@ -91,6 +91,20 @@ it("nested text with variant should override parent's variant", () => {
   );
 });
 
+it("nested non-text component should not override parent's variant", () => {
+  const ChildComponent = () => <>{content}</>;
+
+  const { getByTestId } = render(
+    <Text testID="parent-text" variant="displayLarge">
+      <ChildComponent />
+    </Text>
+  );
+
+  expect(getByTestId('parent-text')).toHaveStyle(
+    MD3LightTheme.fonts.displayLarge
+  );
+});
+
 it("nested text without variant, but with styles, should override parent's styles", () => {
   const customStyle = { fontSize: 50, lineHeight: 70 };
   const { getByTestId } = render(


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When a component is used as a child to Text i.e. `<Text><MyComponent /></Text>` the variant specified in the text is ignored.
i.e.
```tsx
function Custom() {
  return <>{'<Custom /> nested in headlineMedium'}</>;
}

function Example() {
  return (
    <Text>
      <Custom />
    </Text>
  );
}
```

This is due to [logic inside of the Text component trying to deal with nested Text components](https://github.com/callstack/react-native-paper/blob/main/src/components/Typography/Text.tsx#L98-L130). This logic however applies to all components and breaks rendering components within Text.

### Related issue

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

#4172 

### Test plan

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

1. `Text.test.tsx` contains tests for regressions - nested text with variant should override parent's variant
2. Added test to `Text.test.tsx` - nested non-text component should not override parent's variant

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->

#### Before
![image](https://github.com/callstack/react-native-paper/assets/14974903/38103a74-ec36-4569-badf-d7e336d15f3a)

#### After
![image](https://github.com/callstack/react-native-paper/assets/14974903/b149cd52-df4c-4afa-85a2-d92b0559a044)
