### PR TITLE
fix(fab.group): subitems are accessibility focusable when collapsed

### DIFF
--- a/example/src/Examples/FABExample.tsx
+++ b/example/src/Examples/FABExample.tsx
@@ -145,6 +145,7 @@ const FABExample = () => {
           <FAB.Group
             open={open}
             icon={open ? 'calendar-today' : 'plus'}
+            accessibilityLabel='Calendar FAB'
             toggleStackOnLongPress={toggleStackOnLongPress}
             actions={[
               { icon: 'plus', onPress: () => {} },

--- a/example/src/Examples/FABExample.tsx
+++ b/example/src/Examples/FABExample.tsx
@@ -145,7 +145,7 @@ const FABExample = () => {
           <FAB.Group
             open={open}
             icon={open ? 'calendar-today' : 'plus'}
-            accessibilityLabel='Calendar FAB'
+            accessibilityLabel="Calendar FAB"
             toggleStackOnLongPress={toggleStackOnLongPress}
             actions={[
               { icon: 'plus', onPress: () => {} },

--- a/src/components/FAB/FABGroup.tsx
+++ b/src/components/FAB/FABGroup.tsx
@@ -383,8 +383,9 @@ const FABGroup = ({
                 ]}
                 pointerEvents={open ? 'box-none' : 'none'}
                 accessibilityRole="button"
-                importantForAccessibility="yes"
-                accessible={true}
+                importantForAccessibility={open ? 'yes' : 'no-hide-descendants'}
+                accessibilityElementsHidden={!open}
+                accessible={open}
                 accessibilityLabel={accessibilityLabel}
               >
                 {it.label && (


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Goal**: Improve the accessibility of the `FAB.Group` component by preventing hidden items from being focused.




### Related issue

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

Previously, FAB.Group items were accessibility focusable even when the menu was collapsed:

[recording1.webm](https://github.com/user-attachments/assets/f239db6e-8d22-4de7-8d14-0c89f6cab775)

**Note**: This only fixes the issue on Android and iOS. A similar issue persists on web.

### Test plan

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

**iOS**:
1. Open the example app in the simulator.
2. Open the "Floating Action Button" example.
3. Enable VoiceOver system-wide.
4. Move VoiceOver focus to the simulator.
5. Move VoiceOver focus to the next item. Verify that the item is not a hidden member of the `FAB.Group`.
6. Repeat step 5 until focus is on the "+" FAB.
7. Activate the current item.
8. Move VoiceOver focus to the next item until the floating calendar FAB has focus. Verify that the menu items ("unlabeled", "star", "email", "remind", toggle on long press") each are focusable.
   - Note: VoiceOver will focus items not in the FAB.Group menu during this step. This is a separate issue.

**Screen recording**:

[recording2.webm](https://github.com/user-attachments/assets/39674380-51c2-48c4-9342-d22260b4608d)



**Note**: The above screen recording also uses Expo SDK 51 (I was having trouble deploying the example with SDK 48).


<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
