### PR TITLE
fix(animated-fab): label styling (web)

### DIFF
--- a/src/components/FAB/utils.ts
+++ b/src/components/FAB/utils.ts
@@ -436,13 +436,17 @@ export const getExtendedFabStyle = ({
   return isV3 ? v3Extended : extended;
 };
 
+let cachedContext: CanvasRenderingContext2D | null = null;
+
 const getCanvasContext = () => {
-  const fragment = document.createDocumentFragment();
+  if (cachedContext) {
+    return cachedContext;
+  }
+
   const canvas = document.createElement('canvas');
+  cachedContext = canvas.getContext('2d');
 
-  fragment.appendChild(canvas);
-
-  return canvas.getContext('2d');
+  return cachedContext;
 };
 
 export const getLabelSizeWeb = (ref: MutableRefObject<HTMLElement | null>) => {

--- a/src/components/FAB/utils.ts
+++ b/src/components/FAB/utils.ts
@@ -1,4 +1,11 @@
-import { Animated, ColorValue, I18nManager, ViewStyle } from 'react-native';
+import { MutableRefObject } from 'react';
+import {
+  Animated,
+  ColorValue,
+  I18nManager,
+  Platform,
+  ViewStyle,
+} from 'react-native';
 
 import color from 'color';
 
@@ -427,4 +434,37 @@ export const getExtendedFabStyle = ({
   const { isV3 } = theme;
 
   return isV3 ? v3Extended : extended;
+};
+
+const getCanvasContext = () => {
+  const fragment = document.createDocumentFragment();
+  const canvas = document.createElement('canvas');
+
+  fragment.appendChild(canvas);
+
+  return canvas.getContext('2d');
+};
+
+export const getLabelSizeWeb = (ref: MutableRefObject<HTMLElement | null>) => {
+  if (Platform.OS !== 'web' || ref.current === null) {
+    return null;
+  }
+
+  const canvasContext = getCanvasContext();
+
+  if (!canvasContext) {
+    return null;
+  }
+
+  const elementStyles = window.getComputedStyle(ref.current);
+  canvasContext.font = elementStyles.font;
+
+  const metrics = canvasContext.measureText(ref.current.innerText);
+
+  return {
+    width: metrics.width,
+    height:
+      (metrics.fontBoundingBoxAscent ?? 0) +
+      (metrics.fontBoundingBoxDescent ?? 0),
+  };
 };

--- a/src/components/Typography/AnimatedText.tsx
+++ b/src/components/Typography/AnimatedText.tsx
@@ -4,6 +4,7 @@ import { Animated, I18nManager, StyleSheet, TextStyle } from 'react-native';
 import type { VariantProp } from './types';
 import { useInternalTheme } from '../../core/theming';
 import type { ThemeProp } from '../../types';
+import { forwardRef } from '../../utils/forwardRef';
 
 type Props<T> = React.ComponentPropsWithRef<typeof Animated.Text> & {
   /**
@@ -33,12 +34,10 @@ type Props<T> = React.ComponentPropsWithRef<typeof Animated.Text> & {
  *
  * @extends Text props https://reactnative.dev/docs/text#props
  */
-function AnimatedText({
-  style,
-  theme: themeOverrides,
-  variant,
-  ...rest
-}: Props<never>) {
+const AnimatedText = forwardRef(function AnimatedText(
+  { style, theme: themeOverrides, variant, ...rest }: Props<never>,
+  ref
+) {
   const theme = useInternalTheme(themeOverrides);
   const writingDirection = I18nManager.getConstants().isRTL ? 'rtl' : 'ltr';
 
@@ -54,6 +53,7 @@ function AnimatedText({
 
     return (
       <Animated.Text
+        ref={ref}
         {...rest}
         style={[
           font,
@@ -71,6 +71,7 @@ function AnimatedText({
     };
     return (
       <Animated.Text
+        ref={ref}
         {...rest}
         style={[
           styles.text,
@@ -83,7 +84,7 @@ function AnimatedText({
       />
     );
   }
-}
+});
 
 const styles = StyleSheet.create({
   text: {


### PR DESCRIPTION

### Motivation

Currently, whole styling related logic in AnimatedFAB component relies on `onTextLayout`, which is mobile specific, so FAB's label is not styled well in web.  


### Related issue

https://github.com/callstack/react-native-paper/issues/4478

### Test plan

* Animated FAB is looking good when example app is running in web browser and there's no regression for mobile devices.

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
