### PR TITLE
fix(text-input-affix): fix right TextInput.Affix alignment with onPress

### DIFF
--- a/src/components/TextInput/Adornment/TextInputAffix.tsx
+++ b/src/components/TextInput/Adornment/TextInputAffix.tsx
@@ -153,7 +153,18 @@ const TextInputAffix = ({
 
   const textColor = getTextColor({ theme, disabled });
 
-  const affix = (
+  const content = (
+    <Text
+      maxFontSizeMultiplier={maxFontSizeMultiplier}
+      style={[{ color: textColor }, textStyle, labelStyle]}
+      onLayout={onTextLayout}
+      testID={`${testID}-text`}
+    >
+      {text}
+    </Text>
+  );
+
+  return (
     <Animated.View
       style={[
         styles.container,
@@ -169,30 +180,19 @@ const TextInputAffix = ({
       onLayout={onLayout}
       testID={testID}
     >
-      <Text
-        maxFontSizeMultiplier={maxFontSizeMultiplier}
-        style={[{ color: textColor }, textStyle, labelStyle]}
-        onLayout={onTextLayout}
-        testID={`${testID}-text`}
-      >
-        {text}
-      </Text>
+      {onPress ? (
+        <Pressable
+          onPress={onPress}
+          accessibilityRole="button"
+          accessibilityLabel={accessibilityLabel}
+        >
+          {content}
+        </Pressable>
+      ) : (
+        content
+      )}
     </Animated.View>
   );
-
-  if (onPress) {
-    return (
-      <Pressable
-        onPress={onPress}
-        accessibilityRole="button"
-        accessibilityLabel={accessibilityLabel}
-        style={styles.container}
-      >
-        {affix}
-      </Pressable>
-    );
-  }
-  return affix;
 };
 
 TextInputAffix.displayName = 'TextInput.Affix';

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -198,61 +198,54 @@ exports[`call onPress when affix adornment pressed 1`] = `
     />
   </View>
   <View
-    accessibilityLabel="+39"
-    accessibilityRole="button"
-    accessibilityState={
-      {
-        "busy": undefined,
-        "checked": undefined,
-        "disabled": undefined,
-        "expanded": undefined,
-        "selected": undefined,
-      }
-    }
-    accessibilityValue={
-      {
-        "max": undefined,
-        "min": undefined,
-        "now": undefined,
-        "text": undefined,
-      }
-    }
-    accessible={true}
     collapsable={false}
-    focusable={true}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
+    onLayout={[Function]}
     style={
       {
         "alignItems": "center",
         "justifyContent": "center",
+        "left": 16,
+        "opacity": 0,
         "position": "absolute",
+        "top": null,
       }
     }
+    testID="left-affix-adornment"
   >
     <View
-      collapsable={false}
-      onLayout={[Function]}
-      style={
+      accessibilityLabel="+39"
+      accessibilityRole="button"
+      accessibilityState={
         {
-          "alignItems": "center",
-          "justifyContent": "center",
-          "left": 16,
-          "opacity": 0,
-          "position": "absolute",
-          "top": null,
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
         }
       }
-      testID="left-affix-adornment"
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
     >
       <Text
         maxFontSizeMultiplier={1.5}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

The position of the right TextInput.Affix is not calculated correctly when the onPress method is provided. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### Related issue
#4407 
<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

Run Example and add a right affix to TextInput with the onPress property. Affix should render the same as without onPress. You can also try the example from the related issue.

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->

**The first recording shows how the component behaves before the fix (without and with the onPress property). The second is the result after the fix.**

https://github.com/callstack/react-native-paper/assets/165782545/91013325-ef40-458f-817e-7b6207961945



https://github.com/callstack/react-native-paper/assets/165782545/1b7e2a75-49bd-471a-8542-dc073c3f57da


