### PR TITLE
fix: ensure DataTable.Title respects font scaling to prevent clipping

### DIFF
--- a/src/components/DataTable/DataTableTitle.tsx
+++ b/src/components/DataTable/DataTableTitle.tsx
@@ -3,6 +3,7 @@ import {
   Animated,
   GestureResponderEvent,
   I18nManager,
+  PixelRatio,
   Pressable,
   StyleProp,
   StyleSheet,
@@ -137,7 +138,7 @@ const DataTableTitle = ({
         style={[
           styles.cell,
           // height must scale with numberOfLines
-          { maxHeight: 24 * numberOfLines },
+          { maxHeight: 24 * PixelRatio.getFontScale() * numberOfLines },
           // if numberOfLines causes wrap, center is lost. Align directly, sensitive to numeric and RTL
           numberOfLines > 1
             ? numeric


### PR DESCRIPTION
### Motivation
Currently, text inside DataTable.Title gets cut off vertically when users increase font size in accessibility settings. This happens because the maxHeight does not account for scaled font sizes.

This PR ensures that the component properly respects PixelRatio.getFontScale(), preventing text clipping when font size is increased.

### Related issue
Fixes: [#4490](https://github.com/callstack/react-native-paper/issues/4490)

### Test plan

Steps to Reproduce the Issue (Before Fix)

- Open a screen with DataTable.Title.
- Go to Device Settings > Accessibility > Font Size and increase the font size.
- Observe that the text gets cut off vertically.

Steps to Verify the Fix

- Apply this PR’s changes.
- Increase font size in accessibility settings.
- Verify that the text is now fully visible and scales correctly without clipping.