### PR TITLE
feat: pressable card title

### DIFF
--- a/example/src/Examples/CardExample.tsx
+++ b/example/src/Examples/CardExample.tsx
@@ -62,6 +62,25 @@ const CardExample = () => {
             </TextComponent>
           </Card.Content>
         </Card>
+        <Card style={styles.card} mode={selectedMode}>
+          <Card.Cover
+            source={require('../../assets/images/wrecked-ship.jpg')}
+          />
+          <Card.Title
+            title="Pressable Title"
+            onPressTitle={() => {
+              isWeb
+                ? alert('The title is Pressed')
+                : Alert.alert('The title is Pressed');
+            }}
+          />
+          <Card.Content>
+            <TextComponent variant="bodyMedium">
+              This is a card with a pressable title. {'\n'}If you press the
+              title I will alert
+            </TextComponent>
+          </Card.Content>
+        </Card>
         {isV3 && (
           <Card style={styles.card} mode={selectedMode}>
             <Card.Cover source={require('../../assets/images/bridge.jpg')} />

--- a/src/components/Card/CardTitle.tsx
+++ b/src/components/Card/CardTitle.tsx
@@ -234,7 +234,6 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'column',
     justifyContent: 'center',
-    alignSelf: 'flex-start',
   },
 
   title: {

--- a/src/components/Card/CardTitle.tsx
+++ b/src/components/Card/CardTitle.tsx
@@ -159,11 +159,22 @@ const CardTitle = ({
   onPressTitle,
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
-  const TitleComponent = theme.isV3 ? Text : Title;
+  let TitleContainer = theme.isV3 ? Text : Title;
   const SubtitleComponent = theme.isV3 ? Text : Caption;
 
   const minHeight = subtitle || left || right ? 72 : 50;
   const marginBottom = subtitle ? 0 : 2;
+
+  const TitleComponent = (props: { title: React.ReactNode }) => (
+    <TitleContainer
+      style={[styles.title, { marginBottom }, titleStyle]}
+      numberOfLines={titleNumberOfLines}
+      variant={titleVariant}
+      maxFontSizeMultiplier={titleMaxFontSizeMultiplier}
+    >
+      {props.title}
+    </TitleContainer>
+  );
 
   return (
     <View style={[styles.container, { minHeight }, style]}>
@@ -178,24 +189,10 @@ const CardTitle = ({
       <View style={[styles.titles]}>
         {title && onPressTitle ? (
           <Pressable onPress={onPressTitle} style={[styles.title]}>
-            <TitleComponent
-              style={[{ marginBottom }, titleStyle]}
-              numberOfLines={titleNumberOfLines}
-              variant={titleVariant}
-              maxFontSizeMultiplier={titleMaxFontSizeMultiplier}
-            >
-              {title}
-            </TitleComponent>
+            <TitleComponent {...{ title }} />
           </Pressable>
         ) : (
-          <TitleComponent
-            style={[styles.title, { marginBottom }, titleStyle]}
-            numberOfLines={titleNumberOfLines}
-            variant={titleVariant}
-            maxFontSizeMultiplier={titleMaxFontSizeMultiplier}
-          >
-            {title}
-          </TitleComponent>
+          <TitleComponent {...{ title }} />
         )}
         {subtitle && (
           <SubtitleComponent

--- a/src/components/Card/CardTitle.tsx
+++ b/src/components/Card/CardTitle.tsx
@@ -177,9 +177,9 @@ const CardTitle = ({
 
       <View style={[styles.titles]}>
         {title && onPressTitle ? (
-          <TouchableOpacity onPress={onPressTitle}>
+          <TouchableOpacity onPress={onPressTitle} style={[styles.title]}>
             <TitleComponent
-              style={[styles.title, { marginBottom }, titleStyle]}
+              style={[{ marginBottom }, titleStyle]}
               numberOfLines={titleNumberOfLines}
               variant={titleVariant}
               maxFontSizeMultiplier={titleMaxFontSizeMultiplier}
@@ -238,6 +238,7 @@ const styles = StyleSheet.create({
   },
 
   title: {
+    alignSelf: 'flex-start',
     minHeight: 30,
     paddingRight: 16,
   },

--- a/src/components/Card/CardTitle.tsx
+++ b/src/components/Card/CardTitle.tsx
@@ -3,6 +3,7 @@ import {
   StyleProp,
   StyleSheet,
   TextStyle,
+  TouchableOpacity,
   View,
   ViewStyle,
 } from 'react-native';
@@ -109,6 +110,11 @@ export type Props = React.ComponentPropsWithRef<typeof View> & {
    * @optional
    */
   theme?: ThemeProp;
+  /**
+   * @optional
+   * Makes the card title pressable
+   */
+  onPressTitle?: () => void;
 };
 
 const LEFT_SIZE = 40;
@@ -150,6 +156,7 @@ const CardTitle = ({
   rightStyle,
   style,
   theme: themeOverrides,
+  onPressTitle,
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
   const TitleComponent = theme.isV3 ? Text : Title;
@@ -169,7 +176,18 @@ const CardTitle = ({
       ) : null}
 
       <View style={[styles.titles]}>
-        {title && (
+        {title && onPressTitle ? (
+          <TouchableOpacity onPress={onPressTitle}>
+            <TitleComponent
+              style={[styles.title, { marginBottom }, titleStyle]}
+              numberOfLines={titleNumberOfLines}
+              variant={titleVariant}
+              maxFontSizeMultiplier={titleMaxFontSizeMultiplier}
+            >
+              {title}
+            </TitleComponent>
+          </TouchableOpacity>
+        ) : (
           <TitleComponent
             style={[styles.title, { marginBottom }, titleStyle]}
             numberOfLines={titleNumberOfLines}
@@ -216,6 +234,7 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'column',
     justifyContent: 'center',
+    alignSelf: 'flex-start',
   },
 
   title: {

--- a/src/components/Card/CardTitle.tsx
+++ b/src/components/Card/CardTitle.tsx
@@ -160,7 +160,7 @@ const CardTitle = ({
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
   let TitleContainer = theme.isV3 ? Text : Title;
-  const SubtitleComponent = theme.isV3 ? Text : Caption;
+  const SubtitleContainer = theme.isV3 ? Text : Caption;
 
   const minHeight = subtitle || left || right ? 72 : 50;
   const marginBottom = subtitle ? 0 : 2;
@@ -174,6 +174,16 @@ const CardTitle = ({
     >
       {props.title}
     </TitleContainer>
+  );
+  const SubtitleComponent = (props: { subtitle: React.ReactNode }) => (
+    <SubtitleContainer
+      style={[styles.subtitle, subtitleStyle]}
+      numberOfLines={subtitleNumberOfLines}
+      variant={subtitleVariant}
+      maxFontSizeMultiplier={subtitleMaxFontSizeMultiplier}
+    >
+      {props.subtitle}
+    </SubtitleContainer>
   );
 
   return (
@@ -194,16 +204,7 @@ const CardTitle = ({
         ) : (
           <TitleComponent {...{ title }} />
         )}
-        {subtitle && (
-          <SubtitleComponent
-            style={[styles.subtitle, subtitleStyle]}
-            numberOfLines={subtitleNumberOfLines}
-            variant={subtitleVariant}
-            maxFontSizeMultiplier={subtitleMaxFontSizeMultiplier}
-          >
-            {subtitle}
-          </SubtitleComponent>
-        )}
+        {subtitle && <SubtitleComponent {...{ subtitle }} />}
       </View>
       <View style={rightStyle}>{right ? right({ size: 24 }) : null}</View>
     </View>

--- a/src/components/Card/CardTitle.tsx
+++ b/src/components/Card/CardTitle.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import {
+  Pressable,
   StyleProp,
   StyleSheet,
   TextStyle,
-  TouchableOpacity,
   View,
   ViewStyle,
 } from 'react-native';
@@ -177,7 +177,7 @@ const CardTitle = ({
 
       <View style={[styles.titles]}>
         {title && onPressTitle ? (
-          <TouchableOpacity onPress={onPressTitle} style={[styles.title]}>
+          <Pressable onPress={onPressTitle} style={[styles.title]}>
             <TitleComponent
               style={[{ marginBottom }, titleStyle]}
               numberOfLines={titleNumberOfLines}
@@ -186,7 +186,7 @@ const CardTitle = ({
             >
               {title}
             </TitleComponent>
-          </TouchableOpacity>
+          </Pressable>
         ) : (
           <TitleComponent
             style={[styles.title, { marginBottom }, titleStyle]}


### PR DESCRIPTION
### Motivation
I needed the option to press the card title


### Test plan
Two test cases on the Card.Title component
      - Card.Title without onPressTitle props {...props, onPressTitle:undefined}
            make sure the card functions normally
      - Card.Title with onPressTitle props = () => {Alert.alert("Pressed")}

Both are tested in the Card example👇
<img width="1420" alt="Capture d’écran, le 2023-11-19 à 23 18 44" src="https://github.com/callstack/react-native-paper/assets/78394113/08dff516-3685-443f-8451-075d0e4d3445">


*After press event on card title*


<img width="1410" alt="Capture d’écran, le 2023-11-19 à 23 20 32" src="https://github.com/callstack/react-native-paper/assets/78394113/6392d699-f7cb-4d59-9ba5-8aa4aae6d377">