### PR TITLE
fix: v4 card onPress crash when using RN 0.73

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -6,6 +6,7 @@ import {
   TouchableWithoutFeedback,
   View,
   ViewStyle,
+  Platform,
 } from 'react-native';
 import color from 'color';
 import { white, black } from '../../styles/colors';
@@ -165,7 +166,7 @@ const Card = ({
       Animated.timing(elevation, {
         toValue: isPressTypeIn ? 8 : cardElevation,
         duration: animationDuration,
-        useNativeDriver: true,
+        useNativeDriver: Platform.constants.reactNativeVersion.minor <= 72,
       }).start();
     }
   };


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Using v4 Card with a OnPress in light mode crashes when using react-native version 0.73.

### Related issue

#4224

### Test plan

Tested on react-native version 0.64 and used the pressable theme change button in example app, also tested manual node_modules Card.tsx edit in react-native 0.73.
