### PR TITLE
docs: fix default mode name for HelperText

### DIFF
--- a/docs/src/data/themeColors.js
+++ b/docs/src/data/themeColors.js
@@ -194,7 +194,7 @@ const themeColors = {
     disabled: {
       textColor: 'theme.colors.onSurfaceDisabled',
     },
-    defualt: {
+    default: {
       textColor: 'theme.colors.onSurfaceVariant',
     },
     error: {


### PR DESCRIPTION
fix default mode name for HelperText