### PR TITLE
Content was not horizontally centered

### DIFF
--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -454,7 +454,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingLeft: 4,
     position: 'relative',
-    justifyContent: "center"
+    justifyContent: 'center',
   },
   md3Content: {
     paddingLeft: 0,

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -454,6 +454,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingLeft: 4,
     position: 'relative',
+    justifyContent: "center"
   },
   md3Content: {
     paddingLeft: 0,


### PR DESCRIPTION
### Motivation

The Chip component's content was not horizontally centered, particularly when used with or without an icon and expected to fill its container.

### Related issue

None linked, but this addresses a common visual misalignment when using `Chip` in custom layouts or with dynamic content.
