### PR TITLE
fix: add container prop and improve flex/layout handling

### DIFF
--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -254,6 +254,7 @@ const Appbar = ({
         !theme.isV3 && { elevation },
       ]}
       elevation={elevation as MD3Elevation}
+      container
       {...rest}
     >
       {shouldAddLeftSpacing ? <View style={spacingStyle} /> : null}

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -194,6 +194,7 @@ const Banner = ({
       {...rest}
       style={[!theme.isV3 && styles.elevation, { opacity }, style]}
       theme={theme}
+      container
       {...(theme.isV3 && { elevation })}
     >
       <View style={[styles.wrapper, contentStyle]}>

--- a/src/components/BottomNavigation/BottomNavigationBar.tsx
+++ b/src/components/BottomNavigation/BottomNavigationBar.tsx
@@ -574,6 +574,7 @@ const BottomNavigationBar = <Route extends BaseRoute>({
           : 'none'
       }
       onLayout={onLayout}
+      container
     >
       <Animated.View
         style={[styles.barContent, { backgroundColor }]}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -350,6 +350,7 @@ const Button = (
         ] as Animated.WithAnimatedValue<StyleProp<ViewStyle>>
       }
       {...(isV3 && { elevation: elevation })}
+      container
     >
       <TouchableRipple
         borderless

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -304,6 +304,7 @@ const Card = (
         elevation: isMode('elevated') ? computedElevation : 0,
       })}
       testID={`${testID}-container`}
+      container
       {...rest}
     >
       {isMode('outlined') && (

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -316,6 +316,7 @@ const Chip = ({
       {...rest}
       testID={`${testID}-container`}
       theme={theme}
+      container
     >
       <TouchableRipple
         borderless

--- a/src/components/FAB/AnimatedFAB.tsx
+++ b/src/components/FAB/AnimatedFAB.tsx
@@ -404,6 +404,7 @@ const AnimatedFAB = ({
       ]}
       {...(isV3 && { elevation: md3Elevation })}
       theme={theme}
+      container
     >
       <Animated.View
         style={[

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -289,6 +289,7 @@ const FAB = forwardRef<View, Props>(
         pointerEvents={visible ? 'auto' : 'none'}
         testID={`${testID}-container`}
         {...(isV3 && { elevation: md3Elevation })}
+        container
       >
         <TouchableRipple
           borderless

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -181,6 +181,7 @@ const IconButton = forwardRef<View, Props>(
           !isV3 && disabled && styles.disabled,
           style,
         ]}
+        container
         {...(isV3 && { elevation: 0 })}
       >
         <TouchableRipple

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -675,6 +675,7 @@ const Menu = ({
                 {...(theme.isV3 && { elevation })}
                 testID={`${testID}-surface`}
                 theme={theme}
+                container
               >
                 {(scrollableMenuHeight && (
                   <ScrollView

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -220,6 +220,7 @@ function Modal({
           testID={`${testID}-surface`}
           theme={theme}
           style={[{ opacity }, styles.content, contentContainerStyle]}
+          container
         >
           {children}
         </Surface>

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -275,6 +275,7 @@ const Searchbar = forwardRef<TextInputHandles, Props>(
         ]}
         testID={`${testID}-container`}
         {...(theme.isV3 && { elevation })}
+        container
         theme={theme}
       >
         <IconButton

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -321,6 +321,7 @@ const Snackbar = ({
           style,
         ]}
         testID={testID}
+        container
         {...(isV3 && { elevation })}
         {...rest}
       >

--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -51,6 +51,10 @@ export type Props = Omit<React.ComponentPropsWithRef<typeof View>, 'style'> & {
    */
   testID?: string;
   ref?: React.RefObject<View>;
+  /**
+   * @internal
+   */
+  container?: boolean;
 };
 
 const MD2Surface = forwardRef<View, Props>(
@@ -161,6 +165,7 @@ const SurfaceIOS = forwardRef<
       testID,
       children,
       mode = 'elevated',
+      container,
       ...props
     },
     ref
@@ -202,12 +207,15 @@ const SurfaceIOS = forwardRef<
         ...(isElevated && getStyleForShadowLayer(elevation, 1)),
         ...filteredStyles,
         ...borderRadiusStyles,
-        flex: flattenedStyles.height || flattenedStyles.flex ? 1 : undefined,
+        flex:
+          flattenedStyles.height || (!container && flattenedStyles.flex)
+            ? 1
+            : undefined,
         backgroundColor: bgColor,
       };
 
       return [outerLayerViewStyles, innerLayerViewStyles];
-    }, [style, elevation, backgroundColor, mode]);
+    }, [style, elevation, backgroundColor, mode, container]);
 
     return (
       <Animated.View


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

This PR improves the behavior of the `Surface` component regarding flexbox layout and style inheritance, especially on iOS, and introduces a new **internal** `container` prop for more explicit control. 
This prop allows internal components (like Button, Card, etc.) to explicitly specify whether the `Surface` should behave as a main layout container or as a simple wrapper.

### Related issue

#3652 
#4632 

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

Tested against two mentioned issues:

<img width="300" alt="Zrzut ekranu 2025-05-15 o 13 01 37" src="https://github.com/user-attachments/assets/8dfec65b-198c-41bc-85f5-9556ae7d29bd" />

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
