### PR TITLE
Checkbox custom icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lint": "yarn lint-no-fix --fix",
     "lint-no-fix": "eslint --ext '.js,.ts,.tsx' .",
     "test": "jest",
-    "prepack": "bob build && node ./scripts/generate-mappings.js",
+    "prepare": "bob build && node ./scripts/generate-mappings.js",
     "release": "release-it",
     "docs": "yarn --cwd docs",
     "example": "yarn --cwd example"

--- a/package.json
+++ b/package.json
@@ -34,8 +34,6 @@
     "bootstrap"
   ],
   "workspaces": [
-    "example",
-    "docs"
   ],
   "scripts": {
     "typescript": "tsc --noEmit",

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -35,6 +35,10 @@ export type Props = {
    * testID to be used on tests.
    */
   testID?: string;
+  /**
+   * custom icon.
+   */
+  icon?: (props: { size: number; color: string }) => JSX.Element;
 };
 
 /**

--- a/src/components/Checkbox/CheckboxAndroid.tsx
+++ b/src/components/Checkbox/CheckboxAndroid.tsx
@@ -41,6 +41,10 @@ export type Props = $RemoveChildren<typeof TouchableRipple> & {
    * testID to be used on tests.
    */
   testID?: string;
+  /**
+   * custom icon.
+   */
+  icon?: (props: { size: number; color: string }) => JSX.Element;
 };
 
 // From https://material.io/design/motion/speed.html#duration
@@ -59,6 +63,7 @@ const CheckboxAndroid = ({
   disabled,
   onPress,
   testID,
+  icon: customIcon,
   ...rest
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
@@ -134,13 +139,15 @@ const CheckboxAndroid = ({
       theme={theme}
     >
       <Animated.View style={{ transform: [{ scale: scaleAnim }] }}>
-        <MaterialCommunityIcon
-          allowFontScaling={false}
-          name={icon}
-          size={24}
-          color={selectionControlColor}
-          direction="ltr"
-        />
+        {customIcon?.({ size: 24, color: selectionControlColor }) || (
+          <MaterialCommunityIcon
+            allowFontScaling={false}
+            name={icon}
+            size={24}
+            color={selectionControlColor}
+            direction="ltr"
+          />
+        )}
         <View style={[StyleSheet.absoluteFill, styles.fillContainer]}>
           <Animated.View
             style={[

--- a/src/components/Checkbox/CheckboxIOS.tsx
+++ b/src/components/Checkbox/CheckboxIOS.tsx
@@ -32,6 +32,10 @@ export type Props = $RemoveChildren<typeof TouchableRipple> & {
    * testID to be used on tests.
    */
   testID?: string;
+  /**
+   * custom icon.
+   */
+  icon?: (props: { size: number; color: string }) => JSX.Element;
 };
 
 /**
@@ -47,6 +51,7 @@ const CheckboxIOS = ({
   onPress,
   theme: themeOverrides,
   testID,
+  icon: customIcon,
   ...rest
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
@@ -77,13 +82,15 @@ const CheckboxIOS = ({
       theme={theme}
     >
       <View style={{ opacity }}>
-        <MaterialCommunityIcon
-          allowFontScaling={false}
-          name={icon}
-          size={24}
-          color={checkedColor}
-          direction="ltr"
-        />
+        {customIcon?.({ size: 24, color: checkedColor }) || (
+          <MaterialCommunityIcon
+            allowFontScaling={false}
+            name={icon}
+            size={24}
+            color={checkedColor}
+            direction="ltr"
+          />
+        )}
       </View>
     </TouchableRipple>
   );

--- a/src/components/Checkbox/CheckboxItem.tsx
+++ b/src/components/Checkbox/CheckboxItem.tsx
@@ -100,6 +100,10 @@ export type Props = {
    */
   testID?: string;
   /**
+   * custom icon.
+   */
+  icon?: (props: { size: number; color: string }) => JSX.Element;
+  /**
    * Checkbox control position.
    */
   position?: 'leading' | 'trailing';
@@ -142,6 +146,7 @@ const CheckboxItem = ({
   labelStyle,
   theme: themeOverrides,
   testID,
+  icon,
   mode,
   position = 'trailing',
   accessibilityLabel = label,
@@ -154,7 +159,7 @@ const CheckboxItem = ({
   ...props
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
-  const checkboxProps = { ...props, status, theme, disabled };
+  const checkboxProps = { ...props, status, theme, disabled, icon };
   const isLeading = position === 'leading';
   let checkbox;
 

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -227,17 +227,17 @@ const Menu = ({
     keyboardHeightRef.current = 0;
   }, []);
 
-  const keyboardDidShowListenerRef: React.RefObject<
+  const keyboardDidShowListenerRef: React.MutableRefObject<
     EmitterSubscription | undefined
   > = React.useRef(undefined);
-  const keyboardDidHideListenerRef: React.RefObject<
+  const keyboardDidHideListenerRef: React.MutableRefObject<
     EmitterSubscription | undefined
   > = React.useRef(undefined);
 
-  const backHandlerSubscriptionRef: React.RefObject<
+  const backHandlerSubscriptionRef: React.MutableRefObject<
     NativeEventSubscription | undefined
   > = React.useRef(undefined);
-  const dimensionsSubscriptionRef: React.RefObject<
+  const dimensionsSubscriptionRef: React.MutableRefObject<
     NativeEventSubscription | undefined
   > = React.useRef(undefined);
 


### PR DESCRIPTION
We use MaterialIcons in our app instead of MaterialComunityIcons and we have a problem with the checkbox not having a property for specifying a custom icon
