### PR TITLE
fix: omit safe area insets in appbar header types

### DIFF
--- a/src/components/Appbar/AppbarHeader.tsx
+++ b/src/components/Appbar/AppbarHeader.tsx
@@ -22,7 +22,10 @@ import { useInternalTheme } from '../../core/theming';
 import shadow from '../../styles/shadow';
 import type { ThemeProp } from '../../types';
 
-export type Props = React.ComponentProps<typeof Appbar> & {
+export type Props = Omit<
+  React.ComponentProps<typeof Appbar>,
+  'safeAreaInsets'
+> & {
   /**
    * Whether the background color is a dark color. A dark header will render light text and vice-versa.
    */


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Update types to omit the `safeAreaInsets` prop from `Appbar.Header`, as it is not intended to be a user-facing prop.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### Related issue

Detected via: https://github.com/callstack/react-native-paper/pull/4331

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
