### PR TITLE
fix: Allow passthrough of safeAreaInsets on Appbar.Header

### DIFF
--- a/src/components/Appbar/AppbarHeader.tsx
+++ b/src/components/Appbar/AppbarHeader.tsx
@@ -137,7 +137,7 @@ const AppbarHeader = ({
           backgroundColor,
           zIndex,
           elevation,
-          paddingTop: statusBarHeight ?? safeAreaInsets.top ?? top,
+          paddingTop: statusBarHeight ?? safeAreaInsets?.top ?? top,
           paddingHorizontal: Math.max(left, right),
         },
         borderRadius,

--- a/src/components/Appbar/AppbarHeader.tsx
+++ b/src/components/Appbar/AppbarHeader.tsx
@@ -98,6 +98,7 @@ const AppbarHeader = ({
   elevated = false,
   theme: themeOverrides,
   testID = 'appbar-header',
+  safeAreaInsets,
   ...rest
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
@@ -136,7 +137,7 @@ const AppbarHeader = ({
           backgroundColor,
           zIndex,
           elevation,
-          paddingTop: statusBarHeight ?? top,
+          paddingTop: statusBarHeight ?? safeAreaInsets.top ?? top,
           paddingHorizontal: Math.max(left, right),
         },
         borderRadius,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

If you use `Appbar.Header` within a `<SafeAreaView>` — there's no way to remove the top padding if you don't want it.

`safeAreaInsets` is a valid prop for this component, but setting it does nothing.

```
    <Appbar.Header
      safeAreaInsets={{ top: 0 }}
    >
```

This PR allows developers to have control over the insets of this component.

### Test plan

This is a two line change, but as I'm not intimately familiar with this repo, I might be overlooking something.

To test, simply modify the safeAreaInsets on the Appbar.Header to modify the top padding.

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
