### PR TITLE
fix: fix error on width change of AnimatedFAB when label is empty string

### DIFF
--- a/src/components/FAB/AnimatedFAB.tsx
+++ b/src/components/FAB/AnimatedFAB.tsx
@@ -328,8 +328,8 @@ const AnimatedFAB = ({
   const onTextLayout = ({
     nativeEvent,
   }: NativeSyntheticEvent<TextLayoutEventData>) => {
-    const currentWidth = Math.ceil(nativeEvent.lines[0].width);
-    const currentHeight = Math.ceil(nativeEvent.lines[0].height);
+    const currentWidth = Math.ceil(nativeEvent.lines[0]?.width ?? 0);
+    const currentHeight = Math.ceil(nativeEvent.lines[0]?.height ?? 0);
 
     if (currentWidth !== textWidth || currentHeight !== textHeight) {
       setTextHeight(currentHeight);


### PR DESCRIPTION
`onTextLayout`  sets the width of the text for the `AnimatedFAB` when the text changes.  If the `label` is an empty string the `nativeEvent.lines[0]` is undefined for iOS.  This change handles this case and defaults to `0`.

### Motivation

On iOS, when the `label` is changed from a non-empty string to and empty string, it throws an Uncaught error

`Cannot read property 'width' of undefined`

### Related issue

None

### Test plan

Tested on iPhone 11 by changing the `label` from a non-empty string to an empty string.  Before the fix, this would throw an Uncaught error.  After the fix, not error was thrown and the component resized as expected.
