### PR TITLE
fix: correct border radius based on roundness

### DIFF
--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -197,7 +197,7 @@ const Chip = ({
   ...rest
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
-  const { isV3 } = theme;
+  const { isV3, roundness } = theme;
 
   const { current: elevation } = React.useRef<Animated.Value>(
     new Animated.Value(isV3 && elevated ? 1 : 0)
@@ -233,7 +233,7 @@ const Chip = ({
   });
 
   const opacity = isV3 ? 0.38 : 0.26;
-  const defaultBorderRadius = isV3 ? 8 : 16;
+  const defaultBorderRadius = roundness * (isV3 ? 2 : 4);
   const iconSize = isV3 ? 18 : 16;
 
   const {

--- a/src/components/FAB/utils.ts
+++ b/src/components/FAB/utils.ts
@@ -366,7 +366,7 @@ const v3LargeSize = {
 const getCustomFabSize = (customSize: number, roundness: number) => ({
   height: customSize,
   width: customSize,
-  borderRadius: customSize / roundness,
+  borderRadius: roundness === 0 ? 0 : customSize / roundness,
 });
 
 export const getFabStyle = ({

--- a/src/components/__tests__/Chip.test.tsx
+++ b/src/components/__tests__/Chip.test.tsx
@@ -79,6 +79,18 @@ it('renders active chip if only onLongPress handler is passed', () => {
   });
 });
 
+it('renders chip with zero border radius', () => {
+  const { getByTestId } = render(
+    <Chip testID="active-chip" theme={{ roundness: 0 }}>
+      Active chip
+    </Chip>
+  );
+
+  expect(getByTestId('active-chip')).toHaveStyle({
+    borderRadius: 0,
+  });
+});
+
 describe('getChipColors - text color', () => {
   it('should return correct disabled color, for theme version 3', () => {
     expect(

--- a/src/components/__tests__/FAB.test.tsx
+++ b/src/components/__tests__/FAB.test.tsx
@@ -138,6 +138,14 @@ it('renders FAB with custom border radius', () => {
   expect(getByTestId('fab-container')).toHaveStyle({ borderRadius: 0 });
 });
 
+it('renders FAB with zero border radius', () => {
+  const { getByTestId } = render(
+    <FAB theme={{ roundness: 0 }} onPress={() => {}} icon="plus" testID="fab" />
+  );
+
+  expect(getByTestId('fab-container')).toHaveStyle({ borderRadius: 0 });
+});
+
 it('renders FAB without uppercase styling by default', () => {
   const { getByTestId } = render(
     <FAB onPress={() => {}} label="Add items" testID="fab" />


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Make the border radius in `Chip` and `FAB` based on the `roundness` value from the `theme`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### Related issue

#4238

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

Added unit tests

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
