### PR TITLE
feat: allow usage of custom border radius for animated fab

### DIFF
--- a/src/components/FAB/AnimatedFAB.tsx
+++ b/src/components/FAB/AnimatedFAB.tsx
@@ -419,7 +419,10 @@ const AnimatedFAB = ({
         </View>
         <Animated.View
           pointerEvents="box-none"
-          style={[styles.innerWrapper, { borderRadius }]}
+          style={[
+            styles.innerWrapper,
+            { borderRadius: restStyle?.borderRadius || borderRadius },
+          ]}
         >
           <Animated.View
             style={[
@@ -427,7 +430,7 @@ const AnimatedFAB = ({
               {
                 width: extendedWidth,
                 backgroundColor,
-                borderRadius,
+                borderRadius: restStyle?.borderRadius || borderRadius,
               },
               combinedStyles.innerWrapper,
             ]}

--- a/src/components/FAB/AnimatedFAB.tsx
+++ b/src/components/FAB/AnimatedFAB.tsx
@@ -351,7 +351,7 @@ const AnimatedFAB = ({
               scale: visibility,
             },
           ],
-          borderRadius,
+          borderRadius: restStyle?.borderRadius || borderRadius,
         },
         !isV3 && {
           elevation: md2Elevation,
@@ -375,7 +375,7 @@ const AnimatedFAB = ({
             ],
           },
           styles.standard,
-          { borderRadius },
+          { borderRadius: restStyle?.borderRadius || borderRadius },
         ]}
       >
         <View style={[StyleSheet.absoluteFill, styles.shadowWrapper]}>
@@ -389,7 +389,7 @@ const AnimatedFAB = ({
                   inputRange: propForDirection([distance, 0.9 * distance, 0]),
                   outputRange: propForDirection([1, 0.15, 0]),
                 }),
-                borderRadius,
+                borderRadius: restStyle?.borderRadius || borderRadius,
               },
             ]}
             testID={`${testID}-extended-shadow`}
@@ -408,7 +408,8 @@ const AnimatedFAB = ({
                   inputRange: propForDirection([distance, 0]),
                   outputRange: propForDirection([
                     SIZE / (extendedWidth / SIZE),
-                    borderRadius,
+                    (restStyle?.borderRadius as number | undefined) ||
+                      borderRadius,
                   ]),
                 }),
               },
@@ -447,7 +448,7 @@ const AnimatedFAB = ({
               accessibilityRole="button"
               accessibilityState={newAccessibilityState}
               testID={testID}
-              style={{ borderRadius }}
+              style={{ borderRadius: restStyle?.borderRadius || borderRadius }}
               theme={theme}
             >
               <View


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->
### Motivation
I was using the `AnimatedFAB` component, But I wanted it's `borderRadius` to be completely round. But, when I applied the `borderRadius` property on the style, it does not work. So, to fix that issue and allow the usage of custom `borderRadius`, I came up with this feature.

### Test plan
Assign any number to `borderRadius`, and it should work.
<img width="353" alt="Screenshot 2025-01-01 at 10 32 40 PM" src="https://github.com/user-attachments/assets/accfcf15-ad24-42d0-a761-b042ad80ce39" />
<img width="353" alt="Screenshot 2025-01-01 at 10 32 55 PM" src="https://github.com/user-attachments/assets/e2fb59ff-237e-440d-9abc-180556b156af" />
