### PR TITLE
fix: issue when uncontrolled input value is set programmatically i.e …

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -290,7 +290,13 @@ const TextInput = forwardRef<TextInputHandles, Props>(
     React.useImperativeHandle(ref, () => ({
       focus: () => root.current?.focus(),
       clear: () => root.current?.clear(),
-      setNativeProps: (args: Object) => root.current?.setNativeProps(args),
+      setNativeProps: (args: Object) => {
+        if ('text' in args) {
+          // Update uncontrolledValue when text is set via setNativeProps
+          setUncontrolledValue(args.text as string);
+        }
+        root.current?.setNativeProps(args);
+      },
       isFocused: () => root.current?.isFocused() || false,
       blur: () => root.current?.blur(),
       forceFocus: () => root.current?.focus(),

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -290,7 +290,7 @@ const TextInput = forwardRef<TextInputHandles, Props>(
     React.useImperativeHandle(ref, () => ({
       focus: () => root.current?.focus(),
       clear: () => root.current?.clear(),
-      setNativeProps: (args: Object) => {
+      setNativeProps: (args: { text?: string } & Object) => {
         if ('text' in args) {
           // Update uncontrolledValue when text is set via setNativeProps
           setUncontrolledValue(args.text as string);


### PR DESCRIPTION
…without typing

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

We have a use case which I feel is very common. We have remark suggestions for an entry. Once suggestion is chosen from list of suggestions and value is set using setNativeProps method, uncontrolledValue is not updated this is resulting input label and palceholder to get overlapped.

This can also happen in cases where pastes the content into input without typing it.  

### Related issue


### Screenshots
- Before

![Screenshot_20250113-170518](https://github.com/user-attachments/assets/0839b8c7-ea51-4903-ada2-80ce1554f487)

- After
![Screenshot_20250113-170721](https://github.com/user-attachments/assets/6204c3cf-222d-40cc-be36-663da7d45f7b)



### Test plan
- I don't this any major testing is required. I have kept the changes to minimum. It should not effect the other functionality. 