### PR TITLE
Avoid gratuitous re-rendering of components using settings or theme

### DIFF
--- a/src/core/PaperProvider.tsx
+++ b/src/core/PaperProvider.tsx
@@ -76,7 +76,7 @@ const PaperProvider = (props: Props) => {
     };
   }, [props.theme, isOnlyVersionInTheme]);
 
-  const getTheme = () => {
+  const theme = React.useMemo(() => {
     const themeVersion = props.theme?.version || 3;
     const scheme = colorScheme || 'light';
     const defaultThemeBase = defaultThemesByVersion[themeVersion][scheme];
@@ -95,21 +95,24 @@ const PaperProvider = (props: Props) => {
       ...extendedThemeBase,
       isV3: extendedThemeBase.version === 3,
     };
-  };
+  }, [colorScheme, props.theme, reduceMotionEnabled]);
 
   const { children, settings } = props;
+
+  const settingsValue = React.useMemo(
+    () => ({
+      icon: MaterialCommunityIcon,
+      rippleEffectEnabled: true,
+      ...settings,
+    }),
+    [settings]
+  );
 
   return (
     <SafeAreaProviderCompat>
       <PortalHost>
-        <SettingsProvider
-          value={{
-            icon: MaterialCommunityIcon,
-            rippleEffectEnabled: true,
-            ...settings,
-          }}
-        >
-          <ThemeProvider theme={getTheme()}>{children}</ThemeProvider>
+        <SettingsProvider value={settingsValue}>
+          <ThemeProvider theme={theme}>{children}</ThemeProvider>
         </SettingsProvider>
       </PortalHost>
     </SafeAreaProviderCompat>


### PR DESCRIPTION
### Motivation

If an app has components surrounding PaperProvider that occasionally refresh, then components that use the theme provided by PaperProvider will refresh even if they don't need to. E.g. { animation: { scale: 1 } } changes every time because object equality is violated, even though the theme object contents are the same from render to render.

The theme is unlikely to change often, so memoizing it should not have much memory overhead.

### Related issue

n/a

### Test plan

An app's appearance should continue to follow theme changes, but the react-devtools profiler should not show components re-rendering because of theme (or settings) changes when there haven't been any, even if a PaperProvider parent is re-rendered.

One can also use a hook like the following to look for changes to a theme fetched with useTheme():

export const useTraceUpdate = (v: any) => {
	const prev = React.useRef(v)
	React.useEffect(() => {
		// Compare v and prev, output differences, etc.
		prev.current = v
	}, [v])
}

useTraceUpdate(theme)

Passes lint and test