### PR TITLE
docs: add link to expo-react-native-paper app template

### DIFF
--- a/docs/docs/guides/01-getting-started.md
+++ b/docs/docs/guides/01-getting-started.md
@@ -52,7 +52,7 @@ module.exports = {
 ```
 
 :::note
-For your next React Native project, consider using the expo-react-native-paper template. This template utilizes Expo's routing for navigation, providing a streamlined development experience with Expo and React Native Paper.
+For your next React Native project, consider using the [expo-react-native-paper](https://github.com/youzarsiph/expo-react-native-paper) template. This template utilizes Expo's routing for navigation, providing a streamlined development experience with Expo and React Native Paper.
 :::
 
 If you created your project using Expo, it'll look something like this:

--- a/docs/docs/guides/01-getting-started.md
+++ b/docs/docs/guides/01-getting-started.md
@@ -51,6 +51,10 @@ module.exports = {
 };
 ```
 
+:::note
+For your next React Native project, consider using the expo-react-native-paper template. This template utilizes Expo's routing for navigation, providing a streamlined development experience with Expo and React Native Paper.
+:::
+
 If you created your project using Expo, it'll look something like this:
 
 ```js


### PR DESCRIPTION


### Motivation

This commit introduces a link to the [`expo-react-native-paper`](https://github.com/youzarsiph/expo-react-native-paper) template in the `docs/docs/guides/01-getting-started.md` file. The `expo-react-native-paper` template is a valuable resource for developers starting new projects with React Native Paper and Expo.

The template is designed with pre-configured navigation examples using Expo's router, which can significantly expedite the development process. By including this link, we aim to provide developers with a quick and efficient way to kickstart their React Native projects.

We believe that this addition will enhance the usability of `react-native-paper` and provide a more comprehensive experience for developers.
