### PR TITLE
Fixed ThemeProp mapping - SegmentedButtonItem.tsx

### DIFF
--- a/src/components/SegmentedButtons/SegmentedButtonItem.tsx
+++ b/src/components/SegmentedButtons/SegmentedButtonItem.tsx
@@ -12,7 +12,7 @@ import {
 } from 'react-native';
 
 import color from 'color';
-import type { ThemeProp } from 'src/types';
+import type { ThemeProp } from '../../../src/types';
 
 import {
   getSegmentedButtonBorderRadius,


### PR DESCRIPTION
## Fix: Correct `ThemeProp` import path in `SegmentedButtonItem.tsx`

This pull request corrects the import path for `ThemeProp` in `SegmentedButtonItem.tsx`.  The original import path was incorrect, leading to a broken build or runtime errors.

**Motivation:**

The current import `import type { ThemeProp } from 'src/types';` is relative to the component's location and does not correctly resolve the `ThemeProp` type.  This change updates the import to the correct relative path: `import type { ThemeProp } from '../../../src/types';`

**Related Issue:**

(If applicable, link to the related issue here.  Otherwise, leave this section blank or describe the problem.)

**Test Plan:**

1. Build the project.  Verify that the build succeeds without errors related to `ThemeProp`.
2. Run the application and ensure that the Segmented Buttons functionality works as expected.  Confirm that there are no runtime errors related to the `ThemeProp` type.


This commit resolves this issue by fixing the import statement. The change involves a single addition and deletion within `SegmentedButtonItem.tsx`. The pull request is mergeable and passes lint, TypeScript, and tests.