### PR TITLE
fix: apply elevation as prop for md3

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -291,11 +291,12 @@ const Card = (
       ref={ref}
       style={[
         isV3 && !isMode('elevated') && { backgroundColor },
-        !isV3 && isMode('outlined')
-          ? styles.resetElevation
-          : {
-              elevation: computedElevation as unknown as number,
-            },
+        !isV3 &&
+          (isMode('outlined')
+            ? styles.resetElevation
+            : {
+                elevation: computedElevation as unknown as number,
+              }),
         borderRadiusCombinedStyles,
         style,
       ]}

--- a/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
@@ -24,7 +24,6 @@ exports[`Card renders an outlined card 1`] = `
       {
         "backgroundColor": "rgba(255, 251, 254, 1)",
         "borderRadius": 12,
-        "elevation": 1,
         "flex": undefined,
         "shadowColor": "#000",
         "shadowOffset": {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

This PR resolves an issue with the `Card` component's elevation handling. 
Previously, `elevation` was applied via _styles_, which works for the _old_ Material Design system, but in MD3, it needs to be set directly using the `elevation` prop.

### Related issue

Fixes: #4714 

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

Tested on both Expo SDK 52 and 53 - with `react-native` `0.77.2` and `0.79.2`
Run the android app, pressed the `Card` in all 3 modes - the crash doesn't occur.

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
