### PR TITLE
feat(button): add trailing icon support

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -75,7 +75,7 @@ export type Props = $Omit<React.ComponentProps<typeof Surface>, 'mode'> & {
   /**
    * Trailing icon to display for the `Button`.
    */
-  trailingIcon? IconSource;
+  trailingIcon?: IconSource;
   /**
    * Whether the button is disabled. A disabled button is greyed out and `onPress` is not called on touch.
    */
@@ -419,11 +419,13 @@ const Button = (
           >
             {children}
           </Text>
-          <View style={[styles.content, contentStyle]}>
-          {trailingIcon && loading !== true ? (
-            <View style={trailingIconStyle} testID={`${testID}-trailing-icon-container`}>
+          {trailingIcon ? (
+            <View
+              style={trailingIconStyle}
+              testID={`${testID}-trailing-icon-container`}
+            >
               <Icon
-                source={trailingIcon}
+                source={trailingIconStyle}
                 size={customLabelSize ?? iconSize}
                 color={
                   typeof customLabelColor === 'string'

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -319,7 +319,7 @@ const Button = (
             styles[`md3IconTextMode${compact ? 'Compact' : ''}`],
         ];
 
-  const trailingIconStyle = 
+  const trailingIconStyle =
     StyleSheet.flatten(contentStyle)?.flexDirection === 'row-reverse'
       ? [
           styles.icon,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -73,6 +73,10 @@ export type Props = $Omit<React.ComponentProps<typeof Surface>, 'mode'> & {
    */
   icon?: IconSource;
   /**
+   * Trailing icon to display for the `Button`.
+   */
+  trailingIcon? IconSource;
+  /**
    * Whether the button is disabled. A disabled button is greyed out and `onPress` is not called on touch.
    */
   disabled?: boolean;
@@ -170,6 +174,7 @@ const Button = (
     dark,
     loading,
     icon,
+    trailingIcon,
     buttonColor: customButtonColor,
     textColor: customTextColor,
     rippleColor: customRippleColor,
@@ -314,6 +319,23 @@ const Button = (
             styles[`md3IconTextMode${compact ? 'Compact' : ''}`],
         ];
 
+  const trailingIconStyle = 
+    StyleSheet.flatten(contentStyle)?.flexDirection === 'row-reverse'
+      ? [
+          styles.icon,
+          isV3 && styles[`md3Icon${compact ? 'Compact' : ''}`],
+          isV3 &&
+            isMode('text') &&
+            styles[`md3IconTextMode${compact ? 'Compact' : ''}`],
+        ]
+      : [
+          styles.iconReverse,
+          isV3 && styles[`md3IconReverse${compact ? 'Compact' : ''}`],
+          isV3 &&
+            isMode('text') &&
+            styles[`md3IconReverseTextMode${compact ? 'Compact' : ''}`],
+        ];
+
   return (
     <Surface
       {...rest}
@@ -397,6 +419,20 @@ const Button = (
           >
             {children}
           </Text>
+          <View style={[styles.content, contentStyle]}>
+          {trailingIcon && loading !== true ? (
+            <View style={trailingIconStyle} testID={`${testID}-trailing-icon-container`}>
+              <Icon
+                source={trailingIcon}
+                size={customLabelSize ?? iconSize}
+                color={
+                  typeof customLabelColor === 'string'
+                    ? customLabelColor
+                    : textColor
+                }
+              />
+            </View>
+          ) : null}
         </View>
       </TouchableRipple>
     </Surface>

--- a/src/components/__tests__/Button.test.tsx
+++ b/src/components/__tests__/Button.test.tsx
@@ -58,6 +58,14 @@ it('renders button with icon', () => {
   expect(tree).toMatchSnapshot();
 });
 
+it('renders button with trailing icon', () => {
+  const tree = render(
+    <Button trailingIcon="camera">Icon Button</Button>
+  ).toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
 it('renders button with icon in reverse order', () => {
   const tree = render(
     <Button icon="chevron-right" contentStyle={styles.flexing}>

--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -1166,6 +1166,175 @@ exports[`renders button with icon in reverse order 1`] = `
 </View>
 `;
 
+exports[`renders button with trailing icon 1`] = `
+<View
+  collapsable={false}
+  style={
+    {
+      "backgroundColor": "transparent",
+      "borderRadius": 20,
+      "shadowColor": "#000",
+      "shadowOffset": {
+        "height": 0,
+        "width": 0,
+      },
+      "shadowOpacity": 0,
+      "shadowRadius": 0,
+    }
+  }
+  testID="button-container-outer-layer"
+>
+  <View
+    collapsable={false}
+    style={
+      {
+        "backgroundColor": "transparent",
+        "borderColor": "transparent",
+        "borderRadius": 20,
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "flex": undefined,
+        "minWidth": 64,
+        "shadowColor": "#000",
+        "shadowOffset": {
+          "height": 0,
+          "width": 0,
+        },
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
+      }
+    }
+    testID="button-container"
+  >
+    <View
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": true,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          {
+            "borderRadius": 20,
+          },
+        ]
+      }
+      testID="button"
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            [
+              {
+                "textAlign": "left",
+              },
+              {
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
+              },
+              [
+                {
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                [
+                  {
+                    "marginHorizontal": 16,
+                    "marginVertical": 9,
+                    "textAlign": "center",
+                  },
+                  false,
+                  {
+                    "marginHorizontal": 12,
+                  },
+                  undefined,
+                  false,
+                  {
+                    "color": "rgba(103, 80, 164, 1)",
+                    "fontFamily": "System",
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                    "letterSpacing": 0.1,
+                    "lineHeight": 20,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+          testID="button-text"
+        >
+          Icon Button
+        </Text>
+        <View
+          style={
+            [
+              {
+                "marginLeft": -4,
+                "marginRight": 12,
+              },
+              {
+                "marginLeft": -16,
+                "marginRight": 16,
+              },
+              {
+                "marginLeft": -8,
+                "marginRight": 12,
+              },
+            ]
+          }
+          testID="button-trailing-icon-container"
+        />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
 exports[`renders contained contained with mode 1`] = `
 <View
   collapsable={false}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->
This PR adds a support for a trailing icon on the button component.

### Motivation

The motivation mostly stems from the issue I encountered in #4324.
I suppose I'm not the only one that needed an extra icon on their button so this PR adds exactly that.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### Related issue

Not necessarily related, but motivated me to open this PR. #4324 
<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
Import the Button component and add a `trailingIcon` prop.