### PR TITLE
fix(text-input): very long input label truncated when scaled

### DIFF
--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -5,6 +5,7 @@ import {
   Platform,
   StyleSheet,
   useWindowDimensions,
+  View,
 } from 'react-native';
 
 import AnimatedText from '../../Typography/AnimatedText';
@@ -48,6 +49,7 @@ const InputLabel = (props: InputLabelProps) => {
     testID,
     isV3,
     inputContainerLayout,
+    scaledLabel,
   } = props;
 
   const { INPUT_PADDING_HORIZONTAL } = getConstants(isV3);
@@ -110,11 +112,17 @@ const InputLabel = (props: InputLabelProps) => {
     ],
   };
 
+  const labelWidth =
+    (inputContainerLayout.width + INPUT_PADDING_HORIZONTAL / 2) /
+    (scaledLabel ? labelScale : 1);
+
   const commonStyles = [
     placeholderStyle,
     {
       top: topPosition,
-      maxWidth: inputContainerLayout.width + INPUT_PADDING_HORIZONTAL / 2,
+    },
+    {
+      maxWidth: labelWidth,
     },
     labelStyle,
     paddingOffset || {},
@@ -127,65 +135,79 @@ const InputLabel = (props: InputLabelProps) => {
   return (
     // Position colored placeholder and gray placeholder on top of each other and crossfade them
     // This gives the effect of animating the color, but allows us to use native driver
-    <Animated.View
+    <View
       pointerEvents="none"
-      style={[
-        StyleSheet.absoluteFill,
-        styles.labelContainer,
-        Platform.OS !== 'web' && { width },
-        { opacity },
-        labelTranslationX,
-      ]}
+      style={[StyleSheet.absoluteFill, styles.overflow]}
     >
-      {labelBackground?.({
-        labeled,
-        labelLayoutWidth,
-        labelStyle,
-        placeholderStyle,
-        baseLabelTranslateX,
-        topPosition,
-        label,
-        backgroundColor,
-        roundness,
-        maxFontSizeMultiplier: maxFontSizeMultiplier,
-        testID,
-      })}
-      <AnimatedText
-        variant="bodySmall"
-        onLayout={onLayoutAnimatedText}
-        onTextLayout={onLabelTextLayout}
+      <Animated.View
+        pointerEvents="none"
         style={[
-          commonStyles,
-          {
-            color: activeColor,
-          },
+          StyleSheet.absoluteFill,
+          styles.labelContainer,
+          Platform.OS !== 'web' && { width },
+          { opacity },
+          labelTranslationX,
         ]}
-        numberOfLines={1}
-        maxFontSizeMultiplier={maxFontSizeMultiplier}
-        testID={`${testID}-label-active`}
       >
-        {label}
-      </AnimatedText>
-      <AnimatedText
-        variant={focused ? 'bodyLarge' : 'bodySmall'}
-        style={[
-          commonStyles,
-          {
-            color: textColor,
-            opacity: placeholderOpacity,
-          },
-        ]}
-        numberOfLines={1}
-        maxFontSizeMultiplier={maxFontSizeMultiplier}
-        testID={`${testID}-label-inactive`}
-      >
-        {label}
-      </AnimatedText>
-    </Animated.View>
+        <View
+          style={{
+            width: labelWidth,
+          }}
+        >
+          {labelBackground?.({
+            labeled,
+            labelLayoutWidth,
+            labelStyle,
+            placeholderStyle,
+            baseLabelTranslateX,
+            topPosition,
+            label,
+            backgroundColor,
+            roundness,
+            maxFontSizeMultiplier: maxFontSizeMultiplier,
+            testID,
+          })}
+          <AnimatedText
+            variant="bodySmall"
+            onLayout={onLayoutAnimatedText}
+            onTextLayout={onLabelTextLayout}
+            style={[
+              commonStyles,
+              {
+                color: activeColor,
+              },
+            ]}
+            numberOfLines={1}
+            maxFontSizeMultiplier={maxFontSizeMultiplier}
+            testID={`${testID}-label-active`}
+          >
+            {label}
+          </AnimatedText>
+          <AnimatedText
+            variant={focused ? 'bodyLarge' : 'bodySmall'}
+            style={[
+              commonStyles,
+              {
+                color: textColor,
+                opacity: placeholderOpacity,
+              },
+            ]}
+            numberOfLines={1}
+            maxFontSizeMultiplier={maxFontSizeMultiplier}
+            testID={`${testID}-label-inactive`}
+          >
+            {label}
+          </AnimatedText>
+        </View>
+      </Animated.View>
+    </View>
   );
 };
 
 const styles = StyleSheet.create({
+  overflow: {
+    overflow: 'hidden',
+  },
   labelContainer: {
     zIndex: 3,
   },

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -482,6 +482,8 @@ const TextInput = forwardRef<TextInputHandles, Props>(
 
     const { maxFontSizeMultiplier = 1.5 } = rest;
 
+    const scaledLabel = !!(value || focused);
+
     if (mode === 'outlined') {
       return (
         <TextInputOutlined
@@ -520,6 +522,7 @@ const TextInput = forwardRef<TextInputHandles, Props>(
           onRightAffixLayoutChange={onRightAffixLayoutChange}
           maxFontSizeMultiplier={maxFontSizeMultiplier}
           contentStyle={contentStyle}
+          scaledLabel={scaledLabel}
         />
       );
     }
@@ -561,6 +564,7 @@ const TextInput = forwardRef<TextInputHandles, Props>(
         onRightAffixLayoutChange={onRightAffixLayoutChange}
         maxFontSizeMultiplier={maxFontSizeMultiplier}
         contentStyle={contentStyle}
+        scaledLabel={scaledLabel}
       />
     );
   }

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -74,6 +74,7 @@ const TextInputFlat = ({
   placeholderTextColor,
   testID = 'text-input-flat',
   contentStyle,
+  scaledLabel,
   ...rest
 }: ChildTextInputProps) => {
   const isAndroid = Platform.OS === 'android';
@@ -375,6 +376,7 @@ const TextInputFlat = ({
             labeled={parentState.labeled}
             error={parentState.error}
             focused={parentState.focused}
+            scaledLabel={scaledLabel}
             wiggle={Boolean(parentState.value && labelProps.labelError)}
             labelLayoutMeasured={parentState.labelLayout.measured}
             labelLayoutWidth={parentState.labelLayout.width}

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -76,6 +76,7 @@ const TextInputOutlined = ({
   placeholderTextColor,
   testID = 'text-input-outlined',
   contentStyle,
+  scaledLabel,
   ...rest
 }: ChildTextInputProps) => {
   const adornmentConfig = getAdornmentConfig({ left, right });
@@ -364,6 +365,7 @@ const TextInputOutlined = ({
             labeled={parentState.labeled}
             error={parentState.error}
             focused={parentState.focused}
+            scaledLabel={scaledLabel}
             wiggle={Boolean(parentState.value && labelProps.labelError)}
             labelLayoutMeasured={parentState.labelLayout.measured}
             labelLayoutWidth={parentState.labelLayout.width}

--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -45,6 +45,7 @@ type TextInputProps = React.ComponentPropsWithRef<typeof NativeTextInput> & {
   contentStyle?: StyleProp<TextStyle>;
   outlineStyle?: StyleProp<ViewStyle>;
   underlineStyle?: StyleProp<ViewStyle>;
+  scaledLabel?: boolean;
 };
 
 export type RenderProps = {
@@ -140,6 +141,7 @@ export type InputLabelProps = {
   labelBackground?: any;
   maxFontSizeMultiplier?: number | undefined | null;
   isV3?: boolean;
+  scaledLabel?: boolean;
 } & LabelProps;
 
 export type LabelBackgroundProps = {

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -48,103 +48,129 @@ exports[`call onPress when affix adornment pressed 1`] = `
     }
   >
     <View
-      collapsable={false}
       pointerEvents="none"
       style={
-        {
-          "bottom": 0,
-          "left": 0,
-          "opacity": 1,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-          "transform": [
-            {
-              "translateX": 0,
-            },
-          ],
-          "zIndex": 3,
-        }
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          {
+            "overflow": "hidden",
+          },
+        ]
       }
     >
-      <Text
+      <View
         collapsable={false}
-        maxFontSizeMultiplier={1.5}
-        numberOfLines={1}
-        onLayout={[Function]}
-        onTextLayout={[Function]}
+        pointerEvents="none"
         style={
           {
-            "color": "rgba(103, 80, 164, 1)",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
+            "bottom": 0,
             "left": 0,
-            "letterSpacing": 0.15,
-            "lineHeight": 19.2,
-            "maxWidth": 73,
-            "opacity": 0,
-            "paddingLeft": 16,
-            "paddingRight": 16,
+            "opacity": 1,
             "position": "absolute",
-            "textAlign": "left",
-            "top": 30,
+            "right": 0,
+            "top": 0,
             "transform": [
               {
                 "translateX": 0,
               },
-              {
-                "translateY": 0,
-              },
-              {
-                "scale": 1,
-              },
             ],
-            "writingDirection": "ltr",
+            "zIndex": 3,
           }
         }
-        testID="text-input-flat-label-active"
       >
-        Flat input
-      </Text>
-      <Text
-        collapsable={false}
-        maxFontSizeMultiplier={1.5}
-        numberOfLines={1}
-        style={
-          {
-            "color": "rgba(73, 69, 79, 1)",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
-            "left": 0,
-            "letterSpacing": 0.15,
-            "lineHeight": 19.2,
-            "maxWidth": 73,
-            "opacity": 0,
-            "paddingLeft": 16,
-            "paddingRight": 16,
-            "position": "absolute",
-            "textAlign": "left",
-            "top": 30,
-            "transform": [
-              {
-                "translateX": 0,
-              },
-              {
-                "translateY": 0,
-              },
-              {
-                "scale": 1,
-              },
-            ],
-            "writingDirection": "ltr",
+        <View
+          style={
+            {
+              "width": 73,
+            }
           }
-        }
-        testID="text-input-flat-label-inactive"
-      >
-        Flat input
-      </Text>
+        >
+          <Text
+            collapsable={false}
+            maxFontSizeMultiplier={1.5}
+            numberOfLines={1}
+            onLayout={[Function]}
+            onTextLayout={[Function]}
+            style={
+              {
+                "color": "rgba(103, 80, 164, 1)",
+                "fontFamily": "System",
+                "fontSize": 16,
+                "fontWeight": undefined,
+                "left": 0,
+                "letterSpacing": 0.15,
+                "lineHeight": 19.2,
+                "maxWidth": 73,
+                "opacity": 0,
+                "paddingLeft": 16,
+                "paddingRight": 16,
+                "position": "absolute",
+                "textAlign": "left",
+                "top": 30,
+                "transform": [
+                  {
+                    "translateX": 0,
+                  },
+                  {
+                    "translateY": 0,
+                  },
+                  {
+                    "scale": 1,
+                  },
+                ],
+                "writingDirection": "ltr",
+              }
+            }
+            testID="text-input-flat-label-active"
+          >
+            Flat input
+          </Text>
+          <Text
+            collapsable={false}
+            maxFontSizeMultiplier={1.5}
+            numberOfLines={1}
+            style={
+              {
+                "color": "rgba(73, 69, 79, 1)",
+                "fontFamily": "System",
+                "fontSize": 16,
+                "fontWeight": undefined,
+                "left": 0,
+                "letterSpacing": 0.15,
+                "lineHeight": 19.2,
+                "maxWidth": 73,
+                "opacity": 0,
+                "paddingLeft": 16,
+                "paddingRight": 16,
+                "position": "absolute",
+                "textAlign": "left",
+                "top": 30,
+                "transform": [
+                  {
+                    "translateX": 0,
+                  },
+                  {
+                    "translateY": 0,
+                  },
+                  {
+                    "scale": 1,
+                  },
+                ],
+                "writingDirection": "ltr",
+              }
+            }
+            testID="text-input-flat-label-inactive"
+          >
+            Flat input
+          </Text>
+        </View>
+      </View>
     </View>
     <TextInput
       cursorColor="rgba(103, 80, 164, 1)"
@@ -328,120 +354,146 @@ exports[`correctly applies a component as the text label 1`] = `
     }
   >
     <View
-      collapsable={false}
       pointerEvents="none"
       style={
-        {
-          "bottom": 0,
-          "left": 0,
-          "opacity": 0,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-          "transform": [
-            {
-              "translateX": 4,
-            },
-          ],
-          "width": 750,
-          "zIndex": 3,
-        }
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          {
+            "overflow": "hidden",
+          },
+        ]
       }
     >
-      <Text
+      <View
         collapsable={false}
-        maxFontSizeMultiplier={1.5}
-        numberOfLines={1}
-        onLayout={[Function]}
-        onTextLayout={[Function]}
+        pointerEvents="none"
         style={
           {
-            "color": "rgba(103, 80, 164, 1)",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
+            "bottom": 0,
             "left": 0,
-            "letterSpacing": 0.15,
-            "lineHeight": undefined,
-            "maxWidth": 73,
             "opacity": 0,
-            "paddingLeft": 16,
-            "paddingRight": 16,
             "position": "absolute",
-            "textAlign": "left",
-            "top": 30,
+            "right": 0,
+            "top": 0,
             "transform": [
               {
-                "translateX": 0,
-              },
-              {
-                "translateY": -12,
-              },
-              {
-                "scale": 0.75,
+                "translateX": 4,
               },
             ],
-            "writingDirection": "ltr",
+            "width": 750,
+            "zIndex": 3,
           }
         }
-        testID="text-input-flat-label-active"
       >
-        <Text
+        <View
           style={
             {
-              "color": "#f44336",
+              "width": 97.33333333333333,
             }
           }
         >
-          Flat input
-        </Text>
-      </Text>
-      <Text
-        collapsable={false}
-        maxFontSizeMultiplier={1.5}
-        numberOfLines={1}
-        style={
-          {
-            "color": "rgba(73, 69, 79, 1)",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
-            "left": 0,
-            "letterSpacing": 0.15,
-            "lineHeight": undefined,
-            "maxWidth": 73,
-            "opacity": 0,
-            "paddingLeft": 16,
-            "paddingRight": 16,
-            "position": "absolute",
-            "textAlign": "left",
-            "top": 30,
-            "transform": [
+          <Text
+            collapsable={false}
+            maxFontSizeMultiplier={1.5}
+            numberOfLines={1}
+            onLayout={[Function]}
+            onTextLayout={[Function]}
+            style={
               {
-                "translateX": 0,
-              },
-              {
-                "translateY": -12,
-              },
-              {
-                "scale": 0.75,
-              },
-            ],
-            "writingDirection": "ltr",
-          }
-        }
-        testID="text-input-flat-label-inactive"
-      >
-        <Text
-          style={
-            {
-              "color": "#f44336",
+                "color": "rgba(103, 80, 164, 1)",
+                "fontFamily": "System",
+                "fontSize": 16,
+                "fontWeight": undefined,
+                "left": 0,
+                "letterSpacing": 0.15,
+                "lineHeight": undefined,
+                "maxWidth": 97.33333333333333,
+                "opacity": 0,
+                "paddingLeft": 16,
+                "paddingRight": 16,
+                "position": "absolute",
+                "textAlign": "left",
+                "top": 30,
+                "transform": [
+                  {
+                    "translateX": 0,
+                  },
+                  {
+                    "translateY": -12,
+                  },
+                  {
+                    "scale": 0.75,
+                  },
+                ],
+                "writingDirection": "ltr",
+              }
             }
-          }
-        >
-          Flat input
-        </Text>
-      </Text>
+            testID="text-input-flat-label-active"
+          >
+            <Text
+              style={
+                {
+                  "color": "#f44336",
+                }
+              }
+            >
+              Flat input
+            </Text>
+          </Text>
+          <Text
+            collapsable={false}
+            maxFontSizeMultiplier={1.5}
+            numberOfLines={1}
+            style={
+              {
+                "color": "rgba(73, 69, 79, 1)",
+                "fontFamily": "System",
+                "fontSize": 16,
+                "fontWeight": undefined,
+                "left": 0,
+                "letterSpacing": 0.15,
+                "lineHeight": undefined,
+                "maxWidth": 97.33333333333333,
+                "opacity": 0,
+                "paddingLeft": 16,
+                "paddingRight": 16,
+                "position": "absolute",
+                "textAlign": "left",
+                "top": 30,
+                "transform": [
+                  {
+                    "translateX": 0,
+                  },
+                  {
+                    "translateY": -12,
+                  },
+                  {
+                    "scale": 0.75,
+                  },
+                ],
+                "writingDirection": "ltr",
+              }
+            }
+            testID="text-input-flat-label-inactive"
+          >
+            <Text
+              style={
+                {
+                  "color": "#f44336",
+                }
+              }
+            >
+              Flat input
+            </Text>
+          </Text>
+        </View>
+      </View>
     </View>
     <TextInput
       cursorColor="rgba(103, 80, 164, 1)"
@@ -542,104 +594,130 @@ exports[`correctly applies cursorColor prop 1`] = `
     }
   >
     <View
-      collapsable={false}
       pointerEvents="none"
       style={
-        {
-          "bottom": 0,
-          "left": 0,
-          "opacity": 0,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-          "transform": [
-            {
-              "translateX": 4,
-            },
-          ],
-          "width": 750,
-          "zIndex": 3,
-        }
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          {
+            "overflow": "hidden",
+          },
+        ]
       }
     >
-      <Text
+      <View
         collapsable={false}
-        maxFontSizeMultiplier={1.5}
-        numberOfLines={1}
-        onLayout={[Function]}
-        onTextLayout={[Function]}
+        pointerEvents="none"
         style={
           {
-            "color": "rgba(103, 80, 164, 1)",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
+            "bottom": 0,
             "left": 0,
-            "letterSpacing": 0.15,
-            "lineHeight": undefined,
-            "maxWidth": 73,
             "opacity": 0,
-            "paddingLeft": 16,
-            "paddingRight": 16,
             "position": "absolute",
-            "textAlign": "left",
-            "top": 30,
+            "right": 0,
+            "top": 0,
             "transform": [
               {
-                "translateX": 0,
-              },
-              {
-                "translateY": -12,
-              },
-              {
-                "scale": 0.75,
+                "translateX": 4,
               },
             ],
-            "writingDirection": "ltr",
+            "width": 750,
+            "zIndex": 3,
           }
         }
-        testID="text-input-flat-label-active"
       >
-        Flat input
-      </Text>
-      <Text
-        collapsable={false}
-        maxFontSizeMultiplier={1.5}
-        numberOfLines={1}
-        style={
-          {
-            "color": "rgba(73, 69, 79, 1)",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
-            "left": 0,
-            "letterSpacing": 0.15,
-            "lineHeight": undefined,
-            "maxWidth": 73,
-            "opacity": 0,
-            "paddingLeft": 16,
-            "paddingRight": 16,
-            "position": "absolute",
-            "textAlign": "left",
-            "top": 30,
-            "transform": [
-              {
-                "translateX": 0,
-              },
-              {
-                "translateY": -12,
-              },
-              {
-                "scale": 0.75,
-              },
-            ],
-            "writingDirection": "ltr",
+        <View
+          style={
+            {
+              "width": 97.33333333333333,
+            }
           }
-        }
-        testID="text-input-flat-label-inactive"
-      >
-        Flat input
-      </Text>
+        >
+          <Text
+            collapsable={false}
+            maxFontSizeMultiplier={1.5}
+            numberOfLines={1}
+            onLayout={[Function]}
+            onTextLayout={[Function]}
+            style={
+              {
+                "color": "rgba(103, 80, 164, 1)",
+                "fontFamily": "System",
+                "fontSize": 16,
+                "fontWeight": undefined,
+                "left": 0,
+                "letterSpacing": 0.15,
+                "lineHeight": undefined,
+                "maxWidth": 97.33333333333333,
+                "opacity": 0,
+                "paddingLeft": 16,
+                "paddingRight": 16,
+                "position": "absolute",
+                "textAlign": "left",
+                "top": 30,
+                "transform": [
+                  {
+                    "translateX": 0,
+                  },
+                  {
+                    "translateY": -12,
+                  },
+                  {
+                    "scale": 0.75,
+                  },
+                ],
+                "writingDirection": "ltr",
+              }
+            }
+            testID="text-input-flat-label-active"
+          >
+            Flat input
+          </Text>
+          <Text
+            collapsable={false}
+            maxFontSizeMultiplier={1.5}
+            numberOfLines={1}
+            style={
+              {
+                "color": "rgba(73, 69, 79, 1)",
+                "fontFamily": "System",
+                "fontSize": 16,
+                "fontWeight": undefined,
+                "left": 0,
+                "letterSpacing": 0.15,
+                "lineHeight": undefined,
+                "maxWidth": 97.33333333333333,
+                "opacity": 0,
+                "paddingLeft": 16,
+                "paddingRight": 16,
+                "position": "absolute",
+                "textAlign": "left",
+                "top": 30,
+                "transform": [
+                  {
+                    "translateX": 0,
+                  },
+                  {
+                    "translateY": -12,
+                  },
+                  {
+                    "scale": 0.75,
+                  },
+                ],
+                "writingDirection": "ltr",
+              }
+            }
+            testID="text-input-flat-label-inactive"
+          >
+            Flat input
+          </Text>
+        </View>
+      </View>
     </View>
     <TextInput
       cursorColor="#f44336"
@@ -740,104 +818,130 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
     }
   >
     <View
-      collapsable={false}
       pointerEvents="none"
       style={
-        {
-          "bottom": 0,
-          "left": 0,
-          "opacity": 0,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-          "transform": [
-            {
-              "translateX": 4,
-            },
-          ],
-          "width": 750,
-          "zIndex": 3,
-        }
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          {
+            "overflow": "hidden",
+          },
+        ]
       }
     >
-      <Text
+      <View
         collapsable={false}
-        maxFontSizeMultiplier={1.5}
-        numberOfLines={1}
-        onLayout={[Function]}
-        onTextLayout={[Function]}
+        pointerEvents="none"
         style={
           {
-            "color": "rgba(103, 80, 164, 1)",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
+            "bottom": 0,
             "left": 0,
-            "letterSpacing": 0.15,
-            "lineHeight": undefined,
-            "maxWidth": 73,
             "opacity": 0,
-            "paddingLeft": 16,
-            "paddingRight": 16,
             "position": "absolute",
-            "textAlign": "left",
-            "top": 30,
+            "right": 0,
+            "top": 0,
             "transform": [
               {
-                "translateX": 0,
-              },
-              {
-                "translateY": -12,
-              },
-              {
-                "scale": 0.75,
+                "translateX": 4,
               },
             ],
-            "writingDirection": "ltr",
+            "width": 750,
+            "zIndex": 3,
           }
         }
-        testID="text-input-flat-label-active"
       >
-        Flat input
-      </Text>
-      <Text
-        collapsable={false}
-        maxFontSizeMultiplier={1.5}
-        numberOfLines={1}
-        style={
-          {
-            "color": "rgba(73, 69, 79, 1)",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
-            "left": 0,
-            "letterSpacing": 0.15,
-            "lineHeight": undefined,
-            "maxWidth": 73,
-            "opacity": 0,
-            "paddingLeft": 16,
-            "paddingRight": 16,
-            "position": "absolute",
-            "textAlign": "left",
-            "top": 30,
-            "transform": [
-              {
-                "translateX": 0,
-              },
-              {
-                "translateY": -12,
-              },
-              {
-                "scale": 0.75,
-              },
-            ],
-            "writingDirection": "ltr",
+        <View
+          style={
+            {
+              "width": 97.33333333333333,
+            }
           }
-        }
-        testID="text-input-flat-label-inactive"
-      >
-        Flat input
-      </Text>
+        >
+          <Text
+            collapsable={false}
+            maxFontSizeMultiplier={1.5}
+            numberOfLines={1}
+            onLayout={[Function]}
+            onTextLayout={[Function]}
+            style={
+              {
+                "color": "rgba(103, 80, 164, 1)",
+                "fontFamily": "System",
+                "fontSize": 16,
+                "fontWeight": undefined,
+                "left": 0,
+                "letterSpacing": 0.15,
+                "lineHeight": undefined,
+                "maxWidth": 97.33333333333333,
+                "opacity": 0,
+                "paddingLeft": 16,
+                "paddingRight": 16,
+                "position": "absolute",
+                "textAlign": "left",
+                "top": 30,
+                "transform": [
+                  {
+                    "translateX": 0,
+                  },
+                  {
+                    "translateY": -12,
+                  },
+                  {
+                    "scale": 0.75,
+                  },
+                ],
+                "writingDirection": "ltr",
+              }
+            }
+            testID="text-input-flat-label-active"
+          >
+            Flat input
+          </Text>
+          <Text
+            collapsable={false}
+            maxFontSizeMultiplier={1.5}
+            numberOfLines={1}
+            style={
+              {
+                "color": "rgba(73, 69, 79, 1)",
+                "fontFamily": "System",
+                "fontSize": 16,
+                "fontWeight": undefined,
+                "left": 0,
+                "letterSpacing": 0.15,
+                "lineHeight": undefined,
+                "maxWidth": 97.33333333333333,
+                "opacity": 0,
+                "paddingLeft": 16,
+                "paddingRight": 16,
+                "position": "absolute",
+                "textAlign": "left",
+                "top": 30,
+                "transform": [
+                  {
+                    "translateX": 0,
+                  },
+                  {
+                    "translateY": -12,
+                  },
+                  {
+                    "scale": 0.75,
+                  },
+                ],
+                "writingDirection": "ltr",
+              }
+            }
+            testID="text-input-flat-label-inactive"
+          >
+            Flat input
+          </Text>
+        </View>
+      </View>
     </View>
     <TextInput
       cursorColor="rgba(103, 80, 164, 1)"
@@ -931,143 +1035,169 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
     }
   >
     <View
-      collapsable={false}
       pointerEvents="none"
       style={
-        {
-          "bottom": 0,
-          "left": 0,
-          "opacity": 0,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-          "transform": [
-            {
-              "translateX": 3,
-            },
-          ],
-          "width": 750,
-          "zIndex": 3,
-        }
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          {
+            "overflow": "hidden",
+          },
+        ]
       }
     >
-      <Text
+      <View
         collapsable={false}
-        maxFontSizeMultiplier={1.5}
-        numberOfLines={1}
+        pointerEvents="none"
         style={
           {
-            "backgroundColor": "rgba(255, 251, 254, 1)",
-            "color": "transparent",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
-            "left": 8,
-            "letterSpacing": 0.15,
-            "lineHeight": undefined,
-            "opacity": 1,
-            "paddingHorizontal": 0,
-            "position": "absolute",
-            "textAlign": "left",
-            "top": 59,
-            "transform": [
-              {
-                "translateX": 0,
-              },
-              {
-                "translateY": -52,
-              },
-              {
-                "scale": 0.75,
-              },
-              {
-                "scaleY": 0.2,
-              },
-            ],
-            "width": -16,
-            "writingDirection": "ltr",
-          }
-        }
-        testID="text-input-outlined-label-background"
-      >
-        Outline Input
-      </Text>
-      <Text
-        collapsable={false}
-        maxFontSizeMultiplier={1.5}
-        numberOfLines={1}
-        onLayout={[Function]}
-        onTextLayout={[Function]}
-        style={
-          {
-            "color": "rgba(103, 80, 164, 1)",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
+            "bottom": 0,
             "left": 0,
-            "letterSpacing": 0.15,
-            "lineHeight": undefined,
-            "maxWidth": 73,
             "opacity": 0,
-            "paddingHorizontal": 16,
             "position": "absolute",
-            "textAlign": "left",
-            "top": 58,
+            "right": 0,
+            "top": 0,
             "transform": [
               {
-                "translateX": 0,
-              },
-              {
-                "translateY": -52,
-              },
-              {
-                "scale": 0.75,
+                "translateX": 3,
               },
             ],
-            "writingDirection": "ltr",
+            "width": 750,
+            "zIndex": 3,
           }
         }
-        testID="text-input-outlined-label-active"
       >
-        Outline Input
-      </Text>
-      <Text
-        collapsable={false}
-        maxFontSizeMultiplier={1.5}
-        numberOfLines={1}
-        style={
-          {
-            "color": "rgba(73, 69, 79, 1)",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
-            "left": 0,
-            "letterSpacing": 0.15,
-            "lineHeight": undefined,
-            "maxWidth": 73,
-            "opacity": 0,
-            "paddingHorizontal": 16,
-            "position": "absolute",
-            "textAlign": "left",
-            "top": 58,
-            "transform": [
-              {
-                "translateX": 0,
-              },
-              {
-                "translateY": -52,
-              },
-              {
-                "scale": 0.75,
-              },
-            ],
-            "writingDirection": "ltr",
+        <View
+          style={
+            {
+              "width": 97.33333333333333,
+            }
           }
-        }
-        testID="text-input-outlined-label-inactive"
-      >
-        Outline Input
-      </Text>
+        >
+          <Text
+            collapsable={false}
+            maxFontSizeMultiplier={1.5}
+            numberOfLines={1}
+            style={
+              {
+                "backgroundColor": "rgba(255, 251, 254, 1)",
+                "color": "transparent",
+                "fontFamily": "System",
+                "fontSize": 16,
+                "fontWeight": undefined,
+                "left": 8,
+                "letterSpacing": 0.15,
+                "lineHeight": undefined,
+                "opacity": 1,
+                "paddingHorizontal": 0,
+                "position": "absolute",
+                "textAlign": "left",
+                "top": 59,
+                "transform": [
+                  {
+                    "translateX": 0,
+                  },
+                  {
+                    "translateY": -52,
+                  },
+                  {
+                    "scale": 0.75,
+                  },
+                  {
+                    "scaleY": 0.2,
+                  },
+                ],
+                "width": -16,
+                "writingDirection": "ltr",
+              }
+            }
+            testID="text-input-outlined-label-background"
+          >
+            Outline Input
+          </Text>
+          <Text
+            collapsable={false}
+            maxFontSizeMultiplier={1.5}
+            numberOfLines={1}
+            onLayout={[Function]}
+            onTextLayout={[Function]}
+            style={
+              {
+                "color": "rgba(103, 80, 164, 1)",
+                "fontFamily": "System",
+                "fontSize": 16,
+                "fontWeight": undefined,
+                "left": 0,
+                "letterSpacing": 0.15,
+                "lineHeight": undefined,
+                "maxWidth": 97.33333333333333,
+                "opacity": 0,
+                "paddingHorizontal": 16,
+                "position": "absolute",
+                "textAlign": "left",
+                "top": 58,
+                "transform": [
+                  {
+                    "translateX": 0,
+                  },
+                  {
+                    "translateY": -52,
+                  },
+                  {
+                    "scale": 0.75,
+                  },
+                ],
+                "writingDirection": "ltr",
+              }
+            }
+            testID="text-input-outlined-label-active"
+          >
+            Outline Input
+          </Text>
+          <Text
+            collapsable={false}
+            maxFontSizeMultiplier={1.5}
+            numberOfLines={1}
+            style={
+              {
+                "color": "rgba(73, 69, 79, 1)",
+                "fontFamily": "System",
+                "fontSize": 16,
+                "fontWeight": undefined,
+                "left": 0,
+                "letterSpacing": 0.15,
+                "lineHeight": undefined,
+                "maxWidth": 97.33333333333333,
+                "opacity": 0,
+                "paddingHorizontal": 16,
+                "position": "absolute",
+                "textAlign": "left",
+                "top": 58,
+                "transform": [
+                  {
+                    "translateX": 0,
+                  },
+                  {
+                    "translateY": -52,
+                  },
+                  {
+                    "scale": 0.75,
+                  },
+                ],
+                "writingDirection": "ltr",
+              }
+            }
+            testID="text-input-outlined-label-inactive"
+          >
+            Outline Input
+          </Text>
+        </View>
+      </View>
     </View>
     <TextInput
       cursorColor="rgba(103, 80, 164, 1)"
@@ -1168,104 +1298,130 @@ exports[`correctly applies paddingLeft from contentStyleProp 1`] = `
     }
   >
     <View
-      collapsable={false}
       pointerEvents="none"
       style={
-        {
-          "bottom": 0,
-          "left": 0,
-          "opacity": 0,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-          "transform": [
-            {
-              "translateX": 4,
-            },
-          ],
-          "width": 750,
-          "zIndex": 3,
-        }
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          {
+            "overflow": "hidden",
+          },
+        ]
       }
     >
-      <Text
+      <View
         collapsable={false}
-        maxFontSizeMultiplier={1.5}
-        numberOfLines={1}
-        onLayout={[Function]}
-        onTextLayout={[Function]}
+        pointerEvents="none"
         style={
           {
-            "color": "rgba(103, 80, 164, 1)",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
+            "bottom": 0,
             "left": 0,
-            "letterSpacing": 0.15,
-            "lineHeight": undefined,
-            "maxWidth": 73,
             "opacity": 0,
-            "paddingLeft": 16,
-            "paddingRight": 16,
             "position": "absolute",
-            "textAlign": "left",
-            "top": 30,
+            "right": 0,
+            "top": 0,
             "transform": [
               {
-                "translateX": 0,
-              },
-              {
-                "translateY": -12,
-              },
-              {
-                "scale": 0.75,
+                "translateX": 4,
               },
             ],
-            "writingDirection": "ltr",
+            "width": 750,
+            "zIndex": 3,
           }
         }
-        testID="text-input-flat-label-active"
       >
-        With padding
-      </Text>
-      <Text
-        collapsable={false}
-        maxFontSizeMultiplier={1.5}
-        numberOfLines={1}
-        style={
-          {
-            "color": "rgba(73, 69, 79, 1)",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
-            "left": 0,
-            "letterSpacing": 0.15,
-            "lineHeight": undefined,
-            "maxWidth": 73,
-            "opacity": 0,
-            "paddingLeft": 16,
-            "paddingRight": 16,
-            "position": "absolute",
-            "textAlign": "left",
-            "top": 30,
-            "transform": [
-              {
-                "translateX": 0,
-              },
-              {
-                "translateY": -12,
-              },
-              {
-                "scale": 0.75,
-              },
-            ],
-            "writingDirection": "ltr",
+        <View
+          style={
+            {
+              "width": 97.33333333333333,
+            }
           }
-        }
-        testID="text-input-flat-label-inactive"
-      >
-        With padding
-      </Text>
+        >
+          <Text
+            collapsable={false}
+            maxFontSizeMultiplier={1.5}
+            numberOfLines={1}
+            onLayout={[Function]}
+            onTextLayout={[Function]}
+            style={
+              {
+                "color": "rgba(103, 80, 164, 1)",
+                "fontFamily": "System",
+                "fontSize": 16,
+                "fontWeight": undefined,
+                "left": 0,
+                "letterSpacing": 0.15,
+                "lineHeight": undefined,
+                "maxWidth": 97.33333333333333,
+                "opacity": 0,
+                "paddingLeft": 16,
+                "paddingRight": 16,
+                "position": "absolute",
+                "textAlign": "left",
+                "top": 30,
+                "transform": [
+                  {
+                    "translateX": 0,
+                  },
+                  {
+                    "translateY": -12,
+                  },
+                  {
+                    "scale": 0.75,
+                  },
+                ],
+                "writingDirection": "ltr",
+              }
+            }
+            testID="text-input-flat-label-active"
+          >
+            With padding
+          </Text>
+          <Text
+            collapsable={false}
+            maxFontSizeMultiplier={1.5}
+            numberOfLines={1}
+            style={
+              {
+                "color": "rgba(73, 69, 79, 1)",
+                "fontFamily": "System",
+                "fontSize": 16,
+                "fontWeight": undefined,
+                "left": 0,
+                "letterSpacing": 0.15,
+                "lineHeight": undefined,
+                "maxWidth": 97.33333333333333,
+                "opacity": 0,
+                "paddingLeft": 16,
+                "paddingRight": 16,
+                "position": "absolute",
+                "textAlign": "left",
+                "top": 30,
+                "transform": [
+                  {
+                    "translateX": 0,
+                  },
+                  {
+                    "translateY": -12,
+                  },
+                  {
+                    "scale": 0.75,
+                  },
+                ],
+                "writingDirection": "ltr",
+              }
+            }
+            testID="text-input-flat-label-inactive"
+          >
+            With padding
+          </Text>
+        </View>
+      </View>
     </View>
     <TextInput
       cursorColor="rgba(103, 80, 164, 1)"
@@ -1368,104 +1524,130 @@ exports[`correctly applies textAlign center 1`] = `
     }
   >
     <View
-      collapsable={false}
       pointerEvents="none"
       style={
-        {
-          "bottom": 0,
-          "left": 0,
-          "opacity": 0,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-          "transform": [
-            {
-              "translateX": 4,
-            },
-          ],
-          "width": 750,
-          "zIndex": 3,
-        }
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          {
+            "overflow": "hidden",
+          },
+        ]
       }
     >
-      <Text
+      <View
         collapsable={false}
-        maxFontSizeMultiplier={1.5}
-        numberOfLines={1}
-        onLayout={[Function]}
-        onTextLayout={[Function]}
+        pointerEvents="none"
         style={
           {
-            "color": "rgba(103, 80, 164, 1)",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
+            "bottom": 0,
             "left": 0,
-            "letterSpacing": 0.15,
-            "lineHeight": undefined,
-            "maxWidth": 73,
             "opacity": 0,
-            "paddingLeft": 16,
-            "paddingRight": 16,
             "position": "absolute",
-            "textAlign": "left",
-            "top": 30,
+            "right": 0,
+            "top": 0,
             "transform": [
               {
-                "translateX": 0,
-              },
-              {
-                "translateY": -12,
-              },
-              {
-                "scale": 0.75,
+                "translateX": 4,
               },
             ],
-            "writingDirection": "ltr",
+            "width": 750,
+            "zIndex": 3,
           }
         }
-        testID="text-input-flat-label-active"
       >
-        Flat input
-      </Text>
-      <Text
-        collapsable={false}
-        maxFontSizeMultiplier={1.5}
-        numberOfLines={1}
-        style={
-          {
-            "color": "rgba(73, 69, 79, 1)",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
-            "left": 0,
-            "letterSpacing": 0.15,
-            "lineHeight": undefined,
-            "maxWidth": 73,
-            "opacity": 0,
-            "paddingLeft": 16,
-            "paddingRight": 16,
-            "position": "absolute",
-            "textAlign": "left",
-            "top": 30,
-            "transform": [
-              {
-                "translateX": 0,
-              },
-              {
-                "translateY": -12,
-              },
-              {
-                "scale": 0.75,
-              },
-            ],
-            "writingDirection": "ltr",
+        <View
+          style={
+            {
+              "width": 97.33333333333333,
+            }
           }
-        }
-        testID="text-input-flat-label-inactive"
-      >
-        Flat input
-      </Text>
+        >
+          <Text
+            collapsable={false}
+            maxFontSizeMultiplier={1.5}
+            numberOfLines={1}
+            onLayout={[Function]}
+            onTextLayout={[Function]}
+            style={
+              {
+                "color": "rgba(103, 80, 164, 1)",
+                "fontFamily": "System",
+                "fontSize": 16,
+                "fontWeight": undefined,
+                "left": 0,
+                "letterSpacing": 0.15,
+                "lineHeight": undefined,
+                "maxWidth": 97.33333333333333,
+                "opacity": 0,
+                "paddingLeft": 16,
+                "paddingRight": 16,
+                "position": "absolute",
+                "textAlign": "left",
+                "top": 30,
+                "transform": [
+                  {
+                    "translateX": 0,
+                  },
+                  {
+                    "translateY": -12,
+                  },
+                  {
+                    "scale": 0.75,
+                  },
+                ],
+                "writingDirection": "ltr",
+              }
+            }
+            testID="text-input-flat-label-active"
+          >
+            Flat input
+          </Text>
+          <Text
+            collapsable={false}
+            maxFontSizeMultiplier={1.5}
+            numberOfLines={1}
+            style={
+              {
+                "color": "rgba(73, 69, 79, 1)",
+                "fontFamily": "System",
+                "fontSize": 16,
+                "fontWeight": undefined,
+                "left": 0,
+                "letterSpacing": 0.15,
+                "lineHeight": undefined,
+                "maxWidth": 97.33333333333333,
+                "opacity": 0,
+                "paddingLeft": 16,
+                "paddingRight": 16,
+                "position": "absolute",
+                "textAlign": "left",
+                "top": 30,
+                "transform": [
+                  {
+                    "translateX": 0,
+                  },
+                  {
+                    "translateY": -12,
+                  },
+                  {
+                    "scale": 0.75,
+                  },
+                ],
+                "writingDirection": "ltr",
+              }
+            }
+            testID="text-input-flat-label-inactive"
+          >
+            Flat input
+          </Text>
+        </View>
+      </View>
     </View>
     <TextInput
       cursorColor="rgba(103, 80, 164, 1)"
@@ -1566,104 +1748,130 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
     }
   >
     <View
-      collapsable={false}
       pointerEvents="none"
       style={
-        {
-          "bottom": 0,
-          "left": 0,
-          "opacity": 0,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-          "transform": [
-            {
-              "translateX": 4,
-            },
-          ],
-          "width": 750,
-          "zIndex": 3,
-        }
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          {
+            "overflow": "hidden",
+          },
+        ]
       }
     >
-      <Text
+      <View
         collapsable={false}
-        maxFontSizeMultiplier={1.5}
-        numberOfLines={1}
-        onLayout={[Function]}
-        onTextLayout={[Function]}
+        pointerEvents="none"
         style={
           {
-            "color": "rgba(103, 80, 164, 1)",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
+            "bottom": 0,
             "left": 0,
-            "letterSpacing": 0.15,
-            "lineHeight": undefined,
-            "maxWidth": 73,
             "opacity": 0,
-            "paddingLeft": 16,
-            "paddingRight": 56,
             "position": "absolute",
-            "textAlign": "left",
-            "top": 30,
+            "right": 0,
+            "top": 0,
             "transform": [
               {
-                "translateX": 0,
-              },
-              {
-                "translateY": -12,
-              },
-              {
-                "scale": 0.75,
+                "translateX": 4,
               },
             ],
-            "writingDirection": "ltr",
+            "width": 750,
+            "zIndex": 3,
           }
         }
-        testID="text-input-flat-label-active"
       >
-        Flat input
-      </Text>
-      <Text
-        collapsable={false}
-        maxFontSizeMultiplier={1.5}
-        numberOfLines={1}
-        style={
-          {
-            "color": "rgba(73, 69, 79, 1)",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
-            "left": 0,
-            "letterSpacing": 0.15,
-            "lineHeight": undefined,
-            "maxWidth": 73,
-            "opacity": 0,
-            "paddingLeft": 16,
-            "paddingRight": 56,
-            "position": "absolute",
-            "textAlign": "left",
-            "top": 30,
-            "transform": [
-              {
-                "translateX": 0,
-              },
-              {
-                "translateY": -12,
-              },
-              {
-                "scale": 0.75,
-              },
-            ],
-            "writingDirection": "ltr",
+        <View
+          style={
+            {
+              "width": 97.33333333333333,
+            }
           }
-        }
-        testID="text-input-flat-label-inactive"
-      >
-        Flat input
-      </Text>
+        >
+          <Text
+            collapsable={false}
+            maxFontSizeMultiplier={1.5}
+            numberOfLines={1}
+            onLayout={[Function]}
+            onTextLayout={[Function]}
+            style={
+              {
+                "color": "rgba(103, 80, 164, 1)",
+                "fontFamily": "System",
+                "fontSize": 16,
+                "fontWeight": undefined,
+                "left": 0,
+                "letterSpacing": 0.15,
+                "lineHeight": undefined,
+                "maxWidth": 97.33333333333333,
+                "opacity": 0,
+                "paddingLeft": 16,
+                "paddingRight": 56,
+                "position": "absolute",
+                "textAlign": "left",
+                "top": 30,
+                "transform": [
+                  {
+                    "translateX": 0,
+                  },
+                  {
+                    "translateY": -12,
+                  },
+                  {
+                    "scale": 0.75,
+                  },
+                ],
+                "writingDirection": "ltr",
+              }
+            }
+            testID="text-input-flat-label-active"
+          >
+            Flat input
+          </Text>
+          <Text
+            collapsable={false}
+            maxFontSizeMultiplier={1.5}
+            numberOfLines={1}
+            style={
+              {
+                "color": "rgba(73, 69, 79, 1)",
+                "fontFamily": "System",
+                "fontSize": 16,
+                "fontWeight": undefined,
+                "left": 0,
+                "letterSpacing": 0.15,
+                "lineHeight": undefined,
+                "maxWidth": 97.33333333333333,
+                "opacity": 0,
+                "paddingLeft": 16,
+                "paddingRight": 56,
+                "position": "absolute",
+                "textAlign": "left",
+                "top": 30,
+                "transform": [
+                  {
+                    "translateX": 0,
+                  },
+                  {
+                    "translateY": -12,
+                  },
+                  {
+                    "scale": 0.75,
+                  },
+                ],
+                "writingDirection": "ltr",
+              }
+            }
+            testID="text-input-flat-label-inactive"
+          >
+            Flat input
+          </Text>
+        </View>
+      </View>
     </View>
     <TextInput
       cursorColor="rgba(103, 80, 164, 1)"
@@ -1966,104 +2174,130 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
     }
   >
     <View
-      collapsable={false}
       pointerEvents="none"
       style={
-        {
-          "bottom": 0,
-          "left": 0,
-          "opacity": 0,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-          "transform": [
-            {
-              "translateX": 14,
-            },
-          ],
-          "width": 750,
-          "zIndex": 3,
-        }
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          {
+            "overflow": "hidden",
+          },
+        ]
       }
     >
-      <Text
+      <View
         collapsable={false}
-        maxFontSizeMultiplier={1.5}
-        numberOfLines={1}
-        onLayout={[Function]}
-        onTextLayout={[Function]}
+        pointerEvents="none"
         style={
           {
-            "color": "rgba(103, 80, 164, 1)",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
+            "bottom": 0,
             "left": 0,
-            "letterSpacing": 0.15,
-            "lineHeight": undefined,
-            "maxWidth": 73,
             "opacity": 0,
-            "paddingLeft": 56,
-            "paddingRight": 56,
             "position": "absolute",
-            "textAlign": "left",
-            "top": 30,
+            "right": 0,
+            "top": 0,
             "transform": [
               {
-                "translateX": 0,
-              },
-              {
-                "translateY": -12,
-              },
-              {
-                "scale": 0.75,
+                "translateX": 14,
               },
             ],
-            "writingDirection": "ltr",
+            "width": 750,
+            "zIndex": 3,
           }
         }
-        testID="text-input-flat-label-active"
       >
-        Flat input
-      </Text>
-      <Text
-        collapsable={false}
-        maxFontSizeMultiplier={1.5}
-        numberOfLines={1}
-        style={
-          {
-            "color": "rgba(73, 69, 79, 1)",
-            "fontFamily": "System",
-            "fontSize": 16,
-            "fontWeight": undefined,
-            "left": 0,
-            "letterSpacing": 0.15,
-            "lineHeight": undefined,
-            "maxWidth": 73,
-            "opacity": 0,
-            "paddingLeft": 56,
-            "paddingRight": 56,
-            "position": "absolute",
-            "textAlign": "left",
-            "top": 30,
-            "transform": [
-              {
-                "translateX": 0,
-              },
-              {
-                "translateY": -12,
-              },
-              {
-                "scale": 0.75,
-              },
-            ],
-            "writingDirection": "ltr",
+        <View
+          style={
+            {
+              "width": 97.33333333333333,
+            }
           }
-        }
-        testID="text-input-flat-label-inactive"
-      >
-        Flat input
-      </Text>
+        >
+          <Text
+            collapsable={false}
+            maxFontSizeMultiplier={1.5}
+            numberOfLines={1}
+            onLayout={[Function]}
+            onTextLayout={[Function]}
+            style={
+              {
+                "color": "rgba(103, 80, 164, 1)",
+                "fontFamily": "System",
+                "fontSize": 16,
+                "fontWeight": undefined,
+                "left": 0,
+                "letterSpacing": 0.15,
+                "lineHeight": undefined,
+                "maxWidth": 97.33333333333333,
+                "opacity": 0,
+                "paddingLeft": 56,
+                "paddingRight": 56,
+                "position": "absolute",
+                "textAlign": "left",
+                "top": 30,
+                "transform": [
+                  {
+                    "translateX": 0,
+                  },
+                  {
+                    "translateY": -12,
+                  },
+                  {
+                    "scale": 0.75,
+                  },
+                ],
+                "writingDirection": "ltr",
+              }
+            }
+            testID="text-input-flat-label-active"
+          >
+            Flat input
+          </Text>
+          <Text
+            collapsable={false}
+            maxFontSizeMultiplier={1.5}
+            numberOfLines={1}
+            style={
+              {
+                "color": "rgba(73, 69, 79, 1)",
+                "fontFamily": "System",
+                "fontSize": 16,
+                "fontWeight": undefined,
+                "left": 0,
+                "letterSpacing": 0.15,
+                "lineHeight": undefined,
+                "maxWidth": 97.33333333333333,
+                "opacity": 0,
+                "paddingLeft": 56,
+                "paddingRight": 56,
+                "position": "absolute",
+                "textAlign": "left",
+                "top": 30,
+                "transform": [
+                  {
+                    "translateX": 0,
+                  },
+                  {
+                    "translateY": -12,
+                  },
+                  {
+                    "scale": 0.75,
+                  },
+                ],
+                "writingDirection": "ltr",
+              }
+            }
+            testID="text-input-flat-label-inactive"
+          >
+            Flat input
+          </Text>
+        </View>
+      </View>
     </View>
     <TextInput
       cursorColor="rgba(103, 80, 164, 1)"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
The label in the TextInput component (both flat and outlined) is truncated when it is longer than the available width. This is expected behaviour, but the issue occurs when the label is moved over an input (focus on input or input with a value). The entire label is scaled, which causes the label to continue to be truncated even though we have space to show the rest of the content. 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
### Goal
Increase maximum text width to the maximum possible space.
### Related issue
#4350 

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan
Use TextInput with very long label. You can use example app

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->
![Simulator Screenshot - iPhone 15 Pro - 2024-05-21 at 10 51 48](https://github.com/callstack/react-native-paper/assets/165782545/aab15010-9c12-45b2-a81f-e7714eac2210)

![Simulator Screenshot - iPhone 15 Pro - 2024-05-21 at 10 51 16](https://github.com/callstack/react-native-paper/assets/165782545/d637fc29-e8eb-4973-b14f-f757e4aeb58b)

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->