### PR TITLE
fix: TextInput loses focus inside Banner on iOS only

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -210,7 +210,6 @@ const Banner = ({
     }
     return (
       <View
-        style={styles.content}
         accessibilityLiveRegion={visible ? 'polite' : 'none'}
         accessibilityRole="alert"
       >

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -189,6 +189,36 @@ const Banner = ({
     Animated.add(position, -1),
     layout.height
   );
+
+  const renderChildrenWithWrapper = () => {
+    if (typeof children === 'string') {
+      return (
+        <Text
+          style={[
+            styles.message,
+            {
+              color: theme.isV3 ? theme.colors.onSurface : theme.colors.text,
+            },
+          ]}
+          accessibilityLiveRegion={visible ? 'polite' : 'none'}
+          accessibilityRole="alert"
+          maxFontSizeMultiplier={maxFontSizeMultiplier}
+        >
+          {children}
+        </Text>
+      );
+    }
+    return (
+      <View
+        style={styles.content}
+        accessibilityLiveRegion={visible ? 'polite' : 'none'}
+        accessibilityRole="alert"
+      >
+        {children}
+      </View>
+    );
+  };
+
   return (
     <Surface
       {...rest}
@@ -220,21 +250,7 @@ const Banner = ({
                 <Icon source={icon} size={40} />
               </View>
             ) : null}
-            <Text
-              style={[
-                styles.message,
-                {
-                  color: theme.isV3
-                    ? theme.colors.onSurface
-                    : theme.colors.text,
-                },
-              ]}
-              accessibilityLiveRegion={visible ? 'polite' : 'none'}
-              accessibilityRole="alert"
-              maxFontSizeMultiplier={maxFontSizeMultiplier}
-            >
-              {children}
-            </Text>
+            {renderChildrenWithWrapper()}
           </View>
           <View style={styles.actions}>
             {actions.map(({ label, ...others }, i) => (


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

TextInput loses focus every type a character is entered and keyboard is dismissed. This happens only on iOS real device.
On android real device it works as expected.

### Related issue

issue #4178

### Result 

<table border="0">
 <tr>
    <td><b style="font-size:30px">1. Banner with TextInput </b></td>
    <td><b style="font-size:30px">2. Banner with Text</b></td>
 </tr>
 <tr>
    <td><img src="https://github.com/callstack/react-native-paper/assets/134603758/dca2bab1-ca44-4fb4-9f6c-4092141347b8" width="240"></td>
    <td><img src="https://github.com/callstack/react-native-paper/assets/134603758/5ce8e07b-056d-4133-bf1a-8a3e72fa01c0" width="240"></td>
 </tr>
</table>


<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
