### PR TITLE
docs: Update TouchableRipple.tsx to note a11y considerations

### DIFF
--- a/src/components/TouchableRipple/TouchableRipple.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.tsx
@@ -104,7 +104,7 @@ export type Props = PressableProps & {
  * ### Accessibility
  * Note that, while `onPress` is not a required prop, not passing an `onPress` prop directly to `TouchableRipple` (e.g., passing it to a component it wraps instead) will likely break the accessibility of the component.
  * When `onPress` is not present, the component will read as a "dimmed", inactive button to screen readers, and will not be reachable at all to voice control users.
- * 
+ *
  * @extends Pressable props https://reactnative.dev/docs/Pressable#props
  */
 const TouchableRipple = (

--- a/src/components/TouchableRipple/TouchableRipple.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.tsx
@@ -101,6 +101,10 @@ export type Props = PressableProps & {
  * export default MyComponent;
  * ```
  *
+ * ### Accessibility
+ * Note that, while `onPress` is not a required prop, not passing an `onPress` prop directly to `TouchableRipple` (e.g., passing it to a component it wraps instead) will likely break the accessibility of the component.
+ * When `onPress` is not present, the component will read as a "dimmed", inactive button to screen readers, and will not be reachable at all to voice control users.
+ * 
  * @extends Pressable props https://reactnative.dev/docs/Pressable#props
  */
 const TouchableRipple = (


### PR DESCRIPTION
### Motivation

Not passing an `onPress` to `TouchableRipple` silently breaks the component for users of several types of accessibility technologies (screen reader, voice control, likely others), either by hiding the element completely (voice control) or announcing it as dimmed/disabled (screen readers), even if there's an active `onPress` in an interior component. 

Most mobile developers do not QA their work on accessibility technologies, so this likely results in many app functions being made inaccessible to accessibility technology users. 

Noting this in the docs would help catch at least devs who read the docs and make them aware of how to preserve the a11y of their UIs using this component. 

Stronger alternatives would be to make `onPress` required; or to add nuance to this logic, and the logic dependent on it: 

```
// TouchableRipple.tsx, line 270
const disabled = disabledProp || !hasPassedTouchHandler;
```

However, updating the docs is a low lift that will help the issue, without requiring any changes in the principles of the component.

If there's openness to either of the other solutions, I'm happy to take a crack at it, but it would require departing from the principle, which looks to be explicitly stated in the code, that a `TouchableRipple` without an `onPress` is disabled.

### Related issue

n/a

### Test plan

Read the updated docs, make sure they're clear and formatted correctly.

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
