### PR TITLE
docs: update expo start command to run example project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ When you're working on a component:
 
 The example app uses [Expo](https://expo.dev/) for the React Native example. You will need to install the Expo app for [Android](https://play.google.com/store/apps/details?id=host.exp.exponent) and [iOS](https://itunes.apple.com/app/apple-store/id982107779) to start developing.
 
-After you're done, you can run `yarn example start` in the project root (or `expo start` in the `example/` folder) and scan the QR code to launch it on your device.
+After you're done, you can run `npx expo start --offline` in the `example/` folder and scan the QR code to launch it on your device.
 
 To run the example on web, run `yarn example web` in the project root.
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This pull request adds the updated command to run expo, so that the "owner" field on app.json doesn't affect the app.
It prevents getting the following error
```
ApiV2Error: Entity Not Authorized.
```

### Related issue

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->
This pull request, addresses this issue https://github.com/callstack/react-native-paper/issues/4473 

### Test plan

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

Previously when trying to run the example project using ```yarn example run``` on root project or ```expo start``` in example folder it would give the error mentioned above.

With the using new command ```npx expo start --offline``` ( which is added with this pull requests on docs), the example project runs without any issue.

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
