### PR TITLE
[BugFix - Severity HIGH] Hide modal through onDismiss callback

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -206,14 +206,14 @@ function Modal({
       accessibilityViewIsModal
       accessibilityLiveRegion="polite"
       style={StyleSheet.absoluteFill}
-      onAccessibilityEscape={hideModal}
+      onAccessibilityEscape={onDismissCallback}
       testID={testID}
     >
       <AnimatedPressable
         accessibilityLabel={overlayAccessibilityLabel}
         accessibilityRole="button"
         disabled={!dismissable}
-        onPress={dismissable ? hideModal : undefined}
+        onPress={dismissable ? onDismissCallback : undefined}
         importantForAccessibility="no"
         style={[
           styles.backdrop,

--- a/src/components/__tests__/Modal.test.tsx
+++ b/src/components/__tests__/Modal.test.tsx
@@ -130,29 +130,6 @@ describe('Modal', () => {
           opacity: 1,
         });
       });
-
-      it('should invoke the onDismiss function after the animation', () => {
-        const onDismiss = jest.fn();
-        const { getByTestId } = render(
-          <Modal testID="modal" visible onDismiss={onDismiss}>
-            {null}
-          </Modal>
-        );
-
-        expect(onDismiss).not.toHaveBeenCalled();
-
-        act(() => {
-          fireEvent.press(getByTestId('modal-backdrop'));
-        });
-
-        expect(onDismiss).not.toHaveBeenCalled();
-
-        act(() => {
-          jest.runAllTimers();
-        });
-
-        expect(onDismiss).toHaveBeenCalledTimes(1);
-      });
     });
 
     describe('if closed via Android back button', () => {


### PR DESCRIPTION
**Current behavior**: When user presses outside of modal, it gets dismissed internally regardless of whether app logic wants to close the modal and then user provided callback is invoked. This results in flicker - internal close and then immediate open due to `visible` state still `true` on modal if the app logic doesn't dismiss the modal immediately. Flicker is also caused if there are frame delays between user callback being invoked and `visible` state being set

**New Behavior**: Initiate dismiss modal only when app logic sets `visible` state to false

**Steps to reproduce bug**: Pass empty function as `onDismiss` callback and press outside of modal - modal flickers

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
Modal flickering on Android on close

https://github.com/user-attachments/assets/2e8f7294-b2f0-4855-9846-1a25014f4dd7