### PR TITLE
fix: isleading prop behaviour

### DIFF
--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -18,6 +18,7 @@ import {
   getAppbarBackgroundColor,
   modeAppbarHeight,
   renderAppbarContent,
+  filterAppbarActions,
 } from './utils';
 import { useInternalTheme } from '../../core/theming';
 import type { MD3Elevation, ThemeProp } from '../../types';
@@ -228,15 +229,6 @@ const Appbar = ({
     shouldAddRightSpacing = shouldCenterContent && rightItemsCount === 0;
   }
 
-  const filterAppbarActions = React.useCallback(
-    (isLeading = false) =>
-      React.Children.toArray(children).filter((child) =>
-        // @ts-expect-error: TypeScript complains about the type of type but it doesn't matter
-        isLeading ? child.props.isLeading : !child.props.isLeading
-      ),
-    [children]
-  );
-
   const spacingStyle = isV3 ? styles.v3Spacing : styles.spacing;
 
   const insets = {
@@ -264,7 +256,11 @@ const Appbar = ({
       {shouldAddLeftSpacing ? <View style={spacingStyle} /> : null}
       {(!isV3 || isMode('small') || isMode('center-aligned')) &&
         renderAppbarContent({
-          children,
+          children: [
+            // Filter appbar actions - first leading icons, then trailing icons
+            ...filterAppbarActions(children, true),
+            ...filterAppbarActions(children),
+          ],
           isDark,
           theme,
           isV3,
@@ -288,7 +284,7 @@ const Appbar = ({
               mode,
             })}
             {renderAppbarContent({
-              children: filterAppbarActions(true),
+              children: filterAppbarActions(children, true),
               isDark,
               isV3,
               renderOnly: ['Appbar.Action'],
@@ -297,7 +293,7 @@ const Appbar = ({
             {/* Right side of row container, can contain other AppbarAction if they are not leading icons */}
             <View style={styles.rightActionControls}>
               {renderAppbarContent({
-                children: filterAppbarActions(false),
+                children: filterAppbarActions(children),
                 isDark,
                 isV3,
                 renderExcept: [
@@ -310,7 +306,6 @@ const Appbar = ({
               })}
             </View>
           </View>
-          {/* Middle of the row, can contain only AppbarContent */}
           {renderAppbarContent({
             children,
             isDark,

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -211,12 +211,14 @@ const Appbar = ({
 
     React.Children.forEach(children, (child) => {
       if (React.isValidElement(child)) {
+        const isLeading = child.props.isLeading === true;
+
         if (child.type === AppbarContent) {
           hasAppbarContent = true;
-        } else if (hasAppbarContent) {
-          rightItemsCount++;
-        } else {
+        } else if (isLeading || !hasAppbarContent) {
           leftItemsCount++;
+        } else {
+          rightItemsCount++;
         }
       }
     });
@@ -254,18 +256,32 @@ const Appbar = ({
       {...rest}
     >
       {shouldAddLeftSpacing ? <View style={spacingStyle} /> : null}
-      {(!isV3 || isMode('small') || isMode('center-aligned')) &&
-        renderAppbarContent({
-          children: [
+      {(!isV3 || isMode('small') || isMode('center-aligned')) && (
+        <>
+          {/* Render only the back action at first place  */}
+          {renderAppbarContent({
+            children,
+            isDark,
+            theme,
+            isV3,
+            renderOnly: ['Appbar.BackAction'],
+            shouldCenterContent: isV3CenterAlignedMode || shouldCenterContent,
+          })}
+          {/* Render the rest of the content except the back action */}
+          {renderAppbarContent({
             // Filter appbar actions - first leading icons, then trailing icons
-            ...filterAppbarActions(children, true),
-            ...filterAppbarActions(children),
-          ],
-          isDark,
-          theme,
-          isV3,
-          shouldCenterContent: isV3CenterAlignedMode || shouldCenterContent,
-        })}
+            children: [
+              ...filterAppbarActions(children, true),
+              ...filterAppbarActions(children),
+            ],
+            isDark,
+            theme,
+            isV3,
+            renderExcept: ['Appbar.BackAction'],
+            shouldCenterContent: isV3CenterAlignedMode || shouldCenterContent,
+          })}
+        </>
+      )}
       {(isMode('medium') || isMode('large')) && (
         <View
           style={[

--- a/src/components/Appbar/AppbarAction.tsx
+++ b/src/components/Appbar/AppbarAction.tsx
@@ -48,7 +48,7 @@ export type Props = React.ComponentPropsWithoutRef<typeof IconButton> & {
   /**
    * @supported Available in v5.x with theme version 3
    *
-   * Whether it's the leading button.
+   * Whether it's the leading button. Note: If `Appbar.BackAction` is present, it will be rendered before any `isLeading` icons.
    */
   isLeading?: boolean;
   style?: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;

--- a/src/components/Appbar/utils.ts
+++ b/src/components/Appbar/utils.ts
@@ -113,6 +113,22 @@ export const modeTextVariant = {
   'center-aligned': 'titleLarge',
 } as const;
 
+/**
+ * Filtruje akcje w Appbarze na podstawie właściwości isLeading.
+ * @param children - Dzieci komponentu Appbar do przefiltrowania
+ * @param isLeading - Czy filtrować akcje wiodące (true) czy niewiodące (false). Domyślnie false.
+ * @returns Przefiltrowana tablica elementów React
+ */
+export const filterAppbarActions = (
+  children: React.ReactNode,
+  isLeading = false
+) => {
+  return React.Children.toArray(children).filter((child) => {
+    if (!React.isValidElement(child)) return false;
+    return isLeading ? child.props.isLeading : !child.props.isLeading;
+  });
+};
+
 export const renderAppbarContent = ({
   children,
   isDark,

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
@@ -652,7 +652,9 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             "paddingHorizontal": 0,
           },
           [
-            false,
+            {
+              "marginLeft": 12,
+            },
             false,
             undefined,
           ],


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

This PR fixes the behavior of the `isLeading` prop in Appbar actions by ensuring consistent handling of leading and trailing in all modes.

### Related issue

Fixes: #4638 
<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

Tested on mobile and web platforms.

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
