### PR TITLE
fix: set default cursor for menu pressable overlay

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -674,6 +674,9 @@ const styles = StyleSheet.create({
   },
   pressableOverlay: {
     ...StyleSheet.absoluteFillObject,
+    ...(Platform.OS === 'web' && {
+      cursor: 'default',
+    }),
     width: '100%',
   },
 });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Set `default` cursor for the `Menu` pressable overlay.

### Related issue

- #4167 

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

N/A

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
