### PR TITLE
fix(text-input): parent scroll with text input height

### DIFF
--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -397,7 +397,7 @@ const TextInputFlat = ({
           multiline,
           style: [
             styles.input,
-            !multiline || (multiline && height) ? { height: flatHeight } : {},
+            multiline && height ? { height: flatHeight } : {},
             paddingFlat,
             {
               paddingLeft,
@@ -440,9 +440,11 @@ const styles = StyleSheet.create({
   labelContainer: {
     paddingTop: 0,
     paddingBottom: 0,
+    flex: 1,
   },
   input: {
     margin: 0,
+    flex: 1,
   },
   inputFlat: {
     paddingTop: 24,

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -264,8 +264,7 @@ const TextInputOutlined = ({
     (dense ? MIN_DENSE_HEIGHT_OUTLINED : MIN_HEIGHT)) as number;
 
   const outlinedHeight =
-    inputHeight + (!height ? (dense ? densePaddingTop / 2 : paddingTop) : 0);
-
+    inputHeight + (dense ? densePaddingTop / 2 : paddingTop);
   const { leftLayout, rightLayout } = parentState;
 
   const leftAffixTopPosition = calculateOutlinedIconAndAffixTopPosition({
@@ -427,9 +426,11 @@ export default TextInputOutlined;
 const styles = StyleSheet.create({
   labelContainer: {
     paddingBottom: 0,
+    flex: 1,
   },
   input: {
     margin: 0,
+    flex: 1,
   },
   inputOutlined: {
     paddingTop: 8,

--- a/src/components/TextInput/helpers.tsx
+++ b/src/components/TextInput/helpers.tsx
@@ -132,7 +132,7 @@ export const adjustPaddingOut = ({
   const refFontHeight = scale * fontSize;
   let result = pad;
 
-  if (height && !multiline) {
+  if (!isAndroid && height && !multiline) {
     return {
       paddingTop: Math.max(0, (height - fontHeight) / 2),
       paddingBottom: Math.max(0, (height - fontHeight) / 2),

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -38,6 +38,7 @@ exports[`call onPress when affix adornment pressed 1`] = `
     style={
       [
         {
+          "flex": 1,
           "paddingBottom": 0,
           "paddingTop": 0,
         },
@@ -160,11 +161,10 @@ exports[`call onPress when affix adornment pressed 1`] = `
       style={
         [
           {
+            "flex": 1,
             "margin": 0,
           },
-          {
-            "height": 56,
-          },
+          {},
           {
             "paddingBottom": 4,
             "paddingTop": 24,
@@ -318,6 +318,7 @@ exports[`correctly applies a component as the text label 1`] = `
     style={
       [
         {
+          "flex": 1,
           "paddingBottom": 0,
           "paddingTop": 0,
         },
@@ -457,11 +458,10 @@ exports[`correctly applies a component as the text label 1`] = `
       style={
         [
           {
+            "flex": 1,
             "margin": 0,
           },
-          {
-            "height": 56,
-          },
+          {},
           {
             "paddingBottom": 4,
             "paddingTop": 24,
@@ -532,6 +532,7 @@ exports[`correctly applies cursorColor prop 1`] = `
     style={
       [
         {
+          "flex": 1,
           "paddingBottom": 0,
           "paddingTop": 0,
         },
@@ -655,11 +656,10 @@ exports[`correctly applies cursorColor prop 1`] = `
       style={
         [
           {
+            "flex": 1,
             "margin": 0,
           },
-          {
-            "height": 56,
-          },
+          {},
           {
             "paddingBottom": 4,
             "paddingTop": 24,
@@ -730,6 +730,7 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
     style={
       [
         {
+          "flex": 1,
           "paddingBottom": 0,
           "paddingTop": 0,
         },
@@ -853,11 +854,10 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
       style={
         [
           {
+            "flex": 1,
             "margin": 0,
           },
-          {
-            "height": 56,
-          },
+          {},
           {
             "paddingBottom": 4,
             "paddingTop": 24,
@@ -921,6 +921,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
     style={
       [
         {
+          "flex": 1,
           "paddingBottom": 0,
         },
         {
@@ -1084,6 +1085,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
       style={
         [
           {
+            "flex": 1,
             "margin": 0,
           },
           {
@@ -1158,6 +1160,7 @@ exports[`correctly applies paddingLeft from contentStyleProp 1`] = `
     style={
       [
         {
+          "flex": 1,
           "paddingBottom": 0,
           "paddingTop": 0,
         },
@@ -1281,11 +1284,10 @@ exports[`correctly applies paddingLeft from contentStyleProp 1`] = `
       style={
         [
           {
+            "flex": 1,
             "margin": 0,
           },
-          {
-            "height": 56,
-          },
+          {},
           {
             "paddingBottom": 4,
             "paddingTop": 24,
@@ -1358,6 +1360,7 @@ exports[`correctly applies textAlign center 1`] = `
     style={
       [
         {
+          "flex": 1,
           "paddingBottom": 0,
           "paddingTop": 0,
         },
@@ -1481,11 +1484,10 @@ exports[`correctly applies textAlign center 1`] = `
       style={
         [
           {
+            "flex": 1,
             "margin": 0,
           },
-          {
-            "height": 56,
-          },
+          {},
           {
             "paddingBottom": 4,
             "paddingTop": 24,
@@ -1556,6 +1558,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
     style={
       [
         {
+          "flex": 1,
           "paddingBottom": 0,
           "paddingTop": 0,
         },
@@ -1679,11 +1682,10 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
       style={
         [
           {
+            "flex": 1,
             "margin": 0,
           },
-          {
-            "height": 56,
-          },
+          {},
           {
             "paddingBottom": 4,
             "paddingTop": 24,
@@ -1956,6 +1958,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
     style={
       [
         {
+          "flex": 1,
           "paddingBottom": 0,
           "paddingTop": 0,
         },
@@ -2079,11 +2082,10 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
       style={
         [
           {
+            "flex": 1,
             "margin": 0,
           },
-          {
-            "height": 56,
-          },
+          {},
           {
             "paddingBottom": 4,
             "paddingTop": 24,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->
**Platform: Android only**

### Motivation
This pull request fixes two bugs that are related to each other.

1. TextInput `mode="outlined"` with `height` style property blocks parent scroll. 

https://github.com/callstack/react-native-paper/assets/165782545/e7b8e7b8-157e-41d0-bbf0-8673a5d01466


2. `mode="outlined"` Left/right suffix is not correctly aligned to input when height style is provided
![Screenshot 2024-05-28 at 12 03 52 2](https://github.com/callstack/react-native-paper/assets/165782545/ceacc3af-22ad-4a10-b36f-72b4857432c4)

3. `mode="flat"`(default) blocks scrolling of the parent with a large font. The bug can be reproduced in the example app “Flat input large font”.

https://github.com/callstack/react-native-paper/assets/165782545/20bf336d-9ed2-4cad-853e-82e8e0159641

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### Related issue
#1556, #4390,  
<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan
1. To test issue 1 and 2 run example app and set `height` style of the Text input prop
2. To test issue 3 run example app, and try to scroll starting from `Flat input large font`
<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

Recording below shows result with the fix:

https://github.com/callstack/react-native-paper/assets/165782545/4a9ef63b-7a7a-42e1-ad99-4ed63dea281a



<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
