### PR TITLE
fix: remove findNodeHandle

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -4,7 +4,6 @@ import {
   Dimensions,
   Easing,
   EmitterSubscription,
-  findNodeHandle,
   I18nManager,
   Keyboard,
   KeyboardEvent as RNKeyboardEvent,
@@ -117,13 +116,12 @@ const focusFirstDOMNode = (el: View | null | undefined) => {
     // When in the browser, we want to focus the first focusable item on toggle
     // For example, when menu is shown, focus the first item in the menu
     // And when menu is dismissed, send focus back to the button to resume tabbing
-    const node: any = findNodeHandle(el);
-    const focusableNode = node.querySelector(
-      // This is a rough list of selectors that can be focused
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-    );
-
-    focusableNode?.focus();
+    if (el instanceof HTMLElement) {
+      el.querySelector<HTMLElement>(
+        // This is a rough list of selectors that can be focused
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )?.focus();
+    }
   }
 };
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Removing `findNodeHandle` as it's deprecated in newer react-native versions and also removed from `react-native-web` `0.20.0` which causes crashes in `Menu` component


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### Related issue

Fixes: #4672 

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

Tested on projects with older expo SDK 52 and the latest expo SDK 53 with rnw@0.20

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
