### PR TITLE
fix: improve ListItem accessibility for title and description

### DIFF
--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -246,6 +246,7 @@ const ListItem = (
             })
           : null}
         <View
+          accessible={true}
           style={[
             theme.isV3 ? styles.itemV3 : styles.item,
             styles.content,

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
@@ -213,6 +213,7 @@ exports[`renders expanded accordion 1`] = `
       }
     >
       <View
+        accessible={true}
         style={
           [
             {

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -55,6 +55,7 @@ exports[`renders list item with custom description 1`] = `
     }
   >
     <View
+      accessible={true}
       style={
         [
           {
@@ -382,6 +383,7 @@ exports[`renders list item with custom title and description styles 1`] = `
     }
   >
     <View
+      accessible={true}
       style={
         [
           {
@@ -527,6 +529,7 @@ exports[`renders list item with left and right items 1`] = `
       GG
     </Text>
     <View
+      accessible={true}
       style={
         [
           {
@@ -772,6 +775,7 @@ exports[`renders list item with left item 1`] = `
       </Text>
     </View>
     <View
+      accessible={true}
       style={
         [
           {
@@ -878,6 +882,7 @@ exports[`renders list item with right item 1`] = `
     }
   >
     <View
+      accessible={true}
       style={
         [
           {
@@ -987,6 +992,7 @@ exports[`renders list item with title and description 1`] = `
     }
   >
     <View
+      accessible={true}
       style={
         [
           {
@@ -1125,6 +1131,7 @@ exports[`renders with a description with typeof number 1`] = `
     }
   >
     <View
+      accessible={true}
       style={
         [
           {

--- a/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
@@ -326,6 +326,7 @@ exports[`renders list section with custom title style 1`] = `
         </Text>
       </View>
       <View
+        accessible={true}
         style={
           [
             {
@@ -483,6 +484,7 @@ exports[`renders list section with custom title style 1`] = `
         </Text>
       </View>
       <View
+        accessible={true}
         style={
           [
             {
@@ -859,6 +861,7 @@ exports[`renders list section with subheader 1`] = `
         </Text>
       </View>
       <View
+        accessible={true}
         style={
           [
             {
@@ -1016,6 +1019,7 @@ exports[`renders list section with subheader 1`] = `
         </Text>
       </View>
       <View
+        accessible={true}
         style={
           [
             {
@@ -1352,6 +1356,7 @@ exports[`renders list section without subheader 1`] = `
         </Text>
       </View>
       <View
+        accessible={true}
         style={
           [
             {
@@ -1509,6 +1514,7 @@ exports[`renders list section without subheader 1`] = `
         </Text>
       </View>
       <View
+        accessible={true}
         style={
           [
             {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

The current implementation of ListItem doesn't properly handle React components passed as title/description props in terms of accessibility. The title and description should be grouped for screen readers and other assistive technologies.

### Related issue

This PR improves accessibility handling in ListItem components by ensuring that React components passed as title and description props maintain their accessibility relation to each other through grouping. This is particularly important for screen readers and other assistive technologies.

### Test plan

1. Tested by passing React components as title and description props to ListItem
2. Verified that the components maintain their accessibility properties
3. Updated and verified snapshots for:
   - ListItem
   - ListAccordion
   - ListSection

All tests are passing, including the updated snapshot tests.

Example usage:
Same as before. 

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->