### PR TITLE
fix : Button contentStyle is not correct #4326

### DIFF
--- a/example/src/Examples/ButtonExample.tsx
+++ b/example/src/Examples/ButtonExample.tsx
@@ -284,7 +284,7 @@ const ButtonExample = () => {
             Custom Font
           </Button>
           <Button
-            mode="outlined"
+            mode="contained"
             contentStyle={styles.buttonWithImageOnTop}
             icon={{
               uri: 'https://avatars0.githubusercontent.com/u/17571969?v=3&s=400',
@@ -372,7 +372,6 @@ const styles = StyleSheet.create({
   },
   buttonWithImageOnTop: {
     flexDirection: 'column',
-    alignItems: 'center',
   },
   flexReverse: {
     flexDirection: 'row-reverse',

--- a/example/src/Examples/ButtonExample.tsx
+++ b/example/src/Examples/ButtonExample.tsx
@@ -283,6 +283,17 @@ const ButtonExample = () => {
           >
             Custom Font
           </Button>
+          <Button
+            mode="outlined"
+            contentStyle={styles.buttonWithImageOnTop}
+            icon={{
+              uri: 'https://avatars0.githubusercontent.com/u/17571969?v=3&s=400',
+            }}
+            onPress={() => {}}
+            style={styles.button}
+          >
+            Image On Top
+          </Button>
           <Button mode="outlined" onPress={() => {}} style={styles.button}>
             <Text variant="titleLarge">Custom text</Text>
           </Button>
@@ -358,6 +369,10 @@ const styles = StyleSheet.create({
   },
   button: {
     margin: 4,
+  },
+  buttonWithImageOnTop: {
+    flexDirection: 'column',
+    alignItems: 'center',
   },
   flexReverse: {
     flexDirection: 'row-reverse',

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -297,21 +297,28 @@ const Button = (
     ...font,
   };
 
+  const contentFlexDirection = StyleSheet.flatten(contentStyle)?.flexDirection;
   const iconStyle =
-    StyleSheet.flatten(contentStyle)?.flexDirection === 'row-reverse'
-      ? [
-          styles.iconReverse,
-          isV3 && styles[`md3IconReverse${compact ? 'Compact' : ''}`],
+    contentFlexDirection === 'column'
+      ? [styles.iconTop]
+      : [
+          contentFlexDirection === 'row-reverse'
+            ? styles.iconReverse
+            : styles.icon,
           isV3 &&
+            contentFlexDirection &&
+            styles[`md3Icon${compact ? 'Compact' : ''}`],
+          isV3 &&
+            isMode('text') &&
+            contentFlexDirection &&
+            styles[`md3IconTextMode${compact ? 'Compact' : ''}`],
+          contentFlexDirection === 'row-reverse' &&
+            isV3 &&
+            styles[`md3IconReverse${compact ? 'Compact' : ''}`],
+          contentFlexDirection === 'row-reverse' &&
+            isV3 &&
             isMode('text') &&
             styles[`md3IconReverseTextMode${compact ? 'Compact' : ''}`],
-        ]
-      : [
-          styles.icon,
-          isV3 && styles[`md3Icon${compact ? 'Compact' : ''}`],
-          isV3 &&
-            isMode('text') &&
-            styles[`md3IconTextMode${compact ? 'Compact' : ''}`],
         ];
 
   return (
@@ -423,6 +430,10 @@ const styles = StyleSheet.create({
   iconReverse: {
     marginRight: 12,
     marginLeft: -4,
+  },
+  iconTop: {
+    marginTop: 8,
+    marginRight: 4,
   },
   /* eslint-disable react-native/no-unused-styles */
   md3Icon: {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -305,12 +305,9 @@ const Button = (
           contentFlexDirection === 'row-reverse'
             ? styles.iconReverse
             : styles.icon,
-          isV3 &&
-            contentFlexDirection &&
-            styles[`md3Icon${compact ? 'Compact' : ''}`],
+          isV3 && styles[`md3Icon${compact ? 'Compact' : ''}`],
           isV3 &&
             isMode('text') &&
-            contentFlexDirection &&
             styles[`md3IconTextMode${compact ? 'Compact' : ''}`],
           contentFlexDirection === 'row-reverse' &&
             isV3 &&

--- a/src/components/__tests__/Button.test.tsx
+++ b/src/components/__tests__/Button.test.tsx
@@ -13,6 +13,9 @@ const styles = StyleSheet.create({
   flexing: {
     flexDirection: 'row-reverse',
   },
+  columnFlex: {
+    flexDirection: 'column',
+  },
   customRadius: {
     borderTopLeftRadius: 16,
     borderTopRightRadius: 0,
@@ -62,6 +65,16 @@ it('renders button with icon in reverse order', () => {
   const tree = render(
     <Button icon="chevron-right" contentStyle={styles.flexing}>
       Right Icon
+    </Button>
+  ).toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders button with icon on top', () => {
+  const tree = render(
+    <Button icon="camera" contentStyle={styles.columnFlex}>
+      Icon on Top
     </Button>
   ).toJSON();
 
@@ -276,6 +289,25 @@ describe('button icon styles', () => {
         });
       })
   );
+});
+
+describe('button icon on top styles', () => {
+  it('should return correct content styles for icon when displayed on top', () => {
+    const { getByTestId } = render(
+      <Button
+        mode={'contained'}
+        icon="camera"
+        contentStyle={styles.columnFlex}
+        testID="compact-button"
+      >
+        Compact text button
+      </Button>
+    );
+    expect(getByTestId('compact-button-icon-container')).toHaveStyle({
+      marginTop: 8,
+      marginRight: 4,
+    });
+  });
 });
 
 describe('getButtonColors - background color', () => {

--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -862,6 +862,8 @@ exports[`renders button with icon 1`] = `
                 "marginLeft": 12,
                 "marginRight": -8,
               },
+              false,
+              false,
             ]
           }
           testID="button-icon-container"
@@ -1063,6 +1065,14 @@ exports[`renders button with icon in reverse order 1`] = `
                 "marginRight": 12,
               },
               {
+                "marginLeft": 16,
+                "marginRight": -16,
+              },
+              {
+                "marginLeft": 12,
+                "marginRight": -8,
+              },
+              {
                 "marginLeft": -16,
                 "marginRight": 16,
               },
@@ -1159,6 +1169,206 @@ exports[`renders button with icon in reverse order 1`] = `
           testID="button-text"
         >
           Right Icon
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`renders button with icon on top 1`] = `
+<View
+  collapsable={false}
+  style={
+    {
+      "backgroundColor": "transparent",
+      "borderRadius": 20,
+      "shadowColor": "#000",
+      "shadowOffset": {
+        "height": 0,
+        "width": 0,
+      },
+      "shadowOpacity": 0,
+      "shadowRadius": 0,
+    }
+  }
+  testID="button-container-outer-layer"
+>
+  <View
+    collapsable={false}
+    style={
+      {
+        "backgroundColor": "transparent",
+        "borderColor": "transparent",
+        "borderRadius": 20,
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "flex": undefined,
+        "minWidth": 64,
+        "shadowColor": "#000",
+        "shadowOffset": {
+          "height": 0,
+          "width": 0,
+        },
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
+      }
+    }
+    testID="button-container"
+  >
+    <View
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": true,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          {
+            "borderRadius": 20,
+          },
+        ]
+      }
+      testID="button"
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            {
+              "flexDirection": "column",
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            [
+              {
+                "marginRight": 4,
+                "marginTop": 8,
+              },
+            ]
+          }
+          testID="button-icon-container"
+        >
+          <Text
+            accessibilityElementsHidden={true}
+            allowFontScaling={false}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "rgba(103, 80, 164, 1)",
+                  "fontSize": 18,
+                },
+                [
+                  {
+                    "lineHeight": 18,
+                    "transform": [
+                      {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  {
+                    "backgroundColor": "transparent",
+                  },
+                ],
+                {
+                  "fontFamily": "Material Design Icons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                {},
+              ]
+            }
+          >
+            󰄀
+          </Text>
+        </View>
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            [
+              {
+                "textAlign": "left",
+              },
+              {
+                "color": "rgba(28, 27, 31, 1)",
+                "writingDirection": "ltr",
+              },
+              [
+                {
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                [
+                  {
+                    "marginHorizontal": 16,
+                    "marginVertical": 9,
+                    "textAlign": "center",
+                  },
+                  false,
+                  {
+                    "marginHorizontal": 16,
+                  },
+                  undefined,
+                  false,
+                  {
+                    "color": "rgba(103, 80, 164, 1)",
+                    "fontFamily": "System",
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                    "letterSpacing": 0.1,
+                    "lineHeight": 20,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+          testID="button-text"
+        >
+          Icon on Top
         </Text>
       </View>
     </View>
@@ -1589,6 +1799,8 @@ exports[`renders loading button 1`] = `
                   "marginLeft": 12,
                   "marginRight": -8,
                 },
+                false,
+                false,
               ],
             ]
           }

--- a/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -1809,6 +1809,11 @@ exports[`DataTable.Pagination renders data table pagination with options select 
                       "marginRight": 12,
                     },
                     {
+                      "marginLeft": 16,
+                      "marginRight": -16,
+                    },
+                    false,
+                    {
                       "marginLeft": -16,
                       "marginRight": 16,
                     },


### PR DESCRIPTION
**Motivation** 

Button contentStyle prop was handling icons style when icon is added in the right/left of the Text. When the icon is added on top of the text, iconStyle has to be added for handling the alignment issue.

### Related issue
https://github.com/callstack/react-native-paper/issues/4326

### Test plan
Test Screenshot of the Button with Image on Top Text is shared below,

Button Text : "**Image On Top**"
![Simulator Screenshot - iPhone 15 Pro - 2024-03-23 at 18 48 28](https://github.com/callstack/react-native-paper/assets/6638819/34c97ab5-ee12-4797-bd94-301878b23cbb)

I have tested this locally, and it works as expected.

