### PR TITLE
Typo fix in docs

### DIFF
--- a/docs/src/data/themeColors.js
+++ b/docs/src/data/themeColors.js
@@ -194,7 +194,7 @@ const themeColors = {
     disabled: {
       textColor: 'theme.colors.onSurfaceDisabled',
     },
-    defualt: {
+    default: {
       textColor: 'theme.colors.onSurfaceVariant',
     },
     error: {


### PR DESCRIPTION
### Related issue
[1] Typo fix in docs. Link - https://callstack.github.io/react-native-paper/docs/components/HelperText/#:~:text=theme.colors.onSurfaceDisabled-,defualt,-theme.colors.onSurfaceVariant