### PR TITLE
fix: use transformOrigin to fix TextInput label position flickering in RN 0.73

### DIFF
--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -111,6 +111,9 @@ const InputLabel = (props: InputLabelProps) => {
             : labeled,
       },
     ],
+    ...(Platform.constants.reactNativeVersion.minor >= 73 && {
+      transformOrigin: 'left',
+    }),
   };
 
   const labelWidth =
@@ -147,7 +150,8 @@ const InputLabel = (props: InputLabelProps) => {
           styles.labelContainer,
           Platform.OS !== 'web' && { width },
           { opacity },
-          labelTranslationX,
+          Platform.constants.reactNativeVersion.minor <= 72 &&
+            labelTranslationX,
         ]}
       >
         <View

--- a/src/components/TextInput/Label/LabelBackground.tsx
+++ b/src/components/TextInput/Label/LabelBackground.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Animated, StyleSheet } from 'react-native';
+import { Animated, StyleSheet, Platform } from 'react-native';
 
 import AnimatedText from '../../Typography/AnimatedText';
 import type { LabelBackgroundProps } from '../types';
@@ -50,8 +50,10 @@ const LabelBackground = ({
           backgroundColor,
           maxHeight: Math.max(roundness / 3, 2),
           bottom: Math.max(roundness, 2),
-          transform: [labelTranslationX],
           opacity,
+        },
+        Platform.constants.reactNativeVersion.minor <= 72 && {
+          transform: [labelTranslationX],
         },
       ]}
     />


### PR DESCRIPTION
### Motivation

This pull request aims to resolve the TextInput flickering issue caused by the use of translateX to adjust the label position. The recent addition of transformOrigin in React Native 0.73 allows us to set the transform origin directly to the left, removing the need for translateX adjustments and preventing flickering.

### Related issue

#4341 
#4245 
#4299 
#4340 

### Test plan

1. Run the application on React Native 0.73 or later.
2. Test TextInput components with floating labels in with mode "outlined"
3. Verify that the label no longer flickers or jumps during state changes.
