### PR TITLE
refactor: remove mode from theme

### DIFF
--- a/docs/docs/guides/02-theming.mdx
+++ b/docs/docs/guides/02-theming.mdx
@@ -63,7 +63,6 @@ You can change the theme prop dynamically and all the components will automatica
 A theme usually contains the following properties:
 
 - `dark` (`boolean`): whether this is a dark theme or light theme.
-- `mode` (`'adaptive' | 'exact'`): color mode for dark theme (See [Dark Theme](#dark-theme)).
 - `roundness` (`number`): roundness of common elements, such as buttons.
 - `colors` (`object`): various colors used throughout different elements.
 

--- a/example/src/Examples/AppbarExample.tsx
+++ b/example/src/Examples/AppbarExample.tsx
@@ -46,9 +46,6 @@ const AppbarExample = ({ navigation }: Props) => {
       header: () => (
         <Appbar.Header
           style={showCustomColor ? styles.customColor : null}
-          theme={{
-            mode: 'adaptive',
-          }}
           mode={appbarMode}
           elevated={showElevated}
         >
@@ -171,7 +168,6 @@ const AppbarExample = ({ navigation }: Props) => {
           },
         ]}
         safeAreaInsets={{ bottom, left, right }}
-        theme={{ mode: 'adaptive' }}
       >
         <Appbar.Action icon="archive" onPress={() => {}} />
         <Appbar.Action icon="email" onPress={() => {}} />

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -69,9 +69,6 @@ export type Props = Omit<
  * The top bar usually contains the screen title, controls such as navigation buttons, menu button etc.
  * The bottom bar usually provides access to a drawer and up to four actions.
  *
- * By default Appbar uses primary color as a background, in dark theme with `adaptive` mode it will use surface colour instead.
- * See [Dark Theme](https://callstack.github.io/react-native-paper/docs/guides/theming#dark-theme) for more informations
- *
  * ## Usage
  * ### Top bar
  * ```js

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -266,9 +266,6 @@ const SceneComponent = React.memo(({ component, ...rest }: any) =>
  * BottomNavigation provides quick navigation between top-level views of an app with a bottom navigation bar.
  * It is primarily designed for use on mobile. If you want to use the navigation bar only see [`BottomNavigation.Bar`](BottomNavigationBar).
  *
- * By default BottomNavigation uses primary color as a background, in dark theme with `adaptive` mode it will use surface colour instead.
- * See [Dark Theme](https://callstack.github.io/react-native-paper/docs/guides/theming#dark-theme) for more information.
- *
  * ## Usage
  * ```js
  * import * as React from 'react';

--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -209,8 +209,6 @@ const SurfaceIOS = forwardRef<
 
 /**
  * Surface is a basic container that can give depth to an element with elevation shadow.
- * On dark theme with `adaptive` mode, surface is constructed by also placing a semi-transparent white overlay over a component surface.
- * See [Dark Theme](https://callstack.github.io/react-native-paper/docs/guides/theming#dark-theme) for more information.
  * Overlay and shadow can be applied by specifying the `elevation` property both on Android and iOS.
  *
  * ## Usage

--- a/src/styles/themes/DarkTheme.tsx
+++ b/src/styles/themes/DarkTheme.tsx
@@ -9,7 +9,6 @@ const { palette, opacity } = tokens.md.ref;
 export const DarkTheme: Theme = {
   ...LightTheme,
   dark: true,
-  mode: 'adaptive',
   colors: {
     primary: palette.primary80,
     primaryContainer: palette.primary30,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -19,8 +19,6 @@ export type Font = {
   fontStyle?: 'normal' | 'italic' | undefined;
 };
 
-type Mode = 'adaptive' | 'exact';
-
 export type Colors = {
   primary: string;
   primaryContainer: string;
@@ -61,7 +59,6 @@ export type ThemeProp = $DeepPartial<InternalTheme>;
 
 export type ThemeBase = {
   dark: boolean;
-  mode?: Mode;
   roundness: number;
   animation: {
     scale: number;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Changes

The main purpose of this PR is removing the concept of theme `mode`s _(adaptive and exact)_ that were previously used to control how dark theme was applied. This simplifies the theming system by removing this additional layer of complexity, making the dark theme behavior more straightforward and consistent.

1. Documentation Changes:
* Removed documentation about dark theme modes (adaptive and exact) from the theming guide
* Removed references to dark theme mode in component documentation

2. Theme Changes:
* Removed mode: 'adaptive' from theme
* Removed mode-related theme overrides from example components

3. Card Component:
* Removed dark adaptive mode logic and animations
* Simplified elevation animation to use a single animated value


