### PR TITLE
feat: added onLongPress to `RadioButton.Item` and `Checkbox.Item`

### DIFF
--- a/src/components/Checkbox/CheckboxItem.tsx
+++ b/src/components/Checkbox/CheckboxItem.tsx
@@ -35,6 +35,10 @@ export type Props = {
    */
   onPress?: (e: GestureResponderEvent) => void;
   /**
+   * Function to execute on long press.
+   */
+  onLongPress?: (e: GestureResponderEvent) => void;
+  /**
    * Accessibility label for the touchable. This is read by the screen reader when the user taps the touchable.
    */
   accessibilityLabel?: string;
@@ -122,6 +126,7 @@ const CheckboxItem = ({
   status,
   label,
   onPress,
+  onLongPress,
   labelStyle,
   theme: themeOverrides,
   testID,
@@ -167,6 +172,7 @@ const CheckboxItem = ({
         disabled,
       }}
       onPress={onPress}
+      onLongPress={onLongPress}
       testID={testID}
       disabled={disabled}
       rippleColor={rippleColor}

--- a/src/components/RadioButton/RadioButtonItem.tsx
+++ b/src/components/RadioButton/RadioButtonItem.tsx
@@ -37,6 +37,10 @@ export type Props = {
    */
   onPress?: (e: GestureResponderEvent) => void;
   /**
+   * Function to execute on long press.
+   */
+  onLongPress?: (e: GestureResponderEvent) => void;
+  /**
    * Accessibility label for the touchable. This is read by the screen reader when the user taps the touchable.
    */
   accessibilityLabel?: string;
@@ -132,6 +136,7 @@ const RadioButtonItem = ({
   style,
   labelStyle,
   onPress,
+  onLongPress,
   disabled,
   color,
   uncheckedColor,
@@ -195,6 +200,7 @@ const RadioButtonItem = ({
                 event,
               })
             }
+            onLongPress={onLongPress}
             accessibilityLabel={accessibilityLabel}
             accessibilityRole="radio"
             accessibilityState={{

--- a/src/components/__tests__/Checkbox/CheckboxItem.test.tsx
+++ b/src/components/__tests__/Checkbox/CheckboxItem.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Platform } from 'react-native';
 
-import { render } from '@testing-library/react-native';
+import { act, fireEvent, render } from '@testing-library/react-native';
 
 import Checkbox from '../../Checkbox';
 
@@ -94,4 +94,23 @@ it('should have maxFontSizeMultiplier set to 1.5 by default', () => {
   );
   const checkboxItemText = getByTestId('checkbox-item-text');
   expect(checkboxItemText.props.maxFontSizeMultiplier).toBe(1.5);
+});
+
+it('should execute onLongPress', () => {
+  const onLongPress = jest.fn();
+
+  const { getByTestId } = render(
+    <Checkbox.Item
+      label="Item"
+      status="unchecked"
+      testID="checkbox-item"
+      onLongPress={onLongPress}
+    />
+  );
+
+  act(() => {
+    fireEvent(getByTestId('checkbox-item'), 'longPress', { key: 'value' });
+  });
+
+  expect(onLongPress).toHaveBeenCalledTimes(1);
 });

--- a/src/components/__tests__/RadioButton/RadioButtonItem.test.tsx
+++ b/src/components/__tests__/RadioButton/RadioButtonItem.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Platform } from 'react-native';
 
-import { render } from '@testing-library/react-native';
+import { act, fireEvent, render } from '@testing-library/react-native';
 
 import RadioButton from '../../RadioButton';
 
@@ -57,4 +57,23 @@ it('can render leading radio button control', () => {
   ).toJSON();
 
   expect(tree).toMatchSnapshot();
+});
+
+it('should execute onLongPress', () => {
+  const onLongPress = jest.fn();
+
+  const { getByTestId } = render(
+    <RadioButton.Item
+      label="Item"
+      value="android"
+      testID="radio-button-item"
+      onLongPress={onLongPress}
+    />
+  );
+
+  act(() => {
+    fireEvent(getByTestId('radio-button-item'), 'longPress', { key: 'value' });
+  });
+
+  expect(onLongPress).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

RadioButton.Item currently does not pass the "onLongPress" prop to the TouchableRipple component. This would be useful to implement to make RadioButton.Item elements be able to handle a secondary action.

### Related issue

#4214 

### Test plan

Create a RadioButton.Item and pass it an onLongPress prop with a function that logs something into the console.

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
