### PR TITLE
fix: Card components no longer require explicit children prop with ch…

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -273,16 +273,28 @@ const Card = (
 
   const content = (
     <View style={[styles.innerContainer, contentStyle]} testID={testID}>
-      {React.Children.map(children, (child, index) =>
-        React.isValidElement(child)
-          ? React.cloneElement(child as React.ReactElement<any>, {
-              index,
-              total,
-              siblings,
-              borderRadiusStyles,
-            })
-          : child
-      )}
+      {React.Children.map(children, (child, index) => {
+        if (!React.isValidElement(child)) {
+          return child;
+        }
+  
+        const childType = child.type;
+        if (
+          childType === CardContent ||
+          childType === CardActions ||
+          childType === CardCover ||
+          childType === CardTitle
+        ) {
+          return React.cloneElement(child as React.ReactElement<any>, {
+            index,
+            total,
+            siblings,
+            borderRadiusStyles,
+          });
+        } else {
+          return child;
+        }
+      })}
     </View>
   );
 


### PR DESCRIPTION

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR addresses an issue where Card components in react-native-paper require an explicit "children" prop even when child views are provided through standard JSX syntax. The current implementation causes problems when non-Card components (like View) are used as direct children, as they receive props they can't handle.

### Related issue

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->
Fixes #4684: Card Components require "children" prop despite child views

### Test plan

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

I've tested the changes with the following scenarios:

- Standard Card with Card.* components (Card.Content, etc.)
- Card with custom View component as direct child 
- Mixed Card and non-Card components as children
- Deeply nested components inside Cards

 Reproduction for Issue #4684:
 * This example demonstrates the issue where Card components need an explicit "children" prop even when they have child views.
 * Current behavior: The card components demand explicit "children" prop even with child views.
 * Expected behavior: The card components should not require "children" prop when child views are present

``

      {/*` Problem: This will throw an error */}
      <Card mode="elevated">
        <Card.Content>
          <Text>Card with child views but no children prop</Text>
        </Card.Content>
      </Card>
      
      {/* Workaround: Explicitly passing children prop */}
      <Card 
        mode="elevated"
        children={
          <Card.Content>
            <Text>Card with explicit children prop</Text>
          </Card.Content>
        }
      />
``

The fix modifies how the Card component handles children by only passing special props to known Card sub-components (Card.Content, etc,) and leaving other components untouched.

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
