### PR TITLE
feat:Multi-line buttons should be possible via configuration

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -147,6 +147,10 @@ export type Props = $Omit<React.ComponentProps<typeof Surface>, 'mode'> & {
    * testID to be used on tests.
    */
   testID?: string;
+  /**
+   * Number of lines the label text is limited to. Defaults to 1
+   */
+  numberOfLines?: number;
 };
 
 /**
@@ -196,6 +200,7 @@ const Button = (
     background,
     maxFontSizeMultiplier,
     touchableRef,
+    numberOfLines = 1,
     ...rest
   }: Props,
   ref: React.ForwardedRef<View>
@@ -383,7 +388,7 @@ const Button = (
           <Text
             variant="labelLarge"
             selectable={false}
-            numberOfLines={1}
+            numberOfLines={numberOfLines}
             testID={`${testID}-text`}
             style={[
               styles.label,

--- a/src/components/__tests__/Button.test.tsx
+++ b/src/components/__tests__/Button.test.tsx
@@ -909,3 +909,19 @@ it('animated value changes correctly', () => {
     transform: [{ scale: 1.5 }],
   });
 });
+
+describe('numberOfLines', ()=> {
+  it('defaults to 1', () => {
+    const { getByTestId } = render(
+      <Button testID="button">Button</Button>
+    );
+    expect(getByTestId('button-text')).toHaveProp('numberOfLines', 1);
+  })
+  it('matches specified prop', () => {
+    const { getByTestId } = render(
+      <Button numberOfLines={2} testID="button">Button</Button>
+    );
+    expect(getByTestId('button-text')).toHaveProp('numberOfLines', 2);
+  })
+});
+


### PR DESCRIPTION
Motivation
Multi-line buttons should be possible via configuration.

Related issue
(https://github.com/callstack/react-native-paper/discussions/2584#discussioncomment-10715321)

Test plan
<Button icon="content-save-edit" onLongPress={handleSubmit(submit)} onPress={() => Alert.alert('Press & hold')} numberOfLines={2} > A short label{'\n'}<Text style={{ fontSize: 8, margin: 0, lineHeight: 12 }}>(Press & hold)</Text> </Button>

image image