### PR TITLE
fix: fix Surface styling when flex set

### DIFF
--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -202,7 +202,7 @@ const SurfaceIOS = forwardRef<
         ...(isElevated && getStyleForShadowLayer(elevation, 1)),
         ...filteredStyles,
         ...borderRadiusStyles,
-        flex: flattenedStyles.height ? 1 : undefined,
+        flex: flattenedStyles.height || flattenedStyles.flex ? 1 : undefined,
         backgroundColor: bgColor,
       };
 


### PR DESCRIPTION

### Motivation

PR fixes the issue when flex is applied to the Surface component and flex style is re-applied only to outer component, not the nested one, so styles can be broken if e.g `flex` and `justifyContent` are applied together.

Exact repro is provided in #4632

### Related issue

Fixes #4632

