### PR TITLE
update CommonActions with navigation

### DIFF
--- a/src/components/BottomNavigation/BottomNavigationBar.tsx
+++ b/src/components/BottomNavigation/BottomNavigationBar.tsx
@@ -278,7 +278,7 @@ const Touchable = <Route extends BaseRoute>({
  *               preventDefault();
  *             } else {
  *              navigation.dispatch({
- *                 ...CommonActions.navigate(route.name, route.params),
+ *                 ...navigation.navigate(route.name, route.params),
  *                 target: state.key,
  *               });
  *             }


### PR DESCRIPTION
**Edited**
I followed the instructions provided in [this documentation](https://callstack.github.io/react-native-paper/docs/components/BottomNavigation/BottomNavigationBar) to implement the BottomNavigation feature. However, the code presented in the documentation resulted in an error stating that `CommonActions` was not defined. After some troubleshooting, I realized that the correct reference should be `navigation` instead of `CommonActions`. Making this change resolved the issue for me.

The problematic line in the code was:
```javascript
...CommonActions.navigate(route.name, route.params),
```

I found the relevant information in the documentation generated from [this file](https://github.com/callstack/react-native-paper/blob/726b98f371a84b302b553793679279d4c86555ff/src/components/BottomNavigation/BottomNavigationBar.tsx#L281).