### PR TITLE
Feat: missing imports for bottom navigation example

### DIFF
--- a/src/components/BottomNavigation/BottomNavigationBar.tsx
+++ b/src/components/BottomNavigation/BottomNavigationBar.tsx
@@ -253,6 +253,7 @@ const Touchable = <Route extends BaseRoute>({
  * import { View, StyleSheet } from 'react-native';
  *
  * import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+ * import { CommonActions } from "@react-navigation/native";
  * import { Text, BottomNavigation } from 'react-native-paper';
  * import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
  *


### PR DESCRIPTION

### Motivation

In the example of the [BottomNavigation.Bar component ](https://callstack.github.io/react-native-paper/docs/components/BottomNavigation/BottomNavigationBar), there is a missing import.

This PR add this import

### Test plan

Check that the import is in the example
