### PR TITLE
fix: correct input label max width

### DIFF
--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -763,6 +763,46 @@ const TextInputExample = () => {
                 style={styles.year}
               />
             </View>
+            <View style={styles.row}>
+              <View style={styles.left}>
+                <TextInput
+                  mode="flat"
+                  label="Month of the car registration (optional)"
+                  placeholder="Month"
+                  style={styles.month}
+                />
+              </View>
+              <View style={styles.right}>
+                <TextInput
+                  mode="flat"
+                  label="Year of the car registration (optional)"
+                  placeholder="Year"
+                  keyboardType="phone-pad"
+                  style={styles.year}
+                  left={<TextInput.Icon icon="calendar" />}
+                />
+              </View>
+            </View>
+            <View style={styles.row}>
+              <View style={styles.left}>
+                <TextInput
+                  mode="outlined"
+                  label="Month of the car registration (optional)"
+                  placeholder="Month"
+                  style={styles.month}
+                />
+              </View>
+              <View style={styles.right}>
+                <TextInput
+                  mode="outlined"
+                  label="Year of the car registration (optional)"
+                  placeholder="Year"
+                  keyboardType="phone-pad"
+                  style={styles.year}
+                  right={<TextInput.Icon icon="calendar" />}
+                />
+              </View>
+            </View>
           </List.Accordion>
         </List.AccordionGroup>
       </ScreenWrapper>
@@ -826,6 +866,12 @@ const styles = StyleSheet.create({
   },
   inputLabelText: {
     color: MD3Colors.tertiary70,
+  },
+  left: {
+    width: '30%',
+  },
+  right: {
+    width: '70%',
   },
 });
 

--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -114,7 +114,7 @@ const InputLabel = (props: InputLabelProps) => {
     placeholderStyle,
     {
       top: topPosition,
-      maxWidth: inputContainerLayout.width + INPUT_PADDING_HORIZONTAL,
+      maxWidth: inputContainerLayout.width + INPUT_PADDING_HORIZONTAL / 2,
     },
     labelStyle,
     paddingOffset || {},

--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -47,6 +47,7 @@ const InputLabel = (props: InputLabelProps) => {
     maxFontSizeMultiplier,
     testID,
     isV3,
+    inputContainerLayout,
   } = props;
 
   const { INPUT_PADDING_HORIZONTAL } = getConstants(isV3);
@@ -113,6 +114,7 @@ const InputLabel = (props: InputLabelProps) => {
     placeholderStyle,
     {
       top: topPosition,
+      maxWidth: inputContainerLayout.width + INPUT_PADDING_HORIZONTAL,
     },
     labelStyle,
     paddingOffset || {},
@@ -121,8 +123,6 @@ const InputLabel = (props: InputLabelProps) => {
   const textColor = (
     labelError && errorColor ? errorColor : placeholderColor
   ) as ColorValue;
-
-  const maxWidth = width - INPUT_PADDING_HORIZONTAL;
 
   return (
     // Position colored placeholder and gray placeholder on top of each other and crossfade them
@@ -173,7 +173,6 @@ const InputLabel = (props: InputLabelProps) => {
           {
             color: textColor,
             opacity: placeholderOpacity,
-            maxWidth,
           },
         ]}
         numberOfLines={1}

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -254,6 +254,10 @@ const TextInput = forwardRef<TextInputHandles, Props>(
       width: 33,
     });
 
+    const [inputContainerLayout, setInputContainerLayout] = React.useState({
+      width: 65,
+    });
+
     const [labelLayout, setLabelLayout] = React.useState<{
       measured: boolean;
       width: number;
@@ -465,6 +469,15 @@ const TextInput = forwardRef<TextInputHandles, Props>(
       []
     );
 
+    const handleInputContainerLayout = React.useCallback(
+      ({ nativeEvent: { layout } }: LayoutChangeEvent) => {
+        setInputContainerLayout({
+          width: layout.width,
+        });
+      },
+      []
+    );
+
     const forceFocus = React.useCallback(() => root.current?.focus(), []);
 
     const { maxFontSizeMultiplier = 1.5 } = rest;
@@ -491,6 +504,7 @@ const TextInput = forwardRef<TextInputHandles, Props>(
             labelLayout,
             leftLayout,
             rightLayout,
+            inputContainerLayout,
           }}
           innerRef={(ref) => {
             root.current = ref;
@@ -500,6 +514,7 @@ const TextInput = forwardRef<TextInputHandles, Props>(
           onBlur={handleBlur}
           onChangeText={handleChangeText}
           onLayoutAnimatedText={handleLayoutAnimatedText}
+          onLayout={handleInputContainerLayout}
           onLabelTextLayout={handleLabelTextLayout}
           onLeftAffixLayoutChange={onLeftAffixLayoutChange}
           onRightAffixLayoutChange={onRightAffixLayoutChange}
@@ -530,6 +545,7 @@ const TextInput = forwardRef<TextInputHandles, Props>(
           labelLayout,
           leftLayout,
           rightLayout,
+          inputContainerLayout,
         }}
         innerRef={(ref) => {
           root.current = ref;
@@ -537,6 +553,7 @@ const TextInput = forwardRef<TextInputHandles, Props>(
         onFocus={handleFocus}
         forceFocus={forceFocus}
         onBlur={handleBlur}
+        onLayout={handleInputContainerLayout}
         onChangeText={handleChangeText}
         onLayoutAnimatedText={handleLayoutAnimatedText}
         onLabelTextLayout={handleLabelTextLayout}

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -68,6 +68,7 @@ const TextInputFlat = ({
   onLabelTextLayout,
   onLeftAffixLayoutChange,
   onRightAffixLayoutChange,
+  onLayout,
   left,
   right,
   placeholderTextColor,
@@ -80,7 +81,7 @@ const TextInputFlat = ({
   const font = isV3 ? theme.fonts.bodyLarge : theme.fonts.regular;
   const hasActiveOutline = parentState.focused || error;
 
-  const { LABEL_PADDING_TOP, FLAT_INPUT_OFFSET, MIN_HEIGHT } =
+  const { LABEL_PADDING_TOP, FLAT_INPUT_OFFSET, MIN_HEIGHT, MIN_WIDTH } =
     getConstants(isV3);
 
   const {
@@ -286,6 +287,8 @@ const TextInputFlat = ({
     maxFontSizeMultiplier: rest.maxFontSizeMultiplier,
     testID,
     contentStyle,
+    inputContainerLayout: parentState.inputContainerLayout,
+    labelTextLayout: parentState.labelTextLayout,
     opacity:
       parentState.value || parentState.focused
         ? parentState.labelLayout.measured
@@ -380,6 +383,7 @@ const TextInputFlat = ({
           ...rest,
           ref: innerRef,
           onChangeText,
+          onLayout,
           placeholder: label ? parentState.placeholder : rest.placeholder,
           editable: !disabled && editable,
           selectionColor,
@@ -408,8 +412,10 @@ const TextInputFlat = ({
                 : I18nManager.getConstants().isRTL
                 ? 'right'
                 : 'left',
-              minWidth:
+              minWidth: Math.min(
                 parentState.labelTextLayout.width + 2 * FLAT_INPUT_OFFSET,
+                MIN_WIDTH
+              ),
             },
             Platform.OS === 'web' && { outline: 'none' },
             adornmentStyleAdjustmentForNativeInput,

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -343,6 +343,7 @@ const TextInputFlat = ({
         theme={theme}
       />
       <View
+        onLayout={onLayout}
         style={[
           styles.labelContainer,
           {
@@ -383,7 +384,6 @@ const TextInputFlat = ({
           ...rest,
           ref: innerRef,
           onChangeText,
-          onLayout,
           placeholder: label ? parentState.placeholder : rest.placeholder,
           editable: !disabled && editable,
           selectionColor,

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -328,7 +328,7 @@ const TextInputOutlined = ({
         outlineColor={outlineColor}
         backgroundColor={backgroundColor}
       />
-      <View>
+      <View onLayout={onLayout}>
         <View
           style={[
             styles.labelContainer,
@@ -355,7 +355,6 @@ const TextInputOutlined = ({
             ...rest,
             ref: innerRef,
             onChangeText,
-            onLayout,
             placeholder: label ? parentState.placeholder : rest.placeholder,
             editable: !disabled && editable,
             selectionColor,

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -68,6 +68,7 @@ const TextInputOutlined = ({
   onLabelTextLayout,
   onLeftAffixLayoutChange,
   onRightAffixLayoutChange,
+  onLayout,
   left,
   right,
   placeholderTextColor,
@@ -81,7 +82,7 @@ const TextInputOutlined = ({
   const font = isV3 ? theme.fonts.bodyLarge : theme.fonts.regular;
   const hasActiveOutline = parentState.focused || error;
 
-  const { INPUT_PADDING_HORIZONTAL, MIN_HEIGHT, ADORNMENT_OFFSET } =
+  const { INPUT_PADDING_HORIZONTAL, MIN_HEIGHT, ADORNMENT_OFFSET, MIN_WIDTH } =
     getConstants(isV3);
 
   const {
@@ -227,6 +228,7 @@ const TextInputOutlined = ({
     maxFontSizeMultiplier: rest.maxFontSizeMultiplier,
     testID,
     contentStyle,
+    inputContainerLayout: parentState.inputContainerLayout,
     opacity:
       parentState.value || parentState.focused
         ? parentState.labelLayout.measured
@@ -353,6 +355,7 @@ const TextInputOutlined = ({
             ...rest,
             ref: innerRef,
             onChangeText,
+            onLayout,
             placeholder: label ? parentState.placeholder : rest.placeholder,
             editable: !disabled && editable,
             selectionColor,
@@ -382,9 +385,11 @@ const TextInputOutlined = ({
                   ? 'right'
                   : 'left',
                 paddingHorizontal: INPUT_PADDING_HORIZONTAL,
-                minWidth:
+                minWidth: Math.min(
                   parentState.labelTextLayout.width +
-                  2 * INPUT_PADDING_HORIZONTAL,
+                    2 * INPUT_PADDING_HORIZONTAL,
+                  MIN_WIDTH
+                ),
               },
               Platform.OS === 'web' && { outline: 'none' },
               adornmentStyleAdjustmentForNativeInput,

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -137,6 +137,11 @@ const TextInputOutlined = ({
     ({ side, type }) =>
       side === AdornmentSide.Left && type === AdornmentType.Icon
   );
+  const isAdornmentRightIcon = adornmentConfig.some(
+    ({ side, type }) =>
+      side === AdornmentSide.Right && type === AdornmentType.Icon
+  );
+
   if (isAdornmentLeftIcon) {
     labelTranslationXOffset =
       (I18nManager.getConstants().isRTL ? -1 : 1) *
@@ -228,7 +233,13 @@ const TextInputOutlined = ({
     maxFontSizeMultiplier: rest.maxFontSizeMultiplier,
     testID,
     contentStyle,
-    inputContainerLayout: parentState.inputContainerLayout,
+    inputContainerLayout: {
+      width:
+        parentState.inputContainerLayout.width +
+        (isAdornmentRightIcon || isAdornmentLeftIcon
+          ? INPUT_PADDING_HORIZONTAL
+          : 0),
+    },
     opacity:
       parentState.value || parentState.focused
         ? parentState.labelLayout.measured
@@ -328,77 +339,74 @@ const TextInputOutlined = ({
         outlineColor={outlineColor}
         backgroundColor={backgroundColor}
       />
-      <View onLayout={onLayout}>
-        <View
-          style={[
-            styles.labelContainer,
+      <View
+        style={[
+          styles.labelContainer,
+          {
+            paddingTop,
+            minHeight,
+          },
+        ]}
+      >
+        {label ? (
+          <InputLabel
+            labeled={parentState.labeled}
+            error={parentState.error}
+            focused={parentState.focused}
+            wiggle={Boolean(parentState.value && labelProps.labelError)}
+            labelLayoutMeasured={parentState.labelLayout.measured}
+            labelLayoutWidth={parentState.labelLayout.width}
+            {...labelProps}
+            labelBackground={LabelBackground}
+            maxFontSizeMultiplier={rest.maxFontSizeMultiplier}
+          />
+        ) : null}
+        {render?.({
+          ...rest,
+          ref: innerRef,
+          onLayout,
+          onChangeText,
+          placeholder: label ? parentState.placeholder : rest.placeholder,
+          editable: !disabled && editable,
+          selectionColor,
+          cursorColor:
+            typeof cursorColor === 'undefined' ? activeColor : cursorColor,
+          placeholderTextColor: placeholderTextColor || placeholderColor,
+          onFocus,
+          onBlur,
+          underlineColorAndroid: 'transparent',
+          multiline,
+          style: [
+            styles.input,
+            !multiline || (multiline && height) ? { height: inputHeight } : {},
+            paddingOut,
             {
-              paddingTop,
-              minHeight,
+              ...font,
+              fontSize,
+              lineHeight,
+              fontWeight,
+              color: inputTextColor,
+              textAlignVertical: multiline ? 'top' : 'center',
+              textAlign: textAlign
+                ? textAlign
+                : I18nManager.getConstants().isRTL
+                ? 'right'
+                : 'left',
+              paddingHorizontal: INPUT_PADDING_HORIZONTAL,
+              minWidth: Math.min(
+                parentState.labelTextLayout.width +
+                  2 * INPUT_PADDING_HORIZONTAL,
+                MIN_WIDTH
+              ),
             },
-          ]}
-        >
-          {label ? (
-            <InputLabel
-              labeled={parentState.labeled}
-              error={parentState.error}
-              focused={parentState.focused}
-              wiggle={Boolean(parentState.value && labelProps.labelError)}
-              labelLayoutMeasured={parentState.labelLayout.measured}
-              labelLayoutWidth={parentState.labelLayout.width}
-              {...labelProps}
-              labelBackground={LabelBackground}
-              maxFontSizeMultiplier={rest.maxFontSizeMultiplier}
-            />
-          ) : null}
-          {render?.({
-            ...rest,
-            ref: innerRef,
-            onChangeText,
-            placeholder: label ? parentState.placeholder : rest.placeholder,
-            editable: !disabled && editable,
-            selectionColor,
-            cursorColor:
-              typeof cursorColor === 'undefined' ? activeColor : cursorColor,
-            placeholderTextColor: placeholderTextColor || placeholderColor,
-            onFocus,
-            onBlur,
-            underlineColorAndroid: 'transparent',
-            multiline,
-            style: [
-              styles.input,
-              !multiline || (multiline && height)
-                ? { height: inputHeight }
-                : {},
-              paddingOut,
-              {
-                ...font,
-                fontSize,
-                lineHeight,
-                fontWeight,
-                color: inputTextColor,
-                textAlignVertical: multiline ? 'top' : 'center',
-                textAlign: textAlign
-                  ? textAlign
-                  : I18nManager.getConstants().isRTL
-                  ? 'right'
-                  : 'left',
-                paddingHorizontal: INPUT_PADDING_HORIZONTAL,
-                minWidth: Math.min(
-                  parentState.labelTextLayout.width +
-                    2 * INPUT_PADDING_HORIZONTAL,
-                  MIN_WIDTH
-                ),
-              },
-              Platform.OS === 'web' && { outline: 'none' },
-              adornmentStyleAdjustmentForNativeInput,
-              contentStyle,
-            ],
-            testID,
-          } as RenderProps)}
-        </View>
-        <TextInputAdornment {...adornmentProps} />
+            Platform.OS === 'web' && { outline: 'none' },
+            adornmentStyleAdjustmentForNativeInput,
+            contentStyle,
+          ],
+          testID,
+        } as RenderProps)}
       </View>
+      <TextInputAdornment {...adornmentProps} />
     </View>
   );
 };

--- a/src/components/TextInput/constants.tsx
+++ b/src/components/TextInput/constants.tsx
@@ -3,6 +3,7 @@ export const MINIMIZED_LABEL_FONT_SIZE = 12;
 export const LABEL_WIGGLE_X_OFFSET = 4;
 
 export const ADORNMENT_SIZE = 24;
+export const MIN_WIDTH = 100;
 
 //Text input affix offset
 export const MD2_AFFIX_OFFSET = 12;

--- a/src/components/TextInput/helpers.tsx
+++ b/src/components/TextInput/helpers.tsx
@@ -5,6 +5,7 @@ import color from 'color';
 import { AdornmentSide, AdornmentType } from './Adornment/enums';
 import type { AdornmentConfig } from './Adornment/types';
 import {
+  MIN_WIDTH,
   ADORNMENT_SIZE,
   MD2_ADORNMENT_OFFSET,
   MD2_AFFIX_OFFSET,
@@ -614,5 +615,6 @@ export const getConstants = (isV3?: boolean) => {
     INPUT_PADDING_HORIZONTAL,
     ADORNMENT_OFFSET,
     OUTLINED_INPUT_OFFSET,
+    MIN_WIDTH,
   };
 };

--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -49,7 +49,6 @@ type TextInputProps = React.ComponentPropsWithRef<typeof NativeTextInput> & {
 
 export type RenderProps = {
   ref: (a?: NativeTextInput | null) => void;
-  onLayout: (event: LayoutChangeEvent) => void;
   onChangeText?: (a: string) => void;
   placeholder?: string;
   placeholderTextColor?: ColorValue;
@@ -91,7 +90,6 @@ export type ChildTextInputProps = {
   onLabelTextLayout: (event: NativeSyntheticEvent<TextLayoutEventData>) => void;
   onLeftAffixLayoutChange: (event: LayoutChangeEvent) => void;
   onRightAffixLayoutChange: (event: LayoutChangeEvent) => void;
-  onLayout: (event: LayoutChangeEvent) => void;
 } & $Omit<TextInputTypesWithoutMode, 'theme'> & { theme: InternalTheme };
 
 export type LabelProps = {

--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -49,6 +49,7 @@ type TextInputProps = React.ComponentPropsWithRef<typeof NativeTextInput> & {
 
 export type RenderProps = {
   ref: (a?: NativeTextInput | null) => void;
+  onLayout: (event: LayoutChangeEvent) => void;
   onChangeText?: (a: string) => void;
   placeholder?: string;
   placeholderTextColor?: ColorValue;
@@ -76,6 +77,7 @@ export type State = {
   labelLayout: { measured: boolean; width: number; height: number };
   leftLayout: { height: number | null; width: number | null };
   rightLayout: { height: number | null; width: number | null };
+  inputContainerLayout: { width: number };
   contentStyle?: StyleProp<ViewProps>;
 };
 export type ChildTextInputProps = {
@@ -89,6 +91,7 @@ export type ChildTextInputProps = {
   onLabelTextLayout: (event: NativeSyntheticEvent<TextLayoutEventData>) => void;
   onLeftAffixLayoutChange: (event: LayoutChangeEvent) => void;
   onRightAffixLayoutChange: (event: LayoutChangeEvent) => void;
+  onLayout: (event: LayoutChangeEvent) => void;
 } & $Omit<TextInputTypesWithoutMode, 'theme'> & { theme: InternalTheme };
 
 export type LabelProps = {
@@ -133,6 +136,7 @@ export type InputLabelProps = {
   opacity: number;
   labelLayoutMeasured: boolean;
   labelLayoutWidth: number;
+  inputContainerLayout: { width: number };
   labelBackground?: any;
   maxFontSizeMultiplier?: number | undefined | null;
   isV3?: boolean;

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -82,6 +82,7 @@ exports[`correctly applies a component as the text label 1`] = `
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
+            "maxWidth": 81,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 16,
@@ -127,7 +128,7 @@ exports[`correctly applies a component as the text label 1`] = `
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
-            "maxWidth": 734,
+            "maxWidth": 81,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 16,
@@ -169,6 +170,7 @@ exports[`correctly applies a component as the text label 1`] = `
       onBlur={[Function]}
       onChangeText={[Function]}
       onFocus={[Function]}
+      onLayout={[Function]}
       placeholder=" "
       placeholderTextColor="rgba(73, 69, 79, 1)"
       selectionColor="rgba(103, 80, 164, 1)"
@@ -294,6 +296,7 @@ exports[`correctly applies cursorColor prop 1`] = `
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
+            "maxWidth": 81,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 16,
@@ -331,7 +334,7 @@ exports[`correctly applies cursorColor prop 1`] = `
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
-            "maxWidth": 734,
+            "maxWidth": 81,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 16,
@@ -365,6 +368,7 @@ exports[`correctly applies cursorColor prop 1`] = `
       onBlur={[Function]}
       onChangeText={[Function]}
       onFocus={[Function]}
+      onLayout={[Function]}
       placeholder=" "
       placeholderTextColor="rgba(73, 69, 79, 1)"
       selectionColor="rgba(103, 80, 164, 1)"
@@ -490,6 +494,7 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
+            "maxWidth": 81,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 16,
@@ -527,7 +532,7 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
-            "maxWidth": 734,
+            "maxWidth": 81,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 16,
@@ -561,6 +566,7 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
       onBlur={[Function]}
       onChangeText={[Function]}
       onFocus={[Function]}
+      onLayout={[Function]}
       placeholder=" "
       placeholderTextColor="rgba(73, 69, 79, 1)"
       selectionColor="rgba(103, 80, 164, 1)"
@@ -722,6 +728,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
               "left": 0,
               "letterSpacing": 0.15,
               "lineHeight": 19.2,
+              "maxWidth": 81,
               "opacity": 0,
               "paddingHorizontal": 16,
               "position": "absolute",
@@ -758,7 +765,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
               "left": 0,
               "letterSpacing": 0.15,
               "lineHeight": 19.2,
-              "maxWidth": 734,
+              "maxWidth": 81,
               "opacity": 0,
               "paddingHorizontal": 16,
               "position": "absolute",
@@ -791,6 +798,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
         onBlur={[Function]}
         onChangeText={[Function]}
         onFocus={[Function]}
+        onLayout={[Function]}
         placeholder=" "
         placeholderTextColor="rgba(73, 69, 79, 1)"
         selectionColor="rgba(103, 80, 164, 1)"
@@ -916,6 +924,7 @@ exports[`correctly applies paddingLeft from contentStyleProp 1`] = `
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
+            "maxWidth": 81,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 16,
@@ -953,7 +962,7 @@ exports[`correctly applies paddingLeft from contentStyleProp 1`] = `
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
-            "maxWidth": 734,
+            "maxWidth": 81,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 16,
@@ -987,6 +996,7 @@ exports[`correctly applies paddingLeft from contentStyleProp 1`] = `
       onBlur={[Function]}
       onChangeText={[Function]}
       onFocus={[Function]}
+      onLayout={[Function]}
       placeholder=" "
       placeholderTextColor="rgba(73, 69, 79, 1)"
       selectionColor="rgba(103, 80, 164, 1)"
@@ -1114,6 +1124,7 @@ exports[`correctly applies textAlign center 1`] = `
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
+            "maxWidth": 81,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 16,
@@ -1151,7 +1162,7 @@ exports[`correctly applies textAlign center 1`] = `
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
-            "maxWidth": 734,
+            "maxWidth": 81,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 16,
@@ -1185,6 +1196,7 @@ exports[`correctly applies textAlign center 1`] = `
       onBlur={[Function]}
       onChangeText={[Function]}
       onFocus={[Function]}
+      onLayout={[Function]}
       placeholder=" "
       placeholderTextColor="rgba(73, 69, 79, 1)"
       selectionColor="rgba(103, 80, 164, 1)"
@@ -1310,6 +1322,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
+            "maxWidth": 81,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 56,
@@ -1347,7 +1360,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
-            "maxWidth": 734,
+            "maxWidth": 81,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 56,
@@ -1381,6 +1394,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
       onBlur={[Function]}
       onChangeText={[Function]}
       onFocus={[Function]}
+      onLayout={[Function]}
       placeholder=" "
       placeholderTextColor="rgba(73, 69, 79, 1)"
       selectionColor="rgba(103, 80, 164, 1)"
@@ -1708,6 +1722,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
+            "maxWidth": 81,
             "opacity": 0,
             "paddingLeft": 56,
             "paddingRight": 56,
@@ -1745,7 +1760,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
-            "maxWidth": 734,
+            "maxWidth": 81,
             "opacity": 0,
             "paddingLeft": 56,
             "paddingRight": 56,
@@ -1779,6 +1794,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
       onBlur={[Function]}
       onChangeText={[Function]}
       onFocus={[Function]}
+      onLayout={[Function]}
       placeholder=" "
       placeholderTextColor="rgba(73, 69, 79, 1)"
       selectionColor="rgba(103, 80, 164, 1)"

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -34,6 +34,7 @@ exports[`correctly applies a component as the text label 1`] = `
     testID="text-input-underline"
   />
   <View
+    onLayout={[Function]}
     style={
       [
         {
@@ -82,7 +83,7 @@ exports[`correctly applies a component as the text label 1`] = `
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
-            "maxWidth": 81,
+            "maxWidth": 73,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 16,
@@ -128,7 +129,7 @@ exports[`correctly applies a component as the text label 1`] = `
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
-            "maxWidth": 81,
+            "maxWidth": 73,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 16,
@@ -170,7 +171,6 @@ exports[`correctly applies a component as the text label 1`] = `
       onBlur={[Function]}
       onChangeText={[Function]}
       onFocus={[Function]}
-      onLayout={[Function]}
       placeholder=" "
       placeholderTextColor="rgba(73, 69, 79, 1)"
       selectionColor="rgba(103, 80, 164, 1)"
@@ -248,6 +248,7 @@ exports[`correctly applies cursorColor prop 1`] = `
     testID="text-input-underline"
   />
   <View
+    onLayout={[Function]}
     style={
       [
         {
@@ -296,7 +297,7 @@ exports[`correctly applies cursorColor prop 1`] = `
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
-            "maxWidth": 81,
+            "maxWidth": 73,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 16,
@@ -334,7 +335,7 @@ exports[`correctly applies cursorColor prop 1`] = `
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
-            "maxWidth": 81,
+            "maxWidth": 73,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 16,
@@ -368,7 +369,6 @@ exports[`correctly applies cursorColor prop 1`] = `
       onBlur={[Function]}
       onChangeText={[Function]}
       onFocus={[Function]}
-      onLayout={[Function]}
       placeholder=" "
       placeholderTextColor="rgba(73, 69, 79, 1)"
       selectionColor="rgba(103, 80, 164, 1)"
@@ -446,6 +446,7 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
     testID="text-input-underline"
   />
   <View
+    onLayout={[Function]}
     style={
       [
         {
@@ -494,7 +495,7 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
-            "maxWidth": 81,
+            "maxWidth": 73,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 16,
@@ -532,7 +533,7 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
-            "maxWidth": 81,
+            "maxWidth": 73,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 16,
@@ -566,7 +567,6 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
       onBlur={[Function]}
       onChangeText={[Function]}
       onFocus={[Function]}
-      onLayout={[Function]}
       placeholder=" "
       placeholderTextColor="rgba(73, 69, 79, 1)"
       selectionColor="rgba(103, 80, 164, 1)"
@@ -637,7 +637,9 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
     }
     testID="text-input-outline"
   />
-  <View>
+  <View
+    onLayout={[Function]}
+  >
     <View
       style={
         [
@@ -728,7 +730,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
               "left": 0,
               "letterSpacing": 0.15,
               "lineHeight": 19.2,
-              "maxWidth": 81,
+              "maxWidth": 73,
               "opacity": 0,
               "paddingHorizontal": 16,
               "position": "absolute",
@@ -765,7 +767,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
               "left": 0,
               "letterSpacing": 0.15,
               "lineHeight": 19.2,
-              "maxWidth": 81,
+              "maxWidth": 73,
               "opacity": 0,
               "paddingHorizontal": 16,
               "position": "absolute",
@@ -798,7 +800,6 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
         onBlur={[Function]}
         onChangeText={[Function]}
         onFocus={[Function]}
-        onLayout={[Function]}
         placeholder=" "
         placeholderTextColor="rgba(73, 69, 79, 1)"
         selectionColor="rgba(103, 80, 164, 1)"
@@ -876,6 +877,7 @@ exports[`correctly applies paddingLeft from contentStyleProp 1`] = `
     testID="text-input-underline"
   />
   <View
+    onLayout={[Function]}
     style={
       [
         {
@@ -924,7 +926,7 @@ exports[`correctly applies paddingLeft from contentStyleProp 1`] = `
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
-            "maxWidth": 81,
+            "maxWidth": 73,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 16,
@@ -962,7 +964,7 @@ exports[`correctly applies paddingLeft from contentStyleProp 1`] = `
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
-            "maxWidth": 81,
+            "maxWidth": 73,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 16,
@@ -996,7 +998,6 @@ exports[`correctly applies paddingLeft from contentStyleProp 1`] = `
       onBlur={[Function]}
       onChangeText={[Function]}
       onFocus={[Function]}
-      onLayout={[Function]}
       placeholder=" "
       placeholderTextColor="rgba(73, 69, 79, 1)"
       selectionColor="rgba(103, 80, 164, 1)"
@@ -1076,6 +1077,7 @@ exports[`correctly applies textAlign center 1`] = `
     testID="text-input-underline"
   />
   <View
+    onLayout={[Function]}
     style={
       [
         {
@@ -1124,7 +1126,7 @@ exports[`correctly applies textAlign center 1`] = `
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
-            "maxWidth": 81,
+            "maxWidth": 73,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 16,
@@ -1162,7 +1164,7 @@ exports[`correctly applies textAlign center 1`] = `
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
-            "maxWidth": 81,
+            "maxWidth": 73,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 16,
@@ -1196,7 +1198,6 @@ exports[`correctly applies textAlign center 1`] = `
       onBlur={[Function]}
       onChangeText={[Function]}
       onFocus={[Function]}
-      onLayout={[Function]}
       placeholder=" "
       placeholderTextColor="rgba(73, 69, 79, 1)"
       selectionColor="rgba(103, 80, 164, 1)"
@@ -1274,6 +1275,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
     testID="text-input-underline"
   />
   <View
+    onLayout={[Function]}
     style={
       [
         {
@@ -1322,7 +1324,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
-            "maxWidth": 81,
+            "maxWidth": 73,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 56,
@@ -1360,7 +1362,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
-            "maxWidth": 81,
+            "maxWidth": 73,
             "opacity": 0,
             "paddingLeft": 16,
             "paddingRight": 56,
@@ -1394,7 +1396,6 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
       onBlur={[Function]}
       onChangeText={[Function]}
       onFocus={[Function]}
-      onLayout={[Function]}
       placeholder=" "
       placeholderTextColor="rgba(73, 69, 79, 1)"
       selectionColor="rgba(103, 80, 164, 1)"
@@ -1674,6 +1675,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
     testID="text-input-underline"
   />
   <View
+    onLayout={[Function]}
     style={
       [
         {
@@ -1722,7 +1724,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
-            "maxWidth": 81,
+            "maxWidth": 73,
             "opacity": 0,
             "paddingLeft": 56,
             "paddingRight": 56,
@@ -1760,7 +1762,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
             "left": 0,
             "letterSpacing": 0.15,
             "lineHeight": 19.2,
-            "maxWidth": 81,
+            "maxWidth": 73,
             "opacity": 0,
             "paddingLeft": 56,
             "paddingRight": 56,
@@ -1794,7 +1796,6 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
       onBlur={[Function]}
       onChangeText={[Function]}
       onFocus={[Function]}
-      onLayout={[Function]}
       placeholder=" "
       placeholderTextColor="rgba(73, 69, 79, 1)"
       selectionColor="rgba(103, 80, 164, 1)"

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -638,207 +638,204 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
     testID="text-input-outline"
   />
   <View
-    onLayout={[Function]}
+    style={
+      [
+        {
+          "paddingBottom": 0,
+        },
+        {
+          "minHeight": 100,
+          "paddingTop": 8,
+        },
+      ]
+    }
   >
     <View
+      collapsable={false}
+      pointerEvents="none"
+      style={
+        {
+          "bottom": 0,
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "transform": [
+            {
+              "translateX": 3,
+            },
+          ],
+          "width": 750,
+          "zIndex": 3,
+        }
+      }
+    >
+      <Text
+        collapsable={false}
+        maxFontSizeMultiplier={1.5}
+        numberOfLines={1}
+        style={
+          {
+            "backgroundColor": "rgba(255, 251, 254, 1)",
+            "color": "transparent",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": undefined,
+            "left": 8,
+            "letterSpacing": 0.15,
+            "lineHeight": 19.2,
+            "opacity": 1,
+            "paddingHorizontal": 0,
+            "position": "absolute",
+            "textAlign": "left",
+            "top": 59,
+            "transform": [
+              {
+                "translateX": 0,
+              },
+              {
+                "translateY": -52,
+              },
+              {
+                "scale": 0.75,
+              },
+              {
+                "scaleY": 0.2,
+              },
+            ],
+            "width": -16,
+            "writingDirection": "ltr",
+          }
+        }
+        testID="text-input-outlined-label-background"
+      >
+        Outline Input
+      </Text>
+      <Text
+        collapsable={false}
+        maxFontSizeMultiplier={1.5}
+        numberOfLines={1}
+        onLayout={[Function]}
+        onTextLayout={[Function]}
+        style={
+          {
+            "color": "rgba(103, 80, 164, 1)",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": undefined,
+            "left": 0,
+            "letterSpacing": 0.15,
+            "lineHeight": 19.2,
+            "maxWidth": 73,
+            "opacity": 0,
+            "paddingHorizontal": 16,
+            "position": "absolute",
+            "textAlign": "left",
+            "top": 58,
+            "transform": [
+              {
+                "translateX": 0,
+              },
+              {
+                "translateY": -52,
+              },
+              {
+                "scale": 0.75,
+              },
+            ],
+            "writingDirection": "ltr",
+          }
+        }
+        testID="text-input-outlined-label-active"
+      >
+        Outline Input
+      </Text>
+      <Text
+        collapsable={false}
+        maxFontSizeMultiplier={1.5}
+        numberOfLines={1}
+        style={
+          {
+            "color": "rgba(73, 69, 79, 1)",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": undefined,
+            "left": 0,
+            "letterSpacing": 0.15,
+            "lineHeight": 19.2,
+            "maxWidth": 73,
+            "opacity": 0,
+            "paddingHorizontal": 16,
+            "position": "absolute",
+            "textAlign": "left",
+            "top": 58,
+            "transform": [
+              {
+                "translateX": 0,
+              },
+              {
+                "translateY": -52,
+              },
+              {
+                "scale": 0.75,
+              },
+            ],
+            "writingDirection": "ltr",
+          }
+        }
+        testID="text-input-outlined-label-inactive"
+      >
+        Outline Input
+      </Text>
+    </View>
+    <TextInput
+      cursorColor="rgba(103, 80, 164, 1)"
+      editable={true}
+      maxFontSizeMultiplier={1.5}
+      multiline={true}
+      onBlur={[Function]}
+      onChangeText={[Function]}
+      onFocus={[Function]}
+      onLayout={[Function]}
+      placeholder=" "
+      placeholderTextColor="rgba(73, 69, 79, 1)"
+      selectionColor="rgba(103, 80, 164, 1)"
       style={
         [
           {
-            "paddingBottom": 0,
+            "margin": 0,
           },
           {
-            "minHeight": 100,
-            "paddingTop": 8,
+            "height": 100,
           },
+          {
+            "paddingBottom": 24,
+            "paddingTop": 24,
+          },
+          {
+            "color": "rgba(28, 27, 31, 1)",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": undefined,
+            "letterSpacing": 0.15,
+            "lineHeight": 19.2,
+            "minWidth": 65,
+            "paddingHorizontal": 16,
+            "textAlign": "left",
+            "textAlignVertical": "top",
+          },
+          false,
+          [
+            {},
+          ],
+          undefined,
         ]
       }
-    >
-      <View
-        collapsable={false}
-        pointerEvents="none"
-        style={
-          {
-            "bottom": 0,
-            "left": 0,
-            "opacity": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
-            "transform": [
-              {
-                "translateX": 3,
-              },
-            ],
-            "width": 750,
-            "zIndex": 3,
-          }
-        }
-      >
-        <Text
-          collapsable={false}
-          maxFontSizeMultiplier={1.5}
-          numberOfLines={1}
-          style={
-            {
-              "backgroundColor": "rgba(255, 251, 254, 1)",
-              "color": "transparent",
-              "fontFamily": "System",
-              "fontSize": 16,
-              "fontWeight": undefined,
-              "left": 8,
-              "letterSpacing": 0.15,
-              "lineHeight": 19.2,
-              "opacity": 1,
-              "paddingHorizontal": 0,
-              "position": "absolute",
-              "textAlign": "left",
-              "top": 59,
-              "transform": [
-                {
-                  "translateX": 0,
-                },
-                {
-                  "translateY": -52,
-                },
-                {
-                  "scale": 0.75,
-                },
-                {
-                  "scaleY": 0.2,
-                },
-              ],
-              "width": -16,
-              "writingDirection": "ltr",
-            }
-          }
-          testID="text-input-outlined-label-background"
-        >
-          Outline Input
-        </Text>
-        <Text
-          collapsable={false}
-          maxFontSizeMultiplier={1.5}
-          numberOfLines={1}
-          onLayout={[Function]}
-          onTextLayout={[Function]}
-          style={
-            {
-              "color": "rgba(103, 80, 164, 1)",
-              "fontFamily": "System",
-              "fontSize": 16,
-              "fontWeight": undefined,
-              "left": 0,
-              "letterSpacing": 0.15,
-              "lineHeight": 19.2,
-              "maxWidth": 73,
-              "opacity": 0,
-              "paddingHorizontal": 16,
-              "position": "absolute",
-              "textAlign": "left",
-              "top": 58,
-              "transform": [
-                {
-                  "translateX": 0,
-                },
-                {
-                  "translateY": -52,
-                },
-                {
-                  "scale": 0.75,
-                },
-              ],
-              "writingDirection": "ltr",
-            }
-          }
-          testID="text-input-outlined-label-active"
-        >
-          Outline Input
-        </Text>
-        <Text
-          collapsable={false}
-          maxFontSizeMultiplier={1.5}
-          numberOfLines={1}
-          style={
-            {
-              "color": "rgba(73, 69, 79, 1)",
-              "fontFamily": "System",
-              "fontSize": 16,
-              "fontWeight": undefined,
-              "left": 0,
-              "letterSpacing": 0.15,
-              "lineHeight": 19.2,
-              "maxWidth": 73,
-              "opacity": 0,
-              "paddingHorizontal": 16,
-              "position": "absolute",
-              "textAlign": "left",
-              "top": 58,
-              "transform": [
-                {
-                  "translateX": 0,
-                },
-                {
-                  "translateY": -52,
-                },
-                {
-                  "scale": 0.75,
-                },
-              ],
-              "writingDirection": "ltr",
-            }
-          }
-          testID="text-input-outlined-label-inactive"
-        >
-          Outline Input
-        </Text>
-      </View>
-      <TextInput
-        cursorColor="rgba(103, 80, 164, 1)"
-        editable={true}
-        maxFontSizeMultiplier={1.5}
-        multiline={true}
-        onBlur={[Function]}
-        onChangeText={[Function]}
-        onFocus={[Function]}
-        placeholder=" "
-        placeholderTextColor="rgba(73, 69, 79, 1)"
-        selectionColor="rgba(103, 80, 164, 1)"
-        style={
-          [
-            {
-              "margin": 0,
-            },
-            {
-              "height": 100,
-            },
-            {
-              "paddingBottom": 24,
-              "paddingTop": 24,
-            },
-            {
-              "color": "rgba(28, 27, 31, 1)",
-              "fontFamily": "System",
-              "fontSize": 16,
-              "fontWeight": undefined,
-              "letterSpacing": 0.15,
-              "lineHeight": 19.2,
-              "minWidth": 65,
-              "paddingHorizontal": 16,
-              "textAlign": "left",
-              "textAlignVertical": "top",
-            },
-            false,
-            [
-              {},
-            ],
-            undefined,
-          ]
-        }
-        testID="text-input-outlined"
-        underlineColorAndroid="transparent"
-        value="Some test value"
-      />
-    </View>
+      testID="text-input-outlined"
+      underlineColorAndroid="transparent"
+      value="Some test value"
+    />
   </View>
 </View>
 `;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Set input's label max width to not overflow the input boundaries.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### Related issue

- #4164 
- #4186 
- #4168

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

ios | android
--- | ---
<img width="488" alt="Zrzut ekranu 2023-11-22 o 23 20 20" src="https://github.com/callstack/react-native-paper/assets/22746080/aa83c73b-a8f2-4ca1-ada5-8f4ed26ec8b1"> | <img width="479" alt="Zrzut ekranu 2023-11-22 o 23 26 51" src="https://github.com/callstack/react-native-paper/assets/22746080/db412168-42bb-4ea9-aba6-c755f2a27d18">



<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
