### PR TITLE
refactor: mark MD2 typography as deprecated

### DIFF
--- a/src/components/Typography/v2/Caption.tsx
+++ b/src/components/Typography/v2/Caption.tsx
@@ -9,8 +9,8 @@ export type Props = React.ComponentProps<typeof Text> & {
 };
 
 // @component-group Typography
-
 /**
+ * @deprecated Deprecated in v5.x - use `<Text variant="bodySmall" />` instead.
  * Typography component for showing a caption.
  *
  * <div class="screenshots">

--- a/src/components/Typography/v2/Headline.tsx
+++ b/src/components/Typography/v2/Headline.tsx
@@ -11,6 +11,7 @@ export type Props = React.ComponentProps<typeof Text> & {
 // @component-group Typography
 
 /**
+ * @deprecated Deprecated in v5.x - use `<Text variant="headlineSmall" />` instead.
  * Typography component for showing a headline.
  *
  * <div class="screenshots">

--- a/src/components/Typography/v2/Paragraph.tsx
+++ b/src/components/Typography/v2/Paragraph.tsx
@@ -10,6 +10,7 @@ export type Props = TextProps & {
 // @component-group Typography
 
 /**
+ * @deprecated Deprecated in v5.x - use `<Text variant="bodyMedium" />` instead.
  * Typography component for showing a paragraph.
  *
  * <div class="screenshots">

--- a/src/components/Typography/v2/Subheading.tsx
+++ b/src/components/Typography/v2/Subheading.tsx
@@ -11,6 +11,7 @@ export type Props = React.ComponentProps<typeof Text> & {
 // @component-group Typography
 
 /**
+ * @deprecated Deprecated in v5.x - use `<Text variant="titleMedium" />` instead.
  * Typography component for showing a subheading.
  *
  * <div class="screenshots">

--- a/src/components/Typography/v2/Title.tsx
+++ b/src/components/Typography/v2/Title.tsx
@@ -10,6 +10,7 @@ export type Props = React.ComponentProps<typeof Text> & {
 // @component-group Typography
 
 /**
+ * @deprecated Deprecated in v5.x - use `<Text variant="titleLarge" />` instead.
  * Typography component for showing a title.
  *
  * <div class="screenshots">


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

In the MD2 we had Caption, Paragraph, Subheading, Title and Headline as typography components, but in MD3 we [introduced](https://callstack.github.io/react-native-paper/docs/guides/migration-guide-to-5.0#typography) new approach based on one Text component.

In the migration guide our recommendation was to replace old components in favour of the new Text with specific variant, as presented below, so I believe we should mark them as deprecated – going to handle that.

### Related issue

Fixes: #4629 

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
