### PR TITLE
fix: platform constants is undefined on web

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -219,7 +219,9 @@ const Button = (
       Animated.timing(elevation, {
         toValue: activeElevation,
         duration: 200 * scale,
-        useNativeDriver: Platform.constants.reactNativeVersion.minor <= 72,
+        useNativeDriver:
+          Platform.OS === 'web' ||
+          Platform.constants.reactNativeVersion.minor <= 72,
       }).start();
     }
   };
@@ -231,7 +233,9 @@ const Button = (
       Animated.timing(elevation, {
         toValue: initialElevation,
         duration: 150 * scale,
-        useNativeDriver: Platform.constants.reactNativeVersion.minor <= 72,
+        useNativeDriver:
+          Platform.OS === 'web' ||
+          Platform.constants.reactNativeVersion.minor <= 72,
       }).start();
     }
   };

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -218,7 +218,9 @@ const Chip = ({
     Animated.timing(elevation, {
       toValue: isV3 ? (elevated ? 2 : 0) : 4,
       duration: 200 * scale,
-      useNativeDriver: Platform.constants.reactNativeVersion.minor <= 72,
+      useNativeDriver:
+        Platform.OS === 'web' ||
+        Platform.constants.reactNativeVersion.minor <= 72,
     }).start();
   });
 
@@ -228,7 +230,9 @@ const Chip = ({
     Animated.timing(elevation, {
       toValue: isV3 && elevated ? 1 : 0,
       duration: 150 * scale,
-      useNativeDriver: Platform.constants.reactNativeVersion.minor <= 72,
+      useNativeDriver:
+        Platform.OS === 'web' ||
+        Platform.constants.reactNativeVersion.minor <= 72,
     }).start();
   });
 


### PR DESCRIPTION
### Motivation
in #4246 a check based on react native version was introduced, however the `Platform.constants` property is `undefined` when targetting web using the `react-native-web` approach [listed in the docs](https://callstack.github.io/react-native-paper/docs/guides/react-native-web), as the platform object is simply:
```
{"OS":"web","isTesting":false}
```
adjust it to check if the `OS` is `web` and use the native driver as before if so.

whilst I'm not totally sure whether using the "native driver" is the best option on web, until #4246 this was the case, so seemed the best option to revert to.

### Interim Workaround
In the meantime, rather than monkey patching `react-native-paper` I'm working around by monkey patching the constants like so:
```
// TODO: workaround for react-native-paper issue
//       https://github.com/callstack/react-native-paper/pull/4257
if (!Platform.constants) {
  Platform.constants = {
    isTesting: Platform.isTesting,
    reactNativeVersion: {major: 0, minor: 73, patch: 0},
  }
}
```
I'm using `expo-router` so have placed this in my general app initialization effect in the root layout.

### Test plan
Before this change, I encounter this error:
![Screenshot from 2024-01-06 23-27-54](https://github.com/callstack/react-native-paper/assets/2555533/c4f60a61-2807-4715-bc48-add08a80fb1b)

Afterwards the error is gone, and the buttons look correct to my eyes.