### PR TITLE
fix: fixed Chip "shadow" and height issue

### DIFF
--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -294,8 +294,7 @@ const Chip = ({
     <Surface
       style={[
         styles.container,
-        isV3 &&
-          (isOutlined ? styles.md3OutlineContainer : styles.md3FlatContainer),
+        isV3 && styles.md3Container,
         !theme.isV3 && {
           elevation: elevationStyle,
         },
@@ -439,11 +438,8 @@ const styles = StyleSheet.create({
     borderStyle: 'solid',
     flexDirection: Platform.select({ default: 'column', web: 'row' }),
   },
-  md3OutlineContainer: {
+  md3Container: {
     borderWidth: 1,
-  },
-  md3FlatContainer: {
-    borderWidth: 0,
   },
   content: {
     flexDirection: 'row',

--- a/src/components/Chip/helpers.tsx
+++ b/src/components/Chip/helpers.tsx
@@ -21,6 +21,16 @@ const getBorderColor = ({
   const isSelectedColor = selectedColor !== undefined;
 
   if (theme.isV3) {
+    if (disabled && !isOutlined) {
+      // If the Chip mode is "flat", and disabled set border color to transparent
+      return 'transparent';
+    }
+
+    if (!isOutlined) {
+      // If the Chip mode is "flat", set border color to transparent
+      return 'transparent';
+    }
+
     if (disabled) {
       return color(theme.colors.onSurfaceVariant).alpha(0.12).rgb().string();
     }

--- a/src/components/__tests__/Chip.test.tsx
+++ b/src/components/__tests__/Chip.test.tsx
@@ -669,10 +669,7 @@ describe('getChipColor - border color', () => {
         isOutlined: false,
       })
     ).toMatchObject({
-      borderColor: color(getTheme().colors.onSurfaceVariant)
-        .alpha(0.12)
-        .rgb()
-        .string(),
+      borderColor: 'transparent',
     });
   });
 
@@ -684,7 +681,7 @@ describe('getChipColor - border color', () => {
         isOutlined: false,
       })
     ).toMatchObject({
-      borderColor: color('purple').alpha(0.29).rgb().string(),
+      borderColor: 'transparent',
     });
   });
 
@@ -695,7 +692,7 @@ describe('getChipColor - border color', () => {
         isOutlined: false,
       })
     ).toMatchObject({
-      borderColor: getTheme().colors.outline,
+      borderColor: 'transparent',
     });
   });
 

--- a/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -23,10 +23,10 @@ exports[`renders chip with close button 1`] = `
     style={
       {
         "backgroundColor": "rgba(232, 222, 248, 1)",
-        "borderColor": "rgba(121, 116, 126, 1)",
+        "borderColor": "transparent",
         "borderRadius": 8,
         "borderStyle": "solid",
-        "borderWidth": 0,
+        "borderWidth": 1,
         "flex": undefined,
         "flexDirection": "column",
         "shadowColor": "#000",
@@ -332,10 +332,10 @@ exports[`renders chip with custom close button 1`] = `
     style={
       {
         "backgroundColor": "rgba(232, 222, 248, 1)",
-        "borderColor": "rgba(121, 116, 126, 1)",
+        "borderColor": "transparent",
         "borderRadius": 8,
         "borderStyle": "solid",
-        "borderWidth": 0,
+        "borderWidth": 1,
         "flex": undefined,
         "flexDirection": "column",
         "shadowColor": "#000",
@@ -641,10 +641,10 @@ exports[`renders chip with icon 1`] = `
     style={
       {
         "backgroundColor": "rgba(232, 222, 248, 1)",
-        "borderColor": "rgba(121, 116, 126, 1)",
+        "borderColor": "transparent",
         "borderRadius": 8,
         "borderStyle": "solid",
-        "borderWidth": 0,
+        "borderWidth": 1,
         "flex": undefined,
         "flexDirection": "column",
         "shadowColor": "#000",
@@ -850,10 +850,10 @@ exports[`renders chip with onPress 1`] = `
     style={
       {
         "backgroundColor": "rgba(232, 222, 248, 1)",
-        "borderColor": "rgba(121, 116, 126, 1)",
+        "borderColor": "transparent",
         "borderRadius": 8,
         "borderStyle": "solid",
-        "borderWidth": 0,
+        "borderWidth": 1,
         "flex": undefined,
         "flexDirection": "column",
         "shadowColor": "#000",
@@ -1164,10 +1164,10 @@ exports[`renders selected chip 1`] = `
     style={
       {
         "backgroundColor": "rgb(232, 222, 248)",
-        "borderColor": "rgba(121, 116, 126, 1)",
+        "borderColor": "transparent",
         "borderRadius": 8,
         "borderStyle": "solid",
-        "borderWidth": 0,
+        "borderWidth": 1,
         "flex": undefined,
         "flexDirection": "column",
         "shadowColor": "#000",

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -136,10 +136,10 @@ exports[`renders list item with custom description 1`] = `
               style={
                 {
                   "backgroundColor": "rgba(232, 222, 248, 1)",
-                  "borderColor": "rgba(121, 116, 126, 1)",
+                  "borderColor": "transparent",
                   "borderRadius": 8,
                   "borderStyle": "solid",
-                  "borderWidth": 0,
+                  "borderWidth": 1,
                   "flex": undefined,
                   "flexDirection": "column",
                   "shadowColor": "#000",


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

![image](https://github.com/user-attachments/assets/584244dc-2162-4306-8381-d232be545885)

There is an issue with the `Chip` component when a `Chip` with `mode="outlined"` is used next to one with `mode="flat"` (see screenshot). The `Chip` with `mode="flat"` displays a kind of "shadow" at the bottom.

This problem is caused by the `Surface` component, which splits styles provided via props into `outerLayerViewStyles` and `innerLayerViewStyles`. Specifically, it is caused by the `backgroundColor`, which has the same value in both `outerLayerViewStyles` and `innerLayerViewStyles` (see below, [reference](https://github.com/callstack/react-native-paper/blob/bc0ecb1a7381928ebb5bc10fa491e27046430dc1/src/components/Surface.tsx#L194C1-L207C9)):

```ts
  const outerLayerViewStyles = {
        ...(isElevated && getStyleForShadowLayer(elevation, 0)),
        ...outerLayerStyles,
        ...borderRadiusStyles,
        backgroundColor: bgColor,
      };

  const innerLayerViewStyles = {
    ...(isElevated && getStyleForShadowLayer(elevation, 1)),
    ...filteredStyles,
    ...borderRadiusStyles,
    flex: flattenedStyles.height ? 1 : undefined,
    backgroundColor: bgColor,
  };
```
A `Chip` with `mode="outlined"` is `2dp` larger in width and height than one with `mode="flat"` due to its `borderWidth` of `1dp`. When both modes are placed next to each other, the outer `View` of the `Surface` component adjusts to fill the height difference, but the inner `View` does not. Since the background color for a disabled `Chip` uses RGBA (with opacity), the inner and outer background colors create overlapping layers, resulting in the visible "shadow" at the bottom.

#### Possible solutions

##### 1. Adding `flexGrow: 1` to the `Surface` used inside `Chip` component

Adding `flexGrow: 1` would resolve the issue by allowing the inner `View` of the `Surface` to grow and match the height of the outer `View`. However, because [outerLayerStylesProperties](https://github.com/callstack/react-native-paper/blob/bc0ecb1a7381928ebb5bc10fa491e27046430dc1/src/components/Surface.tsx#L80C1-L96C3) includes `flexGrow`, it won't be applied to the inner layer out of the box. To manage this, we could pass separate props like `innerLayerStyles` and `outerLayerStyles`. However, this approach might affect other components using `Surface`, making it a more complex solution.

##### 2. Setting `borderWidth:1` for both modes and within the `flat` mode setting the `borderColor` to `transparent` (implemented here)

IMO this is the least impactful solution. It ensures both modes have matching dimensions (width and height) and restricts the change to the `Chip` component itself.


### Related issue

https://github.com/callstack/react-native-paper/issues/4457

### Test plan

You can test it by changing `ChipExample.tsx`

```jsx
 <View style={styles.container}>
      <Chip mode="outlined" selected={false}>
          Not selected, enabled
      </Chip>
      <Chip mode="flat" selected disabled>
          Selected, disabled
      </Chip>
 </View>
```

```jsx

const styles = StyleSheet.create({
  container: {
    marginTop: 16,
    flexDirection: 'row',
    justifyContent: 'space-around',
  },
});

```

![image](https://github.com/user-attachments/assets/7bcc3dfe-f43f-464f-af69-61a1b816698b)
