### PR TITLE
feat: add children style prop to list accordion

### DIFF
--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -85,7 +85,7 @@ export type Props = {
    */
   descriptionStyle?: StyleProp<TextStyle>;
   /**
-   * Style that is passed to children container View.
+   * Style that is passed to each child of the List.Accordion.
    */
   childrenStyle?: StyleProp<ViewStyle | TextStyle | ImageStyle>;
   /**

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -12,6 +12,7 @@ import {
   ViewProps,
   ViewStyle,
   PressableAndroidRippleConfig,
+  ImageStyle,
 } from 'react-native';
 
 import { ListAccordionGroupContext } from './ListAccordionGroup';
@@ -83,6 +84,10 @@ export type Props = {
    * Style that is passed to Description element.
    */
   descriptionStyle?: StyleProp<TextStyle>;
+  /**
+   * Style that is passed to children container View.
+   */
+  childrenStyle?: StyleProp<ViewStyle | TextStyle | ImageStyle>;
   /**
    * Color of the ripple effect.
    */
@@ -169,6 +174,7 @@ const ListAccordion = ({
   theme: themeOverrides,
   titleStyle,
   descriptionStyle,
+  childrenStyle,
   titleNumberOfLines = 1,
   descriptionNumberOfLines = 2,
   rippleColor: customRippleColor,
@@ -327,6 +333,7 @@ const ListAccordion = ({
               return React.cloneElement(child as React.ReactElement<any>, {
                 style: [
                   theme.isV3 ? styles.childV3 : styles.child,
+                  childrenStyle,
                   child.props.style,
                 ],
                 theme,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Prop to override styling placed on children components of list accordion

### Related issue

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->
`children` of the component have `paddingLeft` which cannot be altered without a new prop