### PR TITLE
chore: update use-latest-callback to 0.2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@callstack/react-theme-provider": "^3.0.9",
     "color": "^3.1.2",
-    "use-latest-callback": "^0.1.5"
+    "use-latest-callback": "^0.2.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13209,7 +13209,7 @@ __metadata:
     release-it: "npm:^13.4.0"
     rimraf: "npm:^3.0.2"
     typescript: "npm:5.0.4"
-    use-latest-callback: "npm:^0.1.5"
+    use-latest-callback: "npm:^0.2.3"
   peerDependencies:
     react: "*"
     react-native: "*"
@@ -15624,6 +15624,15 @@ __metadata:
   peerDependencies:
     react: ">=16.8"
   checksum: 10c0/514604ad33cb2f040ad3ece8ee787cc549ec92135ee12ebc6857bb309eeacf5d66426b3b94089842e8215a252d5ca6f04b059387f681688fb70ac37b238209f9
+  languageName: node
+  linkType: hard
+
+"use-latest-callback@npm:^0.2.3":
+  version: 0.2.3
+  resolution: "use-latest-callback@npm:0.2.3"
+  peerDependencies:
+    react: ">=16.8"
+  checksum: 10c0/dc87503f6279ce2980f78e1019231ba20d7509e9d17adac05285babe4d6ba6f68c52f4ef7b5ad777cbc2af9fbaaa09d7adb664ca556da0aebab9f020022880be
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

There's one version 0.1.x of `use-latest-callback` that may cause a type error mentioned in #4579. 
Using caret with major version eq 0 doesn't allow to use higher minor version by default, so I decided to update this dep to 0.2.3 to reduce the risk of usage the broken version which is one of 0.1.x. 

### Related issue

#4579

### Test plan

Example app should work as before and no error should be thrown.