### PR TITLE
fix: correct border end width

### DIFF
--- a/src/components/SegmentedButtons/utils.ts
+++ b/src/components/SegmentedButtons/utils.ts
@@ -69,7 +69,7 @@ export const getSegmentedButtonBorderRadius = ({
     return {
       borderTopRightRadius: 0,
       borderBottomRightRadius: 0,
-      ...(theme.isV3 && { borderRightWidth: 0 }),
+      ...(theme.isV3 && { borderEndWidth: 0 }),
     };
   } else if (segment === 'last') {
     return {
@@ -79,7 +79,7 @@ export const getSegmentedButtonBorderRadius = ({
   } else {
     return {
       borderRadius: 0,
-      ...(theme.isV3 && { borderRightWidth: 0 }),
+      ...(theme.isV3 && { borderEndWidth: 0 }),
     };
   }
 };

--- a/src/components/__tests__/__snapshots__/SegmentedButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/SegmentedButton.test.tsx.snap
@@ -18,8 +18,8 @@ exports[`renders segmented button 1`] = `
           "backgroundColor": "rgba(232, 222, 248, 1)",
           "borderBottomRightRadius": 0,
           "borderColor": "rgba(121, 116, 126, 1)",
+          "borderEndWidth": 0,
           "borderRadius": 20,
-          "borderRightWidth": 0,
           "borderTopRightRadius": 0,
           "borderWidth": 1,
         },
@@ -73,8 +73,8 @@ exports[`renders segmented button 1`] = `
           },
           {
             "borderBottomRightRadius": 0,
+            "borderEndWidth": 0,
             "borderRadius": 20,
-            "borderRightWidth": 0,
             "borderTopRightRadius": 0,
           },
         ]


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Fixing the `rtl` layout for `SegmentedButton`. It requires `react-native@0.77.0` since there was an issue internally in the framework -> #4716 

That PR is an addition to fix the end border.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### Related issue

Fixes: #4649 

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

ios | android
--- | ---
<img width="517" alt="Zrzut ekranu 2025-05-5 o 22 20 26" src="https://github.com/user-attachments/assets/81b67416-95b5-4e5d-a0f5-8d7808e92508" /> | <img width="422" alt="Zrzut ekranu 2025-05-5 o 22 17 38" src="https://github.com/user-attachments/assets/330ecb47-2c96-46ab-95ac-6f3b64d8222a" />


<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
