### PR TITLE
fix: prevent elevation animation for contained Card mode

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -207,6 +207,10 @@ const CardComponent = (
   ]);
 
   const runElevationAnimation = (pressType: HandlePressType) => {
+    if (isV3 && isMode('contained')) {
+      return;
+    }
+
     const isPressTypeIn = pressType === 'in';
     if (dark && isAdaptiveMode) {
       Animated.timing(elevationDarkAdaptive, {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

This PR fixes an error that occurs when trying to animate elevation on a Card component in "contained" mode when pressing Card in contained mode, by preventing elevation animation, in contained mode, where elevation is always 0.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### Related issue

Fixes: #4673
Fixes: #4617 

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

Tested in the rn template app, on the latest rn:

![card](https://github.com/user-attachments/assets/34446f40-3590-4bf5-951c-9702f149b075)

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
