### PR TITLE
feat: add `iconPosition` to FAB

### DIFF
--- a/example/src/Examples/FABExample.tsx
+++ b/example/src/Examples/FABExample.tsx
@@ -10,6 +10,7 @@ import ScreenWrapper from '../ScreenWrapper';
 type FABVariant = 'primary' | 'secondary' | 'tertiary' | 'surface';
 type FABSize = 'small' | 'medium' | 'large';
 type FABMode = 'flat' | 'elevated';
+type FABIconPosition = 'left' | 'right';
 
 const FABExample = () => {
   const [visible, setVisible] = React.useState<boolean>(true);
@@ -21,6 +22,7 @@ const FABExample = () => {
   const variants = ['primary', 'secondary', 'tertiary', 'surface'];
   const sizes = ['small', 'medium', 'large'];
   const modes = ['flat', 'elevated'];
+  const iconPositions = ['left', 'right'];
 
   return (
     <ScreenWrapper style={styles.container}>
@@ -73,6 +75,21 @@ const FABExample = () => {
                   mode={mode as FABMode}
                 />
                 {visible && <Text variant="bodyMedium">{mode}</Text>}
+              </View>
+            ))}
+          </View>
+          <View style={styles.row}>
+            {iconPositions.map((position) => (
+              <View style={styles.fabVariant} key={position}>
+                <FAB
+                  icon="pencil"
+                  label={`icon ${position}`}
+                  style={styles.fab}
+                  onPress={() => {}}
+                  visible={visible}
+                  iconPosition={position as FABIconPosition}
+                />
+                {visible && <Text variant="bodyMedium">icon {position}</Text>}
               </View>
             ))}
           </View>

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -147,6 +147,10 @@ export type Props = $Omit<$RemoveChildren<typeof Surface>, 'mode'> & {
    * TestID used for testing purposes
    */
   testID?: string;
+  /**
+   * Direction that the content will be displayed
+   */
+  iconPosition?: 'left' | 'right';
   ref?: React.RefObject<View>;
 } & IconOrLabel;
 
@@ -205,6 +209,7 @@ const FAB = forwardRef<View, Props>(
       mode = 'elevated',
       variant = 'primary',
       labelMaxFontSizeMultiplier,
+      iconPosition = 'left',
       ...rest
     }: Props,
     ref
@@ -306,7 +311,11 @@ const FAB = forwardRef<View, Props>(
           {...rest}
         >
           <View
-            style={[styles.content, label ? extendedStyle : fabStyle]}
+            style={[
+              styles.content,
+              label ? extendedStyle : fabStyle,
+              iconPosition === 'left' ? styles.iconLeft : styles.iconRight,
+            ]}
             testID={`${testID}-content`}
             pointerEvents="none"
           >
@@ -349,8 +358,13 @@ const styles = StyleSheet.create({
   elevated: {
     elevation: 6,
   },
-  content: {
+  iconLeft: {
     flexDirection: 'row',
+  },
+  iconRight: {
+    flexDirection: 'row-reverse',
+  },
+  content: {
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/src/components/__tests__/FAB.test.tsx
+++ b/src/components/__tests__/FAB.test.tsx
@@ -186,6 +186,23 @@ it('renders FAB with uppercase styling if uppercase prop is truthy', () => {
   });
 });
 
+(['left', 'right'] as const).forEach((iconPosition) => {
+  it(`renders FAB with icon positioned to the ${iconPosition}`, () => {
+    const { getByTestId } = render(
+      <FAB
+        onPress={() => {}}
+        icon="plus"
+        iconPosition={iconPosition}
+        testID={`${iconPosition}-icon-fab`}
+      />
+    );
+
+    expect(getByTestId(`${iconPosition}-icon-fab-content`)).toHaveStyle({
+      flexDirection: iconPosition === 'left' ? 'row' : 'row-reverse',
+    });
+  });
+});
+
 describe('getFABColors - background color', () => {
   it('should return color from styles', () => {
     expect(

--- a/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
@@ -92,13 +92,15 @@ exports[`renders FAB with custom size prop 1`] = `
           [
             {
               "alignItems": "center",
-              "flexDirection": "row",
               "justifyContent": "center",
             },
             {
               "borderRadius": 25,
               "height": 100,
               "width": 100,
+            },
+            {
+              "flexDirection": "row",
             },
           ]
         }
@@ -273,13 +275,15 @@ exports[`renders custom color for the icon and label of the FAB 1`] = `
           [
             {
               "alignItems": "center",
-              "flexDirection": "row",
               "justifyContent": "center",
             },
             {
               "borderRadius": 16,
               "height": 56,
               "width": 56,
+            },
+            {
+              "flexDirection": "row",
             },
           ]
         }
@@ -454,13 +458,15 @@ exports[`renders default FAB 1`] = `
           [
             {
               "alignItems": "center",
-              "flexDirection": "row",
               "justifyContent": "center",
             },
             {
               "borderRadius": 16,
               "height": 56,
               "width": 56,
+            },
+            {
+              "flexDirection": "row",
             },
           ]
         }
@@ -635,13 +641,15 @@ exports[`renders disabled FAB 1`] = `
           [
             {
               "alignItems": "center",
-              "flexDirection": "row",
               "justifyContent": "center",
             },
             {
               "borderRadius": 16,
               "height": 56,
               "width": 56,
+            },
+            {
+              "flexDirection": "row",
             },
           ]
         }
@@ -817,13 +825,15 @@ exports[`renders extended FAB 1`] = `
           [
             {
               "alignItems": "center",
-              "flexDirection": "row",
               "justifyContent": "center",
             },
             {
               "borderRadius": 16,
               "height": 56,
               "paddingHorizontal": 16,
+            },
+            {
+              "flexDirection": "row",
             },
           ]
         }
@@ -1039,12 +1049,14 @@ exports[`renders extended FAB with custom size prop 1`] = `
           [
             {
               "alignItems": "center",
-              "flexDirection": "row",
               "justifyContent": "center",
             },
             {
               "height": 100,
               "paddingHorizontal": 16,
+            },
+            {
+              "flexDirection": "row",
             },
           ]
         }
@@ -1259,13 +1271,15 @@ exports[`renders large FAB 1`] = `
           [
             {
               "alignItems": "center",
-              "flexDirection": "row",
               "justifyContent": "center",
             },
             {
               "borderRadius": 28,
               "height": 96,
               "width": 96,
+            },
+            {
+              "flexDirection": "row",
             },
           ]
         }
@@ -1440,13 +1454,15 @@ exports[`renders loading FAB 1`] = `
           [
             {
               "alignItems": "center",
-              "flexDirection": "row",
               "justifyContent": "center",
             },
             {
               "borderRadius": 16,
               "height": 56,
               "width": 56,
+            },
+            {
+              "flexDirection": "row",
             },
           ]
         }
@@ -1745,13 +1761,15 @@ exports[`renders loading FAB with custom size prop 1`] = `
           [
             {
               "alignItems": "center",
-              "flexDirection": "row",
               "justifyContent": "center",
             },
             {
               "borderRadius": 25,
               "height": 100,
               "width": 100,
+            },
+            {
+              "flexDirection": "row",
             },
           ]
         }
@@ -2050,13 +2068,15 @@ exports[`renders not visible FAB 1`] = `
           [
             {
               "alignItems": "center",
-              "flexDirection": "row",
               "justifyContent": "center",
             },
             {
               "borderRadius": 16,
               "height": 56,
               "width": 56,
+            },
+            {
+              "flexDirection": "row",
             },
           ]
         }
@@ -2231,13 +2251,15 @@ exports[`renders small FAB 1`] = `
           [
             {
               "alignItems": "center",
-              "flexDirection": "row",
               "justifyContent": "center",
             },
             {
               "borderRadius": 12,
               "height": 40,
               "width": 40,
+            },
+            {
+              "flexDirection": "row",
             },
           ]
         }
@@ -2412,13 +2434,15 @@ exports[`renders visible FAB 1`] = `
           [
             {
               "alignItems": "center",
-              "flexDirection": "row",
               "justifyContent": "center",
             },
             {
               "borderRadius": 16,
               "height": 56,
               "width": 56,
+            },
+            {
+              "flexDirection": "row",
             },
           ]
         }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When using the `Floating Action Button` component, we are able to provide the icon and the label that we want to use. But, searching between the documentation and the code, it seems that there are no implemented way of changing the order the label and the icon are displayed.

By default, we render the `icon` and the `label` respectively in this order. But we may want to render the `label` before the `icon`, and that is not possible at this moment. Because of that, this PR adds a new prop called `iconPosition` (we can change it if necessary) that will change the `flex-direction` prop based on the value:

- When the `iconPosition` is `left`, the `flex-direction` will be set to `row` (the current default value);
- When the `iconPosition` is `right`, the `flex-direction` will be set to `row-inverted`;

### Related issue

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

I didn't find any issues about this, but I need to implement a solution that will use the FAB component, but the UX Designer wants the icon to be rendered on the right of the label. I did try to fix this on my side, but I thought that it would be a good idea to have this option by default, because other developers may also want to change the display order.

### Test plan

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

- Open the `example` app;
- Navigate to the `Floating Action Button` examples;
- You will find the example that I added with the two possible values for this prop;

![CleanShot 2024-06-17 at 15 35 53@2x](https://github.com/callstack/react-native-paper/assets/25802240/cf19d188-a73a-45ca-87bf-e99694f1062e)


But you can easily test on your own by simply adding the `iconPosition` prop to the `FAB` component. The `left` is the default value, so:

- If the `iconPosition` is not defined, it will assume the `left` value and stay as it is today.
- If the `iconPosition` is set to `right`, the label and the icon should change places.
- If the `iconPosition` is set but no `label` is provided, the `flex-direction` will be changed to `row-inverted` but it should not impact on the final result.


<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
