### PR TITLE
fix: adjust label opacity

### DIFF
--- a/src/components/BottomNavigation/BottomNavigationBar.tsx
+++ b/src/components/BottomNavigation/BottomNavigationBar.tsx
@@ -747,7 +747,7 @@ const BottomNavigationBar = <Route extends BaseRoute>({
                   : 0) - (!isV3 ? 2 : 0),
             };
 
-            const isV3Shifting = isV3 && shifting && labeled;
+            const isLegacyOrV3Shifting = !isV3 || (isV3 && shifting && labeled);
 
             const font = isV3 ? theme.fonts.labelMedium : {};
 
@@ -778,7 +778,7 @@ const BottomNavigationBar = <Route extends BaseRoute>({
                     style={[
                       styles.iconContainer,
                       isV3 && styles.v3IconContainer,
-                      (!isV3 || isV3Shifting) && {
+                      isLegacyOrV3Shifting && {
                         transform: [{ translateY }],
                       },
                     ]}
@@ -803,7 +803,11 @@ const BottomNavigationBar = <Route extends BaseRoute>({
                       style={[
                         styles.iconWrapper,
                         isV3 && styles.v3IconWrapper,
-                        { opacity: isV3 ? v3ActiveOpacity : activeOpacity },
+                        {
+                          opacity: isLegacyOrV3Shifting
+                            ? activeOpacity
+                            : v3ActiveOpacity,
+                        },
                       ]}
                     >
                       {renderIcon ? (
@@ -825,7 +829,9 @@ const BottomNavigationBar = <Route extends BaseRoute>({
                         styles.iconWrapper,
                         isV3 && styles.v3IconWrapper,
                         {
-                          opacity: isV3 ? v3InactiveOpacity : inactiveOpacity,
+                          opacity: isLegacyOrV3Shifting
+                            ? inactiveOpacity
+                            : v3InactiveOpacity,
                         },
                       ]}
                     >
@@ -867,8 +873,10 @@ const BottomNavigationBar = <Route extends BaseRoute>({
                       <Animated.View
                         style={[
                           styles.labelWrapper,
-                          (!isV3 || isV3Shifting) && {
-                            opacity: activeOpacity,
+                          {
+                            opacity: isLegacyOrV3Shifting
+                              ? activeOpacity
+                              : v3ActiveOpacity,
                           },
                         ]}
                       >
@@ -898,7 +906,11 @@ const BottomNavigationBar = <Route extends BaseRoute>({
                         <Animated.View
                           style={[
                             styles.labelWrapper,
-                            { opacity: inactiveOpacity },
+                            {
+                              opacity: isLegacyOrV3Shifting
+                                ? inactiveOpacity
+                                : v3InactiveOpacity,
+                            },
                           ]}
                         >
                           {renderLabel ? (

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
@@ -298,6 +298,7 @@ exports[`allows customizing Route's type via generics 1`] = `
                     {
                       "bottom": 0,
                       "left": 0,
+                      "opacity": 1,
                       "position": "absolute",
                       "right": 0,
                       "top": 0,
@@ -551,6 +552,7 @@ exports[`allows customizing Route's type via generics 1`] = `
                     {
                       "bottom": 0,
                       "left": 0,
+                      "opacity": 0,
                       "position": "absolute",
                       "right": 0,
                       "top": 0,
@@ -2735,6 +2737,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
                     {
                       "bottom": 0,
                       "left": 0,
+                      "opacity": 1,
                       "position": "absolute",
                       "right": 0,
                       "top": 0,
@@ -3062,6 +3065,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
                     {
                       "bottom": 0,
                       "left": 0,
+                      "opacity": 0,
                       "position": "absolute",
                       "right": 0,
                       "top": 0,
@@ -3389,6 +3393,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
                     {
                       "bottom": 0,
                       "left": 0,
+                      "opacity": 0,
                       "position": "absolute",
                       "right": 0,
                       "top": 0,
@@ -3716,6 +3721,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
                     {
                       "bottom": 0,
                       "left": 0,
+                      "opacity": 0,
                       "position": "absolute",
                       "right": 0,
                       "top": 0,
@@ -4043,6 +4049,7 @@ exports[`renders bottom navigation with getLazy 1`] = `
                     {
                       "bottom": 0,
                       "left": 0,
+                      "opacity": 0,
                       "position": "absolute",
                       "right": 0,
                       "top": 0,
@@ -6007,6 +6014,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
                     {
                       "bottom": 0,
                       "left": 0,
+                      "opacity": 1,
                       "position": "absolute",
                       "right": 0,
                       "top": 0,
@@ -6195,6 +6203,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
                     {
                       "bottom": 0,
                       "left": 0,
+                      "opacity": 0,
                       "position": "absolute",
                       "right": 0,
                       "top": 0,
@@ -6383,6 +6392,7 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
                     {
                       "bottom": 0,
                       "left": 0,
+                      "opacity": 0,
                       "position": "absolute",
                       "right": 0,
                       "top": 0,
@@ -7830,6 +7840,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                     {
                       "bottom": 0,
                       "left": 0,
+                      "opacity": 1,
                       "position": "absolute",
                       "right": 0,
                       "top": 0,
@@ -8157,6 +8168,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                     {
                       "bottom": 0,
                       "left": 0,
+                      "opacity": 0,
                       "position": "absolute",
                       "right": 0,
                       "top": 0,
@@ -8484,6 +8496,7 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
                     {
                       "bottom": 0,
                       "left": 0,
+                      "opacity": 0,
                       "position": "absolute",
                       "right": 0,
                       "top": 0,
@@ -9960,6 +9973,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                     {
                       "bottom": 0,
                       "left": 0,
+                      "opacity": 1,
                       "position": "absolute",
                       "right": 0,
                       "top": 0,
@@ -10287,6 +10301,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                     {
                       "bottom": 0,
                       "left": 0,
+                      "opacity": 0,
                       "position": "absolute",
                       "right": 0,
                       "top": 0,
@@ -10614,6 +10629,7 @@ exports[`renders non-shifting bottom navigation 1`] = `
                     {
                       "bottom": 0,
                       "left": 0,
+                      "opacity": 0,
                       "position": "absolute",
                       "right": 0,
                       "top": 0,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

This PR fixes the opacity behavior of labels in the `BottomNavigationBar` component - fix properly applies active/inactive opacity values based on the component's state and version.

### Related issue

Fixes: #4369 
Fixes: #4348 

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

empty label when not focused | bold label for focused
--- | ---
![label_for_focused_tab](https://github.com/user-attachments/assets/b659269f-ae85-415d-8ece-5c46f6d02dc8) | ![bottom_navigation_bold_focused](https://github.com/user-attachments/assets/7aa41aba-8d3e-431a-b8e0-d09500e37403)

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
