### PR TITLE
fix: add rippleColor prop

### DIFF
--- a/src/components/Checkbox/CheckboxItem.tsx
+++ b/src/components/Checkbox/CheckboxItem.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  ColorValue,
   GestureResponderEvent,
   StyleProp,
   StyleSheet,
@@ -45,6 +46,10 @@ export type Props = {
    * Custom color for checkbox.
    */
   color?: string;
+  /**
+   * Color of the ripple effect.
+   */
+  rippleColor?: ColorValue;
   /**
    * Additional styles for container View.
    */
@@ -126,6 +131,7 @@ const CheckboxItem = ({
   disabled,
   labelVariant = 'bodyLarge',
   labelMaxFontSizeMultiplier = 1.5,
+  rippleColor,
   ...props
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
@@ -163,6 +169,7 @@ const CheckboxItem = ({
       onPress={onPress}
       testID={testID}
       disabled={disabled}
+      rippleColor={rippleColor}
       theme={theme}
     >
       <View

--- a/src/components/RadioButton/RadioButtonItem.tsx
+++ b/src/components/RadioButton/RadioButtonItem.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  ColorValue,
   GestureResponderEvent,
   StyleProp,
   StyleSheet,
@@ -47,6 +48,10 @@ export type Props = {
    * Custom color for radio.
    */
   color?: string;
+  /**
+   * Color of the ripple effect.
+   */
+  rippleColor?: ColorValue;
   /**
    * Status of radio button.
    */
@@ -130,6 +135,7 @@ const RadioButtonItem = ({
   disabled,
   color,
   uncheckedColor,
+  rippleColor,
   status,
   theme: themeOverrides,
   accessibilityLabel = label,
@@ -198,6 +204,7 @@ const RadioButtonItem = ({
             testID={testID}
             disabled={disabled}
             theme={theme}
+            rippleColor={rippleColor}
           >
             <View style={[styles.container, style]} pointerEvents="none">
               {isLeading && radioButton}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Add missing `rippleColor` in control inputs such as `CheckboxItem` and `RadioButtonItem`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### Related issue

- #4165 

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

N/A
