### PR TITLE
fix: Set Default iOS LineHeight to 0 for Text Alignment Consistency Across Languages

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -130,6 +130,10 @@ export type Props = $Omit<React.ComponentProps<typeof Surface>, 'mode'> & {
    * Specifies the largest possible scale a text font can reach.
    */
   maxFontSizeMultiplier?: number;
+  /**
+   * Label text number Of Lines of the button.
+   */
+  noOfLines?: number;
   style?: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
   /**
    * Style for the button text.
@@ -186,6 +190,7 @@ const Button = (
     onPressOut,
     onLongPress,
     delayLongPress,
+    noOfLines,
     style,
     theme: themeOverrides,
     uppercase: uppercaseProp,
@@ -266,6 +271,7 @@ const Button = (
 
   const borderRadius = (isV3 ? 5 : 1) * roundness;
   const iconSize = isV3 ? 18 : 16;
+  const numberOfLines = noOfLines ? 1 : noOfLines;
 
   const { backgroundColor, borderColor, textColor, borderWidth } =
     getButtonColors({
@@ -383,7 +389,7 @@ const Button = (
           <Text
             variant="labelLarge"
             selectable={false}
-            numberOfLines={1}
+            numberOfLines={numberOfLines}
             testID={`${testID}-text`}
             style={[
               styles.label,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -130,10 +130,6 @@ export type Props = $Omit<React.ComponentProps<typeof Surface>, 'mode'> & {
    * Specifies the largest possible scale a text font can reach.
    */
   maxFontSizeMultiplier?: number;
-  /**
-   * Label text number Of Lines of the button.
-   */
-  noOfLines?: number;
   style?: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
   /**
    * Style for the button text.
@@ -190,7 +186,6 @@ const Button = (
     onPressOut,
     onLongPress,
     delayLongPress,
-    noOfLines,
     style,
     theme: themeOverrides,
     uppercase: uppercaseProp,
@@ -271,7 +266,6 @@ const Button = (
 
   const borderRadius = (isV3 ? 5 : 1) * roundness;
   const iconSize = isV3 ? 18 : 16;
-  const numberOfLines = noOfLines ? 1 : noOfLines;
 
   const { backgroundColor, borderColor, textColor, borderWidth } =
     getButtonColors({
@@ -389,7 +383,7 @@ const Button = (
           <Text
             variant="labelLarge"
             selectable={false}
-            numberOfLines={numberOfLines}
+            numberOfLines={1}
             testID={`${testID}-text`}
             style={[
               styles.label,

--- a/src/components/SegmentedButtons/SegmentedButtonItem.tsx
+++ b/src/components/SegmentedButtons/SegmentedButtonItem.tsx
@@ -237,7 +237,11 @@ const SegmentedButtonItem = ({
           ) : null}
           {showIcon ? (
             <Animated.View testID={`${testID}-icon`} style={iconStyle}>
-              <IconComponent color={textColor} source={icon ? icon:'progress-question'} size={iconSize} />
+              <IconComponent
+                color={textColor}
+                source={icon ? icon : 'progress-question'}
+                size={iconSize}
+              />
             </Animated.View>
           ) : null}
           <Text

--- a/src/components/SegmentedButtons/SegmentedButtonItem.tsx
+++ b/src/components/SegmentedButtons/SegmentedButtonItem.tsx
@@ -35,6 +35,10 @@ export type Props = {
    */
   icon?: IconSource;
   /**
+   * Whether an icon change is animated.
+   */
+  animated?: boolean;
+  /**
    * @supported Available in v5.x with theme version 3
    * Custom color for unchecked Text and Icon.
    */
@@ -106,6 +110,7 @@ export type Props = {
 
 const SegmentedButtonItem = ({
   checked,
+  animated = false,
   accessibilityLabel,
   disabled,
   style,
@@ -202,7 +207,9 @@ const SegmentedButtonItem = ({
       : theme.fonts.labelLarge),
     color: textColor,
   };
-
+  
+  const IconComponent = animated ? CrossFadeIcon : Icon;
+  
   return (
     <View style={[buttonStyle, styles.button, style]}>
       <TouchableRipple
@@ -229,7 +236,7 @@ const SegmentedButtonItem = ({
           ) : null}
           {showIcon ? (
             <Animated.View testID={`${testID}-icon`} style={iconStyle}>
-              <Icon source={icon} size={iconSize} color={textColor} />
+              <IconComponent color={textColor} source={icon ? icon:'progress-question'} size={iconSize} />
             </Animated.View>
           ) : null}
           <Text

--- a/src/components/SegmentedButtons/SegmentedButtonItem.tsx
+++ b/src/components/SegmentedButtons/SegmentedButtonItem.tsx
@@ -20,11 +20,11 @@ import {
   getSegmentedButtonDensityPadding,
 } from './utils';
 import { useInternalTheme } from '../../core/theming';
+import CrossFadeIcon from '../CrossFadeIcon';
 import type { IconSource } from '../Icon';
 import Icon from '../Icon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import Text from '../Typography/Text';
-import CrossFadeIcon from '../CrossFadeIcon';
 
 export type Props = {
   /**

--- a/src/components/SegmentedButtons/SegmentedButtonItem.tsx
+++ b/src/components/SegmentedButtons/SegmentedButtonItem.tsx
@@ -79,6 +79,10 @@ export type Props = {
    */
   label?: string;
   /**
+   * Label text number of lines of the button.
+   */
+  numberOfLines?: number;
+  /**
    * Button segment.
    */
   segment?: 'first' | 'last';
@@ -124,6 +128,7 @@ const SegmentedButtonItem = ({
   icon,
   testID,
   label,
+  numberOfLines,
   onPress,
   segment,
   density = 'regular',
@@ -209,6 +214,7 @@ const SegmentedButtonItem = ({
     color: textColor,
   };
   const IconComponent = animated ? CrossFadeIcon : Icon;
+  const NumberOfLines = numberOfLines ? numberOfLines : 1;
   return (
     <View style={[buttonStyle, styles.button, style]}>
       <TouchableRipple
@@ -246,7 +252,7 @@ const SegmentedButtonItem = ({
             variant="labelLarge"
             style={[styles.label, labelTextStyle, labelStyle]}
             selectable={false}
-            numberOfLines={1}
+            numberOfLines={NumberOfLines}
             maxFontSizeMultiplier={labelMaxFontSizeMultiplier}
             testID={`${testID}-label`}
           >

--- a/src/components/SegmentedButtons/SegmentedButtonItem.tsx
+++ b/src/components/SegmentedButtons/SegmentedButtonItem.tsx
@@ -24,7 +24,7 @@ import type { IconSource } from '../Icon';
 import Icon from '../Icon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import Text from '../Typography/Text';
-import CrossFadeIcon from '../../../src/components/CrossFadeIcon';
+import CrossFadeIcon from '../CrossFadeIcon';
 
 export type Props = {
   /**

--- a/src/components/SegmentedButtons/SegmentedButtonItem.tsx
+++ b/src/components/SegmentedButtons/SegmentedButtonItem.tsx
@@ -24,6 +24,7 @@ import type { IconSource } from '../Icon';
 import Icon from '../Icon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import Text from '../Typography/Text';
+import CrossFadeIcon from '../../../src/components/CrossFadeIcon';
 
 export type Props = {
   /**

--- a/src/components/SegmentedButtons/SegmentedButtonItem.tsx
+++ b/src/components/SegmentedButtons/SegmentedButtonItem.tsx
@@ -208,9 +208,7 @@ const SegmentedButtonItem = ({
       : theme.fonts.labelLarge),
     color: textColor,
   };
-  
   const IconComponent = animated ? CrossFadeIcon : Icon;
-  
   return (
     <View style={[buttonStyle, styles.button, style]}>
       <TouchableRipple

--- a/src/components/SegmentedButtons/SegmentedButtons.tsx
+++ b/src/components/SegmentedButtons/SegmentedButtons.tsx
@@ -53,6 +53,7 @@ export type Props = {
    * - `icon`: icon to display for the item
    * - `disabled`: whether the button is disabled
    * - `accessibilityLabel`: acccessibility label for the button. This is read by the screen reader when the user taps the button.
+   * - `numberOfLines`: label text number of lines of the button
    * - `checkedColor`: custom color for checked Text and Icon
    * - `uncheckedColor`: custom color for unchecked Text and Icon
    * - `onPress`: callback that is called when button is pressed
@@ -66,6 +67,7 @@ export type Props = {
     icon?: IconSource;
     disabled?: boolean;
     accessibilityLabel?: string;
+    numberOfLines?: number;
     checkedColor?: string;
     uncheckedColor?: string;
     onPress?: (event: GestureResponderEvent) => void;

--- a/src/components/SegmentedButtons/SegmentedButtons.tsx
+++ b/src/components/SegmentedButtons/SegmentedButtons.tsx
@@ -79,6 +79,7 @@ export type Props = {
    * Density is applied to the height, to allow usage in denser UIs
    */
   density?: 'regular' | 'small' | 'medium' | 'high';
+  animated?: boolean;
   style?: StyleProp<ViewStyle>;
   theme?: ThemeProp;
 } & ConditionalValue;
@@ -132,6 +133,7 @@ const SegmentedButtons = ({
   buttons,
   multiSelect,
   density,
+  animated,
   style,
   theme: themeOverrides,
 }: Props) => {
@@ -172,6 +174,7 @@ const SegmentedButtons = ({
             {...item}
             key={i}
             checked={checked}
+            animated={animated}
             segment={segment}
             density={density}
             onPress={onPress}

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -147,6 +147,7 @@ const Text = (
           styles.text,
           { writingDirection, color: theme.colors.onSurface },
           textStyle,
+          Platform.OS == 'ios' && { lineHeight: 0 }
         ]}
         {...rest}
       />
@@ -161,7 +162,7 @@ const Text = (
       <NativeText
         {...rest}
         ref={root}
-        style={[styles.text, textStyle, { writingDirection }, style]}
+        style={[styles.text, textStyle, { writingDirection }, style, Platform.OS == 'ios' && { lineHeight: 0 }]}
       />
     );
   }


### PR DESCRIPTION
This update sets the default lineHeight property to 0 for iOS Text components. This adjustment ensures consistent text alignment when rendering content in English and other languages. By standardizing the lineHeight, issues with misaligned or uneven text appearance in multi-language scenarios are resolved, enhancing UI readability and design uniformity.

**Key Changes:**

- Default lineHeight for iOS is explicitly set to 0 for Text components.
- Improves alignment consistency across languages with varying script sizes and styles.
- No impact on Android, maintaining platform-specific behavior.