### PR TITLE
fix: zero badge rendering

### DIFF
--- a/src/components/Drawer/DrawerCollapsedItem.tsx
+++ b/src/components/Drawer/DrawerCollapsedItem.tsx
@@ -208,7 +208,7 @@ const DrawerCollapsedItem = ({
             style={[styles.icon, { top: iconPadding }]}
             testID={`${testID}-container`}
           >
-            {badge && (
+            {badge !== false && (
               <View style={styles.badgeContainer}>
                 {typeof badge === 'boolean' ? (
                   <Badge visible={badge} size={badgeSize} />


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Changed the condition from `badge && (...)` to badge `!== false && (...)` to properly handle the case when `badge === 0`. 
This ensures that numeric badges with value 0 are displayed correctly within the Badge component rather than being improperly rendered as plain text. 
The previous implementation caused JavaScript to evaluate 0 && (...) as falsy, resulting in the `Badge` component wrapper being skipped when the badge value was zero.

### Related issue

Fixes: #4492 
<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
