### PR TITLE
Handle deprecation of BackHandler.removeEventListener

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -159,7 +159,7 @@ function Modal({
     if (subscription.current?.remove) {
       subscription.current?.remove();
     } else {
-      BackHandler.removeEventListener('hardwareBackPress', handleBack);
+      BackHandler.removeEventListener?.('hardwareBackPress', handleBack);
     }
   };
 

--- a/src/utils/addEventListener.tsx
+++ b/src/utils/addEventListener.tsx
@@ -21,7 +21,7 @@ export function addEventListener<
         return;
       }
 
-      Module.removeEventListener(eventName, handler);
+      Module.removeEventListener?.(eventName, handler);
       removed = true;
     },
   };
@@ -45,7 +45,7 @@ export function addListener<
         return;
       }
 
-      Module.removeEventListener(eventName, handler);
+      Module.removeEventListener?.(eventName, handler);
       removed = true;
     },
   };


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

In RN 0.77, they deprecated BackHandler.removeEventListener. The `Modal` component on the 4.x branch is set up to call `hideModal` when it's mounted with `visible={false}`, and because `showModal` has never been called, there's no existing subscription. Because of this, we fall to the `else` case which calls `BackHandler.removeEventListener`. Pre RN 0.77, this wasn't a problem, but because the function no longer exists, it now throws an error.

This patch simply adds a null check before trying to call the `BackHandler.removeEventListener`, which causes the above situation to fail gracefully.

### Related issue

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
