### PR TITLE
docs: correct Card and List.Item displayed names

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -22,8 +22,13 @@ import { forwardRef } from '../../utils/forwardRef';
 import hasTouchHandler from '../../utils/hasTouchHandler';
 import { splitStyles } from '../../utils/splitStyles';
 import Surface from '../Surface';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+
+type CardComposition = {
+  Content: typeof CardContent;
+  Actions: typeof CardActions;
+  Cover: typeof CardCover;
+  Title: typeof CardTitle;
+};
 
 type OutlinedCardProps = {
   mode: 'outlined';
@@ -131,7 +136,8 @@ export type Props = $Omit<React.ComponentProps<typeof Surface>, 'mode'> & {
  * export default MyComponent;
  * ```
  */
-const CardComponent = (
+
+const Card = (
   {
     elevation: cardElevation = 1,
     delayLongPress,
@@ -330,24 +336,19 @@ const CardComponent = (
   );
 };
 
-const Component = forwardRef(CardComponent);
-Component.displayName = 'Card';
+Card.displayName = 'Card';
+const Component = forwardRef(Card);
 
-const Card = Component as typeof Component & {
-  Content: typeof CardContent;
-  Actions: typeof CardActions;
-  Cover: typeof CardCover;
-  Title: typeof CardTitle;
-};
+const CardComponent = Component as typeof Component & CardComposition;
 
 // @component ./CardContent.tsx
-Card.Content = CardContent;
+CardComponent.Content = CardContent;
 // @component ./CardActions.tsx
-Card.Actions = CardActions;
+CardComponent.Actions = CardActions;
 // @component ./CardCover.tsx
-Card.Cover = CardCover;
+CardComponent.Cover = CardCover;
 // @component ./CardTitle.tsx
-Card.Title = CardTitle;
+CardComponent.Title = CardTitle;
 
 const styles = StyleSheet.create({
   innerContainer: {
@@ -365,4 +366,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default Card;
+export default CardComponent;

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -270,8 +270,8 @@ const ListItem = (
   );
 };
 
+ListItem.displayName = 'List.Item';
 const Component = forwardRef(ListItem);
-Component.displayName = 'List.Item';
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Fixing components names presented in the documentation:

List.Item | Card
--- | ---
<img width="1584" alt="Zrzut ekranu 2025-04-17 o 13 53 01" src="https://github.com/user-attachments/assets/7fb0bb6f-f35a-4d22-a81e-2f08b57cef8e" /> | <img width="1584" alt="Zrzut ekranu 2025-04-17 o 13 53 07" src="https://github.com/user-attachments/assets/4e022b02-5ac3-4006-898a-b816d646a88f" />

### Related issue

Fixes: https://github.com/callstack/react-native-paper/issues/4656
<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
