### PR TITLE
feat: add contentStyle to the list item title and description container

### DIFF
--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -108,6 +108,10 @@ export type Props = $RemoveChildren<typeof TouchableRipple> & {
    * Specifies the largest possible scale a description font can reach.
    */
   descriptionMaxFontSizeMultiplier?: number;
+  /**
+   * TestID used for testing purposes
+   */
+  testID?: string;
 };
 
 /**
@@ -149,6 +153,7 @@ const ListItem = (
     descriptionStyle,
     descriptionMaxFontSizeMultiplier,
     titleMaxFontSizeMultiplier,
+    testID,
     ...rest
   }: Props,
   ref: React.ForwardedRef<View>
@@ -231,6 +236,7 @@ const ListItem = (
       style={[theme.isV3 ? styles.containerV3 : styles.container, style]}
       onPress={onPress}
       theme={theme}
+      testID={testID}
     >
       <View style={theme.isV3 ? styles.rowV3 : styles.row}>
         {left
@@ -245,6 +251,7 @@ const ListItem = (
             styles.content,
             contentStyle,
           ]}
+          testID={`${testID}-content`}
         >
           {renderTitle()}
 

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -67,6 +67,10 @@ export type Props = $RemoveChildren<typeof TouchableRipple> & {
    */
   style?: StyleProp<ViewStyle>;
   /**
+   * Style that is passed to the container wrapping title and descripton.
+   */
+  contentStyle?: StyleProp<ViewStyle>;
+  /**
    * Style that is passed to Title element.
    */
   titleStyle?: StyleProp<TextStyle>;
@@ -136,6 +140,7 @@ const ListItem = (
     onPress,
     theme: themeOverrides,
     style,
+    contentStyle,
     titleStyle,
     titleNumberOfLines = 1,
     descriptionNumberOfLines = 2,
@@ -235,7 +240,11 @@ const ListItem = (
             })
           : null}
         <View
-          style={[theme.isV3 ? styles.itemV3 : styles.item, styles.content]}
+          style={[
+            theme.isV3 ? styles.itemV3 : styles.item,
+            styles.content,
+            contentStyle,
+          ]}
         >
           {renderTitle()}
 

--- a/src/components/__tests__/ListItem.test.tsx
+++ b/src/components/__tests__/ListItem.test.tsx
@@ -17,11 +17,20 @@ const styles = StyleSheet.create({
   description: {
     color: red500,
   },
+  content: {
+    paddingLeft: 0,
+  },
 });
+
+const testID = 'list-item';
 
 it('renders list item with title and description', () => {
   const tree = render(
-    <ListItem title="First Item" description="Description for first item" />
+    <ListItem
+      title="First Item"
+      testID={testID}
+      description="Description for first item"
+    />
   ).toJSON();
 
   expect(tree).toMatchSnapshot();
@@ -31,6 +40,7 @@ it('renders list item with left item', () => {
   const tree = render(
     <ListItem
       title="First Item"
+      testID={testID}
       left={(props) => <ListIcon {...props} icon="folder" />}
     />
   ).toJSON();
@@ -40,7 +50,11 @@ it('renders list item with left item', () => {
 
 it('renders list item with right item', () => {
   const tree = render(
-    <ListItem title="First Item" right={() => <Text>GG</Text>} />
+    <ListItem
+      title="First Item"
+      testID={testID}
+      right={() => <Text>GG</Text>}
+    />
   ).toJSON();
 
   expect(tree).toMatchSnapshot();
@@ -51,6 +65,7 @@ it('renders list item with left and right items', () => {
     <ListItem
       title="First Item"
       description="Item description"
+      testID={testID}
       left={() => <Text>GG</Text>}
       right={(props) => <ListIcon {...props} icon="folder" />}
     />
@@ -64,6 +79,7 @@ it('renders list item with custom title and description styles', () => {
     <ListItem
       title="First Item"
       description="Item description"
+      testID={testID}
       titleStyle={styles.title}
       descriptionStyle={styles.description}
     />
@@ -93,6 +109,7 @@ it('renders list item with custom description', () => {
           </View>
         </View>
       )}
+      testID={testID}
     />
   ).toJSON();
 
@@ -106,6 +123,7 @@ it('renders with a description with typeof number', () => {
       description={123}
       titleStyle={styles.title}
       descriptionStyle={styles.description}
+      testID={testID}
     />
   ).toJSON();
 
@@ -120,10 +138,24 @@ it('calling onPress on ListItem right component', () => {
     <ListItem
       title="First Item"
       description="Item description"
+      testID={testID}
       right={() => <IconButton icon="pencil" onPress={onPress} />}
     />
   );
 
   fireEvent(getByTestId('icon-button'), 'onPress');
   expect(onPress).toHaveBeenCalledTimes(1);
+});
+
+it('renders list item with custom content style', () => {
+  const { getByTestId } = render(
+    <ListItem
+      title="First Item"
+      description="Item description"
+      contentStyle={styles.content}
+      testID={testID}
+    />
+  );
+
+  expect(getByTestId('list-item-content')).toHaveStyle(styles.content);
 });

--- a/src/components/__tests__/ListSection.test.tsx
+++ b/src/components/__tests__/ListSection.test.tsx
@@ -15,15 +15,19 @@ const styles = StyleSheet.create({
   },
 });
 
+const testID = 'list-item';
+
 it('renders list section without subheader', () => {
   const tree = render(
     <ListSection>
       <ListItem
         title="First Item"
+        testID={testID}
         left={(props) => <ListIcon {...props} icon="folder" />}
       />
       <ListItem
         title="Second Item"
+        testID={testID}
         left={(props) => <ListIcon {...props} icon="folder" />}
       />
     </ListSection>
@@ -38,10 +42,12 @@ it('renders list section with subheader', () => {
       <ListSubheader>Some title</ListSubheader>
       <ListItem
         title="First Item"
+        testID={testID}
         left={(props) => <ListIcon {...props} icon="folder" />}
       />
       <ListItem
         title="Second Item"
+        testID={testID}
         left={(props) => <ListIcon {...props} icon="folder" />}
       />
     </ListSection>
@@ -55,10 +61,12 @@ it('renders list section with custom title style', () => {
     <ListSection title="Some title" titleStyle={styles.itemColor}>
       <ListItem
         title="First Item"
+        testID={testID}
         left={(props) => <ListIcon {...props} icon="folder" />}
       />
       <ListItem
         title="Second Item"
+        testID={testID}
         left={(props) => <ListIcon {...props} icon="folder" />}
       />
     </ListSection>

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
@@ -226,6 +226,7 @@ exports[`renders expanded accordion 1`] = `
             undefined,
           ]
         }
+        testID="undefined-content"
       >
         <Text
           numberOfLines={1}

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
@@ -223,6 +223,7 @@ exports[`renders expanded accordion 1`] = `
               "flexShrink": 1,
               "justifyContent": "center",
             },
+            undefined,
           ]
         }
       >

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -64,6 +64,7 @@ exports[`renders list item with custom description 1`] = `
             "flexShrink": 1,
             "justifyContent": "center",
           },
+          undefined,
         ]
       }
     >
@@ -388,6 +389,7 @@ exports[`renders list item with custom title and description styles 1`] = `
             "flexShrink": 1,
             "justifyContent": "center",
           },
+          undefined,
         ]
       }
     >
@@ -530,6 +532,7 @@ exports[`renders list item with left and right items 1`] = `
             "flexShrink": 1,
             "justifyContent": "center",
           },
+          undefined,
         ]
       }
     >
@@ -772,6 +775,7 @@ exports[`renders list item with left item 1`] = `
             "flexShrink": 1,
             "justifyContent": "center",
           },
+          undefined,
         ]
       }
     >
@@ -875,6 +879,7 @@ exports[`renders list item with right item 1`] = `
             "flexShrink": 1,
             "justifyContent": "center",
           },
+          undefined,
         ]
       }
     >
@@ -981,6 +986,7 @@ exports[`renders list item with title and description 1`] = `
             "flexShrink": 1,
             "justifyContent": "center",
           },
+          undefined,
         ]
       }
     >
@@ -1116,6 +1122,7 @@ exports[`renders with a description with typeof number 1`] = `
             "flexShrink": 1,
             "justifyContent": "center",
           },
+          undefined,
         ]
       }
     >

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`renders list item with custom description 1`] = `
       ],
     ]
   }
+  testID="list-item"
 >
   <View
     style={
@@ -67,6 +68,7 @@ exports[`renders list item with custom description 1`] = `
           undefined,
         ]
       }
+      testID="list-item-content"
     >
       <Text
         numberOfLines={1}
@@ -368,6 +370,7 @@ exports[`renders list item with custom title and description styles 1`] = `
       ],
     ]
   }
+  testID="list-item"
 >
   <View
     style={
@@ -392,6 +395,7 @@ exports[`renders list item with custom title and description styles 1`] = `
           undefined,
         ]
       }
+      testID="list-item-content"
     >
       <Text
         numberOfLines={1}
@@ -508,6 +512,7 @@ exports[`renders list item with left and right items 1`] = `
       ],
     ]
   }
+  testID="list-item"
 >
   <View
     style={
@@ -535,6 +540,7 @@ exports[`renders list item with left and right items 1`] = `
           undefined,
         ]
       }
+      testID="list-item-content"
     >
       <Text
         numberOfLines={1}
@@ -700,6 +706,7 @@ exports[`renders list item with left item 1`] = `
       ],
     ]
   }
+  testID="list-item"
 >
   <View
     style={
@@ -778,6 +785,7 @@ exports[`renders list item with left item 1`] = `
           undefined,
         ]
       }
+      testID="list-item-content"
     >
       <Text
         numberOfLines={1}
@@ -858,6 +866,7 @@ exports[`renders list item with right item 1`] = `
       ],
     ]
   }
+  testID="list-item"
 >
   <View
     style={
@@ -882,6 +891,7 @@ exports[`renders list item with right item 1`] = `
           undefined,
         ]
       }
+      testID="list-item-content"
     >
       <Text
         numberOfLines={1}
@@ -965,6 +975,7 @@ exports[`renders list item with title and description 1`] = `
       ],
     ]
   }
+  testID="list-item"
 >
   <View
     style={
@@ -989,6 +1000,7 @@ exports[`renders list item with title and description 1`] = `
           undefined,
         ]
       }
+      testID="list-item-content"
     >
       <Text
         numberOfLines={1}
@@ -1101,6 +1113,7 @@ exports[`renders with a description with typeof number 1`] = `
       ],
     ]
   }
+  testID="list-item"
 >
   <View
     style={
@@ -1125,6 +1138,7 @@ exports[`renders with a description with typeof number 1`] = `
           undefined,
         ]
       }
+      testID="list-item-content"
     >
       <Text
         numberOfLines={1}

--- a/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
@@ -335,6 +335,7 @@ exports[`renders list section with custom title style 1`] = `
               "flexShrink": 1,
               "justifyContent": "center",
             },
+            undefined,
           ]
         }
       >
@@ -489,6 +490,7 @@ exports[`renders list section with custom title style 1`] = `
               "flexShrink": 1,
               "justifyContent": "center",
             },
+            undefined,
           ]
         }
       >
@@ -862,6 +864,7 @@ exports[`renders list section with subheader 1`] = `
               "flexShrink": 1,
               "justifyContent": "center",
             },
+            undefined,
           ]
         }
       >
@@ -1016,6 +1019,7 @@ exports[`renders list section with subheader 1`] = `
               "flexShrink": 1,
               "justifyContent": "center",
             },
+            undefined,
           ]
         }
       >
@@ -1349,6 +1353,7 @@ exports[`renders list section without subheader 1`] = `
               "flexShrink": 1,
               "justifyContent": "center",
             },
+            undefined,
           ]
         }
       >
@@ -1503,6 +1508,7 @@ exports[`renders list section without subheader 1`] = `
               "flexShrink": 1,
               "justifyContent": "center",
             },
+            undefined,
           ]
         }
       >

--- a/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
@@ -260,6 +260,7 @@ exports[`renders list section with custom title style 1`] = `
         ],
       ]
     }
+    testID="list-item"
   >
     <View
       style={
@@ -338,6 +339,7 @@ exports[`renders list section with custom title style 1`] = `
             undefined,
           ]
         }
+        testID="list-item-content"
       >
         <Text
           numberOfLines={1}
@@ -415,6 +417,7 @@ exports[`renders list section with custom title style 1`] = `
         ],
       ]
     }
+    testID="list-item"
   >
     <View
       style={
@@ -493,6 +496,7 @@ exports[`renders list section with custom title style 1`] = `
             undefined,
           ]
         }
+        testID="list-item-content"
       >
         <Text
           numberOfLines={1}
@@ -789,6 +793,7 @@ exports[`renders list section with subheader 1`] = `
         ],
       ]
     }
+    testID="list-item"
   >
     <View
       style={
@@ -867,6 +872,7 @@ exports[`renders list section with subheader 1`] = `
             undefined,
           ]
         }
+        testID="list-item-content"
       >
         <Text
           numberOfLines={1}
@@ -944,6 +950,7 @@ exports[`renders list section with subheader 1`] = `
         ],
       ]
     }
+    testID="list-item"
   >
     <View
       style={
@@ -1022,6 +1029,7 @@ exports[`renders list section with subheader 1`] = `
             undefined,
           ]
         }
+        testID="list-item-content"
       >
         <Text
           numberOfLines={1}
@@ -1278,6 +1286,7 @@ exports[`renders list section without subheader 1`] = `
         ],
       ]
     }
+    testID="list-item"
   >
     <View
       style={
@@ -1356,6 +1365,7 @@ exports[`renders list section without subheader 1`] = `
             undefined,
           ]
         }
+        testID="list-item-content"
       >
         <Text
           numberOfLines={1}
@@ -1433,6 +1443,7 @@ exports[`renders list section without subheader 1`] = `
         ],
       ]
     }
+    testID="list-item"
   >
     <View
       style={
@@ -1511,6 +1522,7 @@ exports[`renders list section without subheader 1`] = `
             undefined,
           ]
         }
+        testID="list-item-content"
       >
         <Text
           numberOfLines={1}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Possibility to override styles of the item container which wraps title and description.

### Related issue

- #4109 
- #4180 

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

updated snapshot.

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
