### PR TITLE
fix: allow pass-through of accessibilityRole on Chip

### DIFF
--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -181,6 +181,7 @@ const Chip = ({
   disabled = false,
   background,
   accessibilityLabel,
+  accessibilityRole = 'button',
   closeIconAccessibilityLabel = 'Close',
   onPress,
   onLongPress,
@@ -323,7 +324,7 @@ const Chip = ({
         rippleColor={rippleColor}
         disabled={disabled}
         accessibilityLabel={accessibilityLabel}
-        accessibilityRole="button"
+        accessibilityRole={accessibilityRole}
         accessibilityState={accessibilityState}
         testID={testID}
         theme={theme}


### PR DESCRIPTION
### Motivation

The `Chip` component is frequently used for display purposes, and in these cases is often never clickable. However, the `Chip` element still announces as a button because it has `accessibilityRole="button"` hardcoded.

When the `Chip` element is not being used as a button, a more sensible `accessibilityRole` should be able to be passed through. This PR keeps the default `"button"` `accessibilityRole`, but adds the ability to pass in a different `accessibilityRole` if `"button"` doesn't make sense.

### Related issue

n/a

### Test plan

* Pass `accessibilityRole='text'` as a prop to a Chip, and navigate to the Chip via screen reader. It should *not* announce as a button.
* Do not pass any `accessibilityRole` prop, and navigate to the chip via screen reader; it should announce as a button.

I have tested this locally, and it works as expected. 
