### PR TITLE
Exporing TextComponent type

### DIFF
--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -11,7 +11,7 @@ import AnimatedText from './AnimatedText';
 import type { VariantProp } from './types';
 import StyledText from './v2/StyledText';
 import { useInternalTheme } from '../../core/theming';
-import type { ThemeProp } from '../../types';
+import type { ThemeProp, TextComponent } from '../../types';
 import { forwardRef } from '../../utils/forwardRef';
 
 export type Props<T> = React.ComponentProps<typeof NativeText> & {
@@ -172,10 +172,6 @@ const styles = StyleSheet.create({
     textAlign: 'left',
   },
 });
-
-type TextComponent<T> = (
-  props: Props<T> & { ref?: React.RefObject<TextRef> }
-) => JSX.Element;
 
 const Component = forwardRef(Text) as TextComponent<never>;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -166,4 +166,5 @@ export type {
   ThemeBase,
   MD3Elevation,
   MD3TypescaleKey,
+  TextComponent,
 } from './types';

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1,6 +1,7 @@
 import type * as React from 'react';
 
 import type { $DeepPartial } from '@callstack/react-theme-provider';
+import type { Props, TextRef } from './components/Typography/Text';
 
 export type Font = {
   fontFamily: string;
@@ -172,6 +173,10 @@ export type MD3Type = {
   fontSize: number;
   fontStyle?: Font['fontStyle'];
 };
+
+export type TextComponent<T> = (
+  props: Props<T> & { ref?: React.RefObject<TextRef> }
+) => JSX.Element;
 
 export type MD3Typescale =
   | {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
With this change I can create my own typed custom text component.
Eg:
```tsx
import {
  customText,
  useTheme,
  TextComponent,
  MD3Theme, 
  MD3TypescaleKey
} from 'react-native-paper'
import { MD3Type } from 'react-native-paper/lib/typescript/types'

enum CustomTextVariantType {
  'titleSmaller'
}
type CustomTextVariantsKeysType = keyof typeof CustomTextVariantType
type DefaultTextVariantsKeysType = keyof typeof MD3TypescaleKey
export type TextVariantsType<T = any> = {
  [ key in CustomTextVariantsKeysType ]: T
} & {
  [ key in DefaultTextVariantsKeysType ]?: T
}

export type CustomThemeType = Omit<MD3Theme, 'fonts'> & {
  fonts: TextVariantsType<MD3Type>
}

type VariantType = keyof typeof CustomTextVariantType
type ComponentType = {
  variant: VariantType
} & Props

function CustomText( {
  children,
  variant
}: ComponentType ): JSX.Element {
  const { fonts } = useTheme<CustomThemeType>()
  const list: TextVariantsType<TextComponent<CustomTextVariantType>> = {
    titleSmaller: customText<CustomTextVariantType.titleSmaller>()
  }
  const Component = list[ variant ]

  return <Component
    style={ {
      ...fonts[ variant ]
    } }
  >
    { children }
  </Component>
}

export default CustomText
```