### PR TITLE
fix: remove cover padding

### DIFF
--- a/src/components/Card/CardCover.tsx
+++ b/src/components/Card/CardCover.tsx
@@ -86,7 +86,6 @@ const styles = StyleSheet.create({
     flex: 1,
     height: undefined,
     width: undefined,
-    padding: 16,
     justifyContent: 'flex-end',
   },
 });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Removing padding around the image within `Card.Cover`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### Related issue

Fixes:  #4648 

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

Tested on iOS, Android and web, with all three modes `elevated`, `outlined` and `contained`.

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
