### PR TITLE
fix: android bottom tabs crash fix when used with react-native-screens

### DIFF
--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -548,7 +548,8 @@ const BottomNavigation = <Route extends BaseRoute>({
               removeClippedSubviews={
                 // On iOS, set removeClippedSubviews to true only when not focused
                 // This is an workaround for a bug where the clipped view never re-appears
-                Platform.OS === 'ios' ? navigationState.index !== index : true
+                // On Android, it is disabled until https://github.com/software-mansion/react-native-screens/issues/2491 is fixed
+                Platform.OS === 'ios' ? navigationState.index !== index : false
               }
             >
               <Animated.View


### PR DESCRIPTION
This PR fixes the issue with `MaterialBottomTabsNavigator` when used with `react-native-screens` by setting `removeClippedSubviews` for `BottomNavigation` scene to false.

### Motivation

Having this flag set to `true` was causing android application to crash when the `MaterialBottomTabsNavigator` was used inside native stack navigator.

### Related issue

Closes https://github.com/callstack/react-native-paper/issues/4546

### Test plan

Tested on https://github.com/maciekBudzinski/rnp-material-bottom-tabs-repro-issue

Before:

[before.webm](https://github.com/user-attachments/assets/43c1ebff-f03b-4870-87f1-bf31602c4e97)

After:

[after.webm](https://github.com/user-attachments/assets/c41cb127-2e23-4c58-bf3b-bd049200c05d)