### PR TITLE
fix: incorrect imports

### DIFF
--- a/src/components/Appbar/AppbarAction.tsx
+++ b/src/components/Appbar/AppbarAction.tsx
@@ -8,10 +8,10 @@ import type {
 } from 'react-native';
 
 import color from 'color';
-import type { ThemeProp } from 'src/types';
 
 import { useInternalTheme } from '../../core/theming';
 import { black } from '../../styles/themes/v2/colors';
+import type { ThemeProp } from '../../types';
 import { forwardRef } from '../../utils/forwardRef';
 import type { IconSource } from '../Icon';
 import IconButton from '../IconButton/IconButton';

--- a/src/components/BottomNavigation/utils.ts
+++ b/src/components/BottomNavigation/utils.ts
@@ -1,7 +1,7 @@
 import color from 'color';
-import type { InternalTheme } from 'src/types';
 
 import type { black, white } from '../../styles/themes/v2/colors';
+import type { InternalTheme } from '../../types';
 
 type BaseProps = {
   defaultColor: typeof black | typeof white;

--- a/src/components/Card/CardActions.tsx
+++ b/src/components/Card/CardActions.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 
-import type { ThemeProp } from 'src/types';
-
 import { useInternalTheme } from '../../core/theming';
+import type { ThemeProp } from '../../types';
 
 export type Props = React.ComponentPropsWithRef<typeof View> & {
   /**

--- a/src/components/DataTable/DataTablePagination.tsx
+++ b/src/components/DataTable/DataTablePagination.tsx
@@ -9,9 +9,9 @@ import {
 } from 'react-native';
 
 import color from 'color';
-import type { ThemeProp } from 'src/types';
 
 import { useInternalTheme } from '../../core/theming';
+import type { ThemeProp } from '../../types';
 import Button from '../Button/Button';
 import IconButton from '../IconButton/IconButton';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';

--- a/src/components/Dialog/DialogActions.tsx
+++ b/src/components/Dialog/DialogActions.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 
-import type { ThemeProp } from 'src/types';
-
 import { useInternalTheme } from '../../core/theming';
+import type { ThemeProp } from '../../types';
 
 export type Props = React.ComponentPropsWithRef<typeof View> & {
   /**

--- a/src/components/Dialog/DialogIcon.tsx
+++ b/src/components/Dialog/DialogIcon.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import type { ThemeProp } from 'src/types';
-
 import { useInternalTheme } from '../../core/theming';
+import type { ThemeProp } from '../../types';
 import Icon, { IconSource } from '../Icon';
 
 export type Props = {

--- a/src/components/Dialog/DialogScrollArea.tsx
+++ b/src/components/Dialog/DialogScrollArea.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 
-import type { ThemeProp } from 'src/types';
-
 import { useInternalTheme } from '../../core/theming';
+import type { ThemeProp } from '../../types';
 
 export type Props = React.ComponentPropsWithRef<typeof View> & {
   /**

--- a/src/components/List/ListSubheader.tsx
+++ b/src/components/List/ListSubheader.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import { StyleProp, StyleSheet, TextStyle } from 'react-native';
 
 import color from 'color';
-import type { ThemeProp } from 'src/types';
 
 import { useInternalTheme } from '../../core/theming';
+import type { ThemeProp } from '../../types';
 import Text from '../Typography/Text';
 
 export type Props = React.ComponentProps<typeof Text> & {

--- a/src/components/List/utils.ts
+++ b/src/components/List/utils.ts
@@ -1,7 +1,8 @@
 import { FlexAlignType, ColorValue, StyleSheet } from 'react-native';
 
 import color from 'color';
-import type { EllipsizeProp, InternalTheme } from 'src/types';
+
+import type { EllipsizeProp, InternalTheme } from '../../types';
 
 type Description =
   | React.ReactNode

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 
-import type { InternalTheme } from 'src/types';
-
 import PortalConsumer from './PortalConsumer';
 import PortalHost, { PortalContext, PortalMethods } from './PortalHost';
 import {
@@ -9,6 +7,7 @@ import {
   Provider as SettingsProvider,
 } from '../../core/settings';
 import { ThemeProvider, withInternalTheme } from '../../core/theming';
+import type { InternalTheme } from '../../types';
 
 export type Props = {
   /**

--- a/src/components/SegmentedButtons/SegmentedButtonItem.tsx
+++ b/src/components/SegmentedButtons/SegmentedButtonItem.tsx
@@ -12,7 +12,6 @@ import {
 } from 'react-native';
 
 import color from 'color';
-import type { ThemeProp } from 'src/types';
 
 import {
   getSegmentedButtonBorderRadius,
@@ -20,6 +19,7 @@ import {
   getSegmentedButtonDensityPadding,
 } from './utils';
 import { useInternalTheme } from '../../core/theming';
+import type { ThemeProp } from '../../types';
 import type { IconSource } from '../Icon';
 import Icon from '../Icon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';

--- a/src/components/SegmentedButtons/SegmentedButtons.tsx
+++ b/src/components/SegmentedButtons/SegmentedButtons.tsx
@@ -8,11 +8,10 @@ import {
   ViewStyle,
 } from 'react-native';
 
-import type { ThemeProp } from 'src/types';
-
 import SegmentedButtonItem from './SegmentedButtonItem';
 import { getDisabledSegmentedButtonStyle } from './utils';
 import { useInternalTheme } from '../../core/theming';
+import type { ThemeProp } from '../../types';
 import type { IconSource } from '../Icon';
 
 type ConditionalValue =

--- a/src/components/TextInput/Addons/Underline.tsx
+++ b/src/components/TextInput/Addons/Underline.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { Animated, StyleSheet, StyleProp, ViewStyle } from 'react-native';
 
-import type { ThemeProp } from 'src/types';
-
 import { useInternalTheme } from '../../../core/theming';
+import type { ThemeProp } from '../../../types';
 
 type UnderlineProps = {
   parentState: {

--- a/src/components/TextInput/Adornment/TextInputAdornment.tsx
+++ b/src/components/TextInput/Adornment/TextInputAdornment.tsx
@@ -6,8 +6,6 @@ import type {
   Animated,
 } from 'react-native';
 
-import type { ThemeProp } from 'src/types';
-
 import { AdornmentSide, AdornmentType, InputMode } from './enums';
 import TextInputAffix, { AffixAdornment } from './TextInputAffix';
 import TextInputIcon, { IconAdornment } from './TextInputIcon';
@@ -15,6 +13,7 @@ import type {
   AdornmentConfig,
   AdornmentStyleAdjustmentForNativeInput,
 } from './types';
+import type { ThemeProp } from '../../../types';
 import { getConstants } from '../helpers';
 
 export function getAdornmentConfig({

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -9,10 +9,9 @@ import {
   ViewStyle,
 } from 'react-native';
 
-import type { ThemeProp } from 'src/types';
-
 import { getTooltipPosition, Measurement } from './utils';
 import { useInternalTheme } from '../../core/theming';
+import type { ThemeProp } from '../../types';
 import { addEventListener } from '../../utils/addEventListener';
 import Portal from '../Portal/Portal';
 import Text from '../Typography/Text';

--- a/src/components/Typography/v2/StyledText.tsx
+++ b/src/components/Typography/v2/StyledText.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import { I18nManager, StyleProp, StyleSheet, TextStyle } from 'react-native';
 
 import color from 'color';
-import type { ThemeProp } from 'src/types';
 
 import Text from './Text';
 import { useInternalTheme } from '../../../core/theming';
+import type { ThemeProp } from '../../../types';
 
 type Props = React.ComponentProps<typeof Text> & {
   alpha?: number;

--- a/src/components/Typography/v2/Text.tsx
+++ b/src/components/Typography/v2/Text.tsx
@@ -6,9 +6,8 @@ import {
   TextStyle,
 } from 'react-native';
 
-import type { MD2Theme } from 'src/types';
-
 import { useInternalTheme } from '../../../core/theming';
+import type { MD2Theme } from '../../../types';
 import { forwardRef } from '../../../utils/forwardRef';
 
 type Props = React.ComponentProps<typeof NativeText> & {


### PR DESCRIPTION
### Motivation

TypeScript build `tsc --noEmit` is failed in applications when using some components from `react-native-paper`

Example: `error TS2305: Module '"src/types"' has no exported member 'ThemeProp'`