### PR TITLE
fix(text-input-label-background): custom component background height

### DIFF
--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -20,6 +20,7 @@ const InputLabel = (props: InputLabelProps) => {
     focused,
     opacity,
     labelLayoutWidth,
+    labelLayoutHeight,
     labelBackground,
     label,
     labelError,
@@ -157,6 +158,7 @@ const InputLabel = (props: InputLabelProps) => {
           {labelBackground?.({
             labeled,
             labelLayoutWidth,
+            labelLayoutHeight,
             labelStyle,
             placeholderStyle,
             baseLabelTranslateX,

--- a/src/components/TextInput/Label/LabelBackground.tsx
+++ b/src/components/TextInput/Label/LabelBackground.tsx
@@ -7,10 +7,10 @@ import type { LabelBackgroundProps } from '../types';
 const LabelBackground = ({
   labeled,
   labelLayoutWidth,
+  labelLayoutHeight,
   placeholderStyle,
   baseLabelTranslateX,
   topPosition,
-  label,
   backgroundColor,
   roundness,
   labelStyle,
@@ -69,6 +69,7 @@ const LabelBackground = ({
         {
           top: topPosition + 1,
           width: labelLayoutWidth - placeholderStyle.paddingHorizontal,
+          height: labelLayoutHeight,
           backgroundColor,
           opacity,
           transform: labelTextTransform,
@@ -76,9 +77,7 @@ const LabelBackground = ({
       ]}
       numberOfLines={1}
       maxFontSizeMultiplier={maxFontSizeMultiplier}
-    >
-      {typeof label === 'string' ? label : label?.props.children}
-    </AnimatedText>,
+    />,
   ];
 };
 

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -380,6 +380,7 @@ const TextInputFlat = ({
             wiggle={Boolean(parentState.value && labelProps.labelError)}
             labelLayoutMeasured={parentState.labelLayout.measured}
             labelLayoutWidth={parentState.labelLayout.width}
+            labelLayoutHeight={parentState.labelLayout.height}
             {...labelProps}
           />
         ) : null}

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -368,6 +368,7 @@ const TextInputOutlined = ({
             wiggle={Boolean(parentState.value && labelProps.labelError)}
             labelLayoutMeasured={parentState.labelLayout.measured}
             labelLayoutWidth={parentState.labelLayout.width}
+            labelLayoutHeight={parentState.labelLayout.height}
             {...labelProps}
             labelBackground={LabelBackground}
             maxFontSizeMultiplier={rest.maxFontSizeMultiplier}

--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -137,6 +137,7 @@ export type InputLabelProps = {
   opacity: number;
   labelLayoutMeasured: boolean;
   labelLayoutWidth: number;
+  labelLayoutHeight: number;
   inputContainerLayout: { width: number };
   labelBackground?: any;
   maxFontSizeMultiplier?: number | undefined | null;
@@ -148,6 +149,7 @@ export type LabelBackgroundProps = {
   labelStyle: any;
   labeled: Animated.Value;
   labelLayoutWidth: number;
+  labelLayoutHeight: number;
   maxFontSizeMultiplier?: number | undefined | null;
   theme?: ThemeProp;
 } & LabelProps;

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -1084,6 +1084,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
                 "fontFamily": "System",
                 "fontSize": 16,
                 "fontWeight": undefined,
+                "height": 0,
                 "left": 8,
                 "letterSpacing": 0.15,
                 "lineHeight": undefined,
@@ -1111,9 +1112,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
               }
             }
             testID="text-input-outlined-label-background"
-          >
-            Outline Input
-          </Text>
+          />
           <Text
             collapsable={false}
             maxFontSizeMultiplier={1.5}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
Label with nested text components are displayed twice.

Previously, to calculate the background of a label, the label itself was rendered and the color of its text was set to `transparent`. Everything worked for the label as a string or a single <Text> element. For nested <Text> components, setting `color: "transparent"` didn't work and the text was duplicated (nested text color was not set as transparent). This pull request changes the way to get the right shape, as we already store the height of the label. Instead of rendering the label, we simply use the height value. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### Related issue
#4441 

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan
Run example app and use label from the related issue or example below

```js
<TextInput
  mode="outlined"
  label={
    <Text style={{ color: 'red' }}>
      First <Text style={{ color: 'blue' }}>Second</Text>
    </Text>
  }
  placeholder="Type something"
  value={outlinedText}
  onChangeText={(outlinedText) =>
    inputActionHandler('outlinedText', outlinedText)
  }
/>
```
 
| **BEFORE**                                                                                                       | **AFTER**                                                                                                       |
|------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
|  ![image](https://github.com/callstack/react-native-paper/assets/165782545/1a80015d-3edc-4f11-a7ff-ba92103e4483) | ![image](https://github.com/callstack/react-native-paper/assets/165782545/12b0032f-29bb-41a3-bfb1-a18261183ab4) |
| Red "First" is not duplicated, but blue "Second" is displayed twice. Second one is a tiny one                    | The label is not duplicated. The background has not changed                                                     |



<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
