### PR TITLE
fix: Text Input Label overlaps Left element on react native 0.77

### DIFF
--- a/src/components/TextInput/Label/InputLabel.tsx
+++ b/src/components/TextInput/Label/InputLabel.tsx
@@ -114,7 +114,7 @@ const InputLabel = (props: InputLabelProps) => {
       },
     ],
     ...(!isWeb &&
-      Platform.constants.reactNativeVersion.minor >= 73 && {
+      Platform.constants.reactNativeVersion.minor >= 78 && {
         transformOrigin: 'left',
       }),
   };
@@ -152,7 +152,7 @@ const InputLabel = (props: InputLabelProps) => {
           StyleSheet.absoluteFill,
           !isWeb && { width },
           { opacity },
-          (isWeb || Platform.constants.reactNativeVersion.minor <= 72) &&
+          (isWeb || Platform.constants.reactNativeVersion.minor <= 77) &&
             labelTranslationX,
         ]}
       >

--- a/src/components/TextInput/Label/LabelBackground.tsx
+++ b/src/components/TextInput/Label/LabelBackground.tsx
@@ -54,7 +54,7 @@ const LabelBackground = ({
           bottom: Math.max(roundness, 2),
           opacity,
         },
-        (isWeb || Platform.constants.reactNativeVersion.minor <= 72) && {
+        (isWeb || Platform.constants.reactNativeVersion.minor <= 77) && {
           transform: [labelTranslationX],
         },
       ]}


### PR DESCRIPTION
The label for a `Text Input`, when not in focus, overlaps the `left` component. This PR updates the threshold values required for `translationX` to be in accordance with support for React Native version `0.77` as release `5.14.1` mentions in the [changelog](https://github.com/callstack/react-native-paper/releases/tag/v5.14.1).

### Related issue
`InputLabel` does not translate accordingly when `left` component is present on react native `0.77`.

### Test plan
Create a simple `TextInput` with a text `label` and any `left` element (either `TextInput.Icon` or `TextInput.Affix`). The current version (`5.14.1` with react native `0.77`) works like this:

<img width="339" alt="image" src="https://github.com/user-attachments/assets/dad7bdf8-0a8e-45aa-9da5-e447a2dd4f7d" />

After updating threshold for `translateX` the result is:

<img width="342" alt="image" src="https://github.com/user-attachments/assets/ca1d40a3-5241-4752-b00c-41427793da38" />
