### PR TITLE
fix: correct elevation in disabled button for MD2

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -325,7 +325,7 @@ const Button = (
           compact && styles.compact,
           buttonStyle,
           style,
-          !isV3 && { elevation },
+          !isV3 && !disabled && { elevation },
         ] as ViewStyle
       }
       {...(isV3 && { elevation: elevation })}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Fixes `elevation` value - reset it to 0 - when `Button` is disabled in MD2.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### Related issue

- #4151 

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

Tested according to the latest expo snack attached in the issue.

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
