### PR TITLE
Update 03-icons.mdx

### DIFF
--- a/docs/docs/guides/03-icons.mdx
+++ b/docs/docs/guides/03-icons.mdx
@@ -8,7 +8,7 @@ import IconsList from '@site/src/components/IconsList.tsx';
 
 ## Configuring icons
 
-Many of the components require the [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons) library to render correctly. If you're using Expo, you don't need to do anything extra, but if it's a vanilla React Native project, you need link the library as described in the getting started guide.
+Many of the components require the [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons) library to render correctly. If you're using Expo, you don't need to do anything extra, but if it's a vanilla React Native project, you need to link the library as described in the getting started guide.
 
 If you opted out of vector icons support using [babel-plugin-optional-require](https://github.com/satya164/babel-plugin-optional-require), you won't be able to use icon names for the icon prop. Some components may not look correct without vector icons and might need extra configuration.
 


### PR DESCRIPTION
a 'to' was missing in the first paragraph, added

### Motivation

I was reading the docs for the first time as I am learning RNP to use it on my upcoming projects and found a minor issue, a 'to' was missing in the icons guide. I like things to be perfect so I thought to fix it

### Related issue

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

as it is a minor change in the docs not in the actual code, it doesn't break any existing code or UI!

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
