### PR TITLE
fix: no longer spread key prop on BottomNavigationBar - resolves #4401

### DIFF
--- a/src/components/BottomNavigation/BottomNavigationBar.tsx
+++ b/src/components/BottomNavigation/BottomNavigationBar.tsx
@@ -360,7 +360,9 @@ const BottomNavigationBar = <Route extends BaseRoute>({
   navigationState,
   renderIcon,
   renderLabel,
-  renderTouchable = (props: TouchableProps<Route>) => <Touchable {...props} />,
+  renderTouchable = ({ key, ...props }: TouchableProps<Route>) => (
+    <Touchable key={key} {...props} />
+  ),
   getLabelText = ({ route }: { route: Route }) => route.title,
   getBadge = ({ route }: { route: Route }) => route.badge,
   getColor = ({ route }: { route: Route }) => route.color,


### PR DESCRIPTION
### Motivation
Resolves #4401 with suggested fix from @CommanderRedYT

### Related issue
#4401

### Test plan
Tested following contribution guidelines https://github.com/callstack/react-native-paper/blob/main/CONTRIBUTING.md