### PR TITLE
fix: input label not visible on ios if multiline, fixes #4482

### DIFF
--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -138,7 +138,7 @@ const InputLabel = (props: InputLabelProps) => {
     // This gives the effect of animating the color, but allows us to use native driver
     <View
       pointerEvents="none"
-      style={[StyleSheet.absoluteFill, styles.overflow]}
+      style={[StyleSheet.absoluteFill, styles.overflow, styles.labelContainer]}
     >
       <Animated.View
         pointerEvents="none"

--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -144,7 +144,6 @@ const InputLabel = (props: InputLabelProps) => {
         pointerEvents="none"
         style={[
           StyleSheet.absoluteFill,
-          styles.labelContainer,
           Platform.OS !== 'web' && { width },
           { opacity },
           labelTranslationX,

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -85,7 +85,6 @@ exports[`call onPress when affix adornment pressed 1`] = `
               },
             ],
             "width": 750,
-            "zIndex": 3,
           }
         }
       >
@@ -384,7 +383,6 @@ exports[`correctly applies a component as the text label 1`] = `
               },
             ],
             "width": 750,
-            "zIndex": 3,
           }
         }
       >
@@ -627,7 +625,6 @@ exports[`correctly applies cursorColor prop 1`] = `
               },
             ],
             "width": 750,
-            "zIndex": 3,
           }
         }
       >
@@ -854,7 +851,6 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
               },
             ],
             "width": 750,
-            "zIndex": 3,
           }
         }
       >
@@ -1074,7 +1070,6 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
               },
             ],
             "width": 750,
-            "zIndex": 3,
           }
         }
       >
@@ -1341,7 +1336,6 @@ exports[`correctly applies paddingLeft from contentStyleProp 1`] = `
               },
             ],
             "width": 750,
-            "zIndex": 3,
           }
         }
       >
@@ -1570,7 +1564,6 @@ exports[`correctly applies textAlign center 1`] = `
               },
             ],
             "width": 750,
-            "zIndex": 3,
           }
         }
       >
@@ -1797,7 +1790,6 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
               },
             ],
             "width": 750,
-            "zIndex": 3,
           }
         }
       >
@@ -2226,7 +2218,6 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
               },
             ],
             "width": 750,
-            "zIndex": 3,
           }
         }
       >

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -62,6 +62,9 @@ exports[`call onPress when affix adornment pressed 1`] = `
           {
             "overflow": "hidden",
           },
+          {
+            "zIndex": 3,
+          },
         ]
       }
     >
@@ -358,6 +361,9 @@ exports[`correctly applies a component as the text label 1`] = `
           {
             "overflow": "hidden",
           },
+          {
+            "zIndex": 3,
+          },
         ]
       }
     >
@@ -598,6 +604,9 @@ exports[`correctly applies cursorColor prop 1`] = `
           {
             "overflow": "hidden",
           },
+          {
+            "zIndex": 3,
+          },
         ]
       }
     >
@@ -822,6 +831,9 @@ exports[`correctly applies default textAlign based on default RTL 1`] = `
           {
             "overflow": "hidden",
           },
+          {
+            "zIndex": 3,
+          },
         ]
       }
     >
@@ -1038,6 +1050,9 @@ exports[`correctly applies height to multiline Outline TextInput 1`] = `
           },
           {
             "overflow": "hidden",
+          },
+          {
+            "zIndex": 3,
           },
         ]
       }
@@ -1303,6 +1318,9 @@ exports[`correctly applies paddingLeft from contentStyleProp 1`] = `
           {
             "overflow": "hidden",
           },
+          {
+            "zIndex": 3,
+          },
         ]
       }
     >
@@ -1529,6 +1547,9 @@ exports[`correctly applies textAlign center 1`] = `
           {
             "overflow": "hidden",
           },
+          {
+            "zIndex": 3,
+          },
         ]
       }
     >
@@ -1752,6 +1773,9 @@ exports[`correctly renders left-side affix adornment, and right-side icon adornm
           },
           {
             "overflow": "hidden",
+          },
+          {
+            "zIndex": 3,
           },
         ]
       }
@@ -2178,6 +2202,9 @@ exports[`correctly renders left-side icon adornment, and right-side affix adornm
           },
           {
             "overflow": "hidden",
+          },
+          {
+            "zIndex": 3,
           },
         ]
       }


### PR DESCRIPTION
### Motivation

This PR solves this [issue](https://github.com/callstack/react-native-paper/issues/4482). "When focusing into a TextInput (when mode='flat'), the label disappears. It shows up normally when multiline=false, and this is only a problem on iOS."

### Related issue

[issue](https://github.com/callstack/react-native-paper/issues/4482)

### Test plan

I've checked it on ios simulator and android emulator, since example project is on expo 48 i cannot install it on my phone.
I've also updated `TextInput.test.tsx.snap` snapshot since tests were failing.