### PR TITLE
fix: error log TextInput Icon Default Props

### DIFF
--- a/src/components/TextInput/Adornment/TextInputIcon.tsx
+++ b/src/components/TextInput/Adornment/TextInputIcon.tsx
@@ -129,7 +129,7 @@ const IconAdornment: React.FunctionComponent<
 const TextInputIcon = ({
   icon,
   onPress,
-  forceTextInputFocus=true,
+  forceTextInputFocus = true,
   color: customColor,
   theme: themeOverrides,
   rippleColor,
@@ -175,7 +175,6 @@ const TextInputIcon = ({
   );
 };
 TextInputIcon.displayName = 'TextInput.Icon';
-
 
 const styles = StyleSheet.create({
   container: {

--- a/src/components/TextInput/Adornment/TextInputIcon.tsx
+++ b/src/components/TextInput/Adornment/TextInputIcon.tsx
@@ -129,7 +129,7 @@ const IconAdornment: React.FunctionComponent<
 const TextInputIcon = ({
   icon,
   onPress,
-  forceTextInputFocus,
+  forceTextInputFocus=true,
   color: customColor,
   theme: themeOverrides,
   rippleColor,
@@ -176,9 +176,6 @@ const TextInputIcon = ({
 };
 TextInputIcon.displayName = 'TextInput.Icon';
 
-TextInputIcon.defaultProps = {
-  forceTextInputFocus: true,
-};
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION

### Motivation

This PR prevents the error log TextInput Icon Default Props Will Removed From The Function Component.

### Related issue

Address [#4428 ](https://github.com/callstack/react-native-paper/issues/4428)

### Test plan

Ensure that use of the TextInputIcon does not produce the error (included in linked issue, mentioned above).  
