### PR TITLE
fix: add support for changing the surface mode in the menu

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -74,6 +74,14 @@ export type Props = {
    */
   elevation?: MD3Elevation;
   /**
+   * Mode of the menu's content.
+   * - `elevated` - Surface with a shadow and background color corresponding to set `elevation` value.
+   * - `flat` - Surface without a shadow, with the background color corresponding to set `elevation` value.
+   *
+   * @supported Available in v5.x with theme version 3
+   */
+  mode?: 'flat' | 'elevated';
+  /**
    * @optional
    */
   theme: InternalTheme;
@@ -113,6 +121,8 @@ const DEFAULT_ELEVATION: MD3Elevation = 2;
 export const ELEVATION_LEVELS_MAP = Object.values(
   ElevationLevels
 ) as ElevationLevels[];
+
+const DEFAULT_MODE = 'elevated';
 
 /**
  * Menus display a list of choices on temporary elevated surfaces. Their placement varies based on the element that opens them.
@@ -418,6 +428,7 @@ class Menu extends React.Component<Props, State> {
       contentStyle,
       style,
       elevation = DEFAULT_ELEVATION,
+      mode = DEFAULT_MODE,
       children,
       theme,
       statusBarHeight,
@@ -646,6 +657,7 @@ class Menu extends React.Component<Props, State> {
                 }}
               >
                 <Surface
+                  mode={mode}
                   pointerEvents={pointerEvents}
                   style={[
                     styles.shadowMenuContainer,

--- a/src/components/__tests__/Menu.test.tsx
+++ b/src/components/__tests__/Menu.test.tsx
@@ -206,3 +206,51 @@ it('animated value changes correctly', () => {
     transform: [{ scale: 1.5 }],
   });
 });
+
+it('renders menu with mode "elevated"', () => {
+  const { getByTestId } = render(
+    <Portal.Host>
+      <Menu
+        visible
+        onDismiss={jest.fn()}
+        anchor={<Button mode="outlined">Open menu</Button>}
+        mode="elevated"
+      >
+        <Menu.Item onPress={jest.fn()} title="Undo" />
+        <Menu.Item onPress={jest.fn()} title="Redo" />
+      </Menu>
+    </Portal.Host>
+  );
+
+  const menuSurface = getByTestId('menu-surface');
+
+  // Get flattened styles
+  const styles = StyleSheet.flatten(menuSurface.props.style);
+
+  expect(styles).toHaveProperty('shadowColor');
+  expect(styles).toHaveProperty('shadowOpacity');
+});
+
+it('renders menu with mode "flat"', () => {
+  const { getByTestId } = render(
+    <Portal.Host>
+      <Menu
+        visible
+        onDismiss={jest.fn()}
+        anchor={<Button mode="outlined">Open menu</Button>}
+        mode="flat"
+      >
+        <Menu.Item onPress={jest.fn()} title="Undo" />
+        <Menu.Item onPress={jest.fn()} title="Redo" />
+      </Menu>
+    </Portal.Host>
+  );
+
+  const menuSurface = getByTestId('menu-surface');
+
+  // Get flattened styles
+  const styles = StyleSheet.flatten(menuSurface.props.style);
+
+  expect(styles).not.toHaveProperty('shadowColor');
+  expect(styles).not.toHaveProperty('shadowOpacity');
+});


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
I prefer the "flat" design approach on my components, and would like to be able to use the `Menu` component in flat mode.

### Related issue

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->
You cannot currently change the `mode` on the `Surface` that is used in the `Menu` component.

### Test plan

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->
Pull up the menu example and pass `mode="flat"` to one of the menus to test.

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
