### PR TITLE
Fix - ProgressBar crashes app in new arch on android

### DIFF
--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -203,7 +203,9 @@ const ProgressBar = ({
       accessibilityRole="progressbar"
       accessibilityState={{ busy: visible }}
       accessibilityValue={
-        indeterminate ? {} : { min: 0, max: 100, now: progress * 100 }
+        indeterminate
+          ? {}
+          : { min: 0, max: 100, now: Number((progress * 100).toFixed(2)) }
       }
       style={isWeb && styles.webContainer}
       testID={testID}


### PR DESCRIPTION
### Motivation
In new arch android, ProgressBar crashes app when long length float value is used in `progress`

Error log: Warning: Error: Exception in HostFunction: Loss of precision during arithmetic conversion: (long) 33.33333333333333

So I did a fix and now we can't have long decimal numbers in `accessibilityValue`

### Related issue
https://github.com/callstack/react-native-paper/issues/4544

### Test plan
To reproduce a bug put in ProgressBar prop `progress={0.07}`

0.07*100 in JS is equal to 7.000000000000001

and that was my case.

I tested using dependencies:
"expo": "^52.0.0",
"react-native": "0.76.3",
"react-native-paper": "^5.12.5"

Everything works fine now
