### PR TITLE
fix: Update accessibilityValue handling in ProgressBar to also use the animatedValue

### DIFF
--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -205,7 +205,13 @@ const ProgressBar = ({
       accessibilityValue={
         indeterminate
           ? {}
-          : { min: 0, max: 100, now: Math.round(progress * 100) }
+          : {
+              min: 0,
+              max: 100,
+              now: Math.round(
+                (animatedValue !== undefined ? animatedValue : progress) * 100
+              ),
+            }
       }
       style={isWeb && styles.webContainer}
       testID={testID}

--- a/src/components/__tests__/ProgressBar.test.tsx
+++ b/src/components/__tests__/ProgressBar.test.tsx
@@ -90,3 +90,45 @@ it('renders progress bar with custom style of filled part', async () => {
     borderRadius: 4,
   });
 });
+
+it('sets correct accessibilityValue with progress prop', async () => {
+  const tree = render(<ProgressBar progress={0.2} />);
+  await waitFor(() => tree.getByRole(a11yRole).props.onLayout(layoutEvent));
+
+  expect(tree.getByRole(a11yRole).props.accessibilityValue).toEqual({
+    min: 0,
+    max: 100,
+    now: 20,
+  });
+});
+
+it('sets correct accessibilityValue with animatedValue prop', async () => {
+  const tree = render(<ProgressBar animatedValue={0.4} />);
+  await waitFor(() => tree.getByRole(a11yRole).props.onLayout(layoutEvent));
+
+  expect(tree.getByRole(a11yRole).props.accessibilityValue).toEqual({
+    min: 0,
+    max: 100,
+    now: 40,
+  });
+});
+
+it('updates accessibilityValue when animatedValue changes', async () => {
+  const tree = render(<ProgressBar animatedValue={0.2} />);
+  await waitFor(() => tree.getByRole(a11yRole).props.onLayout(layoutEvent));
+
+  tree.update(<ProgressBar animatedValue={0.6} />);
+
+  expect(tree.getByRole(a11yRole).props.accessibilityValue).toEqual({
+    min: 0,
+    max: 100,
+    now: 60,
+  });
+});
+
+it('sets empty accessibilityValue when indeterminate is true', async () => {
+  const tree = render(<ProgressBar indeterminate />);
+  await waitFor(() => tree.getByRole(a11yRole).props.onLayout(layoutEvent));
+
+  expect(tree.getByRole(a11yRole).props.accessibilityValue).toEqual({});
+});


### PR DESCRIPTION
Set the accessibilityValue if animatedValue is set.

### Motivation

We noticed that the accessibilityValue is probably not set when only setting the animatedValue. Because the progress and animatedValue should not be used in parallel, we can see here that animatedValue is ignored by the accessibilityValue. 

```
    accessibilityValue={
      indeterminate
        ? {}
        : { min: 0, max: 100, now: Math.round(progress * 100) }
    }
```

### Related issue
n.a.


### Test plan

I added tests to check the accessibilitValue of the ProgressBar.
