### PR TITLE
feat: modal disableAnimations and handleEscape props

### DIFF
--- a/example/src/ExampleList.tsx
+++ b/example/src/ExampleList.tsx
@@ -29,6 +29,7 @@ import ListAccordionExampleGroup from './Examples/ListAccordionGroupExample';
 import ListItemExample from './Examples/ListItemExample';
 import ListSectionExample from './Examples/ListSectionExample';
 import MenuExample from './Examples/MenuExample';
+import ModalExample from './Examples/ModalExample';
 import ProgressBarExample from './Examples/ProgressBarExample';
 import RadioButtonExample from './Examples/RadioButtonExample';
 import RadioButtonGroupExample from './Examples/RadioButtonGroupExample';
@@ -79,6 +80,7 @@ export const mainExamples: Record<
   listSection: ListSectionExample,
   listItem: ListItemExample,
   menu: MenuExample,
+  modalExample: ModalExample,
   progressbar: ProgressBarExample,
   radio: RadioButtonExample,
   radioGroup: RadioButtonGroupExample,

--- a/example/src/Examples/ModalExample.tsx
+++ b/example/src/Examples/ModalExample.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { Button, List, Modal, Portal, Text } from 'react-native-paper';
+
+import { useExampleTheme } from '../hooks/useExampleTheme';
+import ScreenWrapper from '../ScreenWrapper';
+
+const ModalExample = () => {
+  const theme = useExampleTheme();
+
+  const [visibleModal1, setVisibleModal1] = React.useState(false);
+  const [visibleModal2, setVisibleModal2] = React.useState(false);
+  const [visibleModal3, setVisibleModal3] = React.useState(false);
+
+  return (
+    <ScreenWrapper>
+      <List.Section title="Simple">
+        <View style={styles.row}>
+          <Portal>
+            <Modal
+              visible={visibleModal1}
+              onDismiss={() => setVisibleModal1(false)}
+              contentContainerStyle={[
+                styles.modal,
+                { backgroundColor: theme.colors.background },
+              ]}
+            >
+              <Text>Example Modal. Click outside this area to dismiss.</Text>
+            </Modal>
+          </Portal>
+          <Button mode="outlined" onPress={() => setVisibleModal1(true)}>
+            Open Modal
+          </Button>
+        </View>
+      </List.Section>
+      <List.Section title="Disable Animations">
+        <View style={styles.row}>
+          <Portal>
+            <Modal
+              disableAnimations={true}
+              visible={visibleModal2}
+              onDismiss={() => setVisibleModal2(false)}
+              contentContainerStyle={[
+                styles.modal,
+                { backgroundColor: theme.colors.background },
+              ]}
+            >
+              <Text>
+                Example Modal with animations disabled. Click outside this area
+                to dismiss.
+              </Text>
+            </Modal>
+          </Portal>
+          <Button mode="outlined" onPress={() => setVisibleModal2(true)}>
+            Open Modal
+          </Button>
+        </View>
+      </List.Section>
+      <List.Section title="Handle escape (web)">
+        <View style={styles.row}>
+          <Portal>
+            <Modal
+              handleEscape={true}
+              visible={visibleModal3}
+              onDismiss={() => setVisibleModal3(false)}
+              contentContainerStyle={[
+                styles.modal,
+                { backgroundColor: theme.colors.background },
+              ]}
+            >
+              <Text>Example Modal with escape handling.</Text>
+            </Modal>
+          </Portal>
+          <Button mode="outlined" onPress={() => setVisibleModal3(true)}>
+            Open Modal
+          </Button>
+        </View>
+      </List.Section>
+    </ScreenWrapper>
+  );
+};
+
+ModalExample.title = 'Modal';
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    margin: 8,
+  },
+  modal: {
+    padding: 20,
+  },
+});
+
+export default ModalExample;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Using a modal with a lot of content, the default Modal animations can sometimes be a bit flaky so I'd like an option to disable the animations. In addition, on web, I'd like an option for the Escape key to dismiss the Modal.

### Related issue

Feature

### Test plan

Added Modal examples in example app.
