### PR TITLE
fix: adjust native driver value based on the rn version

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -3,6 +3,7 @@ import {
   Animated,
   ColorValue,
   GestureResponderEvent,
+  Platform,
   StyleProp,
   StyleSheet,
   TextStyle,
@@ -218,7 +219,7 @@ const Button = (
       Animated.timing(elevation, {
         toValue: activeElevation,
         duration: 200 * scale,
-        useNativeDriver: true,
+        useNativeDriver: Platform.constants.reactNativeVersion.minor <= 72,
       }).start();
     }
   };
@@ -230,7 +231,7 @@ const Button = (
       Animated.timing(elevation, {
         toValue: initialElevation,
         duration: 150 * scale,
-        useNativeDriver: true,
+        useNativeDriver: Platform.constants.reactNativeVersion.minor <= 72,
       }).start();
     }
   };

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -218,7 +218,7 @@ const Chip = ({
     Animated.timing(elevation, {
       toValue: isV3 ? (elevated ? 2 : 0) : 4,
       duration: 200 * scale,
-      useNativeDriver: true,
+      useNativeDriver: Platform.constants.reactNativeVersion.minor <= 72,
     }).start();
   });
 
@@ -228,7 +228,7 @@ const Chip = ({
     Animated.timing(elevation, {
       toValue: isV3 && elevated ? 1 : 0,
       duration: 150 * scale,
-      useNativeDriver: true,
+      useNativeDriver: Platform.constants.reactNativeVersion.minor <= 72,
     }).start();
   });
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Adjust the `useNativeDriver` value in shadow animation to be based on the `react-native` version.

### Related issue

- #4224 

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

Tested on react-native version 0.71, 0.72 and 0.73

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
