### PR TITLE
fix: Button and IconButton TouchableRipple borderRadius

### DIFF
--- a/example/src/Examples/ButtonExample.tsx
+++ b/example/src/Examples/ButtonExample.tsx
@@ -296,6 +296,14 @@ const ButtonExample = () => {
           <Button mode="contained" onPress={() => {}} style={styles.noRadius}>
             Without radius
           </Button>
+          <Button
+            mode="contained-tonal"
+            onPress={() => {}}
+            style={{ borderRadius: styles.customRadiusAndPadding.borderRadius }}
+            contentStyle={styles.customRadiusAndPadding}
+          >
+            Custom radius and padding
+          </Button>
         </View>
 
         <View style={styles.row}>
@@ -355,6 +363,7 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     paddingHorizontal: 12,
     alignItems: 'center',
+    gap: 12,
   },
   button: {
     margin: 4,
@@ -385,6 +394,11 @@ const styles = StyleSheet.create({
   },
   noRadius: {
     borderRadius: 0,
+  },
+  customRadiusAndPadding: {
+    borderRadius: 4,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
   },
 });
 

--- a/example/src/Examples/IconButtonExample.tsx
+++ b/example/src/Examples/IconButtonExample.tsx
@@ -162,6 +162,7 @@ const ButtonExample = () => {
             mode="contained"
             style={styles.slightlyRounded}
             size={24}
+            contentStyle={{ padding: 8 }}
             iconColor={MD3Colors.tertiary50}
             onPress={() => {}}
           />
@@ -215,6 +216,8 @@ const styles = StyleSheet.create({
   },
   slightlyRounded: {
     borderRadius: 4,
+    width: 48,
+    height: 48,
   },
   differentBorderRadius: {
     borderTopLeftRadius: 2,

--- a/example/src/Examples/IconButtonExample.tsx
+++ b/example/src/Examples/IconButtonExample.tsx
@@ -157,6 +157,30 @@ const ButtonExample = () => {
             iconColor={MD3Colors.tertiary50}
             onPress={() => {}}
           />
+          <IconButton
+            icon="eye"
+            mode="contained"
+            style={styles.slightlyRounded}
+            size={24}
+            iconColor={MD3Colors.tertiary50}
+            onPress={() => {}}
+          />
+          <IconButton
+            icon="heart"
+            mode="contained-tonal"
+            style={styles.differentBorderRadius}
+            size={24}
+            iconColor={MD3Colors.tertiary50}
+            onPress={() => {}}
+          />
+          <IconButton
+            icon="heart"
+            mode="outlined"
+            style={styles.differentBorderRadius}
+            size={24}
+            iconColor={MD3Colors.tertiary50}
+            onPress={() => {}}
+          />
           <IconButton icon="camera" size={36} onPress={() => {}} />
           <IconButton
             icon="lock"
@@ -188,6 +212,15 @@ const styles = StyleSheet.create({
   },
   square: {
     borderRadius: 0,
+  },
+  slightlyRounded: {
+    borderRadius: 4,
+  },
+  differentBorderRadius: {
+    borderTopLeftRadius: 2,
+    borderTopRightRadius: 4,
+    borderBottomLeftRadius: 8,
+    borderBottomRightRadius: 6,
   },
 });
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -127,7 +127,7 @@ export type Props = $Omit<React.ComponentProps<typeof Surface>, 'mode'> & {
   delayLongPress?: number;
   /**
    * Style of button's inner content.
-   * Use this prop to apply custom height and width and to set the icon on the right with `flexDirection: 'row-reverse'`.
+   * Use this prop to apply custom height and width, to set a custom padding or to set the icon on the right with `flexDirection: 'row-reverse'`.
    */
   contentStyle?: StyleProp<ViewStyle>;
   /**

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -15,7 +15,11 @@ import {
 
 import color from 'color';
 
-import { ButtonMode, getButtonColors } from './utils';
+import {
+  ButtonMode,
+  getButtonColors,
+  getButtonTouchableRippleStyle,
+} from './utils';
 import { useInternalTheme } from '../../core/theming';
 import type { $Omit, ThemeProp } from '../../types';
 import { forwardRef } from '../../utils/forwardRef';
@@ -345,7 +349,7 @@ const Button = (
         accessible={accessible}
         disabled={disabled}
         rippleColor={rippleColor}
-        style={touchableStyle}
+        style={getButtonTouchableRippleStyle(touchableStyle, borderWidth)}
         testID={testID}
         theme={theme}
       >

--- a/src/components/Button/utils.tsx
+++ b/src/components/Button/utils.tsx
@@ -4,6 +4,7 @@ import color from 'color';
 
 import { black, white } from '../../styles/themes/v2/colors';
 import type { InternalTheme } from '../../types';
+import { splitStyles } from '../../utils/splitStyles';
 
 export type ButtonMode =
   | 'text'
@@ -251,10 +252,14 @@ export const getButtonTouchableRippleStyle = (
 ): ViewStyleBorderRadiusStyles => {
   if (!style) return {};
   const touchableRippleStyle: ViewStyleBorderRadiusStyles = {};
+
+  const [, borderRadiusStyles] = splitStyles(
+    style,
+    (style) => style.startsWith('border') && style.endsWith('Radius')
+  );
+
   (
-    Object.keys(style).filter(
-      (key) => key.startsWith('border') && key.endsWith('Radius')
-    ) as Array<keyof ViewStyleBorderRadiusStyles>
+    Object.keys(borderRadiusStyles) as Array<keyof ViewStyleBorderRadiusStyles>
   ).forEach((key) => {
     const value = style[key as keyof ViewStyleBorderRadiusStyles];
     if (typeof value === 'number') {

--- a/src/components/Button/utils.tsx
+++ b/src/components/Button/utils.tsx
@@ -257,9 +257,11 @@ export const getButtonTouchableRippleStyle = (
     ) as Array<keyof ViewStyleBorderRadiusStyles>
   ).forEach((key) => {
     const value = style[key as keyof ViewStyleBorderRadiusStyles];
-    if (typeof value !== 'undefined' && typeof value === 'number')
-      touchableRippleStyle[key as keyof ViewStyleBorderRadiusStyles] =
-        value - borderWidth;
+    if (typeof value !== 'undefined' && typeof value === 'number') {
+      // Only subtract borderWidth if value is greater than 0
+      const radius = value > 0 ? value - borderWidth : 0;
+      touchableRippleStyle[key as keyof ViewStyleBorderRadiusStyles] = radius;
+    }
   });
   return touchableRippleStyle;
 };

--- a/src/components/Button/utils.tsx
+++ b/src/components/Button/utils.tsx
@@ -257,7 +257,7 @@ export const getButtonTouchableRippleStyle = (
     ) as Array<keyof ViewStyleBorderRadiusStyles>
   ).forEach((key) => {
     const value = style[key as keyof ViewStyleBorderRadiusStyles];
-    if (typeof value !== 'undefined' && typeof value === 'number') {
+    if (typeof value === 'number') {
       // Only subtract borderWidth if value is greater than 0
       const radius = value > 0 ? value - borderWidth : 0;
       touchableRippleStyle[key as keyof ViewStyleBorderRadiusStyles] = radius;

--- a/src/components/Button/utils.tsx
+++ b/src/components/Button/utils.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, type ViewStyle } from 'react-native';
 
 import color from 'color';
 
@@ -229,4 +229,37 @@ export const getButtonColors = ({
     textColor,
     borderWidth,
   };
+};
+
+type ViewStyleBorderRadiusStyles = Partial<
+  Pick<
+    ViewStyle,
+    | 'borderBottomEndRadius'
+    | 'borderBottomLeftRadius'
+    | 'borderBottomRightRadius'
+    | 'borderBottomStartRadius'
+    | 'borderTopEndRadius'
+    | 'borderTopLeftRadius'
+    | 'borderTopRightRadius'
+    | 'borderTopStartRadius'
+    | 'borderRadius'
+  >
+>;
+export const getButtonTouchableRippleStyle = (
+  style?: ViewStyle,
+  borderWidth: number = 0
+): ViewStyleBorderRadiusStyles => {
+  if (!style) return {};
+  const touchableRippleStyle: ViewStyleBorderRadiusStyles = {};
+  (
+    Object.keys(style).filter(
+      (key) => key.startsWith('border') && key.endsWith('Radius')
+    ) as Array<keyof ViewStyleBorderRadiusStyles>
+  ).forEach((key) => {
+    const value = style[key as keyof ViewStyleBorderRadiusStyles];
+    if (typeof value !== 'undefined' && typeof value === 'number')
+      touchableRippleStyle[key as keyof ViewStyleBorderRadiusStyles] =
+        value - borderWidth;
+  });
+  return touchableRippleStyle;
 };

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -68,6 +68,11 @@ export type Props = $RemoveChildren<typeof TouchableRipple> & {
    */
   accessibilityLabel?: string;
   /**
+   * Style of button's inner content.
+   * Use this prop to apply custom height and width or to set a custom padding`.
+   */
+  contentStyle?: StyleProp<ViewStyle>;
+  /**
    * Function to execute on press.
    */
   onPress?: (e: GestureResponderEvent) => void;
@@ -127,6 +132,7 @@ const IconButton = forwardRef<View, Props>(
       theme: themeOverrides,
       testID = 'icon-button',
       loading = false,
+      contentStyle,
       ...rest
     }: Props,
     ref
@@ -183,7 +189,7 @@ const IconButton = forwardRef<View, Props>(
           onPress={onPress}
           rippleColor={rippleColor}
           accessibilityLabel={accessibilityLabel}
-          style={styles.touchable}
+          style={[styles.touchable, contentStyle]}
           // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
           accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
           accessibilityComponentType="button"

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -183,7 +183,7 @@ const IconButton = forwardRef<View, Props>(
           onPress={onPress}
           rippleColor={rippleColor}
           accessibilityLabel={accessibilityLabel}
-          style={[styles.touchable, { borderRadius }]}
+          style={styles.touchable}
           // @ts-expect-error We keep old a11y props for backwards compat with old RN versions
           accessibilityTraits={disabled ? ['button', 'disabled'] : 'button'}
           accessibilityComponentType="button"

--- a/src/components/TouchableRipple/TouchableRipple.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.tsx
@@ -156,7 +156,7 @@ const TouchableRipple = (
         // Get the size of the button to determine how big the ripple should be
         const size = centered
           ? // If ripple is always centered, we don't need to make it too big
-            Math.min(dimensions.width, dimensions.height) * 1.25
+            Math.min(dimensions.width, dimensions.height) * 1.5
           : // Otherwise make it twice as big so clicking on one end spreads ripple to other
             Math.max(dimensions.width, dimensions.height) * 2;
 

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
@@ -169,11 +169,14 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                   {
                     "overflow": "hidden",
                   },
-                  {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                  },
+                  [
+                    {
+                      "alignItems": "center",
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    },
+                    undefined,
+                  ],
                 ]
               }
               testID="search-bar-icon"
@@ -357,11 +360,14 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                     {
                       "overflow": "hidden",
                     },
-                    {
-                      "alignItems": "center",
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    },
+                    [
+                      {
+                        "alignItems": "center",
+                        "flexGrow": 1,
+                        "justifyContent": "center",
+                      },
+                      undefined,
+                    ],
                   ]
                 }
                 testID="search-bar-clear-icon"
@@ -544,11 +550,14 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
               {
                 "overflow": "hidden",
               },
-              {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
-              },
+              [
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                undefined,
+              ],
             ]
           }
           testID="icon-button"
@@ -782,11 +791,14 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
               {
                 "overflow": "hidden",
               },
-              {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
-              },
+              [
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                undefined,
+              ],
             ]
           }
           testID="icon-button"

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
@@ -169,16 +169,11 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                   {
                     "overflow": "hidden",
                   },
-                  [
-                    {
-                      "alignItems": "center",
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    },
-                    {
-                      "borderRadius": 20,
-                    },
-                  ],
+                  {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                  },
                 ]
               }
               testID="search-bar-icon"
@@ -362,16 +357,11 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                     {
                       "overflow": "hidden",
                     },
-                    [
-                      {
-                        "alignItems": "center",
-                        "flexGrow": 1,
-                        "justifyContent": "center",
-                      },
-                      {
-                        "borderRadius": 20,
-                      },
-                    ],
+                    {
+                      "alignItems": "center",
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    },
                   ]
                 }
                 testID="search-bar-clear-icon"
@@ -554,16 +544,11 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
               {
                 "overflow": "hidden",
               },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                {
-                  "borderRadius": 20,
-                },
-              ],
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
             ]
           }
           testID="icon-button"
@@ -797,16 +782,11 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
               {
                 "overflow": "hidden",
               },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                {
-                  "borderRadius": 20,
-                },
-              ],
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
             ]
           }
           testID="icon-button"

--- a/src/components/__tests__/Button.test.tsx
+++ b/src/components/__tests__/Button.test.tsx
@@ -159,6 +159,28 @@ it('renders button with custom border radius', () => {
   expect(getByTestId('custom-radius')).toHaveStyle(styles.customRadius);
 });
 
+it('renders outlined button with custom border radius', () => {
+  const { getByTestId } = render(
+    <Button
+      mode={'outlined'}
+      testID="custom-radius"
+      style={styles.customRadius}
+    >
+      Custom radius
+    </Button>
+  );
+
+  expect(getByTestId('custom-radius-container')).toHaveStyle(
+    styles.customRadius
+  );
+  expect(getByTestId('custom-radius')).toHaveStyle({
+    borderTopLeftRadius: 15, // styles.customRadius - 1px outline
+    borderTopRightRadius: 0,
+    borderBottomLeftRadius: 0,
+    borderBottomRightRadius: 15, // styles.customRadius - 1px outline
+  });
+});
+
 it('renders button without border radius', () => {
   const { getByTestId } = render(
     <Button testID="custom-radius" style={styles.noRadius}>

--- a/src/components/__tests__/IconButton.test.tsx
+++ b/src/components/__tests__/IconButton.test.tsx
@@ -13,6 +13,9 @@ const styles = StyleSheet.create({
   square: {
     borderRadius: 0,
   },
+  slightlyRounded: {
+    borderRadius: 4,
+  },
 });
 
 it('renders icon button by default', () => {
@@ -58,7 +61,21 @@ it('renders icon button with custom border radius', () => {
     />
   );
 
-  expect(getByTestId('icon-button')).toHaveStyle({ borderRadius: 0 });
+  expect(getByTestId('icon-button-container')).toHaveStyle({ borderRadius: 0 });
+});
+
+it('renders icon button with small border radius', () => {
+  const { getByTestId } = render(
+    <IconButton
+      icon="camera"
+      testID="icon-button"
+      size={36}
+      onPress={() => {}}
+      style={styles.slightlyRounded}
+    />
+  );
+
+  expect(getByTestId('icon-button-container')).toHaveStyle({ borderRadius: 4 });
 });
 
 describe('getIconButtonColor - icon color', () => {

--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -1902,7 +1902,7 @@ exports[`renders outlined button with mode 1`] = `
             "overflow": "hidden",
           },
           {
-            "borderRadius": 20,
+            "borderRadius": 19,
           },
         ]
       }

--- a/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -469,16 +469,11 @@ exports[`DataTable.Pagination renders data table pagination 1`] = `
               {
                 "overflow": "hidden",
               },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                {
-                  "borderRadius": 20,
-                },
-              ],
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
             ]
           }
           testID="icon-button"
@@ -612,16 +607,11 @@ exports[`DataTable.Pagination renders data table pagination 1`] = `
               {
                 "overflow": "hidden",
               },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                {
-                  "borderRadius": 20,
-                },
-              ],
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
             ]
           }
           testID="icon-button"
@@ -813,16 +803,11 @@ exports[`DataTable.Pagination renders data table pagination with fast-forward bu
               {
                 "overflow": "hidden",
               },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                {
-                  "borderRadius": 20,
-                },
-              ],
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
             ]
           }
           testID="icon-button"
@@ -956,16 +941,11 @@ exports[`DataTable.Pagination renders data table pagination with fast-forward bu
               {
                 "overflow": "hidden",
               },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                {
-                  "borderRadius": 20,
-                },
-              ],
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
             ]
           }
           testID="icon-button"
@@ -1099,16 +1079,11 @@ exports[`DataTable.Pagination renders data table pagination with fast-forward bu
               {
                 "overflow": "hidden",
               },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                {
-                  "borderRadius": 20,
-                },
-              ],
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
             ]
           }
           testID="icon-button"
@@ -1242,16 +1217,11 @@ exports[`DataTable.Pagination renders data table pagination with fast-forward bu
               {
                 "overflow": "hidden",
               },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                {
-                  "borderRadius": 20,
-                },
-              ],
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
             ]
           }
           testID="icon-button"
@@ -1443,16 +1413,11 @@ exports[`DataTable.Pagination renders data table pagination with label 1`] = `
               {
                 "overflow": "hidden",
               },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                {
-                  "borderRadius": 20,
-                },
-              ],
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
             ]
           }
           testID="icon-button"
@@ -1586,16 +1551,11 @@ exports[`DataTable.Pagination renders data table pagination with label 1`] = `
               {
                 "overflow": "hidden",
               },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                {
-                  "borderRadius": 20,
-                },
-              ],
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
             ]
           }
           testID="icon-button"
@@ -2038,16 +1998,11 @@ exports[`DataTable.Pagination renders data table pagination with options select 
               {
                 "overflow": "hidden",
               },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                {
-                  "borderRadius": 20,
-                },
-              ],
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
             ]
           }
           testID="icon-button"
@@ -2181,16 +2136,11 @@ exports[`DataTable.Pagination renders data table pagination with options select 
               {
                 "overflow": "hidden",
               },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                {
-                  "borderRadius": 20,
-                },
-              ],
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
             ]
           }
           testID="icon-button"
@@ -2324,16 +2274,11 @@ exports[`DataTable.Pagination renders data table pagination with options select 
               {
                 "overflow": "hidden",
               },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                {
-                  "borderRadius": 20,
-                },
-              ],
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
             ]
           }
           testID="icon-button"
@@ -2467,16 +2412,11 @@ exports[`DataTable.Pagination renders data table pagination with options select 
               {
                 "overflow": "hidden",
               },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                {
-                  "borderRadius": 20,
-                },
-              ],
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
             ]
           }
           testID="icon-button"

--- a/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -469,11 +469,14 @@ exports[`DataTable.Pagination renders data table pagination 1`] = `
               {
                 "overflow": "hidden",
               },
-              {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
-              },
+              [
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                undefined,
+              ],
             ]
           }
           testID="icon-button"
@@ -607,11 +610,14 @@ exports[`DataTable.Pagination renders data table pagination 1`] = `
               {
                 "overflow": "hidden",
               },
-              {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
-              },
+              [
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                undefined,
+              ],
             ]
           }
           testID="icon-button"
@@ -803,11 +809,14 @@ exports[`DataTable.Pagination renders data table pagination with fast-forward bu
               {
                 "overflow": "hidden",
               },
-              {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
-              },
+              [
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                undefined,
+              ],
             ]
           }
           testID="icon-button"
@@ -941,11 +950,14 @@ exports[`DataTable.Pagination renders data table pagination with fast-forward bu
               {
                 "overflow": "hidden",
               },
-              {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
-              },
+              [
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                undefined,
+              ],
             ]
           }
           testID="icon-button"
@@ -1079,11 +1091,14 @@ exports[`DataTable.Pagination renders data table pagination with fast-forward bu
               {
                 "overflow": "hidden",
               },
-              {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
-              },
+              [
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                undefined,
+              ],
             ]
           }
           testID="icon-button"
@@ -1217,11 +1232,14 @@ exports[`DataTable.Pagination renders data table pagination with fast-forward bu
               {
                 "overflow": "hidden",
               },
-              {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
-              },
+              [
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                undefined,
+              ],
             ]
           }
           testID="icon-button"
@@ -1413,11 +1431,14 @@ exports[`DataTable.Pagination renders data table pagination with label 1`] = `
               {
                 "overflow": "hidden",
               },
-              {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
-              },
+              [
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                undefined,
+              ],
             ]
           }
           testID="icon-button"
@@ -1551,11 +1572,14 @@ exports[`DataTable.Pagination renders data table pagination with label 1`] = `
               {
                 "overflow": "hidden",
               },
-              {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
-              },
+              [
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                undefined,
+              ],
             ]
           }
           testID="icon-button"
@@ -1998,11 +2022,14 @@ exports[`DataTable.Pagination renders data table pagination with options select 
               {
                 "overflow": "hidden",
               },
-              {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
-              },
+              [
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                undefined,
+              ],
             ]
           }
           testID="icon-button"
@@ -2136,11 +2163,14 @@ exports[`DataTable.Pagination renders data table pagination with options select 
               {
                 "overflow": "hidden",
               },
-              {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
-              },
+              [
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                undefined,
+              ],
             ]
           }
           testID="icon-button"
@@ -2274,11 +2304,14 @@ exports[`DataTable.Pagination renders data table pagination with options select 
               {
                 "overflow": "hidden",
               },
-              {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
-              },
+              [
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                undefined,
+              ],
             ]
           }
           testID="icon-button"
@@ -2412,11 +2445,14 @@ exports[`DataTable.Pagination renders data table pagination with options select 
               {
                 "overflow": "hidden",
               },
-              {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
-              },
+              [
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                undefined,
+              ],
             ]
           }
           testID="icon-button"

--- a/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -1741,7 +1741,7 @@ exports[`DataTable.Pagination renders data table pagination with options select 
                   "overflow": "hidden",
                 },
                 {
-                  "borderRadius": 20,
+                  "borderRadius": 19,
                 },
               ]
             }

--- a/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
@@ -95,16 +95,11 @@ exports[`renders disabled icon button 1`] = `
           {
             "overflow": "hidden",
           },
-          [
-            {
-              "alignItems": "center",
-              "flexGrow": 1,
-              "justifyContent": "center",
-            },
-            {
-              "borderRadius": 20,
-            },
-          ],
+          {
+            "alignItems": "center",
+            "flexGrow": 1,
+            "justifyContent": "center",
+          },
         ]
       }
       testID="icon-button"
@@ -240,16 +235,11 @@ exports[`renders icon button by default 1`] = `
           {
             "overflow": "hidden",
           },
-          [
-            {
-              "alignItems": "center",
-              "flexGrow": 1,
-              "justifyContent": "center",
-            },
-            {
-              "borderRadius": 20,
-            },
-          ],
+          {
+            "alignItems": "center",
+            "flexGrow": 1,
+            "justifyContent": "center",
+          },
         ]
       }
       testID="icon-button"
@@ -385,16 +375,11 @@ exports[`renders icon button with color 1`] = `
           {
             "overflow": "hidden",
           },
-          [
-            {
-              "alignItems": "center",
-              "flexGrow": 1,
-              "justifyContent": "center",
-            },
-            {
-              "borderRadius": 20,
-            },
-          ],
+          {
+            "alignItems": "center",
+            "flexGrow": 1,
+            "justifyContent": "center",
+          },
         ]
       }
       testID="icon-button"
@@ -530,16 +515,11 @@ exports[`renders icon button with size 1`] = `
           {
             "overflow": "hidden",
           },
-          [
-            {
-              "alignItems": "center",
-              "flexGrow": 1,
-              "justifyContent": "center",
-            },
-            {
-              "borderRadius": 23,
-            },
-          ],
+          {
+            "alignItems": "center",
+            "flexGrow": 1,
+            "justifyContent": "center",
+          },
         ]
       }
       testID="icon-button"
@@ -675,16 +655,11 @@ exports[`renders icon change animated 1`] = `
           {
             "overflow": "hidden",
           },
-          [
-            {
-              "alignItems": "center",
-              "flexGrow": 1,
-              "justifyContent": "center",
-            },
-            {
-              "borderRadius": 20,
-            },
-          ],
+          {
+            "alignItems": "center",
+            "flexGrow": 1,
+            "justifyContent": "center",
+          },
         ]
       }
       testID="icon-button"

--- a/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
@@ -95,11 +95,14 @@ exports[`renders disabled icon button 1`] = `
           {
             "overflow": "hidden",
           },
-          {
-            "alignItems": "center",
-            "flexGrow": 1,
-            "justifyContent": "center",
-          },
+          [
+            {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            },
+            undefined,
+          ],
         ]
       }
       testID="icon-button"
@@ -235,11 +238,14 @@ exports[`renders icon button by default 1`] = `
           {
             "overflow": "hidden",
           },
-          {
-            "alignItems": "center",
-            "flexGrow": 1,
-            "justifyContent": "center",
-          },
+          [
+            {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            },
+            undefined,
+          ],
         ]
       }
       testID="icon-button"
@@ -375,11 +381,14 @@ exports[`renders icon button with color 1`] = `
           {
             "overflow": "hidden",
           },
-          {
-            "alignItems": "center",
-            "flexGrow": 1,
-            "justifyContent": "center",
-          },
+          [
+            {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            },
+            undefined,
+          ],
         ]
       }
       testID="icon-button"
@@ -515,11 +524,14 @@ exports[`renders icon button with size 1`] = `
           {
             "overflow": "hidden",
           },
-          {
-            "alignItems": "center",
-            "flexGrow": 1,
-            "justifyContent": "center",
-          },
+          [
+            {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            },
+            undefined,
+          ],
         ]
       }
       testID="icon-button"
@@ -655,11 +667,14 @@ exports[`renders icon change animated 1`] = `
           {
             "overflow": "hidden",
           },
-          {
-            "alignItems": "center",
-            "flexGrow": 1,
-            "justifyContent": "center",
-          },
+          [
+            {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            },
+            undefined,
+          ],
         ]
       }
       testID="icon-button"

--- a/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`renders menu with content styles 1`] = `
                   "overflow": "hidden",
                 },
                 {
-                  "borderRadius": 20,
+                  "borderRadius": 19,
                 },
               ]
             }
@@ -642,7 +642,7 @@ exports[`renders not visible menu 1`] = `
                 "overflow": "hidden",
               },
               {
-                "borderRadius": 20,
+                "borderRadius": 19,
               },
             ]
           }
@@ -808,7 +808,7 @@ exports[`renders visible menu 1`] = `
                   "overflow": "hidden",
                 },
                 {
-                  "borderRadius": 20,
+                  "borderRadius": 19,
                 },
               ]
             }

--- a/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
@@ -128,11 +128,14 @@ exports[`activity indicator snapshot test 1`] = `
               {
                 "overflow": "hidden",
               },
-              {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
-              },
+              [
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                undefined,
+              ],
             ]
           }
           testID="search-bar-icon"
@@ -542,11 +545,14 @@ exports[`renders with placeholder 1`] = `
               {
                 "overflow": "hidden",
               },
-              {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
-              },
+              [
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                undefined,
+              ],
             ]
           }
           testID="search-bar-icon"
@@ -730,11 +736,14 @@ exports[`renders with placeholder 1`] = `
                 {
                   "overflow": "hidden",
                 },
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
+                [
+                  {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                  },
+                  undefined,
+                ],
               ]
             }
             testID="search-bar-clear-icon"
@@ -911,11 +920,14 @@ exports[`renders with text 1`] = `
               {
                 "overflow": "hidden",
               },
-              {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
-              },
+              [
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                undefined,
+              ],
             ]
           }
           testID="search-bar-icon"
@@ -1095,11 +1107,14 @@ exports[`renders with text 1`] = `
                 {
                   "overflow": "hidden",
                 },
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
+                [
+                  {
+                    "alignItems": "center",
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                  },
+                  undefined,
+                ],
               ]
             }
             testID="search-bar-clear-icon"

--- a/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
@@ -128,16 +128,11 @@ exports[`activity indicator snapshot test 1`] = `
               {
                 "overflow": "hidden",
               },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                {
-                  "borderRadius": 20,
-                },
-              ],
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
             ]
           }
           testID="search-bar-icon"
@@ -547,16 +542,11 @@ exports[`renders with placeholder 1`] = `
               {
                 "overflow": "hidden",
               },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                {
-                  "borderRadius": 20,
-                },
-              ],
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
             ]
           }
           testID="search-bar-icon"
@@ -740,16 +730,11 @@ exports[`renders with placeholder 1`] = `
                 {
                   "overflow": "hidden",
                 },
-                [
-                  {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                  },
-                  {
-                    "borderRadius": 20,
-                  },
-                ],
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
               ]
             }
             testID="search-bar-clear-icon"
@@ -926,16 +911,11 @@ exports[`renders with text 1`] = `
               {
                 "overflow": "hidden",
               },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                {
-                  "borderRadius": 20,
-                },
-              ],
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
             ]
           }
           testID="search-bar-icon"
@@ -1115,16 +1095,11 @@ exports[`renders with text 1`] = `
                 {
                   "overflow": "hidden",
                 },
-                [
-                  {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                  },
-                  {
-                    "borderRadius": 20,
-                  },
-                ],
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
               ]
             }
             testID="search-bar-clear-icon"

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -1861,16 +1861,11 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
               {
                 "overflow": "hidden",
               },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                {
-                  "borderRadius": 20,
-                },
-              ],
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
             ]
           }
           testID="right-icon-adornment"
@@ -2222,16 +2217,11 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
               {
                 "overflow": "hidden",
               },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                {
-                  "borderRadius": 20,
-                },
-              ],
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
             ]
           }
           testID="left-icon-adornment"

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -1861,11 +1861,14 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
               {
                 "overflow": "hidden",
               },
-              {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
-              },
+              [
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                undefined,
+              ],
             ]
           }
           testID="right-icon-adornment"
@@ -2217,11 +2220,14 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
               {
                 "overflow": "hidden",
               },
-              {
-                "alignItems": "center",
-                "flexGrow": 1,
-                "justifyContent": "center",
-              },
+              [
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                },
+                undefined,
+              ],
             ]
           }
           testID="left-icon-adornment"

--- a/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -93,16 +93,11 @@ exports[`renders disabled toggle button 1`] = `
       style={
         [
           false,
-          [
-            {
-              "alignItems": "center",
-              "flexGrow": 1,
-              "justifyContent": "center",
-            },
-            {
-              "borderRadius": 4,
-            },
-          ],
+          {
+            "alignItems": "center",
+            "flexGrow": 1,
+            "justifyContent": "center",
+          },
         ]
       }
       testID="icon-button"
@@ -236,16 +231,11 @@ exports[`renders toggle button 1`] = `
       style={
         [
           false,
-          [
-            {
-              "alignItems": "center",
-              "flexGrow": 1,
-              "justifyContent": "center",
-            },
-            {
-              "borderRadius": 4,
-            },
-          ],
+          {
+            "alignItems": "center",
+            "flexGrow": 1,
+            "justifyContent": "center",
+          },
         ]
       }
       testID="icon-button"
@@ -384,16 +374,11 @@ exports[`renders unchecked toggle button 1`] = `
       style={
         [
           false,
-          [
-            {
-              "alignItems": "center",
-              "flexGrow": 1,
-              "justifyContent": "center",
-            },
-            {
-              "borderRadius": 4,
-            },
-          ],
+          {
+            "alignItems": "center",
+            "flexGrow": 1,
+            "justifyContent": "center",
+          },
         ]
       }
       testID="icon-button"

--- a/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -93,11 +93,14 @@ exports[`renders disabled toggle button 1`] = `
       style={
         [
           false,
-          {
-            "alignItems": "center",
-            "flexGrow": 1,
-            "justifyContent": "center",
-          },
+          [
+            {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            },
+            undefined,
+          ],
         ]
       }
       testID="icon-button"
@@ -231,11 +234,14 @@ exports[`renders toggle button 1`] = `
       style={
         [
           false,
-          {
-            "alignItems": "center",
-            "flexGrow": 1,
-            "justifyContent": "center",
-          },
+          [
+            {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            },
+            undefined,
+          ],
         ]
       }
       testID="icon-button"
@@ -374,11 +380,14 @@ exports[`renders unchecked toggle button 1`] = `
       style={
         [
           false,
-          {
-            "alignItems": "center",
-            "flexGrow": 1,
-            "justifyContent": "center",
-          },
+          [
+            {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            },
+            undefined,
+          ],
         ]
       }
       testID="icon-button"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Resolve issue #4266 


### Description

#### Removes the `borderRadius` from the `IconButton` inner `TouchableRipple`.

Using `overflow: hidden` is enough for the inner views to fit the parent view, even taking care of the parent view `borderRadius`.

| Before | After |
| ------- | ------- |
| ![Shot 2024-01-15 at 20 26 40](https://github.com/callstack/react-native-paper/assets/10360816/3191bd4e-c42d-48f9-bb67-58ada411746a) | ![Shot 2024-01-15 at 20 27 22](https://github.com/callstack/react-native-paper/assets/10360816/7d12c952-ec2a-41fa-ad55-394dbd3a4349) |

After the changes, we can even set custom border radius for each corner of `IconButton` and the `TouchableRipple` will fill the button properly

https://github.com/callstack/react-native-paper/assets/10360816/55de1430-d59f-4844-a7bf-fc43b69aa731

#### Updates the `Button` inner `TouchableRipple` props to make the ripple fill the `Button` surface.

The `overflow: hidden` trick could not be applied to `Button` as its `Surface` can be elevated, and when using `overflow: hidden` the elevation shadow will not be displayed correctly.

> It's slightly hard to notice, but before, in the rounded corners it would be a space of ~1px due to the `borderWidth`

| Before | After |
| ------- | ------- |
| ![Shot 2024-01-15 at 20 23 54](https://github.com/callstack/react-native-paper/assets/10360816/3ad3e033-44d4-4227-a2bd-e755bf785d70) | ![Shot 2024-01-15 at 20 22 40](https://github.com/callstack/react-native-paper/assets/10360816/1b1b2b78-eb31-4bfe-a525-42e3e1b1b4ce) |
| ![Shot 2024-01-15 at 20 39 19@2x](https://github.com/callstack/react-native-paper/assets/10360816/a2464b83-e30f-4ee0-8cc8-5f3aaa384ffd) | ![Shot 2024-01-15 at 20 38 37@2x](https://github.com/callstack/react-native-paper/assets/10360816/ea933412-7d89-4db9-8081-9a3878f17d98) |


#### Adds `contentStyle` prop to `IconButton`, similar to the one in `Button`

Previously there was no way to customize the `IconButton` padding, as if we set it to the `style` prop, it would cause the inner `TouchableRipple` to not fill the `IconButton`. Now, `contentStyle` allows doing so by setting the styles to the inner `TouchableRipple` view.



### Test plan

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->

Run `yarn example web` to run the example project and view the updated examples for `Button` and `IconButton`
