### PR TITLE
docs: Update Modal.tsx description to note a11y limitations

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -69,6 +69,7 @@ const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 /**
  * The Modal component is a simple way to present content above an enclosing view.
  * To render the `Modal` above other components, you'll need to wrap it with the [`Portal`](./Portal) component.
+ * Note that this modal is NOT accessible by default; if you need an accessible modal, please use the React Native Modal.
  *
  * ## Usage
  * ```js


### PR DESCRIPTION
### Motivation

Currently, the RNP modal is nearly totally non-accessible, because it renders outside the normal element hierarchy, and so a screen-reader user, navigating by the most common methods (next-element swipe or next-heading), will continue on the page without even being aware the modal has opened. The intended behavior for modals (as seen with the [React Native modal](https://reactnative.dev/docs/modal), or web modals), is for focus to shift to the modal as soon as the modal opens. With the RNP modal, focus remains unaffected, leaving the screen-reader user unaware a modal has even opened, and unable to reach it via the most common navigation actions (next-element or next-heading). 

This adds a note to the docs making end-users aware of this limitation. **This is vitally important, as currently any app implementing the RNP modal becomes an inaccessible app.** (This was responsible for 8 of the top issues in our app flagged during an external accessibility audit, and resulted in us having to pull out all the RNP modals and replace them with either bottomsheets or generic RN modals.) **End users need to be aware of this limitation before they choose to use this component.**

### Related issue

This is related to #3912, but does not address it; it just makes end-users aware of the issue.

### Test plan

Check that text is clear and correctly formatted.