### PR TITLE
fix(snackbar): fix show animation on new architecture

### DIFF
--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -172,10 +172,9 @@ const Snackbar = ({
 
   const { scale } = theme.animation;
 
-  const handleOnVisible = useLatestCallback(() => {
-    // show
+  const animateShow = useLatestCallback(() => {
     if (hideTimeout.current) clearTimeout(hideTimeout.current);
-    setHidden(false);
+
     Animated.timing(opacity, {
       toValue: 1,
       duration: 200 * scale,
@@ -197,6 +196,11 @@ const Snackbar = ({
     });
   });
 
+  const handleOnVisible = useLatestCallback(() => {
+    // show
+    setHidden(false);
+  });
+
   const handleOnHidden = useLatestCallback(() => {
     // hide
     if (hideTimeout.current) {
@@ -213,6 +217,12 @@ const Snackbar = ({
       }
     });
   });
+
+  React.useEffect(() => {
+    if (!hidden) {
+      animateShow();
+    }
+  }, [animateShow, hidden]);
 
   React.useEffect(() => {
     return () => {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
This bug is only available on android with new architecture enabled and is well described (with and example) in the related issue #4445 
From what I've been able to find, the problem occurs when the animation is started before the component is rendered.
In our scenario, the component returns null as long as the `hidden` state is set to true. In the `handleOnVisible` function we have the main steps `setHidden(false)` and Animation start. To fix the bug, I moved the start of the animation to a useEffect that depends on the `hidden` value, so that the animation will start after the state is changed (and component re-rendered).

btw, since this bug only occurs with the new architecture, it is either also a react-native bug or an expected change. I have not found an answer yet. 

### Related issue
#4445 
<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan
Run android app with New Architecture enabled and try to show/hide snackbar.

| **Before**                                                                                            | **After**                                                                                             |
|-------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
| <video src="https://github.com/callstack/react-native-paper/assets/165782545/973ecf72-c749-499c-99fd-1d6b7d6f287e"> |<video src="https://github.com/callstack/react-native-paper/assets/165782545/eb498a83-700c-4607-85bb-5afeee816272"> |
 


<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
