### PR TITLE
fix: fixed issue with textinput styling after new release

### DIFF
--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -443,11 +443,11 @@ const styles = StyleSheet.create({
   labelContainer: {
     paddingTop: 0,
     paddingBottom: 0,
-    flex: 1,
+    flexGrow: 1,
   },
   input: {
     margin: 0,
-    flex: 1,
+    flexGrow: 1,
   },
   inputFlat: {
     paddingTop: 24,

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -429,11 +429,11 @@ export default TextInputOutlined;
 const styles = StyleSheet.create({
   labelContainer: {
     paddingBottom: 0,
-    flex: 1,
+    flexGrow: 1,
   },
   input: {
     margin: 0,
-    flex: 1,
+    flexGrow: 1,
   },
   inputOutlined: {
     paddingTop: 8,

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`call onPress when affix adornment pressed 1`] = `
     style={
       [
         {
-          "flex": 1,
+          "flexGrow": 1,
           "paddingBottom": 0,
           "paddingTop": 0,
         },
@@ -187,7 +187,7 @@ exports[`call onPress when affix adornment pressed 1`] = `
       style={
         [
           {
-            "flex": 1,
+            "flexGrow": 1,
             "margin": 0,
           },
           {},
@@ -337,7 +337,7 @@ exports[`correctly applies a component as the text label 1`] = `
     style={
       [
         {
-          "flex": 1,
+          "flexGrow": 1,
           "paddingBottom": 0,
           "paddingTop": 0,
         },
@@ -503,7 +503,7 @@ exports[`correctly applies a component as the text label 1`] = `
       style={
         [
           {
-            "flex": 1,
+            "flexGrow": 1,
             "margin": 0,
           },
           {},
@@ -577,7 +577,7 @@ exports[`correctly applies cursorColor prop 1`] = `
     style={
       [
         {
-          "flex": 1,
+          "flexGrow": 1,
           "paddingBottom": 0,
           "paddingTop": 0,
         },
@@ -727,7 +727,7 @@ exports[`correctly applies cursorColor prop 1`] = `
       style={
         [
           {
-            "flex": 1,
+            "flexGrow": 1,
             "margin": 0,
           },
           {},
@@ -801,7 +801,7 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
     style={
       [
         {
-          "flex": 1,
+          "flexGrow": 1,
           "paddingBottom": 0,
           "paddingTop": 0,
         },
@@ -951,7 +951,7 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
       style={
         [
           {
-            "flex": 1,
+            "flexGrow": 1,
             "margin": 0,
           },
           {},
@@ -1018,7 +1018,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
     style={
       [
         {
-          "flex": 1,
+          "flexGrow": 1,
           "paddingBottom": 0,
         },
         {
@@ -1207,7 +1207,7 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
       style={
         [
           {
-            "flex": 1,
+            "flexGrow": 1,
             "margin": 0,
           },
           {
@@ -1282,7 +1282,7 @@ exports[`correctly applies paddingLeft from contentStyleProp 1`] = `
     style={
       [
         {
-          "flex": 1,
+          "flexGrow": 1,
           "paddingBottom": 0,
           "paddingTop": 0,
         },
@@ -1432,7 +1432,7 @@ exports[`correctly applies paddingLeft from contentStyleProp 1`] = `
       style={
         [
           {
-            "flex": 1,
+            "flexGrow": 1,
             "margin": 0,
           },
           {},
@@ -1508,7 +1508,7 @@ exports[`correctly applies textAlign center 1`] = `
     style={
       [
         {
-          "flex": 1,
+          "flexGrow": 1,
           "paddingBottom": 0,
           "paddingTop": 0,
         },
@@ -1658,7 +1658,7 @@ exports[`correctly applies textAlign center 1`] = `
       style={
         [
           {
-            "flex": 1,
+            "flexGrow": 1,
             "margin": 0,
           },
           {},
@@ -1732,7 +1732,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
     style={
       [
         {
-          "flex": 1,
+          "flexGrow": 1,
           "paddingBottom": 0,
           "paddingTop": 0,
         },
@@ -1882,7 +1882,7 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
       style={
         [
           {
-            "flex": 1,
+            "flexGrow": 1,
             "margin": 0,
           },
           {},
@@ -2158,7 +2158,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
     style={
       [
         {
-          "flex": 1,
+          "flexGrow": 1,
           "paddingBottom": 0,
           "paddingTop": 0,
         },
@@ -2308,7 +2308,7 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
       style={
         [
           {
-            "flex": 1,
+            "flexGrow": 1,
             "margin": 0,
           },
           {},


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

After the recent update, we've encountered an issue with the TextInput styling where the input field appears collapsed.

Before applying `flexGrow: 1`:

![image](https://github.com/user-attachments/assets/ec38ceb1-da09-4bbf-b0c5-b25484215acf)


After applying `flexGrow: 1`:

![image](https://github.com/user-attachments/assets/d6a13729-9832-4a43-b1b3-acd89950e89d)


### Related issue

https://github.com/callstack/react-native-paper/issues/4463

### Test plan

Screenshots are above.
