### PR TITLE
chore: bump use latest callback to 0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@callstack/react-theme-provider": "^3.0.9",
     "color": "^3.1.2",
-    "use-latest-callback": "^0.1.5"
+    "use-latest-callback": "^0.2.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13209,7 +13209,7 @@ __metadata:
     release-it: "npm:^13.4.0"
     rimraf: "npm:^3.0.2"
     typescript: "npm:5.0.4"
-    use-latest-callback: "npm:^0.1.5"
+    use-latest-callback: "npm:^0.2.3"
   peerDependencies:
     react: "*"
     react-native: "*"
@@ -15624,6 +15624,15 @@ __metadata:
   peerDependencies:
     react: ">=16.8"
   checksum: 10c0/514604ad33cb2f040ad3ece8ee787cc549ec92135ee12ebc6857bb309eeacf5d66426b3b94089842e8215a252d5ca6f04b059387f681688fb70ac37b238209f9
+  languageName: node
+  linkType: hard
+
+"use-latest-callback@npm:^0.2.3":
+  version: 0.2.3
+  resolution: "use-latest-callback@npm:0.2.3"
+  peerDependencies:
+    react: ">=16.8"
+  checksum: 10c0/dc87503f6279ce2980f78e1019231ba20d7509e9d17adac05285babe4d6ba6f68c52f4ef7b5ad777cbc2af9fbaaa09d7adb664ca556da0aebab9f020022880be
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


### Motivation

Update `use-latest-callback` to the latest version - `0.2.3`

### Related issue

Should fix: https://github.com/callstack/react-native-paper/issues/4675

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

Tested on example repo with `react-native@0.79.1` using `yalc`

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
