### PR TITLE
fix: remove deprecated use of defaultProps

### DIFF
--- a/src/components/TextInput/Adornment/TextInputIcon.tsx
+++ b/src/components/TextInput/Adornment/TextInputIcon.tsx
@@ -129,7 +129,7 @@ const IconAdornment: React.FunctionComponent<
 const TextInputIcon = ({
   icon,
   onPress,
-  forceTextInputFocus,
+  forceTextInputFocus = true,
   color: customColor,
   theme: themeOverrides,
   rippleColor,
@@ -175,10 +175,6 @@ const TextInputIcon = ({
   );
 };
 TextInputIcon.displayName = 'TextInput.Icon';
-
-TextInputIcon.defaultProps = {
-  forceTextInputFocus: true,
-};
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION

### Motivation

This PR prevents the error log warning the "defaultProps" will be removed (visible in RN0.74.0)

### Related issue

Addresses #4382

### Test plan

Ensure that use of the `TextInputIcon` does not produce the error (included in linked issue) when run using RN0.74.0
