### PR TITLE
docs: mention Provider on Getting Started for older v5 versions

### DIFF
--- a/docs/docs/guides/01-getting-started.md
+++ b/docs/docs/guides/01-getting-started.md
@@ -84,7 +84,7 @@ module.file_ext=.ios.js
 
 ## Usage
 
-Wrap your root component in `PaperProvider` from `react-native-paper`. If you have a vanilla React Native project, it's a good idea to add it in the component which is passed to `AppRegistry.registerComponent`. This will usually be in the `index.js` file. If you have an Expo project, you can do this inside the exported component in the `App.js` file.
+Wrap your root component in `PaperProvider` from `react-native-paper`(if you are using versions prior to 5.8.0 you need to use `Provider`). If you have a vanilla React Native project, it's a good idea to add it in the component which is passed to `AppRegistry.registerComponent`. This will usually be in the `index.js` file. If you have an Expo project, you can do this inside the exported component in the `App.js` file.
 
 Example:
 


### PR DESCRIPTION
Current v5 docs are misleading for versions older than 5.8.0 because they mention PaperProvider export which doesn't exist in older v5 versions.


### Motivation
Avoid confusion for new users starting in 5.0.0 - 5.7.2 version range

### Related issue
N/A

### Test plan
N/A
