### PR TITLE
Feat/list icon size

### DIFF
--- a/et --hard fde7ba74af67ffe8ad53ed3055e7b8fe9b8a653a
+++ b/et --hard fde7ba74af67ffe8ad53ed3055e7b8fe9b8a653a
@@ -1,0 +1,14576 @@
+[33mcommit eec9b8c7279ca432ec970328e5c662147086b3fc[m[33m ([m[1;36mHEAD[m[33m -> [m[1;32mfeat/list-icon-size[m[33m, [m[1;31morigin/feat/list-icon-size[m[33m)[m
+Author: Peter Torki <pjturki@gmail.com>
+Date:   Fri Aug 22 16:19:00 2025 +0300
+
+    feat(ListIcon): add iconSize prop to allow custom sizing, fixed some eslint issues
+
+[33mcommit fde7ba74af67ffe8ad53ed3055e7b8fe9b8a653a[m
+Author: Peter Torki <pjturki@gmail.com>
+Date:   Fri Aug 22 16:03:45 2025 +0300
+
+    feat(ListIcon): add iconSize prop to allow custom sizing
+
+[33mcommit 4efbbaf871b54ca154a0c572fbd34044f78f8d1a[m
+Author: Peter Torki <pjturki@gmail.com>
+Date:   Fri Aug 22 15:36:03 2025 +0300
+
+    feat(ListIcon): add iconSize prop to allow custom sizing
+
+[33mcommit ff0df5454eb13d6e8e2d8f1c87c0bca8bb3635f0[m[33m ([m[1;31morigin/main[m[33m, [m[1;31morigin/HEAD[m[33m, [m[1;32mmain[m[33m)[m
+Author: Tomasz Janiczek <tomasz.janiczek@callstack.com>
+Date:   Thu Jul 17 18:09:37 2025 +0200
+
+    fix(chore): Tighten GA write access (#4774)
+
+[33mcommit 23447212af201bb18cadd6656ffa434d7e05cd4f[m
+Author: Tomasz Janiczek <tomasz.janiczek@callstack.com>
+Date:   Wed Jul 16 14:32:18 2025 +0200
+
+    fix(chore): Pin github actions to specific commit (#4772)
+
+[33mcommit d68b71bc851d1e9433a806d2f2475d72fb790e6e[m
+Author: Michał Pierzchała <thymikee@gmail.com>
+Date:   Wed Jul 16 14:04:57 2025 +0200
+
+    Update check-repro.yml
+
+[33mcommit 0d0206d6dd0b60e50aea9a57193ec507ca28aed3[m
+Author: Michał Pierzchała <thymikee@gmail.com>
+Date:   Tue Jun 17 16:20:59 2025 +0200
+
+    docs: update link
+
+[33mcommit 22f24f4488f1431f47c6cb1d7852817676ff9f64[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jun 4 09:58:06 2025 +0200
+
+    docs: update banner
+
+[33mcommit b05d4847e84aff444088659e8e6f687fab755445[m
+Author: Thibault Durand <durandt@users.noreply.github.com>
+Date:   Tue May 20 14:43:48 2025 +0200
+
+    docs: Add paragraph explaining how to test a specific PR/commit (#4743)
+
+[33mcommit db7dd004e39c60175854a90337fe6feecf75e76a[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue May 20 13:19:37 2025 +0200
+
+    chore: update react-native in example
+
+[33mcommit c3068fafd6f676ba542cabba25ab2d929a6ec2b2[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue May 20 13:09:17 2025 +0200
+
+    chore: release 5.14.5
+
+[33mcommit 3a6dfde069cfce817482cbf334902d20a895c00d[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue May 20 13:00:05 2025 +0200
+
+    fix: apply elevation as prop for md3 (#4748)
+
+[33mcommit 2d48520e411622752f43270bfc45449ea11c2a4b[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu May 15 14:19:30 2025 +0200
+
+    chore: release 5.14.4
+
+[33mcommit 12ce89db0fcfb0695ec1038adc89d32b215f3fb8[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu May 15 14:19:01 2025 +0200
+
+    fix: add container prop and improve flex/layout handling (#4742)
+
+[33mcommit 1d2a3785498f29243bcade2a9cf01bce54c750b0[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu May 15 10:45:27 2025 +0200
+
+    docs: update contributing guide
+
+[33mcommit 927488659484b6c47ad35891162aa98d8be9f3ed[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue May 13 16:15:49 2025 +0200
+
+    chore: remove comment
+
+[33mcommit b6ee2f1a1c2a7a80b7c7f2b2373064728e2d3147[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue May 13 15:07:01 2025 +0200
+
+    chore: release 5.14.3
+
+[33mcommit 5d0c77929e30d3e0bb3f1460986eb4d7e1d76456[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue May 13 15:05:22 2025 +0200
+
+    fix: revert transformOrigin use from TextInput
+
+[33mcommit 61e292c36daa70a8ec3f5f1f418e96aee95c4f4a[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue May 13 13:17:45 2025 +0200
+
+    chore: release 5.14.2
+
+[33mcommit 5138e4c6471d4abdd1b69756ab9d9b2d22172a8e[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue May 13 13:05:41 2025 +0200
+
+    fix: remove findNodeHandle (#4731)
+
+[33mcommit e3952710fe4e21e28f1ba5f237f8635eeb65ad7c[m
+Author: rnigro-rwb <89093814+rnigro-rwb@users.noreply.github.com>
+Date:   Tue May 13 07:05:26 2025 -0400
+
+    fix: fix error on width change of AnimatedFAB when label is empty string (#4729)
+
+[33mcommit aae6e422fcc992d7287390f972fc256b686f37f8[m
+Author: Paul-Andrei Petan <pap36@bath.ac.uk>
+Date:   Tue May 13 14:02:47 2025 +0300
+
+    fix: update rn version for InputLabel translation (#4730)
+
+[33mcommit 08d5ed9376003456f3f159c7f5e7da52c4538618[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri May 9 13:23:21 2025 +0200
+
+    chore: adjust webpack and ts configs
+
+[33mcommit d184f3c99c6e469fea3a05db66072787be92f42b[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu May 8 18:59:56 2025 +0200
+
+    chore: update package.json
+
+[33mcommit 8b22e4d0ff2a0ebcbf8c9f0e20ef88b30107208e[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu May 8 13:07:23 2025 +0200
+
+    chore: release 5.14.1
+
+[33mcommit 0f9ba45765b7ce26091b333ea17539560b26afb6[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu May 8 13:03:55 2025 +0200
+
+    chore: change icon module require priorities
+
+[33mcommit 1da5d153ee29a18a7bf373bcda01b7f69c12f3b4[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu May 8 10:52:22 2025 +0200
+
+    chore: setup monorepo with yarn workspaces
+
+[33mcommit a01ba86ba88d1ae5421fadc7a5fa8cc17e36501a[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu May 8 09:25:07 2025 +0200
+
+    fix: set transformOrigin only for mobile
+
+[33mcommit d3cb160b40ee183c24b3a3c0c3efbbee747128a0[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed May 7 20:46:41 2025 +0200
+
+    chore: introducing workspaces - monorepo setup (#4722)
+
+[33mcommit 170bffe3d55bfe2e6539436371b8fa327646d161[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed May 7 20:20:35 2025 +0200
+
+    fix: correct border end width (#4719)
+
+[33mcommit 1af818ec414130daa0ee7fc19d622623174dbf90[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed May 7 20:20:16 2025 +0200
+
+    chore: update `react-native` to `0.77.0` (#4716)
+
+[33mcommit c1e8538aea1e01dcb9254dfcdcb60388a0349d6a[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed May 7 16:10:01 2025 +0200
+
+    chore: update react-native-vector-icons to 12.0.0 (#4718)
+
+[33mcommit 3c75257f89756dcb604c8723005132c3caf82177[m
+Author: Bogusz Kaszowski <bogusz.kaszowski@callstack.com>
+Date:   Wed May 7 16:08:20 2025 +0200
+
+    fix: fix Surface styling when flex set (#4634)
+
+[33mcommit 2559198292f291f6209462d4403f24dac779ff6d[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed May 7 15:59:36 2025 +0200
+
+    fix: allow to override hitSlop (#4717)
+
+[33mcommit 895de4b5aef40ae0dedab8f7468d597a650ebeeb[m
+Author: Christopher Wilkinson <git@wilk.tech>
+Date:   Wed May 7 14:54:47 2025 +0100
+
+    fix: hitslop passed to touchable (#4678)
+
+[33mcommit eb27d4a1e60a41eb11d35943f4cb9f9d2e1d9fd5[m
+Author: Buqi Liao <116039191+BuqiLiao@users.noreply.github.com>
+Date:   Wed May 7 06:50:52 2025 -0700
+
+    fix: use transformOrigin to fix label position flickering in RN 0.73 (#4521)
+
+[33mcommit d7010290b1dca1e97bfc3f5832023b1f489a6f01[m
+Author: Andrew <35735666+meatnordrink@users.noreply.github.com>
+Date:   Tue May 6 09:48:21 2025 -0400
+
+    docs: Update Modal.tsx description to note a11y limitations (#4280)
+
+[33mcommit 4fcf6425ad7f69c8ed108879da31ce1ec47d6daa[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon May 5 10:33:50 2025 +0200
+
+    docs: rnvi version tabs and selection note
+
+[33mcommit 0f769b5964fc8efebb72dd08bed157f1007281e7[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon May 5 09:45:50 2025 +0200
+
+    docs: improve left and right props description
+
+[33mcommit 0af3972162c484139b3c7f2d7f1471144eae14c3[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Apr 30 13:21:53 2025 +0200
+
+    chore: release 5.14.0
+
+[33mcommit a91a4c8c54d6804ad05548e1f6e87dfd31d3dd8c[m
+Author: ChenBr <chenbrilling1@gmail.com>
+Date:   Wed Apr 30 14:14:11 2025 +0300
+
+    feat: enable adding styles to the action-wrapper in FABGroup (#4657)
+
+[33mcommit 53ca1f65e20b3bd7ad51ce3983d71157034f776f[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Apr 30 12:47:19 2025 +0200
+
+    chore: deprecate `createMaterialBottomTabNavigator` (#4694)
+
+[33mcommit 699bb06bffa1a114fb573bc080bafca3db534fe9[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Apr 30 11:13:08 2025 +0200
+
+    feat: adjust adaptNavigationTheme to the latest navigation theme changes (#4690)
+
+[33mcommit d0ad27cf36e603df3e4ddffe67d0b4dea720bb44[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Apr 30 10:59:52 2025 +0200
+
+    chore: update react-native-vector-icons (#4696)
+
+[33mcommit 1004de3fdbe1b42887c613075860dc8e7f66b84b[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Apr 30 10:58:35 2025 +0200
+
+    refactor: mark MD2 typography as deprecated (#4706)
+
+[33mcommit e69f9d2694284113ff27f3bcd77716b052c84ead[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Apr 30 10:57:38 2025 +0200
+
+    fix: allow to override content style (#4707)
+
+[33mcommit c98a01c3f52c612103cdf871fd7d9ce77be981d7[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Apr 30 10:57:04 2025 +0200
+
+    feat: add content style prop (#4697)
+
+[33mcommit 95c9390267756102197f61337a61d2a677fd2503[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Apr 30 10:56:23 2025 +0200
+
+    feat: add container style prop (#4691)
+    
+    * feat: add container style prop
+    
+    * feat: add container style prop to list accordion
+
+[33mcommit 218cc327dd31588adf0d10ab02bc92adfe1880b5[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Apr 30 10:55:54 2025 +0200
+
+    fix: add set selection to the searchbar (#4708)
+
+[33mcommit beab66e074e2b0dfa1251ae221308178003d4a9b[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Apr 28 12:53:44 2025 +0200
+
+    docs: correct example code (#4703)
+
+[33mcommit 1c30ad8e051e5bfaae7bb1e29e8f4ef08b20dcd2[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Apr 25 16:16:39 2025 +0200
+
+    chore: release 5.13.5
+
+[33mcommit 21fc01045c9d89a4814ea7818a78dad1091c02b8[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Apr 25 16:11:52 2025 +0200
+
+    fix: isleading prop behaviour (#4699)
+    
+    * fix: isleading prop behaviour
+    
+    * fix: icons alignment
+
+[33mcommit 344ef56bce2e3cad0d69bf414f0ebe2c1854d365[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Apr 25 16:09:30 2025 +0200
+
+    fix: set cursor to auto when touchable is disabled (#4701)
+
+[33mcommit 0889b0b301735bf1ac0bd71bc4d4cc8bec331026[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Apr 25 16:09:16 2025 +0200
+
+    fix: adjust label opacity (#4700)
+
+[33mcommit 9060c3c1c6fbbb50a7c64b3dfbb4d2d78a6da34d[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Apr 25 16:08:58 2025 +0200
+
+    fix: hide actions after closing fab group (#4692)
+
+[33mcommit ff58b002b9230d79850e98b3cae9e17d04be8731[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Apr 25 16:08:07 2025 +0200
+
+    fix: zero badge rendering (#4693)
+
+[33mcommit dd68f60800df2273162957b2e80aa584e35a9046[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Apr 23 14:19:04 2025 +0200
+
+    chore: release 5.13.4
+
+[33mcommit 47e28418be2182a4f25842baace8effc3bfa3398[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Apr 23 09:24:43 2025 +0200
+
+    fix: add missing setSelection method on text input (#4688)
+
+[33mcommit 27a6556df6631d808ebaeeb32ff1cc462444882d[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Apr 22 14:46:23 2025 +0200
+
+    refactor: segmented button typing (#4686)
+
+[33mcommit d4cca22db6cebcd237568d375a64c27611c74fe1[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Apr 22 14:46:08 2025 +0200
+
+    fix: omit safe area insets in appbar header types (#4687)
+
+[33mcommit 23604c01c7d64fc3af676c6a221b5a2823b2bfb1[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Apr 22 13:07:03 2025 +0200
+
+    fix: update tests
+
+[33mcommit 2463579cac52dd52c25ccef16f00e7031d998a1e[m
+Author: TARO ABDOUL-AZIZ <58216243+Aztaro97@users.noreply.github.com>
+Date:   Tue Apr 22 15:00:00 2025 +0400
+
+    fix: :bug: Remove outline on web from TextInputFlat component (#4305)
+
+[33mcommit b59d784669cce4659cd274c69838c4290746c29a[m
+Author: Charles Yang <58612151+Yarles404@users.noreply.github.com>
+Date:   Tue Apr 22 05:38:56 2025 -0500
+
+    docs: grammar cleanup (#4268)
+
+[33mcommit bcd27177cbaf6dae90f7caa75e5f20db41d2be5b[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Apr 22 12:31:52 2025 +0200
+
+    docs: update start command
+
+[33mcommit c9887015cb7de784bfde0806442f6ea724a8d546[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Apr 22 11:09:58 2025 +0200
+
+    fix: correct menu position with translucent status bar (#4685)
+
+[33mcommit 82088119b809f8fef56c265f665b1793e4c181fc[m
+Author: Kamil <kamil.kedzierski94@gmail.com>
+Date:   Tue Apr 22 09:25:49 2025 +0200
+
+    fix: fixed `Chip` "shadow" and height issue (#4461)
+
+[33mcommit 7e938cfd40c88b291a3a0ec085ce3f2c707995f1[m
+Author: Jahir Fiquitiva <jahir.fiquitiva@gmail.com>
+Date:   Tue Apr 22 02:21:13 2025 -0500
+
+    fix: Button and IconButton TouchableRipple borderRadius (#4278)
+
+[33mcommit c5161abe6b4ff60f3b383035c5f7fe50624665dd[m
+Author: Claes-Fredrik Mannby <cf@mannby.com>
+Date:   Fri Apr 18 13:21:16 2025 -0700
+
+    fix: avoid gratuitous re-rendering of components using settings or theme (#4619)
+
+[33mcommit 8fb590a7dee5eff9e669a14cbd9f20bd0d9cfb09[m
+Author: Kacper Żółkiewski <74975508+kacperzolkiewski@users.noreply.github.com>
+Date:   Fri Apr 18 22:15:31 2025 +0200
+
+    fix: ensure DataTable.Title respects font scaling (#4640)
+
+[33mcommit cab5afa03ecbdd895b81541de51b96a83bf4459e[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Apr 18 09:07:55 2025 +0200
+
+    fix: remove cover padding (#4683)
+
+[33mcommit c037c1744ba6b0e7a3de7c3118a88ebec6bc632c[m
+Author: Greg Fenton <greg.fenton@gmail.com>
+Date:   Thu Apr 17 18:58:37 2025 +0500
+
+    docs: add link to Theme documentation (#4485)
+    
+    Provide context to the phrase "in the theme".
+
+[33mcommit 71403f253acbb0475bd2200cde60185d766a5f78[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Apr 17 15:55:08 2025 +0200
+
+    chore: release 5.13.3
+
+[33mcommit 25fed4c806ab0eebece65412e9f941691af09ab5[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Apr 17 15:54:04 2025 +0200
+
+    fix: prevent elevation animation for contained Card mode (#4681)
+
+[33mcommit eab4252d66b705977e322a915ef1a2e027cb68d3[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Apr 17 15:11:53 2025 +0200
+
+    docs: correct Card and List.Item displayed names (#4680)
+
+[33mcommit ed4df90b2e72455f4cd84228138f55b4a8a120a7[m
+Author: Henry Heino <46334387+personalizedrefrigerator@users.noreply.github.com>
+Date:   Thu Apr 17 02:52:00 2025 -0700
+
+    fix: FAB.Group subitems are accessibility focusable when collapsed (#4498)
+
+[33mcommit b35d8ec5f04a080c3cd4857c78676633516e97c8[m
+Author: Simanta Raj Sarma <139645750+SimantaRajSarma@users.noreply.github.com>
+Date:   Thu Apr 17 15:16:25 2025 +0530
+
+    docs: update 03-icons.mdx (#4627)
+
+[33mcommit 4c2e066d926b86eee44e045492ce80e97a361583[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Apr 16 14:30:11 2025 +0200
+
+    chore: release 5.13.2
+
+[33mcommit 964bbbe4f553e659511cbc1fad816bc756f39b5e[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Apr 16 14:29:36 2025 +0200
+
+    chore: bump use latest callback to 0.2.3 (#4679)
+
+[33mcommit 00b00d2ca772a9c4a3c4f41930bfac13afec2167[m
+Author: Bogusz Kaszowski <bogusz.kaszowski@callstack.com>
+Date:   Wed Apr 2 18:24:08 2025 +0200
+
+    fix(menu): fix menu visibility based on props (#4645)
+
+[33mcommit 2367889b5aec3f9521ba9ab7beaf083b2812c9d4[m
+Author: Bogusz Kaszowski <bogusz.kaszowski@callstack.com>
+Date:   Wed Apr 2 18:04:48 2025 +0200
+
+    fix: animated-fab & animated-text ts issues (#4669)
+
+[33mcommit 366e0d63fd5ae0d5dc7799dbd97eee8e4062134c[m
+Author: Bogusz Kaszowski <bogusz.kaszowski@callstack.com>
+Date:   Tue Feb 18 22:35:39 2025 +0100
+
+    fix(animated-fab): label styling (web) (#4567)
+    
+    * fix(animated-fab): label styling (web)
+    
+    * fix(animated-fab): add canvasContext caching (web)
+
+[33mcommit c488fc31f69882097ce4254b0a709f29a96b02fd[m
+Author: Andrew <35735666+meatnordrink@users.noreply.github.com>
+Date:   Thu Feb 6 16:52:05 2025 -0500
+
+    docs: Replace missing word in ActivityIndicator.tsx (#4612)
+
+[33mcommit 8431493c06ebebadf909000bc5c9baf427a0fdcf[m
+Author: Damian Filipek <75132129+damianfilipek81@users.noreply.github.com>
+Date:   Thu Feb 6 22:48:45 2025 +0100
+
+    fix: input label not visible on ios if multiline, fixes #4482 (#4497)
+    
+    * fix: input label not visible on ios if multiline, fixes #4482
+    
+    * fix: remove unnecessary styling from InputLabel
+    
+    ---------
+    
+    Co-authored-by: Bogusz Kaszowski <bogusz.kaszowski@callstack.com>
+
+[33mcommit 8dcfbcc53a1060b116ef3c0677f04716a097466b[m
+Author: fdonv <donval.florian@gmail.com>
+Date:   Fri Jan 10 23:44:22 2025 +0100
+
+    docs: fix default mode name for HelperText (#4525)
+
+[33mcommit bffd4306baa8347ac9029fa98673da947af63254[m
+Author: Balthazar33 <40452950+Balthazar33@users.noreply.github.com>
+Date:   Sat Jan 11 04:12:18 2025 +0530
+
+    docs: typo in property description (#4585)
+
+[33mcommit bf95751fd5d286ee062f215d5d49153b791a6131[m
+Author: Hugo Burton <66514580+hugs7@users.noreply.github.com>
+Date:   Sat Jan 11 08:37:01 2025 +1000
+
+    docs: Match TextInput.Affix screenshot with code example (#4530)
+
+[33mcommit 62c14a9abdff83e6ba4d3a8f1640a35bd13a59fd[m
+Author: Mario Nikolaus <mnikolaus@users.noreply.github.com>
+Date:   Fri Jan 10 23:34:35 2025 +0100
+
+    docs: mention Provider on Getting Started for older v5 versions (#4363)
+
+[33mcommit db2caa0b911477bf094571b8b9cba6837d074d3e[m
+Author: AssafFogelman <109423353+AssafFogelman@users.noreply.github.com>
+Date:   Sat Jan 11 00:31:37 2025 +0200
+
+    docs: update 02-theming.mdx (#4483)
+    
+    deleted a double word - "to"
+
+[33mcommit de2b6b5d5c1a4569668f972937baf7ef77724edb[m
+Author: Pratik Gehlot <pratik.aimachine@gmail.com>
+Date:   Fri Jan 10 14:30:14 2025 -0800
+
+    docs: typo fix (#4480)
+
+[33mcommit af8d9cd3b908641fa3c4c479b6b56ebd1e342af2[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Jan 10 16:59:44 2025 +0100
+
+    chore: release 5.13.1
+
+[33mcommit deaa263654181ffcd4f9ce2837ba5d01f145b480[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Jan 10 16:58:24 2025 +0100
+
+    chore: revert adding expo-font on the root
+
+[33mcommit 5f463b7a389c847b3ea96d3cd3f5ec76495ca710[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Jan 9 19:37:52 2025 +0100
+
+    chore: release example app 3.16.0
+
+[33mcommit 5a628100dc659f43f7eb806736a0ddd16984a6ac[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Jan 9 15:31:10 2025 +0100
+
+    chore: release 5.13.0
+
+[33mcommit 1bf3664751d3cbf533cf33f12a0c773e349fb0e2[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Jan 9 15:18:03 2025 +0100
+
+    chore: update android app (#4597)
+    
+    * chore: update android app
+    
+    * chore: update deprecated actions
+    
+    * chore: update expo-font
+
+[33mcommit 77d3af73a2db020da4a2a90592a4eda030e2a2ee[m
+Author: Bogusz Kaszowski <bogusz.kaszowski@callstack.com>
+Date:   Thu Jan 9 11:56:14 2025 +0100
+
+    feat: New architecture support (#4574)
+    
+    * feat: update deps & enable new arch
+    
+    * chore: migrate Menu to functional component
+    
+    * fix: get rid of a few rerenders of Menu
+    
+    * fix: fix Modal flickering & cleanup
+    
+    * fix: dynamic update of Button styles
+    
+    * chore: update yarn
+    
+    * fix: fix scrolling on ExampleList screen (web)
+    
+    * fix: update runtimeVersion
+    
+    * fix: workaround for fixing textinput styling
+    
+    * chore: circleCI config update
+    
+    * chore: Update AnimatedText's props type
+    
+    Co-authored-by: Satyajit Sahoo <satyajit.happy@gmail.com>
+    
+    * fix: get rid of setting yarn version from circleCI config
+    
+    * fix: setting top offset of Menu based on anchorPosition
+    
+    ---------
+    
+    Co-authored-by: Satyajit Sahoo <satyajit.happy@gmail.com>
+
+[33mcommit 2827b9c71f042a6e1da8e4bb455d911d331c0d74[m
+Author: Davyd NRB <4661784+retyui@users.noreply.github.com>
+Date:   Fri Nov 29 12:29:39 2024 +0100
+
+    chore: Node.js 16 actions are deprecated. (#4323)
+    
+    The following actions uses node12 which is deprecated and will be forced to run on node16: actions/setup-node@v1, actions/cache@v1, actions/github-script@v3.
+    - For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
+    
+    Please update the following actions to use Node.js 20: actions/stale@v3.
+    - For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
+
+[33mcommit 14ddb2bd3db808c67c1ac0c0e01761bd6346afe8[m
+Author: Kamil <kamil.kedzierski94@gmail.com>
+Date:   Thu Nov 28 16:13:45 2024 +0100
+
+    feat: bumped React Native and Expo version (#4477)
+    
+    * chore: bumping version of expo, react-native, android sdk
+    
+    * fix: fixed issues with build
+    
+    * chore: fixed most issues with tests + upgraded react-native-vector-icons
+    
+    * chore: changed wrong version of exposdk in AndroidManifest
+    
+    * fix: fixed issue with icons not showing up on web
+    
+    * fix: flaky TextInput test
+    
+    * fix: library assets not loading
+    
+    * fix: fixed yarn.lock issue
+    
+    * fix: fixed formatting
+    
+    * fix: fixed ts issues
+    
+    * chore: added missing flag
+    
+    * fix: handle RTL when example app running in Expo Go
+    
+    ---------
+    
+    Co-authored-by: Szymon Chmal <szymon.chmal@callstack.com>
+    Co-authored-by: Bogusz Kaszowski <bogusz.kaszowski@callstack.com>
+
+[33mcommit 9162a1fdf4e97c0669de8a8fa2057d8cfbe2e728[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sun Jul 28 20:33:36 2024 +0200
+
+    chore: release 5.12.5
+
+[33mcommit 178122123a63deca741bc5ba5a15fb04e8f66ce0[m
+Author: Kamil <kamil.kedzierski94@gmail.com>
+Date:   Sun Jul 28 20:30:13 2024 +0200
+
+    fix: fixed issue with textinput styling after new release (#4466)
+    
+    * fix: fixed issue with textinput styling after new release
+    
+    * fix: updated snapshots
+
+[33mcommit 0df24ee7735cc9e7683fa1cf56314b9c3b2554de[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sat Jul 27 14:53:18 2024 +0200
+
+    chore: release 5.12.4
+
+[33mcommit d9db02eb68eb2b1b0d9fe45dd9682d89ec4790b2[m
+Author: Sebastian Zabielski <165782545+seb-zabielski@users.noreply.github.com>
+Date:   Sat Jul 27 14:38:22 2024 +0200
+
+    fix(text-input-label-background): custom component background height (#4442)
+
+[33mcommit 2c721ef0b40b3e17185e3fd8ae4ab2f6b2d75ac2[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Sat Jul 27 15:37:50 2024 +0300
+
+    chore: add `touchableRef` to `Button` (#4322)
+
+[33mcommit aaa46eb42cd3b426651b14e92a339efee669dfe2[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Sat Jul 27 15:36:59 2024 +0300
+
+    chore: wrap `Card` in `forwardRef` (#4303)
+
+[33mcommit f34f9a8f5c12627f04cc3773b97f055aded94e55[m
+Author: Sebastian Zabielski <165782545+seb-zabielski@users.noreply.github.com>
+Date:   Sat Jul 27 14:22:46 2024 +0200
+
+    fix(drawer-item): hover effect background color (#4440)
+
+[33mcommit c1495eaf984e868611534b5398253606bd2f1764[m
+Author: Sebastian Zabielski <165782545+seb-zabielski@users.noreply.github.com>
+Date:   Sat Jul 27 14:21:56 2024 +0200
+
+    fix(text-input): parent scroll with text input height (#4422)
+
+[33mcommit f57709720b1e1325021e8c7fe5c9a662b1a4be8d[m
+Author: Sebastian Zabielski <165782545+seb-zabielski@users.noreply.github.com>
+Date:   Sat Jul 27 14:21:24 2024 +0200
+
+    fix(text-input-affix): fix right TextInput.Affix alignment with onPress (#4415)
+
+[33mcommit 1a82b2c73a4bbfe064ae5a2b0ab1af3d31190def[m
+Author: Sebastian Zabielski <165782545+seb-zabielski@users.noreply.github.com>
+Date:   Sat Jul 27 14:20:56 2024 +0200
+
+    fix(text-input): very long input label truncated when scaled (#4414)
+
+[33mcommit eebc77fe099c5bf8d61d8dcfc1052acd84105f26[m
+Author: Lenzi Erickson <lenzi.erickson@gmail.com>
+Date:   Sat Jul 27 05:20:27 2024 -0700
+
+    fix: add support for changing the surface mode in the menu (#4378)
+    
+    * fix: add support for changing the surface mode in the menu
+    
+    * test: adding tests for new mode prop
+
+[33mcommit eed911be589ca2ca0244c0389759e615a18fb809[m
+Author: Sebastian Zabielski <165782545+seb-zabielski@users.noreply.github.com>
+Date:   Sat Jul 27 14:19:22 2024 +0200
+
+    fix(snackbar): fix show animation on new architecture (#4447)
+
+[33mcommit 4b2052a27d52e4cc9becbb05236d864e9a4d68c2[m
+Author: timbocole <tc@post-quantum.com>
+Date:   Sat Jul 27 13:17:54 2024 +0100
+
+    fix: remove deprected use of defaultProps (#4385)
+
+[33mcommit b1fd7394756a5d4856e9c4eeb60a50f29b4a8f29[m
+Author: Andrew <35735666+meatnordrink@users.noreply.github.com>
+Date:   Sat Jul 27 08:17:18 2024 -0400
+
+    fix: allow pass-through of accessibilityRole on Chip (#4327)
+
+[33mcommit bc0ecb1a7381928ebb5bc10fa491e27046430dc1[m
+Author: Rajendran Nadar <17236768+raajnadar@users.noreply.github.com>
+Date:   Sat May 4 12:31:36 2024 +0530
+
+    chore: bump node to 18 for circle CI (#4393)
+
+[33mcommit 813cdd47a90ee3bb693c6ec143af73092cd3edae[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jan 24 20:35:12 2024 +0100
+
+    chore: release 5.12.3
+
+[33mcommit 1abbf108248a8570f7a02e49ec7f366e9bcf059b[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jan 24 20:32:39 2024 +0100
+
+    fix: remove log
+
+[33mcommit bf6c580b303762cab12270b1399f7e5947cf45a2[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jan 24 20:20:48 2024 +0100
+
+    chore: release example app 3.14.0
+
+[33mcommit 2901378be257d147b1bb42f9e9b99fe8ea245f21[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 22 17:52:30 2024 +0100
+
+    chore: release 5.12.2
+
+[33mcommit 24fcc70307136d16136868dc92b4c406294103f8[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 22 17:51:37 2024 +0100
+
+    fix: correct elevation in disabled button for MD2 (#4293)
+
+[33mcommit 4f1be530efc3c1d4b4d1256a3577a7ae6f8457cc[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 22 17:51:24 2024 +0100
+
+    fix: prevent pressing disabled children within tooltip (#4291)
+
+[33mcommit 756f72afcf33457be6409cfc9015a49f8b32b7d2[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 22 14:40:09 2024 +0100
+
+    fix: correct deprecated annotation in nested prop
+
+[33mcommit cd9e303b8242ccd172dc7dbedba0af9f4178b34d[m
+Author: Yousef Abu Shanab <93343012+youzarsiph@users.noreply.github.com>
+Date:   Mon Jan 22 01:54:59 2024 -0800
+
+    docs: Update `BottomNavigationBar.tsx`, add missing import
+
+[33mcommit e24f9f7194c4cbe25c49c5d56e839bddeaef5cb4[m
+Author: Yousef Abu Shanab <93343012+youzarsiph@users.noreply.github.com>
+Date:   Mon Jan 22 01:37:41 2024 -0800
+
+    docs: Update `08-theming-with-react-navigation.md`, add missing import
+
+[33mcommit 9c9a6149ba75d773a4c2595c2af4ff03ed2f704f[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Jan 12 22:30:48 2024 +0100
+
+    chore: release 5.12.1
+
+[33mcommit b7a88e1e1a90b72e94970f4321c4ff4d757b0c0f[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Jan 12 22:28:59 2024 +0100
+
+    fix: correct affix pressable container styles (#4274)
+
+[33mcommit 8e5d12da0685fc5073fd930d4043131b1c472f8b[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jan 10 23:41:38 2024 +0100
+
+    chore: release 5.12.0
+
+[33mcommit 710f61fe23f19319f53d981109649f6e469cd9ae[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jan 10 23:38:53 2024 +0100
+
+    test: update snapshot
+
+[33mcommit f5c848571f92361b18281318d8da6aa61ed11d79[m
+Author: john-trieu-nguyen <34326372+john-trieu-nguyen@users.noreply.github.com>
+Date:   Thu Jan 11 08:38:59 2024 +1100
+
+    fix: textinput long text causes wrapping (ios) (#4261)
+
+[33mcommit 6dd615decb7107560f15f0ab13a43509428b7d45[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jan 10 22:04:28 2024 +0100
+
+    feat: pass background prop to nested touchables (#4108)
+
+[33mcommit 7cf251d010a6c7f545f87ed3d8e876c9e1763c15[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jan 10 22:04:13 2024 +0100
+
+    fix: update input colors (#4259)
+
+[33mcommit a62d6ec8e3feb7cabe0e1104d8b1e597724040bf[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jan 10 22:04:00 2024 +0100
+
+    fix: correct border radius based on roundness (#4260)
+
+[33mcommit aa270b6fc742c03a22a41096acd1897272ec690f[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jan 9 22:37:19 2024 +0100
+
+    test: update snapshot
+
+[33mcommit e3060723ddc20ee9902020fc1ec9f24b3f4d7937[m
+Author: Jeferson S. Brito <30840709+jeferson-sb@users.noreply.github.com>
+Date:   Tue Jan 9 18:29:07 2024 -0300
+
+    feat(text-input): add onPress to affix adornment (#4113)
+
+[33mcommit 441cc6563f3e4a863259a15e4e6ee1810464d97c[m
+Author: Carlinhos <91576261+carl0smat3us@users.noreply.github.com>
+Date:   Mon Jan 8 22:52:01 2024 +0100
+
+    feat(search-bar): minify the SearchBar component usage example (#4243)
+
+[33mcommit 3ebc86a3a5c482a2e4f50fbd3f547a44cc1a3edf[m
+Author: Basith <134603758+abdulbasithqb@users.noreply.github.com>
+Date:   Tue Jan 9 04:49:49 2024 +0700
+
+    fix: improve screen reader experience by fixing redundant FAB.Group item announcements. (#4196)
+
+[33mcommit 220ae167ff67417d6081ae3ddebee5524f6da108[m
+Author: Andrew <35735666+meatnordrink@users.noreply.github.com>
+Date:   Mon Jan 8 14:37:14 2024 -0500
+
+    fix: allow pass-through of accessibilityRole prop on Button.tsx (#4092)
+
+[33mcommit 4d57fe20d8283fbcab4df1df6c9e6723d2b21296[m
+Author: ondrejnedoma <117393974+ondrejnedoma@users.noreply.github.com>
+Date:   Mon Jan 8 20:13:53 2024 +0100
+
+    feat: added onLongPress to `RadioButton.Item` and `Checkbox.Item` (#4215)
+
+[33mcommit f46e9a37e2b376535ea778411de44cb03a0e11fb[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 8 20:08:09 2024 +0100
+
+    test: cover elevation prop by unit test
+
+[33mcommit db595b7c3dc1657091c5b27f2c4133d03e50f759[m
+Author: Alex Zelensky <alexzgit@gmail.com>
+Date:   Mon Jan 8 11:06:23 2024 -0800
+
+    feat: add `elevation` property for Menu component (#4077)
+
+[33mcommit f7d147c69b2c6ac67e995e61cb38fb39a502a2cc[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 8 20:04:46 2024 +0100
+
+    refactor: rephrase prop description
+
+[33mcommit 80edc1a26ab7703dda58e16181346660e42bba70[m
+Author: Kaushik Thallapally <thallapallyk@gmail.com>
+Date:   Mon Jan 8 08:05:49 2024 -0800
+
+    feat: added the loading prop to IconButton and updated react native (#4201)
+
+[33mcommit c42cfa2961b5a6d3df3060c4e34a120e6c56e460[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 8 14:46:08 2024 +0100
+
+    feat: add contentStyle to the list item title and description container (#4205)
+
+[33mcommit bdc2cbc45a1db5da2f8277c3b56c1710f5184fcd[m
+Author: Lev-Shapiro <96536068+Lev-Shapiro@users.noreply.github.com>
+Date:   Mon Jan 8 15:19:24 2024 +0200
+
+    feat: add activeIndicatorStyle to BottomNavigation (#4144)
+
+[33mcommit 3475624771869418f1c9d246128e61fa84cab641[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 8 14:16:34 2024 +0100
+
+    feat: progress bar fill style (#4222)
+
+[33mcommit 74b011dd781c85334252efbfda619b561b18575d[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 8 13:41:00 2024 +0100
+
+    chore: release 5.11.7
+
+[33mcommit 915a9fd870a966067aaece8bf1a24a98ba3ca23d[m
+Author: Augustas Eidikis <43470011+AugustasFriend@users.noreply.github.com>
+Date:   Mon Jan 8 12:43:24 2024 +0100
+
+    fix: include onLayout in TextInput render props (#4239)
+
+[33mcommit 67f1b9c509427f61084665493e5daea5e3b9fd2f[m
+Author: Kyrie <kyriechung@outlook.com>
+Date:   Mon Jan 8 18:31:50 2024 +0800
+
+    feat: dialog support safe area context (#4228)
+
+[33mcommit 46bd31bd35a9590f3ba13ed806f626ad9d54c9f3[m
+Author: Michael Nahkies <michael@nahkies.co.nz>
+Date:   Mon Jan 8 09:58:25 2024 +0000
+
+    fix: platform constants is undefined on web (#4257)
+
+[33mcommit d6b6b667dec9d9d47a8e7ad3afbbd48289b31971[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jan 2 20:05:42 2024 +0100
+
+    chore: release 5.11.6
+
+[33mcommit 81b7533d45504a82fe49e856f494bb4360ebe3f5[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Tue Jan 2 21:04:40 2024 +0200
+
+    chore: wrap `List.Item` in `forwardRef` (#4233)
+
+[33mcommit 726b98f371a84b302b553793679279d4c86555ff[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Dec 27 12:38:34 2023 +0100
+
+    chore: release 5.11.5
+
+[33mcommit 9def38b35d200b14d8075bb8833913f14774b74b[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Dec 27 12:35:52 2023 +0100
+
+    fix: adjust native driver value based on the rn version (#4246)
+
+[33mcommit c190a95e6b2b3842d372ba8f75477752d1042034[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Dec 11 12:03:03 2023 +0100
+
+    chore: release 5.11.4
+
+[33mcommit 6062699b906460ab140eb363d374b1c808951c61[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Dec 11 12:02:05 2023 +0100
+
+    fix: bottom navigation navigation state type correction (#4223)
+
+[33mcommit ac3820a50fe1afb82c19cc0853a451e5c190b769[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Nov 28 12:39:08 2023 +0100
+
+    refactor: replace `TouchableWithoutFeedback` with `Pressable` (#4117)
+
+[33mcommit b2311ef2050b9ac8e231983ed28163ba6539a0dd[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Nov 27 11:05:06 2023 +0100
+
+    chore: release 5.11.3
+
+[33mcommit 6ee89ee96a88311bb3e64d34d628834c02083c34[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Nov 27 10:49:02 2023 +0100
+
+    fix: passing external on layout (#4204)
+
+[33mcommit 27e8234467d455f411de8be15bbb6b53e74ab0c8[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Nov 23 14:51:28 2023 +0100
+
+    chore: release example app 3.13.0
+
+[33mcommit 412f6566ff7989954b35adf8c889e7061e0fa271[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Nov 23 11:01:22 2023 +0100
+
+    chore: release 5.11.2
+
+[33mcommit 56adec8f41f59c9e162f4bd2523b941ee235720c[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Nov 23 10:57:00 2023 +0100
+
+    fix: correct input label max width (#4199)
+
+[33mcommit 47bf28d407ef42b57dd4fe702a49104c017a3230[m
+Author: Artur Morys - Magiera <artus9033@gmail.com>
+Date:   Thu Nov 23 10:56:43 2023 +0100
+
+    fix: tooltip behaviour on web (#4158)
+    
+    Co-authored-by: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit 333da929b9334b444c9956e00e2e7f70122775d0[m
+Author: Hayden Briese <haydenbriese@gmail.com>
+Date:   Thu Nov 23 20:54:42 2023 +1100
+
+    fix(text): variant loss with child component (#4173)
+
+[33mcommit 68e170b91149443a3005a346a73b4fd0fedb6bde[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Nov 23 10:51:03 2023 +0100
+
+    fix: set default cursor for menu pressable overlay (#4188)
+
+[33mcommit 5f15f799642b3f584c93b614f8f797bf799bfa82[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Thu Nov 23 11:50:30 2023 +0200
+
+    chore: wrap `TouchableRipple` in `forwardRef` (#4192)
+
+[33mcommit 0699acc420a96526b9ba9f02eb2ea1a028a7a5d5[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Nov 23 10:49:34 2023 +0100
+
+    fix: add rippleColor prop (#4189)
+
+[33mcommit e7df069511e58c53af3569090d397d1ae65339d5[m
+Author: wilav-dev <71793326+wilav-dev@users.noreply.github.com>
+Date:   Sat Nov 18 05:35:54 2023 -0300
+
+    fix: update FABGroup.tsx (#4160)
+
+[33mcommit f5c14c3698fa260727353a4ce9e8958017ee5156[m
+Author: abdulbasithqb <134603758+abdulbasithqb@users.noreply.github.com>
+Date:   Tue Nov 14 19:43:52 2023 +0530
+
+    chore: Added missing tooltip for 'bold' icon (#4170)
+    
+    Co-authored-by: navedqb <109583873+navedqb@users.noreply.github.com>
+
+[33mcommit 115360f166202d067c9bbed7e2f01d72957a7219[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Nov 14 14:15:06 2023 +0100
+
+    docs: fix lint issue
+
+[33mcommit f4a18d3b8cf2cb58c1e130947b61ca8ee8757a2e[m
+Author: crussell122 <42820804+crussell122@users.noreply.github.com>
+Date:   Tue Nov 14 08:13:55 2023 -0500
+
+    docs: Add Bluebirding Application to Showcase (#4166)
+
+[33mcommit aebeabd8769988b17bb56b0f5673f252e1bda0d9[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Oct 24 10:50:16 2023 +0200
+
+    chore: release 5.11.1
+
+[33mcommit 2d069ee34cb7026b5c82f5226d901115b19610f6[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Oct 17 14:42:36 2023 +0200
+
+    chore: release example app 3.12.0
+
+[33mcommit eb55879aa82ab397a700000f7919a16e438074ff[m
+Author: Lev-Shapiro <96536068+Lev-Shapiro@users.noreply.github.com>
+Date:   Tue Oct 24 10:30:46 2023 +0300
+
+    feat: export type BaseRoute (#4148)
+    
+    Co-authored-by: Lev Shapiro <levshapiro@MacBook-Air-2.local>
+
+[33mcommit 1b89fc66b925837d145d2bf9b6e23f1c82bdb136[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Tue Oct 24 10:24:13 2023 +0300
+
+    chore: forward ref to `Button` (#4150)
+
+[33mcommit e86fc0da4bd17f433ce11676229bc25fb9ff4612[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 16 17:46:13 2023 +0200
+
+    chore: release 5.11.0
+
+[33mcommit a73ee152cd0ad93d052af4239c033eb269262b10[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 16 17:19:06 2023 +0200
+
+    feat: support for maxFontSizeMultiplier in text component (#3823)
+
+[33mcommit 01275e94a6d24b0d9911beb01e90897844ad5d0b[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 16 16:56:14 2023 +0200
+
+    fix: adjust label padding value
+
+[33mcommit 9895ccdcf7dd51343bb6de18c8abbac41fef8c90[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 16 16:09:12 2023 +0200
+
+    fix: adjust Text Input label width (#4128)
+
+[33mcommit 416be23b81ff2f0deeeaa509fd76574a76bb4621[m
+Author: Etotaziba Olei <teneeto@gmail.com>
+Date:   Mon Oct 16 15:03:50 2023 +0100
+
+    feat: add hover support to web (#3909)
+
+[33mcommit 23e7fd8630342d88c5d7abe7f488945885048233[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 16 15:57:22 2023 +0200
+
+    docs: render cell react element without text container (#4134)
+
+[33mcommit 41ee87bd7240084efe42dec3272e092d9b83e220[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 16 15:57:06 2023 +0200
+
+    refactor: add unit test and adjust icon example screen (#4135)
+
+[33mcommit 8c933fd831f0e3aaf053a1b2e19db31812c765ce[m
+Author: Sangamesh Somawar <sangamesh1439@gmail.com>
+Date:   Mon Oct 16 19:14:28 2023 +0530
+
+    feat: exported Icon component (#4014)
+
+[33mcommit de157aea681070068c1c36d58a1ee2d1ae5e390a[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 16 13:39:57 2023 +0200
+
+    chore: rename pull request template
+
+[33mcommit b33018532b4aaa9efc9031fcaa5e548c6b17a8ef[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sat Oct 14 23:19:18 2023 +0200
+
+    docs: add annotation for bottom navigation tab bar color prop (#4132)
+
+[33mcommit 557ba693ed9f85fc10cc86f3c2faa09de35eae30[m
+Author: Alex Fournier <alex-fournier@users.noreply.github.com>
+Date:   Thu Oct 12 14:26:05 2023 +0200
+
+    fix: configureFonts should be deterministic (#4095)
+
+[33mcommit 2bb6256e687bc4f83d711e95a7b06dff3aace3e2[m
+Author: Lev-Shapiro <96536068+Lev-Shapiro@users.noreply.github.com>
+Date:   Thu Oct 12 15:25:05 2023 +0300
+
+    fix(text-input): remove text duplication of label as component (#4115)
+    
+    Co-authored-by: Lev Shapiro <levshapiro@MacBook-Air-2.local>
+
+[33mcommit d698282af14555cef8e546e4ead00bf6fd608e56[m
+Author: Andrew <44983823+andrewvasilchuk@users.noreply.github.com>
+Date:   Thu Oct 5 10:17:05 2023 +0300
+
+    docs: correctly spread default theme colors (#4110)
+
+[33mcommit 6b05c128b637104c2e2a232ee2d8ba34e4047e7c[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Oct 4 16:47:45 2023 +0200
+
+    docs: add extends prop to the props list
+
+[33mcommit a4e31a7239104a59a80e4b8c37b63c2d04346373[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 2 17:41:33 2023 +0200
+
+    docs: correct extends link annotation
+
+[33mcommit fb3f65f9985d2fecb9d8e26d4dfd12b1b8b1782b[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Sep 20 23:35:01 2023 +0200
+
+    chore: release 5.10.6
+
+[33mcommit 5f86955a9cb6728c3f07353a4dcf6f625e55b0dc[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Sep 20 23:24:20 2023 +0200
+
+    fix: correct outlined input adornment position
+
+[33mcommit 9dadd47a17a411563235a9c7fa1b610d7756022c[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Sep 19 09:44:14 2023 +0200
+
+    chore: release example app 3.11.0
+
+[33mcommit 317ca7ae437ac699c014ae32c8716ea54cb7b123[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Sep 18 22:39:37 2023 +0200
+
+    chore: release 5.10.5
+
+[33mcommit 08a5d3c454afdf028ade464c4d94358323e12915[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Sep 18 22:33:12 2023 +0200
+
+    fix: adjust top padding for outlined input without label (#4086)
+
+[33mcommit 761e3cbe78d641c45d621c89e40478f1148b6376[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Sep 18 22:09:51 2023 +0200
+
+    fix: set input min width (#3941)
+
+[33mcommit 36ce39b9787f48de627981b11a31cf341099c463[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Sep 18 21:48:22 2023 +0200
+
+    fix: resolve circular dependencies (#4056)
+
+[33mcommit 634107f5dbbe921de0cd808cf6ba09d5a309f59f[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Sep 18 21:36:04 2023 +0200
+
+    fix: add missing animated import
+
+[33mcommit 2583c79747a270051cf8ce004878c8f5e028213b[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Sep 18 21:21:44 2023 +0200
+
+    fix: create internal back handler to avoid errors on web (#4085)
+
+[33mcommit 8d82d803af27640025f1793092004ff8461858cf[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Sep 18 21:20:09 2023 +0200
+
+    fix: correct touchable radius (#4055)
+
+[33mcommit 7a5520bb2413ab13f512cda4cfa1ce720343332e[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Sep 18 21:19:54 2023 +0200
+
+    fix: using direct dark prop in appbar (#4076)
+
+[33mcommit 2fa36a4daba0f0b338aa26a8d85d471096d7c80d[m
+Author: Tomasz Janiczek <me@janiczek.co.uk>
+Date:   Mon Sep 18 21:17:14 2023 +0200
+
+    fix: textinput sizing for react-native-web@0.19 (#4084)
+    
+    Co-authored-by: Tomasz Janiczek <tomasz.janiczek@callstak.com>
+
+[33mcommit 9d802f65102adb5fedc7728c5ae76d4587cab4b9[m
+Author: Osman Turan <osman@osmanturan.com>
+Date:   Mon Sep 18 22:16:54 2023 +0300
+
+    fix: unfocused TextInput label disappears on new architecture (#3776) (#3899)
+
+[33mcommit 02e9feccf8c478e17746b095fbbb48c622b9bf44[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Sep 4 16:36:15 2023 +0200
+
+    chore: release 5.10.4
+
+[33mcommit cf7a0914bd7f0fb023bb597506da69b4a3d2cc6e[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Sep 4 16:29:54 2023 +0200
+
+    fix: list item flex properties (#4058)
+
+[33mcommit 451783f07b410a4c30244575a71b4b9f31c1a010[m
+Author: Andrew <35735666+meatnordrink@users.noreply.github.com>
+Date:   Mon Sep 4 07:06:26 2023 -0400
+
+    fix: apply accessible prop to touchable in Card.tsx (#4051)
+
+[33mcommit f63db437147a77e205f2d7e10f2964f0d2d73979[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Aug 22 21:52:45 2023 +0200
+
+    chore: correct entry point in webpack config
+
+[33mcommit 2ac08c4d1b5bfde797663f088722882fe22e8e29[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Aug 21 21:23:56 2023 +0200
+
+    chore: release 5.10.3
+
+[33mcommit f873141a04ee38f3f3acb60b9340c84bb4c9938a[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Aug 21 21:17:29 2023 +0200
+
+    fix: correct theme type
+
+[33mcommit a6356560528d21856b0bce5edf7f7ab413f5fe2c[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Aug 21 20:45:13 2023 +0200
+
+    chore: release example app 3.10.0
+
+[33mcommit cac4195a1c57af513c5c32367f50fc118f689f09[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Aug 21 16:12:04 2023 +0200
+
+    chore: update dependencies in lib and example (#4000)
+
+[33mcommit 16d2c24272935793c61984198fde78725d2a059e[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Aug 21 15:46:27 2023 +0200
+
+    chore: release 5.10.2
+
+[33mcommit c1dc14b7b0cf26d215e2fef13cc26763b4ad8c7d[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Aug 21 14:52:37 2023 +0200
+
+    fix: correct theme type
+
+[33mcommit 124f38cf162012e7ba3a241766c595727ec2d9a0[m
+Author: Alex Zelensky <alexzgit@gmail.com>
+Date:   Mon Aug 21 05:47:49 2023 -0700
+
+    fix: custom theme property for RadioButtonItem component (#4036)
+
+[33mcommit be2a27881a0ded63a177d34089e0ee6ed7811377[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sun Aug 20 00:16:00 2023 +0200
+
+    docs: adjust guide for using createMaterialBottomTabNavigator (#4037)
+
+[33mcommit 6b11c68ec211d2f4eb97b36ec891c777c0dabcd5[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sat Aug 19 19:09:34 2023 +0200
+
+    chore: correct react-navigation path
+
+[33mcommit 9d0d717a2d8b7f8e741df67c8710e64213dac05c[m
+Author: Ben Steel <70383237+b-steel@users.noreply.github.com>
+Date:   Sat Aug 19 08:20:16 2023 -0400
+
+    fix(docs): `SegementedButton` theme docs (#4031)
+    
+    Co-authored-by: Ben Steel <ben@think-now.com>
+    Co-authored-by: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit e95b0f233468cac58205bde4846198405f7af2b3[m
+Author: Tomasz Janiczek <me@janiczek.co.uk>
+Date:   Sat Aug 19 13:35:22 2023 +0200
+
+    fix: custom colors list in docs theme builder (#4033)
+    
+    Co-authored-by: Tomasz Janiczek <tomasz.janiczek@callstak.com>
+
+[33mcommit 015e418c600b8c39334d65138decb46787def3c7[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Aug 9 23:46:26 2023 +0200
+
+    chore: release example app 3.9.0
+
+[33mcommit 7d2291ef764bf6a4a205d94bca6f2a5da06509d6[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Aug 9 20:45:54 2023 +0200
+
+    chore: release 5.10.1
+
+[33mcommit 4faddd9218d757713fc561d474bcce1987b3d3b4[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Aug 9 20:45:01 2023 +0200
+
+    fix: selection and cursor colors (#4016)
+
+[33mcommit 2b10066156be4657e89abc22f7b013ffa0e4b279[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Aug 9 14:59:34 2023 +0200
+
+    docs: correct adding custom properties to theme
+
+[33mcommit 5eab178ff46370ba62942ed24aaf344063a16625[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Aug 8 22:30:56 2023 +0200
+
+    docs: create correct prop header to be displayed in TOC (#4018)
+
+[33mcommit 3dc3fdaf8c040b3f77c85fb48d0d8513bbe9ec55[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Aug 2 13:54:34 2023 +0200
+
+    chore: release 5.10.0
+
+[33mcommit ad820914c00bc78da659b8a89dccc4407c5cb1fb[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Aug 2 13:53:12 2023 +0200
+
+    test: update snapshot
+
+[33mcommit 0000bbe5a848e25769bda431876cbf9fb702d745[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Aug 2 13:38:53 2023 +0200
+
+    fix: add missing `rippleColor` in components' nested pressables (#4003)
+
+[33mcommit 9a7f40b578985c7259118fe6baf3dc64f934f103[m
+Author: Evan Cheung <evan.d.cheung@gmail.com>
+Date:   Wed Aug 2 01:20:33 2023 -0700
+
+    feat: option for hiding check icon on selected chip (#3969)
+    
+    Co-authored-by: Evan Cheung <evancheung@funktroniclabs.com>
+
+[33mcommit f62b6946f32b6af8c9d5e1551a8e3f6acf7c2334[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Aug 2 09:53:05 2023 +0200
+
+    fix: add missing `rippleColor` in `FAB` (#4001)
+
+[33mcommit 9cb6442c1bf25288b662198a68c7c609bf1e944d[m
+Author: Gabriel Jean <gabcool@gmail.com>
+Date:   Wed Aug 2 03:52:46 2023 -0400
+
+    fix: added style to component used for text measurement on Android (#3858)
+    
+    Co-authored-by: Gabriel Jean <gab@inkrebit.com>
+
+[33mcommit d60685b0e141ba5e97031fab1dcd0f96becd73e8[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Aug 2 09:50:55 2023 +0200
+
+    fix: adjust offset target value for translation on axis y (#4008)
+
+[33mcommit 264f7fad73494e9618c71d6aec60ed2dc14d7801[m
+Author: Sangamesh Somawar <93119254+sangameshsomawar@users.noreply.github.com>
+Date:   Wed Aug 2 13:20:32 2023 +0530
+
+    fix: chip style (#3994)
+    
+    Co-authored-by: Sangamesh Somawar <sangamesh1439@gmail.com>
+
+[33mcommit a1c1107fcfb2ecb7077d455131235dfd5f8ed480[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Aug 2 09:49:38 2023 +0200
+
+    fix: correct overriding border radius (#3996)
+
+[33mcommit b0ca57f906e5e4c5f5b119a2f528d6a75811dde3[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Aug 2 09:49:23 2023 +0200
+
+    fix: adjust progress bar wrapper height on web (#3997)
+
+[33mcommit c3a2dbd025ced92d0e2b8e690eb41b23be28eae5[m
+Author: Tomasz Janiczek <me@janiczek.co.uk>
+Date:   Wed Aug 2 09:49:08 2023 +0200
+
+    fix: use theme background for transparent text inputs (#3980)
+    
+    Co-authored-by: Tomasz Janiczek <tomasz.janiczek@callstak.com>
+
+[33mcommit ef12434c5d281b504da2aeef9e7e100ceca381c3[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Aug 1 18:06:03 2023 +0200
+
+    chore: bump theme provider, remove patch (#4010)
+
+[33mcommit 5eb73f95877ad19657920c8b4e86f5de3d8632f8[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Jul 27 22:44:28 2023 +0200
+
+    docs: add platform badge
+
+[33mcommit 5896da48e55a693eefad439ad044a2f1414547c8[m
+Author: Sangamesh Somawar <93119254+sangameshsomawar@users.noreply.github.com>
+Date:   Fri Jul 28 02:09:46 2023 +0530
+
+    docs: Improved `selection color` and `cursor color` docs (#3993)
+
+[33mcommit bfdd3766abf96fb6c542e06fb8fe72a20fc67984[m
+Author: Andrew <35735666+meatnordrink@users.noreply.github.com>
+Date:   Tue Jul 25 06:37:31 2023 -0400
+
+    docs: Update Chip.tsx description (#3935)
+
+[33mcommit cc59cfb2978aa286e9100bf0cc9e8fe624aed334[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Jul 24 13:47:36 2023 +0200
+
+    chore: upgrade bob and remove flow (#3964)
+
+[33mcommit 2a2f8df7dabba9b730efaa67f12f844174ef0e9d[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jul 11 23:38:42 2023 +0200
+
+    docs: correct using generated colors in theme
+
+[33mcommit cb53a0ae4d192f65df215fe1828bc6e69beb3943[m
+Author: Tomasz Janiczek <me@janiczek.co.uk>
+Date:   Mon Jul 10 09:27:33 2023 +0200
+
+    fix: flaky test for Segmented button (#3962)
+    
+    Co-authored-by: Tomasz Janiczek <tomasz.janiczek@callstak.com>
+
+[33mcommit 1d026ac2bc569191039f28081bc6e15b30a9cc86[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jul 4 14:40:11 2023 +0200
+
+    chore: release 5.9.1
+
+[33mcommit 17f96c11f1d397d1dc981ce2456f651831fdb54a[m
+Author: soroush behmardi Kalantari <sori.bk@gmail.com>
+Date:   Tue Jul 4 05:01:05 2023 -0700
+
+    fix: missing react-navigation types (#3961)
+
+[33mcommit 3f016c73470a5774918b33075be65cc4ce8b7dec[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sun Jul 2 10:56:08 2023 +0200
+
+    docs: display screenshots properly (#3960)
+
+[33mcommit 835fa9a461ffee91db55075c01f5a153109d70ed[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Jun 29 10:07:40 2023 +0200
+
+    chore: release example app 3.8.0
+
+[33mcommit 14ed2e573e47ee163edef24273ebe3e5773544c5[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jun 28 20:29:03 2023 +0200
+
+    chore: release 5.9.0
+
+[33mcommit 4664a1cc60bfd4fd52bc23c2d2e9140f5d833a72[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jun 28 20:26:29 2023 +0200
+
+    refactor: typography text styles adjustments (#3947)
+
+[33mcommit 05e750fea9902de999b9bd458331cc56daf4c525[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jun 28 20:14:48 2023 +0200
+
+    fix: adjust pointer events on menu wrappers (#3938)
+
+[33mcommit d3d223fc30f2a82d4cfa545b84a5b252527ca1b4[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jun 28 20:13:57 2023 +0200
+
+    fix: correct setting cursor type (#3925)
+
+[33mcommit 810a7b87a36efa5456e8162c730d9e83052a6faf[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jun 28 19:32:52 2023 +0200
+
+    refactor: components adjustments to work with tooltip (#3955)
+
+[33mcommit df00ed2db84592c3ba4ea6e34c404ec9c3db8b01[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jun 28 19:26:55 2023 +0200
+
+    fix: input icon custom color (#3907)
+
+[33mcommit c799ff34e8fd82a598bfdc94b71f655fd143cc9d[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jun 28 19:10:38 2023 +0200
+
+    fix: set default pointer events on web Surface (#3908)
+
+[33mcommit 73e926568bae8791af91d1cde240a346f2c6b33a[m
+Author: Etotaziba Olei <teneeto@gmail.com>
+Date:   Wed Jun 28 18:09:56 2023 +0100
+
+    feat: add cursorColor to TextInput RenderProps types (#3896)
+
+[33mcommit 2096e1b941041c7b79615937334f5dac0888c426[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jun 28 19:08:34 2023 +0200
+
+    fix: update test
+
+[33mcommit 56f193c4ec7fd0e3e320fb6e8a99fe464404dac7[m
+Author: Rene Kathofer <me@rene-kathofer.at>
+Date:   Wed Jun 28 19:06:55 2023 +0200
+
+    feat: add label style to segmented buttons (#3926)
+    
+    Co-authored-by: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit 1188ea2f491a6e8784bc9e33fa58ecf1ac88b5a3[m
+Author: Jennifer Vi Salas <jennysalas@me.com>
+Date:   Wed Jun 28 10:06:06 2023 -0700
+
+    fix: MD2 Checkbox.Android disabled color (#3937)
+
+[33mcommit a5168ae314b3866d22f91e923739839838ad09c4[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jun 28 19:04:24 2023 +0200
+
+    fix: correct condition to accept id equal zero (#3936)
+
+[33mcommit 742c7a0f28363055bd3ff3609f82e2039d9b548f[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jun 28 19:04:07 2023 +0200
+
+    fix: correct theme provider type (#3956)
+
+[33mcommit 2235fde392aabcb7ad9f4a1e3dd7e995030ba760[m
+Author: Tomasz Janiczek <me@janiczek.co.uk>
+Date:   Wed Jun 28 19:03:55 2023 +0200
+
+    fix: remove conditional React Navigation 7 support (#3958)
+    
+    Co-authored-by: Tomasz Janiczek <tomasz.janiczek@callstak.com>
+
+[33mcommit c2806a50131de99fb1f58feabb71488220e5ac7a[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jun 27 10:05:10 2023 +0200
+
+    docs: theme colors admonition
+
+[33mcommit c724ad93f354a77ab6f92e3188b069269684495a[m
+Author: Pedro Guerreiro <48553277+pac-guerreiro@users.noreply.github.com>
+Date:   Mon Jun 26 12:23:27 2023 +0100
+
+    fix: tooltips not working as expected (#3765)
+
+[33mcommit 671e363432b4ba1219047e6768de1e733b16fdc1[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jun 26 09:29:24 2023 +0200
+
+    docs: correct the pagination example (#3953)
+
+[33mcommit 561dbcf737d0d75ff5b86a3f626a0fd3b730de40[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Jun 22 16:23:52 2023 +0200
+
+    docs: create known issues section per component (#3944)
+
+[33mcommit 198c4889357a8794ce7338c244fe5541ce5864a7[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jun 20 13:02:05 2023 +0200
+
+    docs: add theme colors for some  components
+
+[33mcommit 4492c0cfc0740a77d21ffd04500bfcc22dabd803[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jun 20 11:39:21 2023 +0200
+
+    docs: adjust snackbar description with adding additional example
+
+[33mcommit 844f0c789f4e06d5f87ef380f5dfb4add333b38f[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jun 19 15:00:24 2023 +0200
+
+    refactor: create in example dir separate entry files per platform (#3942)
+
+[33mcommit 4f578089542d6d427596f3769d1f251655c705ce[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Jun 16 20:49:44 2023 +0200
+
+    chore: release example app 3.7.0
+
+[33mcommit 3a0eda6d2486c3f9b44326fdfe26c0ca4543c1f5[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Fri Jun 16 16:41:32 2023 +0300
+
+    refactor: device colors (Material You) support in example app (#3809)
+
+[33mcommit 920b47b2655ce0a92d230dc1be6dcc0e4e538d42[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Jun 16 15:36:47 2023 +0200
+
+    fix: adjust icons in password input
+
+[33mcommit fc5bf67a05aa9325fc7d15feec1a9772da72c922[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Jun 16 15:33:10 2023 +0200
+
+    refactor: keep banner when scrolling (#3927)
+
+[33mcommit a045f4416ff0a6d10106a2151959e3bffa41c683[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Jun 16 15:30:41 2023 +0200
+
+    refactor: stops all indicators when pressing pause button (#3929)
+
+[33mcommit da57ccbc1bc94c961690bf15b12ade434de477f3[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Jun 16 15:09:32 2023 +0200
+
+    feat: adding createMaterialBottomTabNavigator (#3870)
+    
+    Co-authored-by: edug <gedu@users.noreply.github.com>
+
+[33mcommit d5f889ea50bd42ea6995864ecc2e9c7620f98206[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jun 12 09:34:17 2023 +0200
+
+    docs: refactor return statement in theme colors
+
+[33mcommit 862eef60ca7cd754ba1259d225b5cf1bd2dae151[m
+Author: Alex Fournier <alex-fournier@users.noreply.github.com>
+Date:   Sun Jun 11 22:46:14 2023 +0200
+
+    docs: fix Appbar.Header default height (#3922)
+
+[33mcommit 1ce31113cd67e7aa450c72d6f86cd4a20c8157a1[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed May 31 22:10:05 2023 +0200
+
+    docs: add theme colors for more components
+
+[33mcommit 4689679d0a8fd0c003383301f59ed5a5143af8df[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue May 30 13:43:07 2023 +0200
+
+    docs: adjust displaying theme colors section
+
+[33mcommit 9c3ea3f950f10e76f4ebccd75709312ac8fc1430[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon May 29 22:27:43 2023 +0200
+
+    docs: add custom links for edit url
+
+[33mcommit 1438ca4ec3eca0ce7dbcd9c19aec85648878fe2c[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon May 29 22:24:55 2023 +0200
+
+    docs: add wip info in theme colors
+
+[33mcommit 5ba66f161ca9109f6fb736548bf705cde22cd333[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon May 29 21:11:50 2023 +0200
+
+    docs: add section for component theme colors (#3851)
+
+[33mcommit 9f1c675660285aa67524e7dce56eb3afaeccf71b[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue May 16 09:21:13 2023 +0200
+
+    chore: release example app 3.6.0
+
+[33mcommit 2b26119e387278e7eca5b858a744b1803e1de818[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon May 15 16:53:24 2023 +0200
+
+    chore: release 5.8.0
+
+[33mcommit 631e826042a19d9e19a51dc27c7a945de6570e61[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Mon May 15 17:43:46 2023 +0300
+
+    chore: pass gesture responder event in FAB.Group `onLongPress` (#3891)
+
+[33mcommit 957997b13ab8c7655420a37fb5a341dd554dafc0[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon May 15 15:26:19 2023 +0200
+
+    style: correct segmented buttons container styles (#3890)
+
+[33mcommit 39b2e82633d3518b88ce403c8eff04ad8c1b7e17[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon May 15 15:17:22 2023 +0200
+
+    feat: add possibility to override touchable ripple color (#3866)
+
+[33mcommit a475b09f6174db2c12f44c130f0980d3e944e301[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon May 15 14:59:27 2023 +0200
+
+    fix: correct list accordion layout (#3856)
+
+[33mcommit 46d12017b0a4331a2dea6348d74ec3c3b14de27d[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon May 15 14:59:13 2023 +0200
+
+    feat: add dismissableBackButton prop to Dialog (#3865)
+
+[33mcommit f36cdab6057553e6c1a5e67cf29239571e0fae4b[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon May 15 14:57:46 2023 +0200
+
+    fix: list item row width (#3863)
+
+[33mcommit 92c4037766de3808b548dba6786fd642ebec077d[m
+Author: Kewin Wereszczyński <47570093+kwereszczynski@users.noreply.github.com>
+Date:   Mon May 15 14:55:45 2023 +0200
+
+    feat: add long press support for fab group (#3881)
+
+[33mcommit 2c25126268fffec6c231feda96a4e0e5e9c7c1cd[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon May 15 14:54:44 2023 +0200
+
+    fix: touchable ripple overlay (#3875)
+
+[33mcommit ab2588b5434f92c81e13b1ea0287ebdd4ffc892a[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Mon May 15 15:51:20 2023 +0300
+
+    fix: iOS Surface flex styles moved to outer layer (#3887)
+
+[33mcommit 2695619aec25b5a64e693debb21fb7e246f8ceae[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon May 15 14:37:03 2023 +0200
+
+    refactor: export PaperProvider to simplify its usage (#3889)
+
+[33mcommit 05321cfb70bd1e4f7cac68e1ff26debf4731f792[m
+Author: Andrew <35735666+meatnordrink@users.noreply.github.com>
+Date:   Wed May 10 09:55:38 2023 -0400
+
+    docs: Update FAB.tsx (#3878)
+
+[33mcommit 896ab233398ace5d12f7892e31888d57ba298a0a[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed May 3 11:25:59 2023 +0200
+
+    chore: release 5.7.2
+
+[33mcommit dbb98e001ab999abb5d7fe7ea4d402311903159b[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed May 3 11:21:53 2023 +0200
+
+    Revert "docs: adding createMaterialBottomTabNavigator into docusaurus" (#3869)
+
+[33mcommit 3c6af020e2e373170d202f0e561b5a578baa1080[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue May 2 16:32:51 2023 +0200
+
+    chore: release 5.7.1
+
+[33mcommit a3e60dd99300108266bee899984fb48cd2524d30[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Apr 28 14:00:54 2023 +0200
+
+    docs: correct the showcase image links
+
+[33mcommit 35fdffea9ed205ae21475fae6ca5ae498f78d9e8[m
+Author: Rehan Khalil <bcs.f17.m.46.b@gmail.com>
+Date:   Fri Apr 28 12:07:29 2023 +0400
+
+    docs: Add WeatherForecast Application to ShowCase (#3850)
+
+[33mcommit 0de06aa159e30e9055615d65fcb7c279e70eecc6[m
+Author: edug <gedu@users.noreply.github.com>
+Date:   Wed Apr 26 21:09:25 2023 +0200
+
+    docs: adding createMaterialBottomTabNavigator into docusaurus (#3783)
+
+[33mcommit a7cc33e5c577493cecdf2caa6ba261f6b5d21288[m
+Author: edug <gedu@users.noreply.github.com>
+Date:   Wed Apr 26 21:08:34 2023 +0200
+
+    fix: Tooltip wasn't showing (#3844)
+
+[33mcommit 3dacabd3302f6314a827578b0dd287cb8027451d[m
+Author: D3faIt <8147434+D3faIt@users.noreply.github.com>
+Date:   Wed Apr 26 16:08:14 2023 +0200
+
+    docs: Fixed images linking to incorrect path (#3837)
+
+[33mcommit 7c310c54e336c2cbfcffc6a400d5cf5d4a893d28[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Apr 17 21:57:13 2023 +0200
+
+    chore: release example app 3.5.0
+
+[33mcommit d7368a79c25dca3b5e9365603786c2d81efb039f[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Apr 17 15:43:07 2023 +0200
+
+    chore: release 5.7.0
+
+[33mcommit f6bb2de0f869cb981e777a5b3ffe0612365def7a[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Apr 17 15:07:38 2023 +0200
+
+    fix: correct content style type (#3822)
+
+[33mcommit 130a0fd5d97992e3c435807bd48c07e31f1094c6[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Apr 17 15:07:11 2023 +0200
+
+    fix: correct animated fab elevation value (#3812)
+
+[33mcommit 0ed4dc4055e0fdc6b3308956f31ab0ef64801439[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Apr 17 15:06:55 2023 +0200
+
+    fix: correct the way how disabling touchable is handled (#3803)
+
+[33mcommit 9337d336bdd1ead92d4ffed140590873fc5b07fb[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Apr 17 15:06:40 2023 +0200
+
+    fix: correct toggle button icon color prop (#3820)
+
+[33mcommit 8bb0f162cf70d8b6719c55cab5a5963d0d778958[m
+Author: Tomasz Janiczek <me@janiczek.co.uk>
+Date:   Mon Apr 17 14:26:28 2023 +0200
+
+    feat: add color generator to docs (#3807)
+    
+    Co-authored-by: Tomasz Janiczek <tomasz.janiczek@callstak.com>
+
+[33mcommit e77119759b152509e367a2e430a5c346997c6063[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Apr 17 13:59:53 2023 +0200
+
+    refactor: rename maxFontSizeMultiplier to labelMaxFontSizeMultiplier
+
+[33mcommit 40419427573fe8b18844387ca9ff8fbec1223127[m
+Author: Dimitris Delis <122785937+dimitrisspacecode@users.noreply.github.com>
+Date:   Mon Apr 17 13:51:46 2023 +0200
+
+    feat: support for maxFontSizeMutliplier on Checkbox.Item (#3791)
+
+[33mcommit 5d445edb24929f9cb76d886e23a7e543755d0bd5[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Apr 17 11:56:32 2023 +0200
+
+    fix: correct input passwords icons
+
+[33mcommit 1fd71db04faffb3ee4e211ca62bc523f0a8b2e65[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Apr 17 11:38:20 2023 +0200
+
+    fix: demo app tweaks (#3821)
+
+[33mcommit f9d3db1d12b78e9cbaa93624384e31050e8a9e19[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Apr 5 20:23:42 2023 +0200
+
+    test: use testing library for snapshots (#3802)
+
+[33mcommit 1b747faaf58cf693795e07ae6bdab3038c491841[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Apr 3 17:15:44 2023 +0200
+
+    chore: release example app 3.4.0
+
+[33mcommit 5b029a66d6c8b29cde59de7eeabdd64922c7cd6c[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Apr 3 16:31:08 2023 +0200
+
+    chore: release 5.6.0
+
+[33mcommit 1c16deb58b15ad26582da1db7f73f93dd84ef070[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Apr 3 16:21:13 2023 +0200
+
+    feat: support flat and elevated mode (#3799)
+
+[33mcommit ecf8ba491bfa778da310b40c453d1b93b3978bd6[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Mon Apr 3 15:37:00 2023 +0300
+
+    chore: remove disabled accessibility trait for `AppbarContent` and `Card` (#3794)
+
+[33mcommit caa308a7d3655003cbc442cf655a3ab8cf66c731[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Apr 3 13:36:55 2023 +0200
+
+    chore: correct icon names
+
+[33mcommit 0a4cfb9db586990edd63b4a9d2261199288e289b[m
+Author: Amakiri Joseph Lucky <amakirij@gmail.com>
+Date:   Mon Apr 3 12:00:22 2023 +0100
+
+    fix: appbar header ignores border bottom radius (#3767)
+
+[33mcommit b6cad7cba761c015639affd583be43ded3037b9c[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sun Apr 2 20:10:04 2023 +0200
+
+    docs: pull out Text from being nested
+
+[33mcommit 77c60eff37a5817604593e410d9caaf0d9113e9d[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Mar 27 22:11:41 2023 +0200
+
+    chore: release 5.5.2
+
+[33mcommit 15e3c9a332b987fb33e250aca4c106560283fd2f[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Mar 27 22:07:30 2023 +0200
+
+    fix: pass ref to ios surface
+
+[33mcommit 084c619e9ab1aed1da46c23fc66d94b80b077905[m
+Author: Tomasz Janiczek <me@janiczek.co.uk>
+Date:   Mon Mar 27 12:53:27 2023 +0200
+
+    feat: add support for fontStyle (#3778)
+    
+    Co-authored-by: Tomasz Janiczek <tomasz.janiczek@callstak.com>
+
+[33mcommit d353ee496587c55c0e94bad9fb7461269b83580e[m
+Author: GJ Tiquia <47134711+gjtiquia@users.noreply.github.com>
+Date:   Mon Mar 27 15:47:52 2023 +0800
+
+    docs: correct typo in code snippet for combining themes with React Navigation (#3784)
+    
+    Co-authored-by: GJ Tiquia <gershom.tiquia@9cat.io>
+
+[33mcommit 4dbcc96f92679a3a2bcdae0ce43039091c601c18[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Mar 24 21:17:07 2023 +0100
+
+    docs: small refactor
+
+[33mcommit e32e94cbac7987583c5bd078c585c2a166696e01[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Mar 24 19:18:01 2023 +0100
+
+    docs: integrate appbar with react-navigation doc adjustments (#3782)
+
+[33mcommit f485172bb5e0bca81add329187c4130278fbf491[m
+Author: pchmn <pchmn.dev@gmail.com>
+Date:   Thu Mar 23 23:11:49 2023 +0100
+
+    docs: explain how to sync dynamic colors with system colors (#3773)
+
+[33mcommit 2daea5070cc9511e411529283c7f3965ac1e2e09[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Mar 23 23:03:43 2023 +0100
+
+    chore: release 5.5.1
+
+[33mcommit b385389b8d850b76b65a1a59077544b590686ef2[m
+Author: Pedro Guerreiro <48553277+pac-guerreiro@users.noreply.github.com>
+Date:   Thu Mar 23 20:53:37 2023 +0000
+
+    fix: data table header title number of lines not working (#3772)
+
+[33mcommit 12795cd0575887551385178bb65af0163a2ff78b[m
+Author: Amakiri Joseph Lucky <amakirij@gmail.com>
+Date:   Thu Mar 23 21:19:18 2023 +0100
+
+    fix: remove abstraction function from event emitter (#3770)
+    
+    Co-authored-by: Tomasz Janiczek <tomasz.janiczek@callstak.com>
+
+[33mcommit 3c375a0dc112803f81749d3861cbf97242dfd6b3[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Thu Mar 23 22:18:07 2023 +0200
+
+    refactor: fix `splitStyles` for Expo Snack (#3779)
+
+[33mcommit d88ff2051c3540fab5d7980efe3423f4ddfc98bd[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Mar 20 22:13:09 2023 +0100
+
+    chore: release example app 3.3.0
+
+[33mcommit 446eb4ba117811d209023ecf9f2f4c245fc682d4[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Mar 20 21:23:33 2023 +0100
+
+    chore: release 5.5.0
+
+[33mcommit baa0372a65d08c4a17aac182ce3aa8244e3ad1ac[m
+Author: Amakiri Joseph Lucky <amakirij@gmail.com>
+Date:   Mon Mar 20 20:55:11 2023 +0100
+
+    fix: add event emit for long press (#3769)
+    
+    Co-authored-by: Tomasz Janiczek <tomasz.janiczek@callstak.com>
+
+[33mcommit 842e0aa995b381827220c048bd86d4e1dee6c457[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Mon Mar 20 17:44:28 2023 +0200
+
+    docs: comment for TypeScript users (#3764)
+
+[33mcommit f390bdd25fb8a37eac49644fd71a3828ef2ad34a[m
+Author: Tomasz Janiczek <me@janiczek.co.uk>
+Date:   Mon Mar 20 15:14:19 2023 +0100
+
+    fix: ignore onTabLongPress in MaterialBottomTabNavigationConfig (#3768)
+    
+    Co-authored-by: Tomasz Janiczek <tomasz.janiczek@callstak.com>
+
+[33mcommit c665f5b8aee06bd44f5e9c93d03c90fd4a90a2f6[m
+Author: Tomasz Janiczek <me@janiczek.co.uk>
+Date:   Mon Mar 20 14:22:46 2023 +0100
+
+    chore: use TS generics for BottomTab types (#3741)
+
+[33mcommit c8c0d8b3e6ed95f47e2e38e7a851e0f05710062c[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Mar 20 13:14:54 2023 +0100
+
+    fix: add support for styling dialog action buttons (#3760)
+
+[33mcommit 7f8852b898c2ae0461eea7ad50c94826fa7ea3f9[m
+Author: Amakiri Joseph Lucky <amakirij@gmail.com>
+Date:   Mon Mar 20 12:56:31 2023 +0100
+
+    fix: add onTabLongPress for Bottom Navigation (#3758)
+
+[33mcommit c6359f838b5b3207580a4d4cd56160cdc9f971d9[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Mar 20 12:21:33 2023 +0100
+
+    docs: correct type links, add admonitions, support extends annotation (#3754)
+
+[33mcommit 352dfc9e2aaba90ddc116baed4a81a36dbeb45ca[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Mon Mar 20 13:21:05 2023 +0200
+
+    refactor: iOS `Surface` major refactoring (#3738)
+
+[33mcommit 844a2b192cc223ed3d024b01d17ea5773776078c[m
+Author: Amakiri Joseph Lucky <amakirij@gmail.com>
+Date:   Tue Mar 14 18:43:30 2023 +0100
+
+    docs: fix broken documentation links after upgrading docs to docusaurus (#3734)
+
+[33mcommit e4448e7feea138979d39e7d752df627011b8a418[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Mar 14 12:43:28 2023 +0100
+
+    docs: add configuration for component's more examples (#3747)
+
+[33mcommit eb9ca32aa6677cea684e2d84af41d6eb3527c730[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Mar 13 20:12:47 2023 +0100
+
+    chore: release 5.4.1
+
+[33mcommit 33fc3538ba19954385af7f0d8e07fe8b1295093d[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Mar 13 20:07:02 2023 +0100
+
+    chore: install use-latest-callback (#3746)
+
+[33mcommit d2432f135b7767bb1d20aea7a1264f77fbc5b761[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Mon Mar 13 21:06:42 2023 +0200
+
+    fix: sync `TouchableRipple` prop types (#3735)
+
+[33mcommit 7fd60e1f818169754dd6a90a670c4f378bc12d0a[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sat Mar 11 16:14:47 2023 +0100
+
+    chore: release 5.4.0
+
+[33mcommit 58a223ba442ba7322b5a8ce31627f112638cf31f[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sat Mar 11 15:54:46 2023 +0100
+
+    fix: revert 'replace MaterialCommunityIcon in favor of internal Icon' (#3745)
+
+[33mcommit 1ef5f69ab2b96e6fc57937a8b208c68dcf152983[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Mar 8 21:12:38 2023 +0100
+
+    chore: release example app 3.2.0
+
+[33mcommit 7c7241a92ccbf46b87a1934a26ba763d40a8a240[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Mar 6 23:39:27 2023 +0100
+
+    chore: release 5.3.1
+
+[33mcommit 9d0aee1f7e37958e343a535b3ebd5ad093def255[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Mar 6 23:35:01 2023 +0100
+
+    chore: correct path to types
+
+[33mcommit 52558a0c3272aeb6a1344eab5e733fd66ec34ccb[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Mar 6 21:41:58 2023 +0100
+
+    chore: release 5.3.0
+
+[33mcommit 7d3bd08fa7b9e76eb32ad6a4dc692d4286805dc3[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Mar 6 21:29:26 2023 +0100
+
+    feat: add react-navigation integration for BottomNavigation (#3676)
+    
+    Co-authored-by: Dimitar Nestorov <dimitar.nestorov@callstack.com>
+
+[33mcommit 252b1a6ad4e20c09b4b07a8ed14680f0138334fe[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Mar 6 16:34:13 2023 +0100
+
+    fix: input's adornment and helper disabled colors (#3726)
+
+[33mcommit 43a9b17b1b9f37298742e34cace0d4824ce001c8[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Mar 6 16:33:52 2023 +0100
+
+    feat: support for titleMaxFontSizeMultiplier (#3727)
+
+[33mcommit db04a8f811a6e2de56da73ff0458cd62061d7229[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Mar 6 16:29:08 2023 +0100
+
+    refactor: adjust searchbar to the latest md guidelines (#3582)
+
+[33mcommit 0396b884969c082e7d54900cfc5c6ec8fc888844[m
+Author: Tomasz Janiczek <me@janiczek.co.uk>
+Date:   Mon Mar 6 15:15:06 2023 +0100
+
+    fix: input label positioning regression (#3728)
+    
+    Co-authored-by: Tomasz Janiczek <tomasz.janiczek@callstak.com>
+
+[33mcommit 90372140e8865a04d9783f8fee2966c8f31011ce[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Mar 6 14:46:02 2023 +0100
+
+    refactor: label opacity interpolation
+
+[33mcommit 0249f378607fb66ecee4c071b0c126fc2d6a862e[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Mon Mar 6 08:37:02 2023 -0300
+
+    feat: add prop accessibilityState for Menu.Item (#3724)
+    
+    Co-authored-by: Bruno Castro <6487206+brunohkbx@users.noreply.github.com>
+
+[33mcommit 91255456e3415b16d3b13a9fef3c116e8b28e397[m
+Author: Nemanja Mikic <n0t_l3ss@outlook.com>
+Date:   Mon Mar 6 12:33:50 2023 +0100
+
+    feat: Add onClearIconPress to SearchBar (#3679)
+
+[33mcommit e961a87d3fc60418825b9886fabe81a855336e01[m
+Author: edug <gedu@users.noreply.github.com>
+Date:   Mon Mar 6 11:13:23 2023 +0100
+
+    fix: Segment checked state (#3701)
+
+[33mcommit e34c3e4ff0097f49e905c9144c1d2e73d6631fbb[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Mar 6 11:11:35 2023 +0100
+
+    refactor: replace MaterialCommunityIcon in favor of internal Icon (#3699)
+
+[33mcommit 5c31ef9ff37bc46ea1a2aacde89e8239c0b3f6d8[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Mar 6 10:28:29 2023 +0100
+
+    fix: adjust surface wrapper opacity (#3709)
+
+[33mcommit 22989b657c1e2406effee2d61fed249861444bed[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Mar 6 10:28:14 2023 +0100
+
+    fix: correct label color for v2 (#3711)
+
+[33mcommit eb5ce8da4bf7866b8a0e961e0d54e46209414ef6[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Mon Mar 6 11:25:10 2023 +0200
+
+    fix: allow for custom variants in `Text` (with factory) (#3660)
+
+[33mcommit f4c87e9ef24bacc83f20937269adbc46b7455cd0[m
+Author: Tomasz Janiczek <me@janiczek.co.uk>
+Date:   Mon Mar 6 10:24:55 2023 +0100
+
+    refactor: fix performance of InputLabel (#3662)
+
+[33mcommit c0cd6c95ce35eb96688f76918ff2b54e465377f3[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Mar 6 10:24:20 2023 +0100
+
+    fix: correct text color (#3686)
+
+[33mcommit 738d65af41ccbaf114e85ddec4c851c59b5f60e1[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Mar 6 10:17:25 2023 +0100
+
+    chore: regenerate yarn.lock
+
+[33mcommit bb56703b0ae2c5b09118342f5db2265297b5709f[m
+Author: Kreshnik Alidema <kreshnik.alidema@gmail.com>
+Date:   Mon Mar 6 10:16:16 2023 +0100
+
+    fix: fix paths in sourcemap files (#3721)
+    
+    Co-authored-by: Kreshnik Alidema <kreshnikalidema@Kreshniks-MacBook-Pro.local>
+
+[33mcommit 2f8a86f01dfad9a9c879acc05eab4ec4c1c4f5c8[m
+Author: Bartłomiej Tomczyk <bartlomiejtomczyk@gmail.com>
+Date:   Mon Mar 6 09:58:29 2023 +0100
+
+    fix: changed accessibility label based on onPress callback (#3719)
+
+[33mcommit 49bdf469fada879dba9d0408070037f3c4005de9[m
+Author: Mohamed-Abdelfattah <45965447+Mohamed-Abdelfattah@users.noreply.github.com>
+Date:   Mon Mar 6 10:56:47 2023 +0200
+
+    docs: update code snippets (#3725)
+
+[33mcommit 291d9a90ea2bf2d9a3416170a9a3a1791cf051b0[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Fri Mar 3 13:07:04 2023 +0200
+
+    docs: fix get started button (#3720)
+
+[33mcommit 393abae715f0df1887f69515c285388d4051879b[m
+Author: Jan Jaworski <jaworek3211@gmail.com>
+Date:   Wed Mar 1 12:40:19 2023 +0100
+
+    fix: contributor name
+
+[33mcommit f684c16eea67cfe916bff78c707749a306172987[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Mar 1 10:28:40 2023 +0100
+
+    docs: configure edit url link (#3715)
+
+[33mcommit c0f9d41220b2047ff83be68918df938124452bf7[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Feb 28 13:26:20 2023 +0100
+
+    Update README.md
+
+[33mcommit c8c03e459929403385ca43644ea8931f6afeff8e[m
+Author: Krystyna Łosieczka <44640941+krysia1@users.noreply.github.com>
+Date:   Mon Feb 27 21:37:40 2023 +0100
+
+    fix: add missing babel plugin for expo web support (#3713)
+
+[33mcommit e56a05c2271060a6a161bb279079c95999c8a4b5[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Mon Feb 27 19:41:21 2023 +0200
+
+    refactor: convert remaining tests to TypeScript (#3655)
+
+[33mcommit 7dd70d7d35a1f9fcf26b62eea3b5c8745553ff0d[m
+Author: Yaman KATBY <m.yaman.katby@gmail.com>
+Date:   Mon Feb 27 12:27:13 2023 +0300
+
+    docs: upgrade docusaurus to v2.3.1 (#3705)
+
+[33mcommit 6849f4dc25b1ac43674045f8c1915d64487c7681[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Feb 22 18:30:08 2023 +0100
+
+    docs: adjust banner placeholder styles
+
+[33mcommit fb8899cf15cd2d8aa05f539412a4fee6e6888f81[m
+Author: Tomasz Janiczek <me@janiczek.co.uk>
+Date:   Wed Feb 22 17:23:18 2023 +0100
+
+    docs: screen flash on initial docs load (#3700)
+    
+    Co-authored-by: Tomasz Janiczek <tomasz.janiczek@callstak.com>
+
+[33mcommit 46b4cebd6b46ac581f2064ece83a0e06dbfe7535[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Feb 21 13:29:56 2023 +0100
+
+    docs: get started buttons adjustments, fix lint warnings
+
+[33mcommit 85e304c1f4c670abfed34917f8e52bd6571df3da[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Feb 20 18:40:49 2023 +0100
+
+    docs: add get started button on initial page (#3697)
+
+[33mcommit c2bf446e7c644665f76aecd90925661ba281f3ea[m
+Author: Yaman KATBY <m.yaman.katby@gmail.com>
+Date:   Mon Feb 20 18:41:38 2023 +0300
+
+    docs: update the editUrl in docusaurus config file (#3696)
+
+[33mcommit c624d98a8eecb38fbafd6c7321526bfb7b6645ec[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Mon Feb 20 14:50:31 2023 +0200
+
+    fix: logo in README (#3693)
+
+[33mcommit f73f651c0b544d0bcd678d3f00e108833c853004[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Feb 20 13:19:31 2023 +0100
+
+    docs: add algolia search functionality (#3692)
+
+[33mcommit ffe741c537a89ed1752bf98353b51c076702d2b5[m
+Author: Daniel Szczepanik <tmlm18@gmail.com>
+Date:   Mon Feb 20 12:51:34 2023 +0100
+
+    docs: migrate to Docusaurus (#3614)
+    
+    Co-authored-by: lukewalczak <lukasz.walczak.pwr@gmail.com>
+    Co-authored-by: Andriy Tsaryov <andriy.tsaryov@gmail.com>
+    Co-authored-by: Yaman KATBY <m.yaman.katby@gmail.com>
+
+[33mcommit 1074ab242280d1fe1b9eba3ab4cd41cd1578ce11[m
+Author: Michael Wood <esiotrot@gmail.com>
+Date:   Wed Feb 15 11:00:12 2023 +0200
+
+    docs: fix copy/paste error (#3675)
+
+[33mcommit e9f5dafe93348d8a72c931bc9e56afa6d2769b45[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Feb 6 21:37:47 2023 +0100
+
+    chore: release 5.2.0
+
+[33mcommit 257f640216c6a57250cb1c5f94d1c4c2e6858c33[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Feb 6 14:21:33 2023 +0100
+
+    feat: add content style prop to the Card (#3657)
+
+[33mcommit 787ba37220ac1e579b6e0296253eb6f2521e51c1[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Feb 6 14:05:42 2023 +0100
+
+    docs: hide section related to creating custom variant
+
+[33mcommit 84d9da2a1d24e04e57a706e30009fb4aaa17b637[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Mon Feb 6 14:09:55 2023 +0200
+
+    chore: show library version in drawer in example app (#3644)
+
+[33mcommit a7eeb628914672e19c4fedc348ad9ffd7caca232[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Feb 6 13:09:22 2023 +0100
+
+    fix: passing flex to the shared and inner layer Surface styles (#3653)
+
+[33mcommit 4189f4ba09b53a5f3223332d23a3851d72ccf6ab[m
+Author: Filippo Mantovan <33987920+Filippo39@users.noreply.github.com>
+Date:   Mon Feb 6 12:36:27 2023 +0100
+
+    feat: allow override of custom theme animation (#3645)
+    
+    Co-authored-by: lukewalczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit af0e9400e0b94ded4c9071c3c5669636b7905620[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Feb 6 11:53:47 2023 +0100
+
+    fix: correct testID
+
+[33mcommit 1384cc2bd18333bb9710014733ce196c4eba232c[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Mon Feb 6 12:47:40 2023 +0200
+
+    ci: disable auto fix for lint (#3650)
+
+[33mcommit 540cb2564c5db79ffbab40dbeac4fd9109ffa6df[m
+Author: Bogusz Kaszowski <bogusz.kaszowski@callstack.com>
+Date:   Mon Feb 6 11:47:00 2023 +0100
+
+    fix: fix overriding default props (#3643)
+
+[33mcommit a3eb45c00002f83f557c87a5fbb4638881ce879f[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Feb 6 11:14:48 2023 +0100
+
+    fix: custom Button styles nested in Card.Actions (#3651)
+
+[33mcommit e4c2e9d5c13d2e27a4a19a6100b7beb02232ace9[m
+Author: Tomasz Janiczek <me@janiczek.co.uk>
+Date:   Mon Feb 6 10:10:21 2023 +0100
+
+    fix: custom input styling in TextInput (#3648) (#3649)
+
+[33mcommit 0970f64eca7aa64ea15a26aa2922b157759101cb[m
+Author: Tomasz Janiczek <me@janiczek.co.uk>
+Date:   Mon Feb 6 09:27:36 2023 +0100
+
+    refactor: fix performance of TextInput (#3642)
+
+[33mcommit 6a863cddebbdb0750841f3c86751663ff86207ac[m
+Author: Tomasz Janiczek <me@janiczek.co.uk>
+Date:   Mon Feb 6 09:23:44 2023 +0100
+
+    fix: android elevation issue (#3617)
+    
+    Co-authored-by: Tomasz Janiczek <tomasz.janiczek@callstak.com>
+
+[33mcommit e4aefd07ad8d720836cfa4edaf669d141592cf15[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Mon Feb 6 10:21:48 2023 +0200
+
+    chore: linter rules to detect `forwardRef` usage (#3632)
+
+[33mcommit 0556ba6957c9477d4cc87c333c3cb2c2c729cac6[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Mon Feb 6 10:19:50 2023 +0200
+
+    fix: style types (#3623)
+
+[33mcommit 6ad12998bf08b919af551c2629025898a35071e4[m
+Author: Tomasz Janiczek <me@janiczek.co.uk>
+Date:   Thu Feb 2 17:00:45 2023 +0100
+
+    refactor: Fix exhaustive deps linting errors (#3605)
+
+[33mcommit f308cd6c1d6616efaf31b9e327ffaf02e0581fa6[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Jan 26 22:57:21 2023 +0100
+
+    chore: release example app 3.0.2
+
+[33mcommit 2854b639ffbe140233d08741857708d47195ffb6[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 23 15:43:06 2023 +0100
+
+    chore: release 5.1.4
+
+[33mcommit 17f071bea44c4ca8c21c33d4e01f0331c1148e20[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 23 15:39:07 2023 +0100
+
+    chore: update dependencies in lib and Expo SDK in the example (#3616)
+
+[33mcommit 4c50ef96952de9f751123993f5e95510af76b81f[m
+Author: Dimitar Nestorov <8790386+DimitarNestorov@users.noreply.github.com>
+Date:   Mon Jan 23 15:24:08 2023 +0200
+
+    fix: TypeScript bloat (#3603)
+
+[33mcommit 1329ae147be36ec73722406615bc998550d2b95c[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 23 14:22:09 2023 +0100
+
+    docs: add note about overriding force-dark functionality
+
+[33mcommit 8ef64766bce5dd0294a10a174d6145ad206d8f25[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 23 14:11:22 2023 +0100
+
+    fix: calls onLayout on input affix (#3597)
+
+[33mcommit eece348e8c90ae21cb1430df23fa5be35b37531e[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 23 14:05:22 2023 +0100
+
+    fix: appbar content title container adjustments (#3596)
+
+[33mcommit 06af55e9bd84aba2ab73dda6c79de158edf0a908[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 23 14:02:50 2023 +0100
+
+    fix: adjust label and icon props optionality (#3613)
+
+[33mcommit 9e50236330da322923ccc93d518172f6042175a0[m
+Author: edug <gedu@users.noreply.github.com>
+Date:   Mon Jan 23 13:59:24 2023 +0100
+
+    fix: activeColor and inactiveColor to match icon colors (#3592)
+
+[33mcommit 4bae880bfa6791ea26ba06014b4f60428e844105[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 23 13:03:33 2023 +0100
+
+    fix: warning related to color literals
+
+[33mcommit 7ec39d7dfe8f252ecce087658999df72b089b3dc[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 23 13:00:47 2023 +0100
+
+    refactor: add paddings to the toggle group example
+
+[33mcommit 622598cd1721dd548900b509a35f755d12fb6e32[m
+Author: Bogusz Kaszowski <bogusz.kaszowski@gmail.com>
+Date:   Fri Jan 20 16:50:48 2023 +0100
+
+    refactor: replace withInternalTheme HOC with useInternalTheme (#3606)
+
+[33mcommit e2c493f5562996afbf02748447a5bfe9f7fa12a5[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Jan 19 18:15:47 2023 +0100
+
+    docs: correct docs
+
+[33mcommit 090d48aca5cb073b038b5e69b1f4dfd701b84719[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Jan 19 17:58:44 2023 +0100
+
+    Updated config.yml
+
+[33mcommit 500480ce6844abd74bed4365a8f175051141f644[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Jan 19 17:50:45 2023 +0100
+
+    chore: revert node change
+
+[33mcommit 9ee7e9bef00d9d9331d4cb81c5cd3b0da087ac70[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Jan 19 17:43:08 2023 +0100
+
+    Updated config.yml
+
+[33mcommit ad5f49c06d7b15788ed2b4ed99c6b43e50854ae3[m
+Author: edug <gedu@users.noreply.github.com>
+Date:   Thu Jan 19 14:58:50 2023 +0100
+
+    fix: Lint warning fixes (#3583)
+
+[33mcommit f7fe59d42f576a438835c186b9c6698a114dbd46[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 16 22:56:58 2023 +0100
+
+    docs: update selected color prop description
+
+[33mcommit bad9c7198daa456c5798fe7bb24d8dc5e93dbd2f[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sat Jan 14 22:03:11 2023 +0100
+
+    fix: format code
+
+[33mcommit 50e06fc620af8e29b80305c57321906e8be5a350[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 9 21:01:14 2023 +0100
+
+    chore: release 5.1.3
+
+[33mcommit ce990de04459c75e443704eb65ce1509b350e987[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 9 16:56:53 2023 +0100
+
+    fix: adjust condition for displaying icon (#3574)
+
+[33mcommit 9273d37e71bdd83148310a6f5189f730f81796cc[m
+Author: edug <gedu@users.noreply.github.com>
+Date:   Mon Jan 9 16:56:30 2023 +0100
+
+    fix: Made ToggleButton.Group TS compatible (#3543)
+
+[33mcommit 90c04333704adc432186177ce65500bffd23a006[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 9 16:51:40 2023 +0100
+
+    fix: allow to override card border color using styles (#3584)
+
+[33mcommit 5cc7511a42beedc97213171d34fb0bc395a68324[m
+Author: Szabó, Péter <me@peterszabo.dev>
+Date:   Mon Jan 9 22:49:17 2023 +0700
+
+    fix: Surface to correctly set start and end on iOS (#3571)
+    
+    Fixes https://github.com/callstack/react-native-paper/issues/3542
+
+[33mcommit 0896b2eb76543536c3327ac691d7989ed301e5e2[m
+Author: Fabrizio Cucci <fabrizio.cucci@gmail.com>
+Date:   Tue Jan 3 17:00:02 2023 +0100
+
+    docs: Replace Paragraph with Text anywhere (#3567)
+
+[33mcommit a30f3090ed0804be0f74a86285111497af0ccd79[m
+Author: Fabrizio Cucci <fabrizio.cucci@gmail.com>
+Date:   Mon Jan 2 20:57:46 2023 +0100
+
+    docs: Fix typo in `Card` doc (#3562)
+
+[33mcommit 87e0b2e738ea276ca30014f635b83e3829196ee5[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Dec 29 14:46:46 2022 +0100
+
+    chore: release 5.1.2
+
+[33mcommit 64c1675d7bae5242b949480365eefade5f1a083a[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Dec 29 14:44:20 2022 +0100
+
+    fix: correct border radius in icon button and card components (#3565)
+
+[33mcommit fe16b9f425bff63dd647a7de6cbae714811b51bf[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Dec 28 20:07:23 2022 +0100
+
+    chore: update paper version in generated component snack
+
+[33mcommit 1a67b0ffe603ecbfda06dc06874e3a122a79a42b[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Dec 28 19:21:17 2022 +0100
+
+    chore: release 5.1.1
+
+[33mcommit f338b7927d8c20b47f3eb3215e3a9cd4d747ccfa[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Dec 28 19:16:16 2022 +0100
+
+    fix: correct animated fab container bg color (#3558)
+
+[33mcommit f46e49e5b611420de3ebd723cdfae5b9222b9441[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Dec 28 19:16:04 2022 +0100
+
+    fix: adjust icon styles in compact button (#3559)
+
+[33mcommit d3246a844c6bd28b46b66522425ee7113b1e6fb9[m
+Author: Mathias Berg <mathias@fyranollfyra.se>
+Date:   Wed Dec 28 19:15:12 2022 +0100
+
+    fix: menu position fix when dimensions change (#3546)
+
+[33mcommit 01c6ea89c1447b51bcd93a5419c8c202f21b44f5[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Dec 28 11:47:42 2022 +0100
+
+    chore: run eas updates only on labeled PRs
+
+[33mcommit 761a8906a34e490ca480816e23b643af3bd64bcd[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Dec 26 13:49:32 2022 +0100
+
+    docs: correct merging themes
+
+[33mcommit f972f427060babb75073601ad234ba46b581fbe3[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Dec 19 18:10:12 2022 +0100
+
+    docs: update examples with adapt navigation theme helper
+
+[33mcommit 7db75058605d14c7f6c8500417c6d1a2e6895fe8[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Dec 19 18:04:16 2022 +0100
+
+    chore: release example app 3.0.1
+
+[33mcommit 69ef757f1e225b96c51b08959bb8f8ad0edaffe9[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Dec 19 10:15:31 2022 +0100
+
+    chore: release 5.1.0
+
+[33mcommit 0c296f41b78a9c906faf23fa0c6e44b434a8cad5[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Dec 19 10:11:06 2022 +0100
+
+    refactor: unify menu and appbar bg color
+
+[33mcommit 385b84cb96c8b4b9e1f8e521349488d0d5deaadf[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Dec 19 10:01:43 2022 +0100
+
+    refactor: correct input flex behavior (#3537)
+
+[33mcommit fb052a4114e90f72275b29cbc494ae4d1f1ef3b2[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Dec 19 10:01:25 2022 +0100
+
+    feat: add delay long press support (#3536)
+
+[33mcommit 88949dc2658cb3fd316415b14df54e5b2d20fa86[m
+Author: Mathias Berg <mathias@fyranollfyra.se>
+Date:   Mon Dec 19 09:46:59 2022 +0100
+
+    fix: Visual fix on IconButton when focused (#3531)
+
+[33mcommit 9abcd0561a2a621fe0e1114c6cffbae6c69b96c9[m
+Author: guilherme-ferraz1 <62260157+guilherme-ferraz1@users.noreply.github.com>
+Date:   Mon Dec 19 05:45:13 2022 -0300
+
+    feat: Add label prop to FAB.Group (#3510)
+
+[33mcommit f626652bbb93ffc8c27dc9e8d3fea150f93479f9[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Mon Dec 19 05:44:38 2022 -0300
+
+    feat: add prop pointerEvents for ListAccordion (#3463)
+
+[33mcommit 0fca19f7927bdca661b7fac62211d37788e52c4a[m
+Author: guilherme-ferraz1 <62260157+guilherme-ferraz1@users.noreply.github.com>
+Date:   Mon Dec 19 05:40:42 2022 -0300
+
+    feat: add customInputStyle to TextInput (#3509)
+
+[33mcommit 031f0db89d50100f55f11030441ee1f5cddf4c96[m
+Author: Mathias Berg <mathias@fyranollfyra.se>
+Date:   Sun Dec 18 21:55:42 2022 +0100
+
+    fix: fix position of menu when dimensions change (#3521)
+    
+    Fixes https://github.com/callstack/react-native-paper/issues/3515
+
+[33mcommit a981d5c4bc0e877273d1486b4f0429a496058bbe[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Dec 15 21:16:22 2022 +0100
+
+    fix: correct fab group label card mode
+
+[33mcommit 9342a808ea50667c6e9034765d66ea4ddff9041c[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Dec 15 11:07:05 2022 +0100
+
+    chore: release 5.0.2
+
+[33mcommit d1ef8a9f0bf7cac2048b9c9fd9db7d2171a7b124[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Dec 12 14:22:52 2022 +0100
+
+    fix: correct toggle button example
+
+[33mcommit 26006e2162292fbe92ac32d721f0763c86b97be1[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Dec 12 12:55:44 2022 +0100
+
+    docs: remove supported annotation for new common props
+
+[33mcommit 5c0a6f66eb66028a3b72ffc5723891dc798cf84c[m
+Author: Süleyman Barış Eser <50797736+suleymanbariseser@users.noreply.github.com>
+Date:   Mon Dec 12 14:26:44 2022 +0300
+
+    fix: automatically close snackbar by duration (#3487)
+
+[33mcommit edf1243a3f0512869a59c5d6753bde536e3e6c7c[m
+Author: l1qu1d <1037693+l1qu1d@users.noreply.github.com>
+Date:   Thu Dec 8 04:47:42 2022 -0600
+
+    docs: fixed <Swtich> example for  Theming with React Navigation - Using Context (#3518)
+
+[33mcommit 3b76d6a2aee3ae44199418892b9708821074d78e[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Dec 7 19:26:10 2022 +0100
+
+    docs: add safe area context lib to the snack deps
+
+[33mcommit f49a817f669327d3aa40fe4df984d24f3c7d4c12[m
+Author: Abrar Wiryawan <abrarwiryawan@gmail.com>
+Date:   Wed Dec 7 21:03:37 2022 +0700
+
+    refactor: typo in parameter name (#3513)
+
+[33mcommit 959a781ebce9f9764c4921c2b5afbd3dcd3af05a[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Dec 7 10:41:23 2022 +0100
+
+    chore: release 5.0.1
+
+[33mcommit 0c2d95164f32072a9eb5da4848a3c5decfa51394[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Dec 7 10:40:42 2022 +0100
+
+    fix: disable native driver in Card elevation animation (#3512)
+
+[33mcommit d36bfad42843656829237e1ae8a920b7c369500c[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Dec 6 11:15:57 2022 +0100
+
+    docs: update docs after release
+
+[33mcommit 5556885b9204cbc1bd57cfdccd580852a9e24f10[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Dec 6 11:11:52 2022 +0100
+
+    chore: release 5.0.0
+
+[33mcommit caa00ba0ba3eba491e25207ea96caadf96e41db1[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Dec 6 10:45:14 2022 +0100
+
+    refactor: make nav example for v3 only
+
+[33mcommit 0987010a8dd4ee2905e97bbe648ec1a3844d96e0[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Dec 6 09:59:14 2022 +0100
+
+    chore: release example app 3.0.0
+
+[33mcommit 78f69afeacfc51f91e2aeb2a3bbc5f2cc8f07915[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Dec 5 16:41:38 2022 +0100
+
+    refactor: clean up example assets
+
+[33mcommit a11c34f0ac300f3a6c715630267b474dee84fd14[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Dec 5 15:52:53 2022 +0100
+
+    refactor: move examples data to utils
+
+[33mcommit 0024f7ed7a9d1b76bb877f71dc5faa4634575cb6[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Dec 5 14:00:53 2022 +0100
+
+    feat: bunch of new examples (#3506)
+
+[33mcommit cb9b028d3f708757ff08cd76b90906b4803bd2bf[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Dec 5 13:38:48 2022 +0100
+
+    feat: replace rn iphone x helper with safe area context (#3478)
+
+[33mcommit 9dc4a7fba6cd0e734b81617214e50149a3365f13[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Dec 5 11:05:36 2022 +0100
+
+    fix: lint
+
+[33mcommit 086efdc5c97ff565a38bc0479045590b6fcb820c[m
+Author: fivecar <39933441+fivecar@users.noreply.github.com>
+Date:   Mon Dec 5 02:01:50 2022 -0800
+
+    docs: update Menu docs for RN Modal (#3503)
+
+[33mcommit e8aef2f614b1253c72ae4c989c22e47563da33bc[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Dec 5 11:01:20 2022 +0100
+
+    refactor: adjust drawer collapsed item icons (#3505)
+
+[33mcommit 86aeeec881d46a57feb02aab2686af36b4f64b37[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Dec 5 10:15:30 2022 +0100
+
+    refactor: adjust Snackbar to Material You (#3497)
+
+[33mcommit 7931d53f7c6292a16ebe139dd842fb12a9f3fe0e[m
+Author: Richard Lindhout <richardlindhout96@gmail.com>
+Date:   Sun Dec 4 20:06:50 2022 +0100
+
+    fix: export gestureResponderEvent to add preventDefault support on web (#3484)
+
+[33mcommit 3a5083c921c05fa455051ec6eb22a2a97b97fd9c[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sat Dec 3 19:08:37 2022 +0100
+
+    docs: add table with fonts variants (#3504)
+
+[33mcommit 3b3c48105028de7cf1f23d4c0430f47f72415634[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Dec 1 17:15:22 2022 +0100
+
+    fix: correct tooltip behaviour on mobile (#3495)
+
+[33mcommit d7c05539d04b803fdb654f2a76c092800641f555[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Nov 30 19:10:10 2022 +0100
+
+    refactor: extend adaptNavigationTheme (#3498)
+
+[33mcommit 5466a530937e3c5c06c1f9ac224d44c6aaa1e813[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Nov 28 15:18:40 2022 +0100
+
+    refactor: correct segmented buttons example code
+
+[33mcommit 6d7bd36cdc31b3d503703d5f3184cb5abb12fb99[m
+Author: maximilianotaverna <31879214+maximilianotaverna@users.noreply.github.com>
+Date:   Mon Nov 28 20:30:36 2022 +1000
+
+    fix: segmented-button-item-style (#3482)
+
+[33mcommit e0f94ea1391fa23b3540b972af2da9219b7a9ea1[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Nov 28 11:11:59 2022 +0100
+
+    refactor: adjust configure fonts overloads (#3494)
+
+[33mcommit 0a60594bbb667e9e2f02deadce2a31f92ca00c7e[m
+Author: Hector Ayala <hran@bombillazo.com>
+Date:   Mon Nov 28 05:34:59 2022 -0400
+
+    fix: update Searchbar font selection based on RNP version (#3471)
+
+[33mcommit e249456f4fb2bc3a7cc0e8b316e405d3e23e0470[m
+Author: Bi0max <rodin.maxim93@gmail.com>
+Date:   Mon Nov 28 10:31:45 2022 +0100
+
+    fix: add tint to elevated Card (#3479)
+
+[33mcommit 12865e922be23d1984f2b299effc54e14b806742[m
+Author: Abdullah Hilson <abdullah.hilson@gmail.com>
+Date:   Mon Nov 28 10:29:41 2022 +0100
+
+    fix: typescript definition for Button's onPress should have event as argument (#3410)
+
+[33mcommit aeb29efcc50b1c76047d843ad256fb39c423bfb3[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sun Nov 27 00:24:13 2022 +0100
+
+    fix: margin bottom in appbar example
+
+[33mcommit 43835bdd245cb1590486aedb4bac22297664b662[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Nov 22 21:08:08 2022 +0100
+
+    refactor: remove custom color from animated progress bar example
+
+[33mcommit e18c0363930c3a5270f8c5433a1fed96284904db[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Nov 22 20:39:33 2022 +0100
+
+    chore: release example app v2.2.0
+
+[33mcommit 04b01cb3d884f583f78ee5517f44ae3456005247[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Nov 22 10:35:20 2022 +0100
+
+    chore: eas update configure changes
+
+[33mcommit 2021ac3a875d9efbdf0807b16a51eee5125e8713[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Nov 22 09:59:32 2022 +0100
+
+    refactor: adjust progress bar track color (#3483)
+
+[33mcommit 807d9014863d55e241555e3654ad573007a9adc3[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Nov 22 09:55:10 2022 +0100
+
+    chore: migrate updates to eas (#3485)
+
+[33mcommit 184855405b38beca27c84e1fa79a9f7734428f3c[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Nov 21 21:54:42 2022 +0100
+
+    chore: update app.json
+
+[33mcommit dbb0b591cb7df8674b4e94cd7ee6aa8ac340d8d8[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Nov 21 21:45:02 2022 +0100
+
+    chore: create updates.yml
+
+[33mcommit 1a3033335298fecd4f8133735d006207f758dd93[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Nov 21 10:06:18 2022 +0100
+
+    chore: correct main for eas
+
+[33mcommit 6d9eea6be85f2d6921c2281f2c98151f6cecdf69[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Nov 21 09:15:09 2022 +0100
+
+    chore: build ios app using eas
+
+[33mcommit 72c57c60efa681f2131ea7fac769e6d3a2a77d93[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sun Nov 20 21:08:47 2022 +0100
+
+    fix: correct card outline radius
+
+[33mcommit 1f58798c9486da120395dee1e96e8e24d209b07a[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sun Nov 20 19:42:36 2022 +0100
+
+    chore: metro config update
+
+[33mcommit a5cd314e0386d6945db7e228008d3122e1356ac9[m
+Author: Luiz Carlos Jr <lcsjuniorsi@gmail.com>
+Date:   Fri Nov 18 10:12:39 2022 -0300
+
+    docs: add Prodigy IoT to showcase (#3475)
+
+[33mcommit d79e198c8c2b3df61a16df3611a3bea1f20b135c[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Nov 16 11:35:51 2022 +0100
+
+    chore: remove analytics
+
+[33mcommit 0fb193a38d2c52d8f9bf3f44575a37f5eb16083a[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Nov 14 20:38:25 2022 +0100
+
+    docs: font config types
+
+[33mcommit b6e6a486e72647647483a97e593a8b49cfe4bccc[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Nov 14 17:13:51 2022 +0100
+
+    chore: add expo analytics segment
+
+[33mcommit cd5b53980d4d6b28f783711be22360884e48cda8[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Nov 14 16:06:43 2022 +0100
+
+    chore: update apps build versions after Expo SDK update
+
+[33mcommit fd8c316bee4ce9dd531eaaaca682815b91d7d536[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Nov 14 15:53:04 2022 +0100
+
+    docs: add tooltip screenshot
+
+[33mcommit 968130e14d9faf514b0e65f67e3855dde1138b14[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Nov 14 14:30:23 2022 +0100
+
+    docs: update RC version in docs
+
+[33mcommit c1a7c9b42675cd90577300027599019e63284e71[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Nov 14 14:25:44 2022 +0100
+
+    chore: release 5.0.0-rc.10
+
+[33mcommit d75825bb2728d44dc517256341149d7f8cf614c0[m
+Author: Denis Slávik <denis.slavik@gmail.com>
+Date:   Mon Nov 14 12:27:05 2022 +0100
+
+    chore:  upgrade example app to expo 46 & update dependencies (#3446)
+
+[33mcommit 22f1d42e9e36ce761f1136bff9e5c53f375db1b2[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Nov 14 12:17:19 2022 +0100
+
+    fix: correct card size within container (#3469)
+
+[33mcommit 37dd68b5ffcab65e0505fa2b40329e37434983bd[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Nov 14 11:22:50 2022 +0100
+
+    refactor: adjust divider component insets (#3468)
+
+[33mcommit 1a871f4f76b7372e38fc6ba4c222a47e18ed3354[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Nov 14 11:05:15 2022 +0100
+
+    docs: correct parameter name
+
+[33mcommit ecf4bf6130b345115f649266a52ebfcbd19decba[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Nov 14 10:59:07 2022 +0100
+
+    fix: card border radius (#3465)
+
+[33mcommit 6ac07d0b33a0be08c640784d7db7891a0389e81f[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Nov 14 10:57:50 2022 +0100
+
+    refactor: adjust configure fonts utility (#3462)
+
+[33mcommit bc2a1c4f4292f64f7d860d57722cc29543bce8e3[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Mon Nov 14 06:49:54 2022 -0300
+
+    feat: create Tooltip component (#3441)
+
+[33mcommit 32cb880ecad0efde84d54ca71efabe122fc789ed[m
+Author: Süleyman Barış Eser <50797736+suleymanbariseser@users.noreply.github.com>
+Date:   Mon Nov 14 12:46:08 2022 +0300
+
+    feat: make ripple color dynamic for ListAccordion (#3448)
+
+[33mcommit 10fdc8954f263f05243aca2a521cace57fe970c8[m
+Author: fivecar <39933441+fivecar@users.noreply.github.com>
+Date:   Mon Nov 14 01:27:27 2022 -0800
+
+    feat: allow menu anchor position to be explicitly set (#3455)
+
+[33mcommit 4bbc636ed09efcabc4c6294cc626482b74fce982[m
+Author: João Vitor Queiroz <58531490+joaovitorqueiroz@users.noreply.github.com>
+Date:   Mon Nov 14 06:24:34 2022 -0300
+
+    fix: unwanted closing of contextMenu (#3452)
+
+[33mcommit cf4e308b8f394d14ac86040e0a6a2551866a8dca[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sun Nov 13 19:29:14 2022 +0100
+
+    refactor: shortening md2 drawer item label
+
+[33mcommit 8d608bda89a07a6ef697bee436b8e9244355308e[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sat Nov 12 20:24:16 2022 +0100
+
+    docs: update rnp version in snacks example
+
+[33mcommit c9892de96314a494f284bc1a88eca614bad06ee9[m
+Author: Huỳnh Thanh Đức <48825180+huynhduc43@users.noreply.github.com>
+Date:   Sat Nov 12 02:25:10 2022 +0700
+
+    docs: update 8.theming-with-react-navigation.md with MD3DarkTheme and MD3LightTheme (#3464)
+
+[33mcommit 80bd932c6b0230cb43cfd64b0537af1bac2d9237[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 31 14:56:56 2022 +0100
+
+    docs: update RC version in docs
+
+[33mcommit 002e65da899800a5a8ea37e9f454469d95730f64[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 31 14:52:33 2022 +0100
+
+    chore: release 5.0.0-rc.9
+
+[33mcommit 7cefb69053d937e8863e7a77b9a4c392cb86a702[m
+Author: Muhammad Hur Ali <hurali97@gmail.com>
+Date:   Mon Oct 31 18:24:32 2022 +0500
+
+    feat: added List.Item examples (#3447)
+    
+    Co-authored-by: lukewalczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit 50b80356f3cdb674d552408625a817aa9ccff456[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 31 13:53:54 2022 +0100
+
+    docs: adjust fab group example, sort bottom nav props
+
+[33mcommit 82349dfbb14f15bb8b5dee1f7f43aaad23c17c57[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 31 13:30:22 2022 +0100
+
+    refactor: add curly braces around if condition
+
+[33mcommit 5c03f20b75dd23d82c80553b8e112950c76a2e0a[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 31 13:21:25 2022 +0100
+
+    test: update snapshot
+
+[33mcommit f76a34e532546d58639af8657a1fce591e9b6c09[m
+Author: Muhammad Hur Ali <hurali97@gmail.com>
+Date:   Mon Oct 31 17:16:48 2022 +0500
+
+    feat: List Item v3 adjustment (#3442)
+
+[33mcommit 61be62a41db5c0ef8ec396d7bf76ca3123d3a610[m
+Author: Muhammad Hur Ali <hurali97@gmail.com>
+Date:   Mon Oct 31 16:08:05 2022 +0500
+
+    feat: getLazy prop for bottom-navigation (#3433)
+    
+    Co-authored-by: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit 8e4a125f8b9d40916d4cfaf04188f0f1a458bc33[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Mon Oct 31 07:56:08 2022 -0300
+
+    fix: react-native-vector-icons issue when running tests (#3419)
+    
+    Co-authored-by: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit a49ab6c68bf6ef1d158a656392d8eaa7378ef5ff[m
+Author: Muhammad Hur Ali <hurali97@gmail.com>
+Date:   Mon Oct 31 15:55:45 2022 +0500
+
+    feat: List image (#3445)
+
+[33mcommit c90ef6414ac82814f91109da0e5f986ffda7f63f[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 31 11:42:34 2022 +0100
+
+    docs: readme and templates updates
+
+[33mcommit 2f87a7cf44ef8e003d7fa3b8b4c154f1a475c051[m
+Author: Muhammad Hur Ali <hurali97@gmail.com>
+Date:   Mon Oct 31 14:04:20 2022 +0500
+
+    fix: added offscreenAlphaCompositing for android only (#3438)
+
+[33mcommit ee5c34bbc461ac250b509eaa16a5f2b47bcfe4ab[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 31 10:04:04 2022 +0100
+
+    fix: add default property to the v3 theme fonts (#3436)
+
+[33mcommit 69fb364ae3fde8653d239b2ffa2cecc4ac6c60bc[m
+Author: Muhammad Hur Ali <hurali97@gmail.com>
+Date:   Mon Oct 31 13:59:33 2022 +0500
+
+    fix: adjust menu layout when keyboard opens (#3418)
+
+[33mcommit 3f3da9622e3a2cacb570fd2496ecbfede93c2ead[m
+Author: Tarık <61876765+tarikpnr@users.noreply.github.com>
+Date:   Mon Oct 31 11:58:55 2022 +0300
+
+    feat: allow styling underline/outline wrapper on `TextInput` (#3397)
+    
+    Co-authored-by: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit 6015d07f93c97ffbbc9c848618afede6f0f54ef7[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Oct 28 13:36:30 2022 +0200
+
+    docs: correct dynamic colors theme section
+
+[33mcommit 8615fc83f3ee0df34ed03b3542a370071fe23e20[m
+Author: Muhammad Hur Ali <hurali97@gmail.com>
+Date:   Mon Oct 24 22:11:48 2022 +0500
+
+    docs: dynamic theme colors (#3429)
+    
+    Co-authored-by: lukewalczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit 1dde7e2e1ad9b5a6d190f18b8513d5274be2e8a6[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Oct 20 15:57:26 2022 +0200
+
+    chore: release 5.0.0-rc.8
+
+[33mcommit fbc9085a081cf27c66b6f523ffc8ad7fef030bf9[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Oct 20 15:56:18 2022 +0200
+
+    docs: update RC version in docs
+
+[33mcommit 8fd61204beeda672f642e1afc089c145e771a1c6[m
+Author: Muhammad Hur Ali <hurali97@gmail.com>
+Date:   Thu Oct 20 18:52:11 2022 +0500
+
+    fix: removed material color utils (#3426)
+
+[33mcommit 13969362575bfcba444cc780825ca22793836d26[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Oct 19 10:26:57 2022 +0200
+
+    chore: release 5.0.0-rc.7
+
+[33mcommit b724970a3cc2ce4af09e35eac032b6dec64802d1[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Wed Oct 19 05:13:24 2022 -0300
+
+    feat: add prop keyboardShouldPersistTaps for Menu (#3420)
+
+[33mcommit cafded2358f0455a4c2bb9a54a40e2fb3dfc1e01[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Oct 18 23:26:43 2022 +0200
+
+    docs: correct markdown
+
+[33mcommit b8ae4b01760ed1ae6144e022d297a0cf295b8f84[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Oct 18 22:54:32 2022 +0200
+
+    fix: correct linting
+
+[33mcommit 71ad62ac5361c59f8af5030741eec2f81669584f[m
+Author: Daniel Szczepanik <tmlm18@gmail.com>
+Date:   Tue Oct 18 22:53:34 2022 +0200
+
+    feat: adjust theme types to match internal and regular usage (#3279)
+
+[33mcommit 57e78bd6776262d67156013e334ccb2146957078[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Oct 18 22:07:49 2022 +0200
+
+    feat: add adaptNavigationTheme utility (#3399)
+
+[33mcommit e3f7ad6c7a6e64192cda829b636515614fc04441[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Tue Oct 18 17:05:58 2022 -0300
+
+    refactor: make Banner actions optional (#3416)
+
+[33mcommit 5700fe5f595e7543e51a8a9b7d2ad397c2a88131[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Oct 18 22:02:30 2022 +0200
+
+    feat: make onDismiss optional on Menu (#3417)
+
+[33mcommit ef448b1b2186009231f42a83f77a57043c35537f[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Tue Oct 18 17:00:40 2022 -0300
+
+    fix: BottomNavigation warn when shifting with the wrong number of tabs (#3408)
+
+[33mcommit 31e90376f8bc98742317f3c8c2d4438531cfe0fa[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Tue Oct 18 16:17:32 2022 -0300
+
+    fix(regression): BottomNavigation can't render a single tab (#3415)
+
+[33mcommit 2b1c1df35410f2801b9a4c4095c7518d62585830[m
+Author: Muhammad Hur Ali <hurali97@gmail.com>
+Date:   Tue Oct 18 01:07:59 2022 +0500
+
+    fix: progress bar animated value (#3414)
+
+[33mcommit 06831c93efca04c41a359e6ddd4922f2c3c39b79[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 17 14:44:46 2022 +0200
+
+    fix: correct input unit test
+
+[33mcommit 6de64d02b1e48010b548ec5b052b5621f62cefa7[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 17 14:37:07 2022 +0200
+
+    feat: add textColor prop for input content text custom color (#3411)
+
+[33mcommit 1d3c4bd864dc49b2c9b7bf3258b6e957afee6ff4[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 17 13:02:01 2022 +0200
+
+    feat: add createDynamicThemeColors utility (#3398)
+
+[33mcommit 99e90f3745cc3dccf774e7102d521cc2f61ed6db[m
+Author: Muhammad Hur Ali <hurali97@gmail.com>
+Date:   Mon Oct 17 15:40:59 2022 +0500
+
+    fix: portal visible after immediately unmount (#3413)
+
+[33mcommit ff56bec7614e99c321206a7705274d47530c6644[m
+Author: Muhammad Hur Ali <hurali97@gmail.com>
+Date:   Mon Oct 17 15:37:51 2022 +0500
+
+    feat: Snackbar support for any children (#3412)
+
+[33mcommit 6be4734505ba64dbb7eff97399b675db443b4ded[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 17 10:50:08 2022 +0200
+
+    fix: set default font properties for Text component without variant (#3409)
+
+[33mcommit ef617df11938902ee20bda55752b924577cfb094[m
+Author: Szymon Rybczak <szymon.rybczak@gmail.com>
+Date:   Mon Oct 17 10:29:22 2022 +0200
+
+    feat: use Pressable in TouchableRipple (#3400)
+
+[33mcommit 1ffc0639028b72a6ff586786ee06f491de311a04[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 17 09:45:36 2022 +0200
+
+    fix: allow to fully override testID in TextInput (#3405)
+
+[33mcommit 55b2d250bc87c1f416048bf0d249004bd2a542ee[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Oct 13 16:00:55 2022 +0200
+
+    fix: correct Banner children type (#3401)
+
+[33mcommit 111a034e36431575bb40f8155367e39ccd9e63ba[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 3 11:34:45 2022 +0200
+
+    chore: update checking version action on opening issue
+
+[33mcommit 7a7c78c5478bd77e1e3432e418a7a69516696987[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 3 11:18:17 2022 +0200
+
+    docs: fix lint in showcase
+
+[33mcommit d0ba9d20e5f08c6b2e476cf2e506d3239fd810c1[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 3 11:11:10 2022 +0200
+
+    chore: update github issue templates (#3393)
+
+[33mcommit 42423ec5453324ef4aafbbdaa45375071fc6f280[m
+Author: lam <1422015387@qq.com>
+Date:   Thu Sep 29 19:06:30 2022 +0800
+
+    docs: adds Kuroga to showcase (#3389)
+
+[33mcommit 5f08d42ff675be9ffabdf987d6ce85c5d7b37ffd[m
+Author: Daksh Bhardwaj <dakshbhardwaj2@gmail.com>
+Date:   Wed Sep 28 20:13:59 2022 +0530
+
+    fix: button ripple radius (#3388)
+
+[33mcommit 0ceae7c9f3226c20168e7d62fbb7cb0de7550ba4[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Sep 27 18:09:44 2022 +0200
+
+    chore: update expo-version to 6.x
+
+[33mcommit 35dc0363544de14936ab9d4c2799651e7089f103[m
+Author: Jan Jaworski <jaworek3211@gmail.com>
+Date:   Tue Sep 27 17:58:08 2022 +0200
+
+    chore: update eslint (#3356)
+    
+    Co-authored-by: Daniel Szczepanik <tmlm18@gmail.com>
+
+[33mcommit 5282be531debc3ca7350abc5d1d4a5464bcc2196[m
+Author: Tarık <61876765+tarikpnr@users.noreply.github.com>
+Date:   Tue Sep 27 18:57:04 2022 +0300
+
+    docs: add PharmaciesOnDuty to Showcase (#3386)
+
+[33mcommit 80987274e3e47b6c8542a48a44fa59f5ba939c2b[m
+Author: Daniel Szczepanik <tmlm18@gmail.com>
+Date:   Mon Sep 26 12:43:43 2022 +0200
+
+    chore: clean up Bug Report template
+
+[33mcommit e0c76135f5c92d7de9668ef4ecf92138405deb12[m
+Author: Michał Pierzchała <thymikee@gmail.com>
+Date:   Fri Sep 23 09:53:50 2022 +0200
+
+    Create FUNDING.yml
+    
+    Setup funding file with callstack account.
+
+[33mcommit fa557e07951dc1862e4a4542204960e102f692d9[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Sep 22 13:13:50 2022 +0200
+
+    chore: release 5.0.0-rc.6
+
+[33mcommit d70ee2b2d18cf67ad7eb5dc612394aa11f210ef4[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Sep 22 13:11:27 2022 +0200
+
+    docs: update RC version in docs
+
+[33mcommit 002ea0f8c707bcb69c25d53b6f3921aa65bfa237[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Sep 22 13:10:26 2022 +0200
+
+    fix: using theme in Text's components, renaming typescales to fonts (#3351)
+
+[33mcommit 78e67818bd58152cc1351967045ac4e240543e57[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Sep 22 13:06:29 2022 +0200
+
+    docs: update migration guide related to FABGroup API changes
+
+[33mcommit 9e19aa8e23ec14c1e52243baa0c08df8668c2505[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Sep 22 12:43:44 2022 +0200
+
+    refactor: replace I18nManager.isRTL with 18nManager.getConstants().isRTL (#3352)
+
+[33mcommit 71f5d51c44ec89ff0b09f7c63f865f73e77b519b[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Sep 22 12:32:39 2022 +0200
+
+    docs: update Fonts doc (#3354)
+
+[33mcommit def317ae887d79f39941761868b5f99a610bcffc[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Sep 22 12:31:52 2022 +0200
+
+    fix: display pill shape only on focused tab (#3374)
+
+[33mcommit b09912427e6c168560c4ffdff4086356e102dedc[m
+Author: Tarık <61876765+tarikpnr@users.noreply.github.com>
+Date:   Thu Sep 22 13:23:18 2022 +0300
+
+    fix: allow styling fab-group action label, renamings (#3363)
+
+[33mcommit c7b2d92fd9cc8d1503fbe62b9557c48cd0ec3116[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Sep 22 12:20:40 2022 +0200
+
+    fix: unblock using custom color in AppbarAction (#3370)
+
+[33mcommit 74d965f25822fb96fe2c3c2b81e42be4c85d6688[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Sep 22 12:20:28 2022 +0200
+
+    fix: correct Searchbar clear icon (#3373)
+
+[33mcommit ea22a49a4de567913a9429db0d13474b278b9cc0[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Sep 20 16:32:37 2022 +0200
+
+    refactor: customize android navigation animation to avoid flash
+
+[33mcommit 5efd68ddbed950b8163ff6b58110e05f9885275c[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Sep 6 11:34:08 2022 +0200
+
+    docs: update the link to the latest snack
+
+[33mcommit 9843b6454490aeb49fb888b022f967999fd0df98[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Sep 5 21:06:16 2022 +0200
+
+    docs: update docs after rc.5 release
+
+[33mcommit 7714a5a1b29322a701a764969699a1c013476d2d[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Sep 5 11:49:37 2022 +0200
+
+    chore: release 5.0.0-rc.5
+
+[33mcommit 6769fcac2284831f5baea907664a7833a242ef6c[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Sep 5 11:27:12 2022 +0200
+
+    fix: correct text input label background layout (#3349)
+
+[33mcommit 028aaf48b20e4b93a6f0640db7152fedf90a9b30[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Sep 5 11:22:20 2022 +0200
+
+    docs: add support for link to types (#3350)
+
+[33mcommit 9d25227379febe1eea476ba76e6cb89c930a1f8e[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Sep 5 11:16:37 2022 +0200
+
+    fix: correct padding offset in TextInput on Android when RTL (#3330)
+
+[33mcommit a7fc35b29603a2bcaf338cce84bc887def96a8d2[m
+Author: Oskar Kwaśniewski <oskarkwasniewski@icloud.com>
+Date:   Mon Sep 5 11:12:01 2022 +0200
+
+    fix: change RouteScreen visibility only on web (#3346)
+
+[33mcommit 95e955d3d49879572cfb23f0fdfcd683da3e6613[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Sep 5 10:58:39 2022 +0200
+
+    fix: correct custom border radius in FAB (#3343)
+
+[33mcommit d1a40d81635990a4cc1fe6be6297a5933853f573[m
+Author: rbcjacques <99039683+rbcjacques@users.noreply.github.com>
+Date:   Wed Aug 31 13:49:50 2022 -0700
+
+    fix: adjust avatar text line height to font scale (#3340)
+    
+    Co-authored-by: Jacques Leupin <jacquesleupin@Jacquess-MacBook-Pro.local>
+
+[33mcommit fdf1aa87690e1db92bbef7bd0d635fdb4ed211e8[m
+Author: Farkhan Azmi <fliazmi@gmail.com>
+Date:   Thu Sep 1 03:45:02 2022 +0700
+
+    docs: update example on getting-started.md (#3342)
+
+[33mcommit e21850f2d003e30ffe0d0f868d207a41839511f9[m
+Author: Andrew <35735666+meatnordrink@users.noreply.github.com>
+Date:   Wed Aug 31 04:16:27 2022 -0400
+
+    docs: noting that Provider includes Portal.Host (#3291)
+    
+    Co-authored-by: lukewalczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit 2ff4590c901669e41ef789a4734ef5aa19931357[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Aug 31 10:15:54 2022 +0200
+
+    fix: adjust initial placeholder text value (#3331)
+
+[33mcommit 0d32dd759011b237c3fb4ffd03577dc96425fd8d[m
+Author: Oskar Kwaśniewski <oskarkwasniewski@icloud.com>
+Date:   Wed Aug 31 10:15:19 2022 +0200
+
+    feat: add SegmentedButtons component (#3283)
+    
+    Co-authored-by: Satyajit Sahoo <satyajit.happy@gmail.com>
+
+[33mcommit 6ff9a20885ffcbe9c864542a26a6ee47db355002[m
+Author: dragonxp <35697471+dragonxp@users.noreply.github.com>
+Date:   Mon Aug 22 19:39:07 2022 +0545
+
+    fix: NotificationsRoute causing error (#3326)
+
+[33mcommit 1c72d1d5f9f1f2f5d4af2f60cb67fe94916cc443[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Aug 22 14:32:57 2022 +0200
+
+    refactor: rename TextInputIcon prop from name to icon (#3317)
+
+[33mcommit 25cd448f7eafc62e68844a44056a54b707b7e1e8[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Aug 22 13:56:05 2022 +0200
+
+    fix: correct text input label color (#3318)
+
+[33mcommit eb8238d36eedc349c329bf8ac0e60374e1afa548[m
+Author: Daksh Bhardwaj <daksh@plgworks.com>
+Date:   Mon Aug 22 16:59:00 2022 +0530
+
+    feat: added loading icon in Searchbar (#3322)
+
+[33mcommit 2b1dc13a01fc07f083a5247dd08dbb6f3b1f2d45[m
+Author: David Mason <rayensbai2@gmail.com>
+Date:   Mon Aug 22 12:17:19 2022 +0100
+
+    docs: add new app to showcase (#3324)
+
+[33mcommit 87a3da28db681e1953e93d290d551070fbcc2e34[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Aug 22 13:13:32 2022 +0200
+
+    chore: add semantic pr title check (#3329)
+
+[33mcommit ec6ed76c46d1fdd728a9942d805366a34d12d1e9[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Aug 19 11:26:21 2022 +0200
+
+    docs: update generating snack link
+
+[33mcommit dea6c86014f9d75c83a0bcf6632cbc44fff5a508[m
+Author: Oskar Kwaśniewski <oskarkwasniewski@icloud.com>
+Date:   Thu Aug 18 11:57:32 2022 +0200
+
+    Fix KeyboardAvoidingView not working with BottomNavigation (#3316)
+
+[33mcommit c681acb2f1536f992bdc9a767ce773e366f507b9[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Aug 17 15:11:39 2022 +0200
+
+    docs: exclude v2 component from the latest documentation
+
+[33mcommit 12b29d1b039b6c259019d27219231928801d0b4d[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Aug 16 18:25:28 2022 +0200
+
+    fix: correct SwitchProps type name
+
+[33mcommit ed0f7d72dd0d0e1b781753ed0f384f410aa65759[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sun Aug 14 21:08:40 2022 +0200
+
+    docs: update banner information
+
+[33mcommit 8cbd9157de02bf101f18b90e075e0c6f0927b647[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sun Aug 14 21:07:26 2022 +0200
+
+    chore: testing library adjustments (#3311)
+
+[33mcommit b027079eed9d15d71d5fc2aa2399e98c0ac83cfc[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Aug 12 10:01:32 2022 +0200
+
+    chore: update react-native-testing-library to v11 (#3300)
+
+[33mcommit 4adda3551946aafc3194e95877ff11285ced4958[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Aug 11 18:19:19 2022 +0200
+
+    fix: exporting types
+
+[33mcommit 3d9d13285a49df4511cb23b694ef58556c1aba20[m
+Author: jessebrennan <jesse@jesse.computer>
+Date:   Wed Aug 10 12:25:56 2022 -0700
+
+    fix: update link to example app (#3308)
+
+[33mcommit 3ebc59f1a9030b01821b6c9543a0f32e50cab7e2[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Aug 10 18:24:03 2022 +0200
+
+    chore: update link to expo example
+
+[33mcommit 365f73561fbeb418b1f1f8e9f4e178cc4f19a920[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Aug 10 18:11:41 2022 +0200
+
+    refactor: small example app adjustments
+
+[33mcommit 274c91b3682f787b6ce5cc5b659066787ce90340[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Aug 9 10:57:05 2022 +0200
+
+    Update rc version in migration guide
+
+[33mcommit f4d287610456129328680199d9e07544db74336b[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Aug 8 18:12:51 2022 +0200
+
+    chore: release 5.0.0-rc.4
+
+[33mcommit 0d5c3c644300ef97a71234a4c502b2a258c549a8[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Aug 8 17:57:23 2022 +0200
+
+    fix: bottom navigation v3 color usage
+
+[33mcommit 02ec12cc810b2090dd6e4a9b67579a0bd78d7610[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Aug 8 15:34:02 2022 +0200
+
+    feat: export DefaultTheme (#3302)
+
+[33mcommit e87b04f5b7cf5eae2efcfb842ce8dc420186a26a[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Aug 8 14:44:34 2022 +0200
+
+    fix: correct BottomNavigation background color (#3298)
+
+[33mcommit 2fdc462224eeec5097fedd118722015747e08747[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Aug 8 14:44:21 2022 +0200
+
+    feat: add support for safe area insets in Appbar (#3301)
+
+[33mcommit 57d69052a92d616e784d36250b5eb4c2d49b6cc4[m
+Author: SvenFE <shensven2016@gmail.com>
+Date:   Mon Aug 8 20:12:03 2022 +0800
+
+    docs: Add CrazyThursday to Showcase (#3284)
+
+[33mcommit b6abd0c1d35620c98f250aa038c36319ffe1a620[m
+Author: subnub <44621867+subnub@users.noreply.github.com>
+Date:   Mon Aug 8 07:46:07 2022 -0400
+
+    docs: add homework helper to showcase (#3265)
+
+[33mcommit 11686c5efb1668564ba769f49a37b4d80ce7177e[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Aug 8 12:39:12 2022 +0200
+
+    fix: correct changing Dialog backdrop color (#3259) (#3260)
+
+[33mcommit 29b91c8d4eff8f7450df9319b93453a6f0bea7ea[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Aug 8 12:38:54 2022 +0200
+
+    fix: pass missing props to surface container (#3275)
+
+[33mcommit b674199cb26e5582d69fd5ccf390696319d8fd40[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Aug 8 12:38:37 2022 +0200
+
+    feat: allow to specify button's mode in CardAction (#3276)
+
+[33mcommit 950aac2a409223f3798a0f2762801322335c2db3[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Aug 8 12:38:06 2022 +0200
+
+    chore: expose components types (#3270)
+
+[33mcommit 996fe1da888d0e28179ababc736eeaa5495d0e6b[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Aug 8 12:37:44 2022 +0200
+
+    feat: extend Button props by adding onPressIn and onPressOut (#3277)
+
+[33mcommit 6afa4fb98c6826c4d6b80db055ef8f21ed07b59a[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Aug 2 23:00:09 2022 +0200
+
+    docs: add installation section in migration guide
+
+[33mcommit da53fdcccc6050e220f148ecdebfbcffab19e586[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jul 26 10:47:14 2022 +0200
+
+    fix: adjust Badge line height to the font scale (#3264)
+
+[33mcommit aa7f774bde46a2d1650f9eb64a7cc8111f56c21b[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jul 26 10:03:54 2022 +0200
+
+    fix: make bottom navigation icon optional
+
+[33mcommit 06568f74b81c12cdc52942c029d99c66c62fd51a[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jul 18 15:51:06 2022 +0200
+
+    docs: update getting started guide (#3261)
+
+[33mcommit 14b6f4cc99b04926fceea15fa03936dddb33edfe[m
+Author: Lukas Kurucz <usrbowe@users.noreply.github.com>
+Date:   Mon Jul 18 02:12:05 2022 +0800
+
+    Fix Github edit link: master -> main (#3254)
+
+[33mcommit 0cf2a54320b876e329ebfe2b6f1897cad186ea40[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sun Jul 17 17:41:18 2022 +0200
+
+    docs: update theming and getting started sections (#3249)
+
+[33mcommit 11b61f455891204161ae34b68fe01dc7fadbe50e[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jul 11 20:41:57 2022 +0200
+
+    fix: adjust status bar style in example app
+
+[33mcommit 00e06ed9cfa43f2cc7cd74c49482e3c96e51075d[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Jul 8 23:18:41 2022 +0200
+
+    fix: correct v2 should center appbar (#3247)
+
+[33mcommit 80867499cddd9b658b59e5336ba5ef04b31873df[m
+Author: Daniel Szczepanik <tmlm18@gmail.com>
+Date:   Fri Jul 8 12:24:13 2022 +0200
+
+    docs: improve readability (#3245)
+    
+    * docs: add small stylistic changes
+    
+    * docs: sort discussed components alphabetically
+
+[33mcommit 6de39e86500d06c684519f80713f3462faa4f8d5[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Jul 7 17:01:42 2022 +0200
+
+    chore: release 5.0.0-rc.3
+
+[33mcommit b4c4ca11fc72e170d320dc161fdf0cce32870fad[m
+Author: Daniel Szczepanik <tmlm18@gmail.com>
+Date:   Thu Jul 7 16:50:20 2022 +0200
+
+    feat: update types to match global approach (#3227)
+
+[33mcommit 5fcc794fb2d8fdd54746b41ae5e1991bf1fb3e25[m
+Author: Andrei Alecu <aandrei03@gmail.com>
+Date:   Thu Jul 7 15:19:22 2022 +0300
+
+    feat: shifting scene animation for BottomNavigator (#3176)
+    
+    Co-authored-by: Andrei Alecu <andreialecu@users.noreply.github.com>
+
+[33mcommit c1b1c58469063f13ca2f9481b59cd6b844551005[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jul 6 10:26:05 2022 +0200
+
+    fix: correct center-aligned mode in AppbarHeader (#3241)
+
+[33mcommit 92733e050985cc40a96bf3e84ac04dba45e49164[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jul 5 09:39:08 2022 +0200
+
+    fix: pass absolute styles to outer shadow layer for ios (#3239)
+
+[33mcommit 17976c4d8642b201ffb61f3f7b0bba22453218a8[m
+Author: Manu <356978+kamui545@users.noreply.github.com>
+Date:   Mon Jul 4 22:09:04 2022 +0200
+
+    fix: fix regression in Appbar.Header statusBarHeight (#3235)
+
+[33mcommit 7461463e1636fc5e4f85cf44d95fa7e8ba23e0b1[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jul 4 14:58:14 2022 +0200
+
+    fix: add style fallback in Surface (#3238)
+
+[33mcommit 375963cb10ad5f8a19760d639218ffdd342caafd[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jun 27 18:57:51 2022 +0200
+
+    chore: update apps build versions
+
+[33mcommit 825bc9b267d726902f377e8fe046cb01cfd97559[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jun 27 18:45:27 2022 +0200
+
+    chore: update react-native-vector-icons (#3211)
+
+[33mcommit 8dca717bb29d92eb5302e2686666d1b43572b76d[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jun 27 18:33:05 2022 +0200
+
+    docs: add information about FAB customSize prop (#3226)
+
+[33mcommit 4025553111c62cabc83d7f99fd72a8401000ec65[m
+Author: Adam Trzciński <trzcinski.adam@gmail.com>
+Date:   Mon Jun 27 18:28:43 2022 +0200
+
+    chore: upgrade expo to 45, react-native to .68 (#3206)
+
+[33mcommit 4918d233b0aa13e979d72711264ff04766c195fc[m
+Author: João Gabriel Quaresma <j.quaresmasantos_98@hotmail.com>
+Date:   Mon Jun 27 12:17:55 2022 -0300
+
+    feat: add FAB size prop (#3156)
+
+[33mcommit 3ade103a599c793498f07b35f32a5be56521d789[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sat Jun 25 22:31:13 2022 +0200
+
+    fix: correct Card colors (#3219)
+
+[33mcommit eb2b9cef2746aa87d52643e9b31e88f2b1edaee6[m
+Author: Daniel Szczepanik <tmlm18@gmail.com>
+Date:   Sat Jun 25 22:29:44 2022 +0200
+
+    feat: add ability to provide version in provider (#3224)
+
+[33mcommit 8250f74744ce6639433a54ac18748c12ff056af2[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sat Jun 25 19:55:43 2022 +0200
+
+    refactor: extract getTheme util to the theming (#3222)
+
+[33mcommit 110287024f9ee0862eda04b7645c5ff01172fbe8[m
+Author: Victorio Molina <54834743+VictorioMolina@users.noreply.github.com>
+Date:   Sat Jun 25 19:47:24 2022 +0200
+
+    fix: supporting empty labels (#3215)
+
+[33mcommit 0bc1c7eb8d2ea0eb70db80a5828bd2282f95086b[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Jun 16 10:19:59 2022 +0200
+
+    docs: correct FAB prop description
+
+[33mcommit 6cbe86c36689b02b2252827f84734195b71a08e2[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jun 15 10:54:19 2022 +0200
+
+    chore: release 5.0.0-rc.2
+
+[33mcommit 91cb88a824e430a281918510ee823e5d86d6fbdc[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jun 15 10:50:49 2022 +0200
+
+    fix: correct web font (#3210)
+
+[33mcommit f63efd2df390b38cd352db499c91d60675b6ac99[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jun 14 23:42:52 2022 +0200
+
+    chore: release 5.0.0-rc.1
+
+[33mcommit d0ecb7e78f81e035014b6d99ec745a905b2ea4e7[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jun 14 23:30:58 2022 +0200
+
+    refactor: set theme v3 as default, update theming docs (#3208)
+
+[33mcommit 88524e8c32f0897f627c7479777b697b38592f8b[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jun 14 23:05:56 2022 +0200
+
+    fix: refactor fonts in components, themes and types (#3207)
+
+[33mcommit d263c8d8734f003a7f359bd40387d2f4181e3b32[m
+Author: nishan (o^▽^o) <nishanbende@gmail.com>
+Date:   Tue Jun 14 18:22:28 2022 +0530
+
+    fix: tiny typo in versioning link (#3205)
+
+[33mcommit ad650f1b4d789fc2fc741d3778531eb01c538ffe[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jun 14 10:58:22 2022 +0200
+
+    docs: deploy docs for v4.x
+
+[33mcommit 8d3830297a4cfeafaaf9fe95b0b92813a1147f9a[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jun 14 10:36:51 2022 +0200
+
+    chore: release 5.0.0-rc.0
+
+[33mcommit ac0f91f95838813b63a72e504b55b23e1f499b83[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jun 14 09:32:28 2022 +0200
+
+    fix: patch Surface shadow, correct FAB styles (#3203)
+
+[33mcommit 95ff55b8714ddbd8d43716b7f69720422c24bcaf[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Jun 10 14:52:54 2022 +0200
+
+    fix: correct icon button surface (#3199)
+
+[33mcommit aa533ea92ed3d0f53f8163e99d75dd853424e9b4[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Jun 10 09:36:16 2022 +0200
+
+    docs: update screenshots (#3196)
+
+[33mcommit 83b70daf036a41c15088caaa399435fd05e0612a[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Jun 9 14:37:21 2022 +0200
+
+    refactor: correct disabling RadioButtonItem, add missing a11y props (#3195)
+
+[33mcommit bd9f01286f26320cf2094ac08bdf5daa481ddb3c[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jun 8 16:45:45 2022 +0200
+
+    docs: generate link to 4.0 docs
+
+[33mcommit cf020b668fbdebf15301b5730ba9e9dad678b7d1[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jun 8 16:28:17 2022 +0200
+
+    refactor: add button cast, update snapshot
+
+[33mcommit a3974fd0af11ce10558440ed0ca098f334adbc4e[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jun 7 22:31:06 2022 +0200
+
+    refactor: renamed card mode prop filled to contained (#3194)
+
+[33mcommit 99e4082e9d05e36fce1cdfd620678e5a726f7f3e[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jun 7 19:47:33 2022 +0200
+
+    refactor: correct dialog child spacing
+
+[33mcommit f393e57fd75f636fb7804751d12e61d626602a13[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jun 7 16:25:56 2022 +0200
+
+    docs: migration guide (#3193)
+
+[33mcommit a4b5a5e2715fa1b8cca7374c12eb73a814622463[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jun 7 14:30:04 2022 +0200
+
+    refactor: correct version in props annotations
+
+[33mcommit 86dd4630b4512ac3f9fa5788d67a3d3c8d904080[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Mon Jun 6 18:44:38 2022 -0300
+
+    chore: remove deprecated accessibility props (#2484)
+
+[33mcommit c115a66471c5ebd51b16843036777d494e26fbf8[m
+Author: Olimpia <olimpia.zurek@gmail.com>
+Date:   Mon Jun 6 22:41:20 2022 +0200
+
+    feat: adjust Card (#3158)
+
+[33mcommit 42b9a4e27eac0c8b68219dc417b80ada4195949f[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jun 6 21:22:58 2022 +0200
+
+    refactor: correct MD3 default appbar height (#3192)
+
+[33mcommit 4db7fe25394e185ebcd74e496d53a7e240924004[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jun 6 17:56:21 2022 +0200
+
+    feat: adjust IconButton to Material You (#3187)
+
+[33mcommit 8718f3f67bd04864ca705bcc620128c026fe6659[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sun Jun 5 21:18:00 2022 +0200
+
+    feat: adjust Checkbox and RadioButton (#3120)
+
+[33mcommit d4ecdd662ff84e195f730d905087acec1865884e[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Jun 2 15:08:42 2022 +0200
+
+    refactor: update colors in FAB and FABGroup (#3190)
+
+[33mcommit e80ff7f7d516b1c4d2691e40c6bfdee7557fe834[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jun 1 21:02:07 2022 +0200
+
+    feat: adjust DrawerItem and DrawerSection, introduce DrawerCollapsedItem (#3073)
+
+[33mcommit 727710ddd36a3b2900ccd6f459d75d5f9fa69207[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jun 1 10:09:26 2022 +0200
+
+    refactor: adjust TouchableRipple to Material You (#3188)
+
+[33mcommit b28c099e646e75edacc46d6ba691e987d7bdd874[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon May 30 18:26:29 2022 +0200
+
+    feat: adjust TextInput (#3108)
+
+[33mcommit ed52b93b148702e7b1644be68b7f64856a99e349[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri May 27 19:21:43 2022 +0200
+
+    feat: adjust Chip (#3113)
+
+[33mcommit 43fe8d8801baf172e7f8f212cad9a1ecdae87cb7[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri May 27 12:23:43 2022 +0200
+
+    feat: adjust FAB, AnimatedFAB and FABGroup components (#3067)
+
+[33mcommit 95c083f488b7b33972775f3a132a89e51818a9bf[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri May 27 12:23:10 2022 +0200
+
+    feat: adjust Button (#3114)
+
+[33mcommit 377ab3b8dbb98a950eaa7f4e3cdb1109cce3de73[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu May 26 14:16:34 2022 +0200
+
+    feat: adjust Menu (#3118)
+
+[33mcommit 65e36e1e5f0c6c11fb27b753db59932d1679627e[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue May 24 12:25:55 2022 +0200
+
+    fix: correct android font (#3184)
+
+[33mcommit 9e9654b04d0a1a66c17e06e858b38df13df149fc[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon May 23 22:40:43 2022 +0200
+
+    feat: adjust Dialog components, introduce DialogIcon (#3079)
+
+[33mcommit ad5fc047ec2f11ff5e50a4ea24f4ad0b4e30f084[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sun May 15 19:56:56 2022 +0200
+
+    feat: adjust colors in rest components (#3105)
+
+[33mcommit c0f50076dd71f5d00a67b50500d11681149b9c14[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed May 11 13:55:19 2022 +0200
+
+    feat: adjust Appbar components into Material You (#3076)
+    
+    Co-authored-by: Daniel Szczepanik <tmlm18@gmail.com>
+
+[33mcommit bc631589ae88a854f820256b00eb625b18216e37[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed May 11 13:54:06 2022 +0200
+
+    feat: adjust BottomNavigation into Material You (#3083)
+
+[33mcommit 01f275b34b4af893f2bf79bdb764e8d6501f5c19[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Apr 27 14:42:37 2022 +0200
+
+    fix: fix font weights for Android (#3165)
+    
+    Co-authored-by: Daniel Szczepanik <tmlm18@gmail.com>
+
+[33mcommit 360fc55ffa0c8ac94049ccb56db1cb2506d20c04[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Apr 21 23:06:42 2022 +0200
+
+    fix: correct font weight in typography variants (#3159)
+
+[33mcommit bda3f87c998502c55dca8992b120abead99a264b[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Apr 21 09:31:10 2022 +0200
+
+    feat: adjust elevation usage in components based on Surface (#3154)
+
+[33mcommit 2e41bb73f4e95af3b165b152c00bed66ac7c4c72[m
+Author: Daniel Szczepanik <tmlm18@gmail.com>
+Date:   Tue Apr 12 20:27:39 2022 +0200
+
+    fix: fix surface component for Android (#3149)
+
+[33mcommit e8b7515bad2eea40e9293b85ff7ef1857fdfd412[m
+Author: Daniel Szczepanik <tmlm18@gmail.com>
+Date:   Sat Mar 26 00:02:53 2022 +0100
+
+    feat: add surface shadows (#3089)
+
+[33mcommit a67bde01e47bfe75cc2303d27338d11fbb206413[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Mar 10 11:46:08 2022 +0100
+
+    chore: patch component-docs from list item badge (#3116)
+
+[33mcommit 65fdf41286b5f8a3aea9452af30a74b61ecc8f62[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Mar 9 19:18:28 2022 +0100
+
+    docs: update docs (#3115)
+
+[33mcommit 8da158ac3327259141d8252b73e8c541d5d9634a[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Mar 8 21:51:06 2022 +0100
+
+    feat: adjust AnimatedText, update Typography component and props description (#3082)
+    
+    * refactor: adjust AnimatedText, update component and props description
+    
+    * refactor: correct prop description
+
+[33mcommit e40e54d31b6192901c8ecd8347a09ac3d73754dd[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Mar 3 15:14:14 2022 +0100
+
+    chore: patch component-docs for badge annotation (#3096)
+
+[33mcommit 72b53fd2a62b6fe5af5ec87d14343d33ed1df0bf[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Feb 10 22:40:19 2022 +0100
+
+    feat: export old colors as MD2Colors and new as MD3Colors (#3074)
+
+[33mcommit 329b775beaa0730d079588c1510cbe8ea2a1e3d5[m
+Author: Daniel Szczepanik <tmlm18@gmail.com>
+Date:   Thu Feb 10 15:45:23 2022 +0100
+
+    feat: adjust theme structure (#3084)
+
+[33mcommit 2a9eff3ef9682ecfd6d9a23521514c430a82fe06[m
+Author: Daniel Szczepanik <tmlm18@gmail.com>
+Date:   Wed Feb 2 15:55:07 2022 +0100
+
+    feat: add theme switcher (#3068)
+
+[33mcommit c0a6ab6a809f3205f5000e7519bae2fb129cb7d8[m
+Author: Daniel Szczepanik <tmlm18@gmail.com>
+Date:   Wed Feb 2 14:34:39 2022 +0100
+
+    feat: adjust typography component, fix theme types (#3066)
+
+[33mcommit a4a3ce273301013047030a1b0e9066b8d7202d5d[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Feb 1 14:37:57 2022 +0100
+
+    fix: correct disabled colors and use background in ScreenWrapper
+
+[33mcommit 51c7592a034bd25fc7321e262008551eca982f6d[m
+Author: Daniel Szczepanik <tmlm18@gmail.com>
+Date:   Tue Feb 1 14:05:18 2022 +0100
+
+    feat: add disabled surface variants
+
+[33mcommit b326658242f8268f7b2ed8d39c66851d5e6f6e6b[m
+Author: Daniel Szczepanik <tmlm18@gmail.com>
+Date:   Tue Feb 1 13:24:11 2022 +0100
+
+    feat: replace old variable references (#3062)
+
+[33mcommit e471fedace8a695eb891d4e797a5c71dbcd6f43e[m
+Author: Daniel Szczepanik <tmlm18@gmail.com>
+Date:   Mon Jan 31 14:45:22 2022 +0100
+
+    feat: update material you theming (#3053)
+
+[33mcommit 5155415ce0ff04463fde8e4a22aa7dc9d7c73311[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jun 7 16:23:28 2022 +0200
+
+    chore: update circle artifacts link
+
+[33mcommit cf99f4e1ded38ccc3f9060a3bdb25cee0b086074[m
+Author: Ernestas P <drplauska@gmail.com>
+Date:   Fri Jun 3 11:12:52 2022 +0300
+
+    chore: update contributor data (#3191)
+    
+    Co-authored-by: Ernestas Plauska <Ernestas_Plauska@epam.com>
+
+[33mcommit f73662dd786bf182d6e02bc11ebd052978e4de40[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri May 20 10:02:28 2022 +0200
+
+    docs: correct regex for switching docs version
+
+[33mcommit 1c8fe7d5ad31470d9af20b633076c39fb8b6a607[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri May 20 09:38:11 2022 +0200
+
+    docs: generate docs for 3.0 version
+
+[33mcommit b5029ba638011d146e98867fb420f268ddcbdc96[m
+Author: Salinder Sidhu <salinder.sid@gmail.com>
+Date:   Fri May 13 05:45:50 2022 -0400
+
+    docs: Add Quakemap to Showcase (#3175)
+
+[33mcommit cc610b4b96ec4387ad547b239df7a0dc754c99f2[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Apr 26 10:10:19 2022 +0200
+
+    chore: release 4.12.1
+
+[33mcommit fcd402e856b69f46d87c4e0775a4faf4e9bdcfd4[m
+Author: Thomas Gladdines <seahorsepip@outlook.com>
+Date:   Tue Apr 26 10:05:04 2022 +0200
+
+    fix: controlled text input (#3145)
+    
+    Co-authored-by: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit 60db40050fbc2e339786d39a07494167ef0ff903[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Apr 26 10:04:26 2022 +0200
+
+    fix: correct elevation when switching modes (#3151)
+
+[33mcommit 789724ec2b12c3e87f915e18deaaf7f98379c2ce[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Mar 30 14:16:35 2022 +0200
+
+    chore: update apps build versions
+
+[33mcommit 3c2bef9500dba6b6b9f2c7cc8adf417de29a6831[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Mar 30 13:33:18 2022 +0200
+
+    chore: udpate example verion
+
+[33mcommit ef65b753242293eb015217298fb6e859a62a08da[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Mar 30 12:13:58 2022 +0200
+
+    chore: release 4.12.0
+
+[33mcommit 62996571bd2fa7c850f5e70ab8cfd79c6e02bf1d[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Mar 30 10:59:11 2022 +0200
+
+    fix: pass maxFontSizeMultiplier to input label and adornments (#3131)
+
+[33mcommit 40bb45b57108569900f27674509dfbad736153cb[m
+Author: Mike Hardy <github@mikehardy.net>
+Date:   Wed Mar 30 02:48:46 2022 -0500
+
+    fix: datatable.title numberOfLines > 1 height + wrapped text align (#3015)
+
+[33mcommit a70a8fc243da6e006f169eef31f3607fbb931070[m
+Author: Sébastien Vray <serybva@users.noreply.github.com>
+Date:   Wed Mar 23 15:22:02 2022 +0100
+
+    Fix: Updated documentation for Webpack 5 (#3057)
+    
+    Co-authored-by: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit 30a4e27cb5541e22989e5262f14d29561b84d454[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Mar 23 13:48:50 2022 +0100
+
+    chore: fix lint and tests (#3128)
+
+[33mcommit 807179ae8d019145b3245156fc9b29ede03d3617[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Wed Mar 23 09:28:09 2022 -0300
+
+    fix(CheckboxItem): properly disable touchable (#3077)
+
+[33mcommit 2876bce17b4b17dec3089d779063895655c26469[m
+Author: Pushpender Singh <73298854+pushpender-singh-ap@users.noreply.github.com>
+Date:   Wed Mar 23 17:49:57 2022 +0530
+
+    feat: TextStyle Props Add in Table and Cell (#3112)
+
+[33mcommit e21c49f17032845288c023ea6dc6d5406f232d7a[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Mar 23 13:19:14 2022 +0100
+
+    feat: introduce new prop labelMaxFontSizeMultiplier for BottomNavigation (#3100)
+
+[33mcommit 16aa48c0693680b8c47ce0941af4282e550994cf[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sun Mar 13 23:33:08 2022 +0100
+
+    chore: update reanimated in example app (#3121)
+
+[33mcommit cffb7989ca15205fc236aacd895e4bfac8492b9a[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sun Mar 13 22:23:30 2022 +0100
+
+    chore: bump react-navigation to v6 (#3063)
+
+[33mcommit 4437229b3daac86b043766540006571fae538919[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sun Mar 13 22:07:10 2022 +0100
+
+    chore: web example support (#3078)
+
+[33mcommit a2600b34985ca54472efb435926d2dd2596aa657[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Jan 27 09:41:44 2022 +0100
+
+    chore: release 4.12.0-alpha.0
+
+[33mcommit dbc2d27f3a9d306788b8bb8ba576f52bbbe45311[m
+Author: Arnab Paryali <arnabparyali@gmail.com>
+Date:   Thu Jan 27 01:08:40 2022 +0530
+
+    feat: add event listeners for Avatar.Image (#3032)
+
+[33mcommit 7a0e3ab15fbe4a93ed81a84fdb3bccaafa2a2e16[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jan 26 20:35:47 2022 +0100
+
+    fix: correct Card animation drivers related to elevation (#3041)
+
+[33mcommit 1fd0e2a9c646e62c22b2b1930dcb8c2425481dca[m
+Author: David Gruseck <david@gruseck.eu>
+Date:   Wed Jan 26 19:09:23 2022 +0100
+
+    fix: cleanup modal backhandler listener on unmount (#3049)
+    
+    Co-authored-by: David Gruseck <david.gruseck@actinate.com>
+
+[33mcommit 8d1cfa1a17ab89ee989b1efc06f346f5b19d2af1[m
+Author: Jan Jaworski <jaworek3211@gmail.com>
+Date:   Tue Jan 18 19:35:20 2022 +0100
+
+    chore: upgrade expo to 44 (#2951)
+
+[33mcommit e049a467800ea8a6b4f922e5122db77a5fb41e3f[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Tue Jan 18 10:47:46 2022 +0100
+
+    refactor: update text input class component to functional (#2218)
+    
+    Co-authored-by: lukewalczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit 9720e0d2086aefe5a887eefbe0a4970847ff8776[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 17 16:56:30 2022 +0100
+
+    chore: update typescript and prettier versions (#3030)
+
+[33mcommit ad00f833085bec08eefde82e477e64eba44698b4[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jan 17 12:03:35 2022 +0100
+
+    refactor: create an util for handling event handlers (#3017)
+
+[33mcommit 81499d7ba6d215e9ce28ab2b69873ec861aeb54c[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Jan 14 10:29:32 2022 +0100
+
+    chore: release 4.11.2
+
+[33mcommit e03c07fae391e2a88718800bc47e451c16ecd787[m
+Author: Svarto <svarto@protonmail.com>
+Date:   Fri Jan 14 10:19:21 2022 +0100
+
+    fix: fixed backgroundColor of textinput label #3020 (#3038)
+
+[33mcommit cca973248f509abf1afd477b8a3bbb05f65130d3[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sun Dec 12 16:57:50 2021 +0100
+
+    chore: release 4.11.1
+
+[33mcommit 65ebc51bde527c969b27b2a0b5e000507bce86a7[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sun Dec 12 16:50:41 2021 +0100
+
+    fix: correct displaying text in outlined text input (#3006)
+
+[33mcommit 3c916b731417cd0d5b21416a76aade35be0d7c88[m
+Author: Arnaud <arnaud.bezancon@advantys.com>
+Date:   Sun Dec 12 16:39:54 2021 +0100
+
+    feat(a11y): button: add accessibility hint prop (#3004)
+
+[33mcommit 5f1fedc8ce8d1a39823ae0cad8ad2b148210f12c[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Dec 10 15:39:12 2021 +0100
+
+    chore: release 4.11.0
+
+[33mcommit 621d26c3ac0a43c8d30bddd36e3dce99af89ae9e[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Dec 10 15:24:49 2021 +0100
+
+    fix: move outline outside of input view container (#2997)
+
+[33mcommit 6c2e53457c9f3818d11eb3e325e105e145c6fa55[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Dec 10 14:26:14 2021 +0100
+
+    fix: correct clickthrough on web tabs within BottomNavigation (#2985)
+
+[33mcommit 6aa2c509bb7cb58689912d84d05b956705843991[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Dec 10 13:09:01 2021 +0100
+
+    fix: add patching container for multiline input on ios (#2979)
+
+[33mcommit abf631a4d595831fcd12be03008be059bb5aeeec[m
+Author: Soma Mbadiwe <smbadiwe@users.noreply.github.com>
+Date:   Fri Dec 10 06:19:52 2021 -0500
+
+    feat: The `label` prop for `TextInput` can now take a component (`ReactElement`) as well as `string` (#2991)
+    
+    Co-authored-by: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit c7bedca6452e2658f48f59f8c9c02dbc4ed1bc41[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Dec 10 10:15:15 2021 +0100
+
+    fix: correct long label in outlined text input (#2960)
+
+[33mcommit 1684719f29957243a7c73e2b2ccc33dd9510d82e[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Fri Dec 10 06:14:56 2021 -0300
+
+    fix: remove outline from Searchbar on Web (#2961)
+
+[33mcommit 69d5ffedb71388350a95bf9e3425a32f845e1991[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Dec 10 10:13:28 2021 +0100
+
+    fix: correct Chip touchable style (#2976)
+
+[33mcommit bd0bae2868f98c65a196f04e686733ae6dde0db8[m
+Author: Eric <eric.ledonge@gmail.com>
+Date:   Fri Dec 10 04:13:07 2021 -0500
+
+    fix: typescript issue in banner when customizing buttons (#2970)
+
+[33mcommit e509bf888e58b276b301490d8ae3602f1e6917d3[m
+Author: Eugene Nagorny <ideviantik@gmail.com>
+Date:   Fri Dec 10 11:11:24 2021 +0200
+
+    fix: outlined input error border width (#2975)
+
+[33mcommit 85d679ea99df0a6090e4a0dce7a57fe4fa7536d6[m
+Author: Tim De Pauw <timdp@users.noreply.github.com>
+Date:   Wed Dec 1 21:54:12 2021 +0100
+
+    docs: Add Clutch to showcase (#2986)
+
+[33mcommit b545cdcbd8c5f1bd5ad3f0e9f095c294527846a4[m
+Author: Steve Pepple <stephen.pepple@gmail.com>
+Date:   Thu Nov 18 01:21:54 2021 -0800
+
+    docs: Add Vibemap to Showcase.js (#2981)
+
+[33mcommit 8dbbac30490566318fe07bc2db875600b5d4c026[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Nov 16 17:18:49 2021 +0100
+
+    chore: release 4.10.1
+
+[33mcommit 8cff4437c13c3ab3bacde5ca7e0237c7d4cd614b[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Nov 9 21:28:24 2021 +0000
+
+    chore: update snack domain to .dev (#2977)
+
+[33mcommit 5f18a39434dc6c66a0fa83283df3a4bcbb30e70b[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Nov 3 10:08:33 2021 +0100
+
+    chore: release 4.10.0
+
+[33mcommit 656d652b871d0dc46748e2278f7550e0f4229db1[m
+Author: Håkan Sjölin <30954044+haakandev@users.noreply.github.com>
+Date:   Wed Nov 3 20:01:00 2021 +1100
+
+    feat: Styling of labels in FAB.Group (#2894)
+
+[33mcommit 50ccce0285d192f83541bf7ad2b99184d7c04f90[m
+Author: Daniel Szczepanik <tmlm18@gmail.com>
+Date:   Wed Nov 3 09:59:32 2021 +0100
+
+    feat: add AnimatedFAB improvements (#2907)
+    
+    Co-authored-by: lukewalczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit 5faa1ec09e320c01977da8e4e5d522c6e4d92b07[m
+Author: guruguru-dekiruko <40130327+grgr-dkrk@users.noreply.github.com>
+Date:   Wed Nov 3 00:41:58 2021 +0900
+
+    fix: unified behavior when focusing on CheckBox.Item with screen reader (#2921)
+
+[33mcommit 5c8544fb3ee191af47499d8af211dfe093e5e82b[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Tue Nov 2 12:30:27 2021 -0300
+
+    fix: make RadioButtonGroup accessible (#2947)
+
+[33mcommit a3563ad979e81688693c8712b12aa1e952a4442b[m
+Author: Simon Buerger <simonbuerger@users.noreply.github.com>
+Date:   Tue Nov 2 17:24:34 2021 +0200
+
+    chore: update @types/react-native (#2953)
+
+[33mcommit 8cff1c0959c9df216922921326e8cfd32ea152d7[m
+Author: Gabriel Belgamo <19699724+belgamo@users.noreply.github.com>
+Date:   Tue Nov 2 12:24:00 2021 -0300
+
+    Allow custom underline color (#1797)
+    
+    Co-authored-by: lukewalczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit 415494b8c1d7edb946b2335d403d223ed8733085[m
+Author: Jan Jaworski <jaworek3211@gmail.com>
+Date:   Tue Nov 2 11:25:57 2021 +0100
+
+    chore: remove unused babel presets (#2952)
+
+[33mcommit 58851e3376430b8c4278faa38f5b43339743784d[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 25 22:34:21 2021 +0200
+
+    refactor: update appearance subscription (#2586)
+
+[33mcommit 91e669c98965171267cbe6383bddd22772a96e5a[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Mon Oct 25 16:42:41 2021 -0300
+
+    fix: chrome autofill in flat TextInput on web (#2850)
+
+[33mcommit 8448593ad748d509efce62213db124ef53587b3b[m
+Author: Koussay Haj Kacem <29253287+essana3@users.noreply.github.com>
+Date:   Mon Oct 25 17:58:17 2021 +0100
+
+    Add custom close icon for the Chip component (#2883)
+    
+    Co-authored-by: Koussay Haj Kacem <koussay.haj.kacem@kaoun.com>
+
+[33mcommit abd82899482d7441687e6505677a44a7c5d3e83f[m
+Author: First Dev <37846767+first-dev@users.noreply.github.com>
+Date:   Mon Oct 25 17:50:36 2021 +0100
+
+    fix: Ripple effect on DrawerItem (#2879)
+    
+    Co-authored-by: lukewalczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit 0aff56aa13473d9ba5a0c765213cec0795619f75[m
+Author: Jan Jaworski <jaworek3211@gmail.com>
+Date:   Mon Oct 25 12:43:54 2021 +0200
+
+    chore: upgrade node version on CI (#2950)
+
+[33mcommit 28261ab66d9ab58efbae5f4465050c1ba8f7084b[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Sat Oct 23 09:03:07 2021 -0300
+
+    feat: custom title for ListItem (#2886)
+    
+    Co-authored-by: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit 0b83b7631faf6f7fbf27b8e1ff2cf835bf781355[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Sat Oct 23 08:51:39 2021 -0300
+
+    feat: improve banner accessibility on Android (#2949)
+
+[33mcommit 003b12cd64873101dc09399bab49c6240edc5ee7[m
+Author: Aleksandra Desmurs-Linczewska <desmurs.linczewska@gmail.com>
+Date:   Fri Oct 22 23:17:16 2021 +0200
+
+    test: update test files to comply with eslint rules (#2941)
+
+[33mcommit 5821ee5fd476020d853f8b07ac25b7861f623ce4[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Fri Oct 22 18:13:05 2021 -0300
+
+    fix: override Card surface colors with theme (#2948)
+
+[33mcommit f3f35e87dd197dd5b6667b2334464d049bc1878a[m
+Author: Aleksandra Desmurs-Linczewska <desmurs.linczewska@gmail.com>
+Date:   Fri Oct 22 23:10:16 2021 +0200
+
+    fix: comply to eslint warnings in example files (#2946)
+
+[33mcommit c99756b373328bd359769079a4b721a94a2586ec[m
+Author: lukasz wolski <lukiwolski@gmail.com>
+Date:   Fri Oct 22 23:06:48 2021 +0200
+
+    fix(2928): Radio Button (RadioButton) onPress Bug (#2931)
+    
+    Co-authored-by: Luki Wolski <lukasz.wolski@prt.manomano.com>
+
+[33mcommit 14916e3ea979cf7f36fb2cf8f4163b81f24b9056[m
+Author: Daniel Yo <danielyo112@gmail.com>
+Date:   Fri Oct 22 12:51:18 2021 -0700
+
+    feat(banner): add optional callback for on animation complete (#2758)
+
+[33mcommit 452c1636aedc16b4360ad3da95f8cf90ae77b9fd[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Oct 20 10:34:30 2021 +0200
+
+    fix: correct displaying progress bar on Android (#2916)
+
+[33mcommit 072e40bcaacb1f63587b75c3bc417837692bbd38[m
+Author: Corbin Crutchley <crutchcorn@gmail.com>
+Date:   Tue Oct 19 06:14:11 2021 -0700
+
+    refactor(modal): migrate to functional component (#2557)
+
+[33mcommit ee9c2d043c5f4863593c2fde70fcc136dc912d8a[m
+Author: haxonadora <42680223+haxonadora@users.noreply.github.com>
+Date:   Tue Oct 19 15:07:51 2021 +0200
+
+    feat: use theme colors in Banner (#2932)
+
+[33mcommit 9c2e84c7eac3a2952c612a43e94f450390d0c871[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Oct 19 09:46:28 2021 +0200
+
+    feat: introduce first iteration of AnimatedFAB component (#2580)
+
+[33mcommit d2f61fbee9bd9bd11daa206313d8069876fbccd5[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Sat Oct 16 18:36:35 2021 +0200
+
+    fix: correct toggling rtl in example app (#2934)
+
+[33mcommit 6ae6fb4bb350d7653b480f2a9fa818a7b6284ba1[m
+Author: Jan Jaworski <jaworek3211@gmail.com>
+Date:   Fri Oct 15 21:22:15 2021 +0200
+
+    chore: upgrade react-theme-provider (#2930)
+
+[33mcommit 0c353376a47ae58169a7f609307f9794e8b002e9[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Oct 14 11:38:45 2021 +0200
+
+    fix: use remove method on the event subscription (#2923)
+
+[33mcommit 8c8e54d3e82956e57d81ea41f56be60bbf36196c[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Oct 8 11:01:49 2021 +0200
+
+    fix: use remove method on the event subscription (#2918)
+
+[33mcommit a488d69b8a10669aa1dd8c67e77aba503e809514[m
+Author: GarioTV <37929387+GabrielDierks@users.noreply.github.com>
+Date:   Tue Oct 5 22:49:44 2021 +0200
+
+    docs: Add Groovy to Showcase (#2871)
+
+[33mcommit e2bd58b716f1a2dc381ed2fe0186b502a284d795[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Thu Sep 23 09:13:28 2021 -0300
+
+    chore(TextInput): run animations using native driver on iOS (#2550)
+
+[33mcommit 143037b85f22ea46ffaea6cf25f74d8fe6f4bb65[m
+Author: Josh Justice <me@codingitwrong.com>
+Date:   Thu Sep 23 08:06:45 2021 -0400
+
+    Docs: React Navigation Integration - update previous prop to back for 6.x (#2898)
+
+[33mcommit 03527be007b6f7a368215d34ddda0f6965ceefcb[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Fri Sep 3 10:18:30 2021 -0300
+
+    chore: bump tar from 4.4.15 to 4.4.19 in /docs (#2880)
+
+[33mcommit 116ff0196d715498a9ab4de9d852486a3830706f[m
+Author: Julian <30495990+julzerinos@users.noreply.github.com>
+Date:   Mon Aug 23 16:46:07 2021 +0200
+
+    fix: Add displayName attribute to DataTable Row (#2872)
+
+[33mcommit 509e55e58cbf6367b2445c89c36d79f0d2feb02f[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Sat Aug 21 07:42:12 2021 -0300
+
+    docs: fix CheckBox/RadioButton position prop (#2867)
+
+[33mcommit 885d4cc358dcf073ffd0f404a6fdf2bcc0127bdc[m
+Author: Thomas Dailey <daileytj89@gmail.com>
+Date:   Fri Aug 20 09:51:35 2021 -0400
+
+    docs: fix typo in TextInput (#2865)
+
+[33mcommit f7796f0ed60d7272a7ec6d0691a75215f357c13f[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Aug 18 10:59:22 2021 +0200
+
+    chore: mark issues with no repro/response as stale (#2857)
+
+[33mcommit 2a2665bf78c68efdff540b5d0b520a6e74185a27[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Wed Aug 11 14:57:01 2021 -0300
+
+    docs: fix Dialog example (#2843)
+
+[33mcommit 38215f03aad9aa5ce1f7b694fedfd6ed7a59ec5d[m
+Author: Andrei Alecu <andreialecu@users.noreply.github.com>
+Date:   Wed Aug 11 17:09:15 2021 +0300
+
+    fix: missing Menu.Item theme prop (#2845)
+
+[33mcommit 446dc094954e753bd5aa0a3c8436cd39c9d23d7b[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Wed Aug 11 10:58:37 2021 -0300
+
+    chore: bump path-parse from 1.0.6 to 1.0.7 in /example (#2848)
+
+[33mcommit 63c054085f7fb1b93db8b783244e2312da31d2af[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Wed Aug 11 10:51:20 2021 -0300
+
+    chore: bump path-parse from 1.0.6 to 1.0.7 (#2849)
+
+[33mcommit 1ac0ed1983669193f99062324977c17948677d2b[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Wed Aug 11 10:42:50 2021 -0300
+
+    chore: bump minimist from 1.2.0 to 1.2.5 in /docs (#2851)
+
+[33mcommit 9fc783d5311635938ff9d5970dc51eff656ff904[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Wed Aug 11 10:39:19 2021 -0300
+
+    chore: bump path-parse from 1.0.6 to 1.0.7 in /docs (#2847)
+
+[33mcommit 09cf10937a4c7ef19afb82d595c003e03b7fc37d[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Wed Aug 11 10:32:10 2021 -0300
+
+    chore: bump tar from 4.4.10 to 4.4.15 in /docs (#2838)
+
+[33mcommit 8eb4435d7365e9fae702cb515cc8be777f2554e3[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Thu Jul 29 15:46:53 2021 -0300
+
+    fix: add missing paddingRight to CardTitle (#2830)
+
+[33mcommit 7bdb7ac4f59aa7f531a0a0f173a97e81fb02e63c[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Thu Jul 29 15:27:46 2021 -0300
+
+    fix: full width Chip touchable not focusing (#2808)
+
+[33mcommit adc65b36d71e3f3fa866e89c9d69939695bacdfe[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Thu Jul 29 15:14:59 2021 -0300
+
+    feat: improve ListAccordion accessibility (#2775)
+
+[33mcommit f03f0c8f904a287f9211ee72a422deae3b1e40a4[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Wed Jul 28 08:24:45 2021 -0300
+
+    fix: do not render empty string as accordion description (#2831)
+
+[33mcommit 60e99ddad1d227611fafdf805dd56a551e878cd6[m
+Author: Kamal Mukkamala <kamalnrf@gmail.com>
+Date:   Thu Jul 1 18:25:12 2021 +0530
+
+    fix: do not apply padding to multiline outlined textinput (#2740) (#2793)
+
+[33mcommit e1f6b0dee40f005a2723592110aed9d75b348a4b[m
+Author: Michał Chudziak <michal.chudziak@gmail.com>
+Date:   Fri Jun 25 15:07:52 2021 +0200
+
+    Add Callstack reference (#2789)
+
+[33mcommit d4c594b0c6c9f8e4eadb1499b8a1b6cceaf5dfa5[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Thu Jun 24 09:28:10 2021 -0300
+
+    fix: TextInput border being cut out (#2786)
+
+[33mcommit 75abfd06bf7b34085115914fcff930ba8deedb5f[m
+Author: Alex Fernandez <alex@xicre.com>
+Date:   Tue Jun 22 09:34:41 2021 -0600
+
+    fix: list.accordion onlongpress type (#2697)
+
+[33mcommit ab20765528cb49a76d27ea4e2ab24984d0a92319[m
+Author: Jérémy M <jeremy.magrin@gmail.com>
+Date:   Tue Jun 22 11:24:11 2021 -0400
+
+    fix: TextInput paddingOut not based on lineHeight when provided (#2621)
+
+[33mcommit 1c071d99f2c5489c66f8ed9664206c40b0459804[m
+Author: Bern Ng <bernnystrom@gmail.com>
+Date:   Tue Jun 22 22:25:02 2021 +0800
+
+    docs: add YumMeals app to showcase page (#2770)
+
+[33mcommit 2095d923f311d30637a8fda9510d9e471cbcee05[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Tue Jun 22 11:17:45 2021 -0300
+
+    chore: bump color-string from 1.5.3 to 1.5.5 in /docs (#2784)
+
+[33mcommit 81f11d9f74044890e4c5831852b5dc35fda541c3[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Tue Jun 22 11:09:44 2021 -0300
+
+    chore: bump postcss from 7.0.27 to 7.0.36 in /example (#2778)
+
+[33mcommit 0a9f945811201317f33ad72aa5174bfa950b36bd[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Tue Jun 22 11:01:29 2021 -0300
+
+    chore: bump postcss from 7.0.17 to 7.0.36 in /docs (#2776)
+
+[33mcommit 1638b94a0fd8a481dfa90bf5833d887023eaec5d[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Jun 21 15:20:30 2021 +0200
+
+    chore: release 4.9.2
+
+[33mcommit a9b6561dd717faf806b1c27002a7a20e4731525d[m
+Author: Jake J Davis <jakejdavis1@gmail.com>
+Date:   Tue Jun 15 15:07:41 2021 +0100
+
+    fix: Drawer.Item content not center aligned (#2754)
+
+[33mcommit 9d53ac1cfa8ec70f2e9c67d8757cd55a274194cc[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Mon Jun 14 12:27:05 2021 -0300
+
+    chore: bump browserslist from 4.12.0 to 4.16.6 in /docs (#2742)
+
+[33mcommit 6ba7a1665ae4ffd66715832007f26fa01f767d9f[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Mon Jun 14 12:03:45 2021 -0300
+
+    chore: bump browserslist from 4.16.0 to 4.16.6 (#2744)
+
+[33mcommit d02ed92c9c91403bf11ad6e2e65e08bbe2a0f24d[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Mon Jun 14 11:58:43 2021 -0300
+
+    chore: bump dns-packet from 1.3.1 to 1.3.4 in /example (#2748)
+
+[33mcommit 40253f5b07a87812315c16a61a6bc19edb077638[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri May 28 13:06:43 2021 +0200
+
+    chore: release 4.9.1
+
+[33mcommit e4b139551f2185ea618b1af9ebd917ed148d6720[m
+Author: Derk-Jan Karrenbeld <derk-jan+github@karrenbeld.info>
+Date:   Fri May 28 13:05:36 2021 +0200
+
+    Revert bottom navigation width for web (#2752)
+    
+    Co-authored-by: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit c7cd2604d89b7e9ac5c58cabdf50f078dd9c4195[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu May 27 17:56:44 2021 +0200
+
+    chore: release 4.9.0
+
+[33mcommit c642587094eae3cb60096f5295fd8eafbbc070a7[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu May 27 17:46:26 2021 +0200
+
+    fix: example app tweaks (#2721)
+
+[33mcommit c30c925b5438d58ec91c8e3f41be151336df91b9[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu May 27 17:33:04 2021 +0200
+
+    fix: correct text position in CheckboxItem, update snapshots (#2749)
+
+[33mcommit 8f95915c6c429953dc6770e913b6589c2fc69598[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Thu May 27 18:08:01 2021 +0300
+
+    feat: DataTable Pagination (#2455)
+    
+    Co-authored-by: lukewalczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit 30068b29c26f1a5016bbe9a5eb11c002f609c3e3[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu May 27 17:07:33 2021 +0200
+
+    fix: add bg color to list accordion to limit ripple area (#2685)
+
+[33mcommit 70f83a98c4197493295ceb6939c2d5dfc19d8cc4[m
+Author: Alejandro <alejandro.carrasco.e90@gmail.com>
+Date:   Thu May 27 11:02:55 2021 -0400
+
+    feat: add outlineColor prop in TextInputOutlined (#2475)
+    
+    * feat: add outlineColor prop in TextInputOutlined
+    
+    * refactor: change outlineColor when input is disabled
+    
+    * refactor: change vars name & improve disabled validation
+
+[33mcommit 70bb52b0ccc6a8211482ab6742794a6a99bbaf52[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Thu May 27 11:54:44 2021 -0300
+
+    fix(android): add importantForAccessibility in Modal component (#2743)
+
+[33mcommit b5d9c6a8bd43d11e42b4555c6cfe2b9581d72fa8[m
+Author: Corbin Crutchley <crutchcorn@gmail.com>
+Date:   Thu May 27 07:54:14 2021 -0700
+
+    fix(BottomNavigation): migrate to tab role instead of button (#2611)
+
+[33mcommit ad88f7f8d8efd826a36fdd0cc34722b84ac1cf24[m
+Author: Varun <44650484+varunhhhrahul@users.noreply.github.com>
+Date:   Thu May 27 20:23:19 2021 +0530
+
+    feat: introduce prop for defining control position (leading/trailing) for checkbox item (#2738)
+    
+    Co-authored-by: Bruno Castro <bruno.castro@codeminer42.com>
+
+[33mcommit ddd6a7ca16259f39c0892e9fc70fc6068368d96f[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu May 27 16:52:56 2021 +0200
+
+    feat: introduce prop for defining control position (leading/trailing) fo RadioButton.Item (#2713)
+
+[33mcommit 213d9745628c9a3963dbcc4f42a07bcd293e1761[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu May 27 16:52:34 2021 +0200
+
+    fix: interpolate shadowOpacity to correct its value for the elevation equal zero (#2736)
+
+[33mcommit 0e024b843b3e2a88149a14929cd699860875483c[m
+Author: Takahiro Sugiura <tasugi@users.noreply.github.com>
+Date:   Thu May 27 23:52:12 2021 +0900
+
+    fix: correct Button elevation (#2735)
+    
+    * fix: correct Button elevation
+    
+    * Update src/components/Button.tsx
+    
+    Use useEffect
+    
+    Co-authored-by: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+    
+    * fix: set the initial elevation to 2 for contained buttons
+    
+    Co-authored-by: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit 0d71218624dc77f6a34a3db88e7739c0dc8aa7f9[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu May 27 16:51:43 2021 +0200
+
+    feat: add a safeAreaInsets prop to bottom navigation (#2746)
+
+[33mcommit 21376d08c7135ef82b7adf1703ccb305f7ad9660[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Tue May 18 09:45:35 2021 -0300
+
+    docs: improve TextInput Affix/Icon docs (#2665)
+
+[33mcommit 20080c4195ce3ec59df6f3a45432601720ee05ce[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Fri May 14 16:12:05 2021 -0300
+
+    feat: add card mode outlined (#2512)
+
+[33mcommit 426c025074f9fe881ee1a5e31818dad9b35dc181[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Wed May 12 14:41:45 2021 -0300
+
+    feat: add prop right to DrawerItem (#2505)
+
+[33mcommit ec9903e04354e859b029a5f95ebfdb55f04060b5[m
+Author: Abdullah Hilson <abdullah.hilson@gmail.com>
+Date:   Wed May 12 15:42:11 2021 +0000
+
+    chore: Expose Snackbar props type (#2709)
+
+[33mcommit 0e0602cf50fa6ab79282e017b84119270041a84b[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Wed May 12 12:29:53 2021 -0300
+
+    feat: improve ProgressBar and ActivityIndicator accessibility (#2673)
+
+[33mcommit 7bae89efe6c52b683d1dbbb5e41b8f7aab4b5eee[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed May 12 17:29:32 2021 +0200
+
+    fix: run animation on card long press (#2701)
+
+[33mcommit d13cd89a324f0b1eeda3404841585c2f4022e575[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed May 12 09:51:15 2021 +0200
+
+    chore: add GitHub action for check repro (#2718)
+
+[33mcommit 2f21b9ad75c56d0307bfaaffaa73e5bb8c8c029c[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Mon May 10 15:12:48 2021 -0300
+
+    chore: bump hosted-git-info from 2.8.8 to 2.8.9 (#2714)
+
+[33mcommit 6399cb53ecd145822de5d4f4ba7d8e53e049a404[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Mon May 10 15:01:51 2021 -0300
+
+    chore: bump handlebars from 4.7.6 to 4.7.7 (#2705)
+
+[33mcommit 80ef3467e94d560c62a3b7af2419a3d5b35d9cb2[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Mon May 10 15:01:03 2021 -0300
+
+    chore: bump ua-parser-js from 0.7.21 to 0.7.28 (#2703)
+
+[33mcommit af954d5e714e411a4504e47b1856de31e4301442[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Mon May 10 14:59:17 2021 -0300
+
+    chore: bump hosted-git-info from 2.7.1 to 2.8.9 in /docs (#2712)
+
+[33mcommit aadb5288c447827fd3432453f1e6f09deb2cda34[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Mon May 10 14:54:20 2021 -0300
+
+    chore: bump lodash from 4.17.19 to 4.17.21 in /docs (#2708)
+
+[33mcommit 3e893dea28d8889c482740179241b357f44b2590[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Mon May 10 14:52:44 2021 -0300
+
+    chore: bump hosted-git-info from 2.8.8 to 2.8.9 in /example (#2715)
+
+[33mcommit 4d0c8c7a2efe73998ecfa9dfb50d6e1f0cbb6fd2[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Mon May 10 14:41:22 2021 -0300
+
+    chore: bump url-parse from 1.4.7 to 1.5.1 in /example (#2707)
+
+[33mcommit fcec3453a120218f80f587bde23bf64cb9ef59c1[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Mon May 10 14:40:38 2021 -0300
+
+    chore: bump ua-parser-js from 0.7.21 to 0.7.28 in /example (#2702)
+
+[33mcommit 3d824472450d1444db037c2098851d8f1d75e177[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Mon May 10 14:30:33 2021 -0300
+
+    chore: bump ssri from 6.0.1 to 6.0.2 in /example (#2693)
+
+[33mcommit 9e3110725df1814a9470561e0c74902199929810[m
+Author: Conor McGrath <conor909@gmail.com>
+Date:   Wed May 5 11:42:56 2021 +0100
+
+    RadioButtonItem label fix (#2687)
+
+[33mcommit 837e9035689b05eb22b51950c79ef81c914f542d[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Apr 23 14:53:52 2021 +0200
+
+    chore: release 4.8.1
+
+[33mcommit 4bba7d467b3a4fbf32665fd204577b63ce724b75[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Apr 23 14:46:06 2021 +0200
+
+    fix: patch for text input label (#2678)
+
+[33mcommit 45c48a1b73ca9db89e3089df8ff2321647a06548[m
+Author: lukewalczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Apr 22 13:52:44 2021 +0200
+
+    chore: release 4.8.0
+
+[33mcommit 5961940562d438749cfbbfd81e2a20c46a8f9024[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Apr 22 13:36:49 2021 +0200
+
+    fix: correct label bug related to some Android devices (#2672)
+
+[33mcommit d926672a86319d0b333fb1c4cf8756fefc09abfb[m
+Author: imgbot[bot] <31301654+imgbot[bot]@users.noreply.github.com>
+Date:   Wed Apr 21 13:09:14 2021 +0200
+
+    docs: optimzie images (#2655)
+
+[33mcommit 3222c70cf15ebb109822beefae8b8a4f97aec4e6[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Tue Apr 20 11:06:56 2021 -0300
+
+    chore: bump ssri from 6.0.1 to 6.0.2 in /docs (#2671)
+
+[33mcommit cd5a036b00c7480504854bfd17128c9a19476388[m
+Author: IOM <sviande@gmail.com>
+Date:   Tue Apr 20 13:13:21 2021 +0200
+
+    fix: component BottomNavigation (#2552)
+
+[33mcommit 00b6d76ebdf7e203c34642df37aea5df4afc1124[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Tue Apr 20 08:12:43 2021 -0300
+
+    feat: add prop color to TextInputIcon (#2661)
+
+[33mcommit 09384ec38efc069e35d1038cadfaff3e5316966d[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Apr 16 09:55:58 2021 +0200
+
+    fix: remove resizeMode style property from CardCover (#2660)
+
+[33mcommit 29ce19e7741fd0c83306010f5c37d0f3ca2cd354[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Apr 16 09:55:40 2021 +0200
+
+    fix: correct flex values in checkbox item label (#2659)
+
+[33mcommit cf70dec1629e6c5f78c7c3f5f2a46603377752d7[m
+Author: Brent Vatne <brentvatne@gmail.com>
+Date:   Thu Apr 15 03:34:59 2021 -0700
+
+    chore: remove constants.expo.tsx and move logic to constants.tsx (#2560)
+
+[33mcommit 9e8e477c6aa37a72af7675e79b9a9fcf342c6339[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Apr 14 12:53:25 2021 +0200
+
+    fix: correct example list background color (#2664)
+
+[33mcommit e309e2e751a33b411d31d9c7d6fb54a24df4ac9e[m
+Author: Joe <jattardowen@gmail.com>
+Date:   Fri Apr 9 17:42:45 2021 +0300
+
+    feat: add prop right to List Accordion (#2531)
+
+[33mcommit 13b965b95e97f18e061984ef27aa2eddd3bc9aa2[m
+Author: Alejandro <alejandro.carrasco.e90@gmail.com>
+Date:   Fri Apr 9 08:48:01 2021 -0400
+
+    feat: add accessibilityLabel prop to MenuItem (#2577)
+    
+    * feat: add accessibilityLabel prop to MenuItem
+    
+    * chore: add description to accessibilityLabel prop
+    
+    Co-authored-by: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+
+[33mcommit 66d93b31b40b0398aef8223f47f8db37a650cfe1[m
+Author: Martin Janeček <admin@ikw.cz>
+Date:   Fri Apr 9 12:58:55 2021 +0200
+
+    fix: Searchbar focus() (#2519)
+    
+    Closes #2393, #2394
+
+[33mcommit 0cd68da71441d0494f6c4a10ee09746765395d69[m
+Author: Frederic <44294931+frederic11@users.noreply.github.com>
+Date:   Fri Apr 9 13:39:19 2021 +0300
+
+    docs: Added Zoomapto app to Showcase Section (#2551)
+
+[33mcommit 4b9a1f23c973a20ec6c51f1700457c49eeff3691[m
+Author: Alejandro <alejandro.carrasco.e90@gmail.com>
+Date:   Fri Apr 9 06:31:06 2021 -0400
+
+    feat: add Button props to Snackbar action (#2569)
+    
+    * feat: add Button props to Snackbar action
+    
+    * chore: omit children action prop
+
+[33mcommit a0bebcf54f185c0ee42c45ce30a9ff4f474a45ca[m
+Author: Vojtech Novak <vonovak@gmail.com>
+Date:   Fri Apr 9 12:22:38 2021 +0200
+
+    chore: change MenuItem to function component (#2589)
+
+[33mcommit d8e154614736ca40132e0cefde9094ce43fe8ee1[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Apr 9 12:19:52 2021 +0200
+
+    feat: pass pointerEvents to the DataTableRow View container (#2637)
+
+[33mcommit 94dbdee5db9268b68b3207c990a03b07d4b5e07e[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Apr 9 12:17:48 2021 +0200
+
+    fix: add prop borderless to ListAccordion component (#2647)
+
+[33mcommit 751651781dae74cbd84c9b175624d34ce67e0600[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Apr 9 12:11:50 2021 +0200
+
+    fix: remove additional outline from web inputs (#2654)
+
+[33mcommit 3593cd53765506caa42fcf7c7b2b6d2f9f23aa70[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Apr 9 12:07:01 2021 +0200
+
+    fix: correct toggle button type (#2651)
+
+[33mcommit cdfb9aba789ecd59ca67dcc90e440061c0880a65[m
+Author: Jonathan S <tgtgam3r@gmail.com>
+Date:   Mon Apr 5 18:25:48 2021 +0100
+
+    fix: Pagination Datatable example (#2525)
+
+[33mcommit 431febf28d0d02faafacceb1b806d56509564ce1[m
+Author: Ana Beatriz A. de M. da Silva <anabeatriz.augusto06@yahoo.com>
+Date:   Fri Apr 2 16:48:20 2021 -0300
+
+    docs: update react-navigation-material-bottom-tabs package's link (#2570)
+
+[33mcommit c646372b8d0f07cca5a9013202d8db68ff40d6ac[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Fri Apr 2 16:46:57 2021 -0300
+
+    chore: bump elliptic from 6.5.3 to 6.5.4 in /docs (#2594)
+
+[33mcommit bf783aad4c50cd8b57ad0419d4715c63e9d8df8d[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Fri Apr 2 16:39:39 2021 -0300
+
+    chore: bump elliptic from 6.5.3 to 6.5.4 in /example (#2595)
+
+[33mcommit 6c310f40d73698c900d512161354733ccbb47db4[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Fri Apr 2 13:04:05 2021 -0300
+
+    chore: bump y18n from 3.2.1 to 3.2.2 (#2638)
+
+[33mcommit 4aa04cf4c8110f92f020b16ef4f203463bda4a97[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Fri Apr 2 12:51:09 2021 -0300
+
+    chore: bump y18n from 4.0.0 to 4.0.1 in /docs (#2636)
+
+[33mcommit 7c6508f71f59a2cfcf9b820da57e51a344e9a683[m
+Author: pedrorosarioo <jrosario.pedro@gmail.com>
+Date:   Fri Apr 2 12:42:01 2021 -0300
+
+    docs: improve theming section (#2612)
+
+[33mcommit 111e3e0c0f3c6051a214265f609043ae94569c99[m
+Author: Takahiro Sugiura <tasugi@users.noreply.github.com>
+Date:   Sat Apr 3 00:26:54 2021 +0900
+
+    fix(badge): define prop visible as optional (#2622)
+    
+    Default value `true` is given for `visible` prop of Badge. But `visible` is defined as mandatory. This prop can be optional.
+
+[33mcommit 06c0595e5f74a33302f4b75f575f33677729274e[m
+Author: Hiroaki KARASAWA <1257695+karszawa@users.noreply.github.com>
+Date:   Sat Apr 3 00:16:57 2021 +0900
+
+    fix: do not render empty string as ListSection title (#2640)
+
+[33mcommit aa835497e1f8e362cec0ce470cd3b0136c581894[m
+Author: Corbin Crutchley <crutchcorn@gmail.com>
+Date:   Wed Mar 24 18:48:02 2021 -0700
+
+    fix(BottomNavigation): selected state now reads properly on voiceover(iOS) (#2610)
+
+[33mcommit 975cfa3be4956b629aa8255e226ff9ca068448eb[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Feb 21 23:34:30 2021 +0100
+
+    chore: release 4.7.2
+
+[33mcommit a37ce1b096824a2c61ebd79e045da3e3fcd7bb06[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Sun Feb 21 23:33:12 2021 +0100
+
+    fix: upgrade ts types to latest version (#2522)
+    
+    Co-authored-by: Satyajit Sahoo <satyajit.happy@gmail.com>
+
+[33mcommit 2333abcc5c06e41bfebaa58ee4369433b2bbc3e4[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Feb 21 23:32:26 2021 +0100
+
+    chore: fix warnings from module-resolver
+
+[33mcommit f6ff96f477888a53e2f4123ff1896d04ddf7c821[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Feb 21 23:18:22 2021 +0100
+
+    chore: make statusbar light in example app
+
+[33mcommit e5c0c777f90b5b3ad06a58d03b3de60ffb200cbd[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Fri Jan 22 13:56:18 2021 +0100
+
+    chore: release 4.7.1
+
+[33mcommit bc3530a8553f1a7bd5fc39497cfbd9b39c05cf1f[m
+Author: Rafał Zakrzewski <zakrzewski.rafal@gmail.com>
+Date:   Fri Jan 22 13:53:58 2021 +0100
+
+    fix: set default cursor for TouchableRipple to 'pointer' on web (#2515)
+
+[33mcommit bb14b9bfedfd51b0bd8a541f939cec65e3b155fa[m
+Author: imgbot[bot] <31301654+imgbot[bot]@users.noreply.github.com>
+Date:   Fri Jan 22 10:36:34 2021 +0100
+
+    docs: Optimize images (#2516)
+
+[33mcommit ff96a3b28c0a6232ff740f606d1aec3ae7347df0[m
+Author: Artur Bień <artur.bien@gmail.com>
+Date:   Fri Jan 22 10:36:02 2021 +0100
+
+    docs: fix flat Chip example (#2517)
+
+[33mcommit ee2a0bebe80e41c16d321e0740e52d8bd8081ed6[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Wed Jan 20 14:19:56 2021 +0100
+
+    docs: add app, play store links to docs home page
+
+[33mcommit 01d05bda015a375548921026b14657f319a83231[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Wed Jan 20 14:07:47 2021 +0100
+
+    docs: add paper example app to showcase
+
+[33mcommit acfdc4483b11e06c9eb3694dc9e1284bdc067222[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Mon Jan 18 10:27:38 2021 +0100
+
+    chore: bump ios native version
+
+[33mcommit a586fa4bbfc1519907eb79459742adfb483999ad[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Mon Jan 18 10:20:05 2021 +0100
+
+    chore: prepare for ios native release and fix issue with broken checkbox and radio litem layout
+
+[33mcommit bcc50ce5cfb0d256db225bb051f845e1108ea51f[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Jan 16 19:23:16 2021 +0100
+
+    docs: update bottom navigation docs
+
+[33mcommit d34f030871ff2a2688b9b54e06e5b3ed85b56a7a[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Fri Jan 15 12:10:29 2021 +0100
+
+    chore: release 4.7.0
+
+[33mcommit 3a70cc5464edeb34c2bbe18cfa8426cc735729df[m
+Author: maltoze <maltoze@qq.com>
+Date:   Fri Jan 15 18:28:16 2021 +0800
+
+    fix: remove cycles from the codebase (#2508)
+
+[33mcommit b92706eed30719d5dd8be4bd8648cca28926713c[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Fri Jan 15 08:48:53 2021 +0100
+
+    chore: bump ios build number
+
+[33mcommit 39df3bc8c694cbf70b2c0b1fb88a9d8996c5c491[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Thu Jan 14 11:52:11 2021 +0100
+
+    chore: add privacy policy for ios native release
+
+[33mcommit d4e73dfb1ec2a829b29a8dd2e7430ae7b3e3e7dd[m
+Author: imgbot[bot] <31301654+imgbot[bot]@users.noreply.github.com>
+Date:   Thu Jan 14 09:52:54 2021 +0100
+
+    docs: optimize images (#2503)
+
+[33mcommit bf1dd243cd532a873e483e2ee5ed73a1a76311d9[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Thu Jan 14 05:24:54 2021 -0300
+
+    docs: fix links showing underline (#2504)
+
+[33mcommit f3fd9c158438200f696017a50922291e4ce71438[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Wed Jan 13 21:12:56 2021 +0100
+
+    chore: improve android example app icon
+
+[33mcommit 97e31592f4c2630e7e47544f0bbcd1fb17ed45ff[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Wed Jan 13 14:17:00 2021 +0100
+
+    chore: improve example app icon and splash screen (#2502)
+
+[33mcommit b171f89b82b1599357017b1ea0341274013de5e7[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Wed Jan 13 12:30:10 2021 +0100
+
+    chore: bump version code of the example app
+
+[33mcommit 17495a9516224e5c76edc083ad5580fc35327648[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Wed Jan 13 12:04:14 2021 +0100
+
+    feat: add splash screen and use non transparent icon (#2500)
+
+[33mcommit f041694517ae0eefbd04e7d446021552b541b573[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Wed Jan 13 10:52:03 2021 +0100
+
+    fix: use correct credentials for publishing example app (#2499)
+
+[33mcommit 6cfc28df39c5daaab0086580490d262b2a442754[m
+Author: imgbot[bot] <31301654+imgbot[bot]@users.noreply.github.com>
+Date:   Wed Jan 13 10:20:36 2021 +0100
+
+    docs: Optimize images (#2493)
+
+[33mcommit d2f65f32c84e2a5b783ab4ee0c4a37606b50d4d3[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Mon Jan 11 15:47:16 2021 +0100
+
+    chore: set permissions only for android
+
+[33mcommit d6bf4d012cda9cda4580cf8801e01036dfdf0a1f[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Mon Jan 11 15:42:39 2021 +0100
+
+    chore: fix owner and set required permissions
+
+[33mcommit cdb8603018e2c69e0aad69795568e0cdfa2fd182[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Mon Jan 11 15:21:24 2021 +0100
+
+    chore: prepare for release
+
+[33mcommit 708d3494f3367ecb856ab5409f5e80dc2d359eb5[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Fri Jan 8 14:01:24 2021 +0100
+
+    chore: release 4.6.0
+
+[33mcommit 6fe48765d448f7d99db2b9a0af597a3919fa9cdc[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Jan 8 11:23:32 2021 +0100
+
+    chore: move to react-native-builder-bob
+
+[33mcommit 1a339aabe2bb01aa339dba12b7c13b30750011a6[m
+Author: Richard Lindhout <richardlindhout96@gmail.com>
+Date:   Fri Jan 8 09:11:26 2021 +0100
+
+    docs: add react-native-paper-tabs + react-native-bottom-sheet to recommended libraries (#2467)
+
+[33mcommit a22ed8d5b22ca9c0e992d1d712a4c83d3a3509b9[m
+Author: Alejandro <alejandro.carrasco.e90@gmail.com>
+Date:   Fri Jan 8 05:08:14 2021 -0300
+
+    feat: add style prop to Modal (#2474)
+
+[33mcommit 2d1c56cc5523c0a33f6dfd6635f53b20151c8cab[m
+Merge: 8c9ef09c 77c72686
+Author: Trancever <dawidu@onet.pl>
+Date:   Tue Jan 5 16:34:13 2021 +0100
+
+    feat: add `small` prop to FAB.Group component
+
+[33mcommit 77c7268654cb14d86fb6a7163c705d6d831e69a4[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Tue Jan 5 16:33:09 2021 +0100
+
+    fix: fix label alignment and typo in prop description
+
+[33mcommit e21ee4d771437062a55f131e63d792b8cd3c6816[m
+Merge: a3b51070 8c9ef09c
+Author: Rafał Zakrzewski <zakrzewski.rafal@gmail.com>
+Date:   Tue Jan 5 15:59:41 2021 +0100
+
+    Merge remote-tracking branch 'upstream/main' into feat/FABGroup-small-prop
+    
+    # Conflicts:
+    #       src/components/FAB/FABGroup.tsx
+
+[33mcommit 8c9ef09c2bccac21ceba35200e90254db2f6166c[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Tue Jan 5 15:40:57 2021 +0100
+
+    refactor: rename default branch from master to main
+
+[33mcommit ff034b2e46f4da4c30072747b69e70fda68fdb61[m
+Merge: cea35301 3c041626
+Author: Trancever <dawidu@onet.pl>
+Date:   Tue Jan 5 14:13:45 2021 +0100
+
+    fix: make icon non-selectable on web
+
+[33mcommit 3c04162664b130c9486cba54afc16b6e57c779d1[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Tue Jan 5 14:02:31 2021 +0100
+
+    test: update snapshot tests
+
+[33mcommit 77c8ecd5f72ca4f8140023bf5dfca705586de22f[m
+Author: Richard Lindhout <richardlindhout96@gmail.com>
+Date:   Tue Dec 29 13:54:01 2020 +0100
+
+    fix: icon non-selectable on the web like on other platforms
+    
+    Small part of https://github.com/callstack/react-native-paper/pull/2283 did not get merged.
+
+[33mcommit cea3530107aef9c12460fdf40c1fb19073a5cfd3[m
+Merge: f60dd8d2 b3a7918a
+Author: Trancever <dawidu@onet.pl>
+Date:   Tue Jan 5 13:49:24 2021 +0100
+
+    Merge branch 'Svarto-patch-1' into main
+
+[33mcommit b3a7918abee55d272115878d6ffe81c74146b093[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Tue Jan 5 13:47:43 2021 +0100
+
+    fix: keep backwards compat and extract to variable
+
+[33mcommit f7a144cfa3ef87551605d9c9026076625c1d4650[m
+Merge: f60dd8d2 65792a38
+Author: Trancever <dawidu@onet.pl>
+Date:   Tue Jan 5 13:43:51 2021 +0100
+
+    Merge branch 'patch-1' of https://github.com/Svarto/react-native-paper into Svarto-patch-1
+
+[33mcommit f60dd8d2c82afe48406beccf5fb90e64f8ab56cb[m
+Author: Rafał Zakrzewski <zakrzewski.rafal@gmail.com>
+Date:   Tue Jan 5 13:29:17 2021 +0100
+
+    fix: pass accessible prop in Button to underlying Touchable component (#2448)
+
+[33mcommit d6b30fb7972bbb2567e8f510f57ac97cca07d925[m
+Author: Jascha <jaschakanngiesser@gmail.com>
+Date:   Tue Jan 5 10:19:06 2021 +0100
+
+    feat: add onLongPress prop to List.Accordion (#2479)
+
+[33mcommit d9790b2e5614a887130785de30918fc494ae4c7e[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Tue Dec 22 18:57:01 2020 -0300
+
+    fix: do not run animation on Badge initial render (#2459)
+
+[33mcommit e17e866768a85e00ff6f77b07726f4bc249281a9[m
+Author: haxonadora <42680223+haxonadora@users.noreply.github.com>
+Date:   Fri Dec 18 15:47:50 2020 +0100
+
+    chore: upgrade expo in example app (#2443)
+
+[33mcommit 1cde7f53193388fc36943aa631da9ccd7d949480[m
+Author: Handi Priyono <35618196+handipriyono@users.noreply.github.com>
+Date:   Fri Dec 18 16:51:50 2020 +0700
+
+    fix: broken link react-native URL docs with anchor (#2446)
+
+[33mcommit f9aee910041885b86221765e1630efa8bd96c12e[m
+Author: Manu <356978+kamui545@users.noreply.github.com>
+Date:   Thu Dec 17 08:59:04 2020 +0100
+
+    fix: use text instead of primary color for Checkbox.Item label (#2429)
+
+[33mcommit 82719deb6d7dbb4c820c7555c8b60003b78d41e1[m
+Author: Jacqui Shadforth <16424236+shadforth@users.noreply.github.com>
+Date:   Wed Dec 16 20:14:19 2020 +1100
+
+    docs: fix font import instructions (#2437)
+
+[33mcommit 3b555e6e60f7922bd3f13de8be707f586ccd2ba5[m
+Author: Tyler Citrin <citrin.tyler@gmail.com>
+Date:   Wed Dec 16 04:12:49 2020 -0500
+
+    docs: add Rozy app to the showcase section (#2432)
+
+[33mcommit 57d6b99f36bb90e7c0b52cde0c4de4aceaa535b8[m
+Author: haxonadora <42680223+haxonadora@users.noreply.github.com>
+Date:   Wed Dec 16 10:11:07 2020 +0100
+
+    fix: fix sorting arrow direction in data table (#2435)
+
+[33mcommit 6ffb9aeab66611ac575995d6c7009b877b106b9f[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Dec 15 17:58:23 2020 +0100
+
+    chore: fix bootstrap script
+
+[33mcommit 381331600eb7920e4ec6ce7a0aea483ad6b196e0[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Dec 15 16:47:04 2020 +0100
+
+    chore: add a custom yarn script to make setup easier (#2434)
+
+[33mcommit 6824188dcad003e96958ae56c3daf2e0346b7a82[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Dec 14 15:37:38 2020 +0100
+
+    refactor: refactor bottom navigation
+
+[33mcommit 991fe326fd55274fcd7983cde1bd1d55f93027f3[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Mon Dec 14 16:22:30 2020 +0300
+
+    refactor: migrate bottom navigation to function component (#2206)
+    
+    Co-authored-by: Satyajit Sahoo <satyajit.happy@gmail.com>
+
+[33mcommit 8ba087b1d78d6c8fa0909c1ea1c7af19d9827d4d[m
+Author: imgbot[bot] <31301654+imgbot[bot]@users.noreply.github.com>
+Date:   Mon Dec 14 13:31:51 2020 +0100
+
+    docs:  Optimize images (#2426)
+
+[33mcommit 560b823c693cfa4d01ab0c346868ea423700027c[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Mon Dec 14 12:48:29 2020 +0100
+
+    chore: release 4.5.0
+
+[33mcommit 0bc4bf7a8d6147225ea09f5d23f8edc173f1583f[m
+Author: haxonadora <42680223+haxonadora@users.noreply.github.com>
+Date:   Mon Dec 14 12:39:42 2020 +0100
+
+    feat: add integrate react navigation and AppBar guide (#2248)
+
+[33mcommit 7d408ab9e0900bf4912f38fbcd952b24d06f2399[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Mon Dec 14 13:21:47 2020 +0300
+
+    fix: fix next page button in datatable pagination (#2412)
+
+[33mcommit 08a7c8152ada1820fa64a90fafa1dd8f696f0282[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Mon Dec 14 10:34:03 2020 +0100
+
+    chore: bump ini from 1.3.5 to 1.3.8 (#2424)
+
+[33mcommit ae8384870ed30cd12564685d18d6851a1f37d3e6[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Mon Dec 14 12:30:35 2020 +0300
+
+    fix: fix padding in flat text input on web (#2410)
+
+[33mcommit 6891d421ec7039859ae3a44adca451f1b53b6228[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Mon Dec 14 10:14:49 2020 +0100
+
+    chore: bump ini from 1.3.5 to 1.3.8 in /example (#2425)
+
+[33mcommit 5dac328fdad8f6332a9e81669eda55aba5863879[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Mon Dec 14 10:14:17 2020 +0100
+
+    chore: bump ini from 1.3.5 to 1.3.8 in /docs (#2423)
+
+[33mcommit d66011387db7f8101fcfced267c4d2e803ab9d6f[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Dec 14 10:13:34 2020 +0100
+
+    fix: replace safe-area-view with iphonex-helper (#2422)
+
+[33mcommit b960ae60047706df63674fe4d670a58241205fae[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Dec 14 10:09:59 2020 +0100
+
+    chore: exclude example when building for publishing (#2421)
+
+[33mcommit 3c8ac3f9a418ccc1c420c2c8f7f5cc42952f2dbb[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Dec 14 10:09:10 2020 +0100
+
+    fix: drop usage of __expo (#2420)
+
+[33mcommit c17e157e9db939de906e72b12775149031f8967e[m
+Author: ZGennadiy <gennadiy.zinchenko@gmail.com>
+Date:   Thu Dec 10 15:18:17 2020 +0300
+
+    docs: fix link to ToggleButton.Row (#2404)
+
+[33mcommit 65792a38044db089bbf8d84ebe6e7ab844ed6d66[m
+Author: Svarto <svarto@protonmail.com>
+Date:   Wed Dec 9 13:46:55 2020 +0000
+
+    Update AppbarBackIcon.tsx
+    
+    The AppbarBackIcon is now editable and follows the size set in the component. This fixes the icon being a fixed size, with the "size" prop in the Appbar.BackAction only changing the enveloping view.
+
+[33mcommit cbaf5775bde8b6080ae85ef79769f21745cf54ec[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Tue Dec 8 13:52:41 2020 +0300
+
+    fix: remove cycles (#2378)
+
+[33mcommit 4b1c150d26f1756b5e1d856322faec5d3da5885e[m
+Author: David Angulo <hello@davidangulo.xyz>
+Date:   Fri Oct 23 22:19:49 2020 +0800
+
+    fix: handle paddingHorizontal in TextInput with icon and affix
+
+[33mcommit 0bd2cab042df779a41b31e20eb839d3d9d803177[m
+Author: Richard Lindhout <richardlindhout96@gmail.com>
+Date:   Sat Oct 10 20:41:24 2020 +0200
+
+    fix: make text non selectable if inside a button
+
+[33mcommit 8e229932a74d89c4f525721ae7720e182b2f2432[m
+Author: Jan Jaworski <jaworek3211@gmail.com>
+Date:   Tue Dec 8 09:54:14 2020 +0100
+
+    docs: fix List.Icon example to work on Snack (#2395)
+
+[33mcommit afa549f3dd0f601980b1ab56ef596442969f057b[m
+Author: Robert Soriano <sorianorobertc@gmail.com>
+Date:   Tue Dec 8 16:36:55 2020 +0800
+
+    docs: fix incorrect function name in theming with React Navigation guide (#2399)
+
+[33mcommit c0325d1a174324b0bcc9852563abfddc7e498b7a[m
+Author: Jan Jaworski <jaworek3211@gmail.com>
+Date:   Tue Dec 8 09:35:16 2020 +0100
+
+    docs: add info about required icon packs (#2400)
+
+[33mcommit a973af024fd7cbf0ccf9d43f86de1cdc78ab0bdd[m
+Author: Richard Lindhout <richardlindhout96@gmail.com>
+Date:   Tue Dec 1 13:51:55 2020 +0100
+
+    fix: add support for textAlign: center on TextInput (#2369)
+
+[33mcommit eda72db9f54335c8aa70bef1739739804a5c1972[m
+Author: Matthew Thompson <mat@matthewjthompson.co.uk>
+Date:   Mon Nov 30 09:07:12 2020 +0000
+
+    docs: explain how to change theme based on device settings (#2384)
+
+[33mcommit 6116bfe4b4cbfbc16fa0c5ff188d2bc38ce57884[m
+Author: Juanjosé Tenorio <juanjose.tenorio@pucp.pe>
+Date:   Mon Nov 30 18:01:53 2020 +0900
+
+    docs: add documentation for multiline support in DataTable.Cell (#2385)
+
+[33mcommit 3ab3200f75e6f84f127c3b35adef8fdff43e884c[m
+Author: Håkan Sjölin <30954044+haakandev@users.noreply.github.com>
+Date:   Thu Nov 26 19:12:16 2020 +1100
+
+    feat: support right side icon in Button (#2376)
+
+[33mcommit ed60faedeb7a1a7e5732b29a77e4233deb619d43[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Wed Nov 25 11:44:23 2020 +0300
+
+    feat: add mode prop to radio button item (#2379)
+
+[33mcommit 0ec3587ca4beadcd7fc180d9dc36cdb0621555a0[m
+Author: Tegan Rauh <3896310+tegandbiscuits@users.noreply.github.com>
+Date:   Mon Nov 23 06:17:37 2020 -0600
+
+    feat: add mode prop to Checkbox.Item component (#2375)
+
+[33mcommit 29354ee0cf37f4db7a89a9da658096886d71de73[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Mon Nov 23 10:14:07 2020 +0100
+
+    chore: release 4.4.1
+
+[33mcommit 7e52b4f822abc76121ade569fef2167905cd5240[m
+Author: Richard Lindhout <richardlindhout96@gmail.com>
+Date:   Mon Nov 23 10:02:03 2020 +0100
+
+    fix: support 0 as value in RadioButton.Group (#2368)
+
+[33mcommit e606ac0d566d15c8fafff08d4d5a8d071c3e1afc[m
+Author: Håkan Sjölin <30954044+haakandev@users.noreply.github.com>
+Date:   Mon Nov 23 19:49:59 2020 +1100
+
+    fix: allow bluring of disabled TextInput (#2344)
+
+[33mcommit eb67ad471bad5a4b3cdc77d3d34e44df51839df1[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Mon Nov 23 05:47:23 2020 -0300
+
+    fix: keep text input placeholder when error is true (#2213)
+
+[33mcommit 61fd1a984edf6f0293fd391dc2264caadf83f281[m
+Author: gregfenton <greg.fenton@gmail.com>
+Date:   Mon Nov 23 03:26:23 2020 -0500
+
+    docs: match example code and screenshot for divider component docs (#2372)
+
+[33mcommit 7b88eaa148c6a1f24f781f754c0b0728d530fb10[m
+Author: Jayesh Tiwari <JayeshTiwari03@users.noreply.github.com>
+Date:   Mon Nov 23 13:53:36 2020 +0530
+
+    docs: add installation instructions using npm (#2365)
+
+[33mcommit eb421bc16747e89e9bc0a96d55deefab6f42680f[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Tue Nov 17 11:19:07 2020 +0100
+
+    fix: set line height to Icon (#2350)
+
+[33mcommit 0fbf3b3d260e6e736e5ad5bad008881755a3d515[m
+Author: Richard Lindhout <richardlindhout96@gmail.com>
+Date:   Tue Nov 17 11:18:09 2020 +0100
+
+    docs: move recommended libraries links to separate lines (#2358)
+    
+    There should be an enter https://callstack.github.io/react-native-paper/recommended-libraries.html
+
+[33mcommit f517f0186ee53d26ce2c864d73ad121c155938e5[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Fri Nov 13 14:54:30 2020 +0100
+
+    chore: release 4.4.0
+
+[33mcommit fe94564e5db364a1574b937dd04b328ab07ccdf8[m
+Author: Richard Lindhout <richardlindhout96@gmail.com>
+Date:   Fri Nov 13 14:38:07 2020 +0100
+
+    docs: update recommended libraries for date and time picker (#2356)
+
+[33mcommit 4481d2eb9c6b4e2905facf1734340527c819b029[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Fri Nov 13 14:33:32 2020 +0100
+
+    fix: avoid initial animation in (Checkbox|RadioButton).Android (#2349)
+
+[33mcommit 326c1a06501e339d1a7c250b03c0a54537f2bf03[m
+Author: gregfenton <greg.fenton@gmail.com>
+Date:   Tue Nov 10 09:46:27 2020 -0500
+
+    docs: improve RadioButton.Group example (#2337)
+
+[33mcommit 2267aba6a351e9222aee09e86d989170b169f253[m
+Author: ja-rojas03 <37358610+ja-rojas03@users.noreply.github.com>
+Date:   Tue Nov 10 09:46:30 2020 -0400
+
+    feat: Add OnLongPress prop to Button component (#2339)
+
+[33mcommit ee9de5ed80c1e6a4a37f31f378e99ac1d4e0b8e0[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Tue Nov 10 16:39:06 2020 +0300
+
+    refactor: update FAB class components to functional (#2187)
+
+[33mcommit cd4d20e453d2848c3d8b33e7fc3e4b4f5aefcaab[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Fri Nov 6 09:23:18 2020 +0100
+
+    chore: release 4.3.1
+
+[33mcommit 387185e2e46fcc8424d6fcc61d64dc54babade5d[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Tue Nov 3 18:34:57 2020 +0300
+
+    refactor: update typography class components to functional (#2227)
+
+[33mcommit c8071bee1a1052440bb4c8c9307146cb2c362c32[m
+Author: jasperro <42558625+jasperro@users.noreply.github.com>
+Date:   Tue Nov 3 16:17:55 2020 +0100
+
+    fix: fix BottomNavigation bug introduced in https://github.com/callstack/react-native-paper/pull/2280
+
+[33mcommit 6cf6ebd2be20dc1f579ef5d4ef8c0ac34daa9de7[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Fri Oct 30 15:19:59 2020 +0100
+
+    chore: release 4.3.0
+
+[33mcommit e182ab75ca871913542f57ce7eab0c85544f28ed[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Fri Oct 30 15:08:46 2020 +0100
+
+    fix: fix issue with broken animation in CrossFadeIcon (#2326)
+
+[33mcommit 72ae715bf336c20398977b5a27fa57ecfd0d9099[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Fri Oct 30 10:18:12 2020 -0300
+
+    feat: add accessibility state expanded to fab group (#2324)
+
+[33mcommit 1cc5fe8f7c7bec9c70541dfe881b345ee08b705c[m
+Author: Olimpia <olimpia.zurek@gmail.com>
+Date:   Fri Oct 30 13:18:27 2020 +0100
+
+    fix: fix textInput icon space in outlined mode (#2267)
+
+[33mcommit 151465f8f545cb197292840b1fa7e97466430a15[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Fri Oct 30 13:02:58 2020 +0300
+
+    refactor: update search bar class component to functional (#2216)
+
+[33mcommit 4daf889a1bf237549d5a77eb264f5d82da572786[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Wed Oct 28 09:39:34 2020 -0300
+
+    docs: render TextInput as a section (#2175)
+    
+    Co-authored-by: Michal <mimuzyk@gmail.com>
+
+[33mcommit 78573b0f48bfb972f57ccebd5d3275a9825a8126[m
+Author: MrMuzyk <mimuzyk@gmail.com>
+Date:   Wed Oct 28 11:14:12 2020 +0100
+
+    fix: fix appbar regression made in https://github.com/callstack/react-native-paper/pull/2179
+
+[33mcommit 0978e4b60c76d9c7e8fb0bbdb964054cb6ecd2ae[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Tue Oct 27 16:24:25 2020 +0300
+
+    refactor: update progress bar class component to functional (#2219)
+
+[33mcommit 5532d312fbc909f4df9858384ccf5168a11b28e5[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Tue Oct 27 14:11:02 2020 +0100
+
+    chore: bump http-proxy from 1.18.0 to 1.18.1 in /example (#2214)
+
+[33mcommit 7666addab78ee6ef3c07d73104c26f5064a78538[m
+Author: gregfenton <greg.fenton@gmail.com>
+Date:   Tue Oct 27 09:04:55 2020 -0400
+
+    docs: fix example usage of Modal component (#2192)
+
+[33mcommit cb5b9b43d4a8c77e9f04c1d94c0c1814bbac7d8c[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Tue Oct 27 15:17:48 2020 +0300
+
+    refactor: update appBar class components to functional (#2179)
+
+[33mcommit f02466a826448e7b6f6419ab1e004738b28fffdf[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Tue Oct 27 15:02:15 2020 +0300
+
+    refactor: update avatar class components to functional (#2180)
+
+[33mcommit fa52e22fbb84f9ff9f9e820ce6534244604700c1[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Tue Oct 27 14:58:32 2020 +0300
+
+    refactor: update dataTable class components to functional with hooks (#2182)
+
+[33mcommit 71f6d44abd8628589563f42e07d2ea097d64408e[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Tue Oct 27 14:47:29 2020 +0300
+
+    refactor: update cross fade icon class component to functional (#2222)
+
+[33mcommit caa0811c2c4976ba90cce1892409a3ed7569ec88[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Tue Oct 27 13:14:05 2020 +0300
+
+    refactor: update List class components to functional (#2188)
+
+[33mcommit 5486169ce381a8ad6733deeaedadfb162d57e837[m
+Author: Leonardo Nogueira <34237655+nogueirahy@users.noreply.github.com>
+Date:   Tue Oct 27 06:57:41 2020 -0300
+
+    test: add test to FAB component (#2320)
+
+[33mcommit 86d897699c5a99bb53643c738b688d59265c2137[m
+Author: jasperro <42558625+jasperro@users.noreply.github.com>
+Date:   Tue Oct 27 10:41:43 2020 +0100
+
+    fix: grey screen on first open of tab on react-native-web (#2280)
+
+[33mcommit e17341be158aaf4b78ce702ed4f9953783f24dc8[m
+Author: jasperro <42558625+jasperro@users.noreply.github.com>
+Date:   Mon Oct 26 12:43:38 2020 +0100
+
+    fix: fix Switch component colors on web (#2269)
+
+[33mcommit b5ad9a3c65b96b81a7040809fd76e76c5f39411d[m
+Author: David Angulo <hello@davidangulo.xyz>
+Date:   Mon Oct 26 06:23:35 2020 +0800
+
+    feat: add textStyle prop for Affix (#2313)
+
+[33mcommit 3df3541f7a32a5d467ee1b672e7bc1178901ee98[m
+Author: MrMuzyk <mimuzyk@gmail.com>
+Date:   Sun Oct 25 23:03:38 2020 +0100
+
+    test: globally mocked timers and native animation helper (#2309)
+
+[33mcommit 9e717556f5533ee2d2e38391f9743d03c9fb2038[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Tue Oct 20 10:16:49 2020 -0300
+
+    test: update missing snapshot from #2263 (#2300)
+
+[33mcommit 14d47ee29d404a9fae43f7fed27552bbe41d8a7c[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Tue Oct 20 09:29:30 2020 -0300
+
+    feat: improve accessibility updating accessibilityRole and accessibilityState (#2263)
+
+[33mcommit ba599f2d9e21223f172a5c92a613e2f76500c65f[m
+Author: Håkan Sjölin <30954044+haakandev@users.noreply.github.com>
+Date:   Tue Oct 20 22:44:38 2020 +1100
+
+    feat: add uppercase prop to FAB (#2296)
+
+[33mcommit 7e63de4f820e52fb221dc9d2897d38fbc3aaa1f4[m
+Author: Olimpia <olimpia.zurek@gmail.com>
+Date:   Tue Oct 20 08:32:42 2020 +0200
+
+    fix: do not set Appearance module when theme prop is passed (#2279)
+
+[33mcommit a071901aeeef187f8f6f765eea2b126fc04a0216[m
+Author: Rafał Zakrzewski <zakrzewski.rafal@gmail.com>
+Date:   Fri Oct 9 11:15:36 2020 +0200
+
+    feat: add contentStyle prop to Menu.Item component (#2278)
+
+[33mcommit e1069f701260a479b4293691badd193d07d8282d[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Fri Oct 9 10:53:26 2020 +0300
+
+    refactor: update Switch class component to functional (#2189)
+
+[33mcommit 90899f5d557db58ae0bd4cb019813e2c6af640eb[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Oct 9 09:23:16 2020 +0200
+
+    fix: use route keys for lazy loading tabs instead of index (#2277)
+
+[33mcommit abc6e1d3ea8c88d2a6cd5334d3b46d5256a804f2[m
+Author: gregfenton <greg.fenton@gmail.com>
+Date:   Thu Oct 8 05:17:54 2020 -0400
+
+    docs: add link to Text.ellipsizeMode prop definition (#2259)
+
+[33mcommit 231c27891e388d2c00dd040d8df54497d8a5cad2[m
+Author: Olimpia <olimpia.zurek@gmail.com>
+Date:   Thu Oct 8 11:14:56 2020 +0200
+
+    fix: pass theme prop to underlying Checkbox in Checkbox.Item (#2275)
+
+[33mcommit 4733c044ccb3bf182463e67e427682b372d36648[m
+Author: Chirag Shah <chirag@bigbinary.com>
+Date:   Thu Oct 8 13:42:02 2020 +0530
+
+    docs: fix typos in bottom navigation (#2273)
+
+[33mcommit 4b26429c49053eaa4c3e0fae208639e01093fa87[m
+Author: Olimpia <olimpia.zurek@gmail.com>
+Date:   Tue Oct 6 13:53:32 2020 +0200
+
+    feat: change type of the icon prop in TextInput.Icon to allow custom Icons (#2255)
+
+[33mcommit b0d8507e3f2ab962d69e7e76fe95ae8fafadadcc[m
+Author: Olimpia <olimpia.zurek@gmail.com>
+Date:   Mon Oct 5 12:28:23 2020 +0200
+
+    feat: add testID to RadioButton components (#2256)
+
+[33mcommit efe17beafcc3bd83f4d84971499bd85647df9c84[m
+Author: Olimpia <olimpia.zurek@gmail.com>
+Date:   Wed Sep 23 11:31:46 2020 +0200
+
+    fix: textInput label jumps to the center (#2250)
+
+[33mcommit 28d120a658378d6934df06bd6ebf82e558e7086e[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Mon Sep 21 10:59:01 2020 +0200
+
+    chore: release 4.2.0
+
+[33mcommit bd91fec13a4621ddb24856fac5b262de8bb5eef7[m
+Author: imgbot[bot] <31301654+imgbot[bot]@users.noreply.github.com>
+Date:   Mon Sep 21 10:08:29 2020 +0200
+
+    docs: optimize images (#2238)
+
+[33mcommit 22868150a54cd89c5e158c043230fbf169fa8990[m
+Author: Mateusz Kosoń <41837132+matkoson@users.noreply.github.com>
+Date:   Fri Sep 18 11:01:04 2020 +0200
+
+    docs: add theming with react navigation guide (#2209)
+
+[33mcommit 689656443e661287b7766d4a2fc4e281f8d59ba8[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Fri Sep 18 11:26:36 2020 +0300
+
+    fix: eslint hooks warnings (#2237)
+
+[33mcommit 6faf6adba15d7da5d85b9bacbc1568a10feb5eb8[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Fri Sep 18 10:55:06 2020 +0300
+
+    refactor: update touchable ripple class components to functional (#2202)
+
+[33mcommit 2e62169febfcd0f5cf2757ab1bb0f9cbbe8a324e[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Fri Sep 18 10:40:57 2020 +0300
+
+    refactor: update chip class component to functional (#2208)
+
+[33mcommit c311efcdb1510852988dc8774fda568a964af831[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Fri Sep 18 10:37:08 2020 +0300
+
+    refactor: update button class component to functional (#2207)
+
+[33mcommit 9a09b877d6961227716f314d20d7d72331b75332[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Thu Sep 17 11:29:56 2020 +0300
+
+    refactor: update divider class component to functional (#2215)
+
+[33mcommit a3b5107062172576a5295569046dacc3a9c673dd[m
+Merge: 9eeea9d7 4734a929
+Author: Rafał Zakrzewski <zakrzewski.rafal@gmail.com>
+Date:   Thu Sep 17 09:54:05 2020 +0200
+
+    chore: resolve conflicts from master branch
+
+[33mcommit 4734a929b571ddae2d0ecf9ecd7189c467c90e5d[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Tue Sep 15 15:21:59 2020 +0300
+
+    refactor:  update card class components to functional with hooks (#2178)
+
+[33mcommit 231f31d82ebd9dda5960417caddd5c4c6d3cbd9a[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Tue Sep 15 15:07:57 2020 +0300
+
+    refactor: update snackbar class component to functional with hooks (#2177)
+
+[33mcommit c2039976dca59bb9d5b567abb280491d7da8d5ad[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Mon Sep 14 17:56:15 2020 +0300
+
+    refactor: update toggle button class components to functional (#2201)
+
+[33mcommit c06ed5d234dcefd124ee68ab86adae3de5db24f5[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Mon Sep 14 17:54:32 2020 +0300
+
+    refactor: update badge class component to functional (#2204)
+
+[33mcommit d4123e4b0daf090d20d407ffdfb12459bd94c1e4[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Mon Sep 14 17:50:03 2020 +0300
+
+    refactor: update banner class component to functional (#2205)
+
+[33mcommit 6a59bdff3563bbdd6d0193739070846be43d9f20[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Mon Sep 14 16:55:15 2020 +0300
+
+    refactor: update activity indicator class component to functional (#2203)
+
+[33mcommit 0b0a5101a27d944724bdad1ea8fcf6b2af9693af[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Mon Sep 14 16:50:25 2020 +0300
+
+    refactor: update helper text from class component to functional (#2199)
+
+[33mcommit 727b361c073e989ed23fd6b02155eb9fb1574016[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Mon Sep 14 16:46:43 2020 +0300
+
+    refactor: update radio button class components to functional (#2200)
+
+[33mcommit 9eeea9d7600761474f3cd5510eb100c67438603f[m
+Author: Rafał Zakrzewski <zakrzewski.rafal@gmail.com>
+Date:   Thu Sep 10 15:39:59 2020 +0200
+
+    docs: add FAB.Group  prop info to docs and examples code
+
+[33mcommit faa9dcb9bf579b5a637a3624245d7060fb106ca8[m
+Author: Rafał Zakrzewski <zakrzewski.rafal@gmail.com>
+Date:   Thu Sep 10 15:28:39 2020 +0200
+
+    style: add innerContainerStyle prop to Card component
+
+[33mcommit a7db7a0b67a9d447a5c38498ef441079c447cb0e[m
+Author: Rafał Zakrzewski <zakrzewski.rafal@gmail.com>
+Date:   Thu Sep 10 15:27:28 2020 +0200
+
+    feat: add  prop to FAB.Group component
+
+[33mcommit 0a8f1b08195509889d1355b504c6bbbb87a61bd6[m
+Author: Natalia Volkova <natalia.volkofff@gmail.com>
+Date:   Tue Sep 8 17:43:52 2020 +0300
+
+    fix: useref instead of state for animated value in checkbox (#2211)
+
+[33mcommit f1a417837bda0a23f9435ead0760d75bc70d2e65[m
+Author: Maria Marchenkova <35371977+marchenk0va@users.noreply.github.com>
+Date:   Tue Sep 8 13:24:01 2020 +0200
+
+    testID property for Checkbox (#2210)
+    
+    * feat: testID prop for Checkbox
+    
+    * feat: testID prop for CheckboxItem
+
+[33mcommit 9ac59d06142167241c2418d6e4c0d3eca2f7f9c0[m
+Author: Natalia <natalia.volkofff@gmail.com>
+Date:   Mon Sep 7 11:11:58 2020 +0300
+
+    refactor: update surface class component to functional (#2196)
+
+[33mcommit 6f9197e68110536b16a19977e461df4bc2b6fa77[m
+Author: Natalia <natalia.volkofff@gmail.com>
+Date:   Fri Sep 4 13:08:30 2020 +0300
+
+    refactor: update dialog class components to functional (#2183)
+
+[33mcommit bee6d1571c08dbbd91d1e1618ffad5e50d503dcf[m
+Author: Natalia <natalia.volkofff@gmail.com>
+Date:   Fri Sep 4 12:09:25 2020 +0300
+
+    refactor: update drawer class components to functional (#2184)
+
+[33mcommit a8fcf469949102068cb2b7199a3635c46e9d6101[m
+Author: Natalia <natalia.volkofff@gmail.com>
+Date:   Thu Sep 3 14:47:11 2020 +0300
+
+    refactor: update Checkbox from class components to functional (#2181)
+
+[33mcommit dea44e5faea1e657dfa3a18dea181c2fdf345e9f[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Tue Sep 1 15:16:39 2020 +0200
+
+    fix: fix chip ripple/highlight effect not covering whole component (#2174)
+
+[33mcommit 8368a0cf97c8122b5ef3ec0b504dce85668cc65d[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Tue Sep 1 10:26:46 2020 +0200
+
+    fix: update link to the snack example app (#2173)
+
+[33mcommit 91283ad51bbb5feacd36e379dffa58b4ad8363ef[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Tue Sep 1 10:19:02 2020 +0200
+
+    fix: use MaterialCommunityIcon for hard coded icons in Chip component (#2171)
+
+[33mcommit 23258e29f980bb466805e073918b38e65d65343c[m
+Author: Manu <356978+kamui545@users.noreply.github.com>
+Date:   Tue Sep 1 09:20:36 2020 +0200
+
+    feat: allow passing custom React Node as source to Avatar.Image (#2168)
+
+[33mcommit 6bf906bca5a446a71daed6003239902001e34ef8[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Tue Sep 1 03:29:15 2020 -0300
+
+    test: fix warnings in Provider.test.js (#2170)
+
+[33mcommit fe3b84bf22506fe20bd923c20289ef6eabe9832f[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Mon Aug 31 15:27:35 2020 +0200
+
+    chore: release 4.1.0
+
+[33mcommit 9bb65cc726f5301ae92269c2b2f644e5d0f84ba1[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Mon Aug 31 09:59:19 2020 -0300
+
+    feat: improve chip accessibility (#2144)
+
+[33mcommit c44f90009515941984faea9ccebdb9baf7388ae6[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Mon Aug 31 04:47:04 2020 -0300
+
+    feat: add prop forceTextInputFocus to icon adornment (#2143)
+
+[33mcommit 495de9cc5174f0bf7ae5f6e45e7200e6c7a7df11[m
+Author: Mars Lan <mars.th.lan@gmail.com>
+Date:   Sun Aug 30 23:46:54 2020 -0700
+
+    fix: allow labelStyle to override all built-in styles in Checkbox.Item (#2064)
+
+[33mcommit ec4b35b9dc6ab24b3e0d67be71c1132e185be7ea[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Sun Aug 30 12:01:07 2020 -0300
+
+    feat: add ellipsizeMode prop to Chip (#2044)
+
+[33mcommit c668417aecc607f0f95c02f239ab8bf5186e57ce[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Fri Aug 28 13:14:01 2020 +0200
+
+    fix: fix TouchableRipple crash when pressed with keyboard on web (#2165)
+
+[33mcommit d35513edbd52cede81757d05644949514f0bd550[m
+Author: Walid <hello@walidvb.com>
+Date:   Fri Aug 28 11:48:56 2020 +0200
+
+    docs: remove </Card> from DataTableTitle example (#2146)
+
+[33mcommit 7c9114756aa7158d534362ba3dc524f0a4db331d[m
+Author: karanjhinga <35536622+karanjhinga@users.noreply.github.com>
+Date:   Fri Aug 28 15:18:09 2020 +0530
+
+    docs: fix link to Toggle button Row (#2152)
+
+[33mcommit b8fbad8f1b181722fc5c2c8eea440725794e4bcc[m
+Author: arekkubaczkowski <a.kubaczkowski@piwik.pro>
+Date:   Thu Aug 20 10:25:47 2020 +0200
+
+    fix: incorrect ripple position (#2141)
+
+[33mcommit 53c8e7a255ede4b15f23e4953518525697dd8dea[m
+Author: Alireza Ghamkhar <mra.ghamkhar@gmail.com>
+Date:   Thu Aug 20 11:50:20 2020 +0430
+
+    fix: pass placeholderTextColor prop down to RN TextInput (#2085)
+
+[33mcommit 0dc3852b2a8618c2670caf915ab99170b99f8c62[m
+Author: Nazır Doğan <nazrdogan@gmail.com>
+Date:   Thu Aug 20 07:15:18 2020 +0000
+
+    docs: fix AvatarImage component usage snippet (#2127)
+
+[33mcommit fb78652bd0250ec84691054f15401edc59473be5[m
+Author: Benoît Bouré <benoit.boure@gmail.com>
+Date:   Tue Aug 18 14:18:36 2020 +0200
+
+    fix: add animated prop to FAB (#2100)
+
+[33mcommit a081ca3377c78eaefc64c0a28e213c86cbd54889[m
+Author: Csaba Illes <nostrus@gmail.com>
+Date:   Tue Aug 18 14:06:38 2020 +0200
+
+    feat: add support for multiline card title (#2121)
+
+[33mcommit 2129f55c096065de827b6d1933d6cf061a8009f8[m
+Author: gregfenton <greg.fenton@gmail.com>
+Date:   Mon Aug 17 03:27:03 2020 -0400
+
+    docs: improve description of platform specific components (#2116)
+
+[33mcommit 205669a5c8e7404697e3ae3c3f0b5b0cbb135380[m
+Author: Lohyc <lohyuchen12345@gmail.com>
+Date:   Mon Aug 17 15:25:54 2020 +0800
+
+    docs: grammar, punctuation, phrasing improvements (#2090)
+
+[33mcommit 76b4ea8a9cb38c18f793154dc7b2ffe562d00de2[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Mon Aug 17 04:22:54 2020 -0300
+
+    feat: improve checkbox accessibility (#2131)
+
+[33mcommit 6cb7e17b23e6903fcbcf0ec0466f8bd60f4114ea[m
+Author: pedrobern <pedrobermoreira@gmail.com>
+Date:   Fri Aug 14 06:25:11 2020 -0300
+
+    fix: Dialog background color in dark adaptive mode (#2124)
+
+[33mcommit 56998845bddb20dd4ff7c39a7344e2de74738e10[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Wed Aug 5 17:11:04 2020 +0200
+
+    chore: bump elliptic from 6.5.0 to 6.5.3 in /docs (#2089)
+
+[33mcommit 3db35b1739686bf554dee6fbc78247d12e9f22f8[m
+Author: pedrobern <pedrobermoreira@gmail.com>
+Date:   Wed Aug 5 11:59:24 2020 -0300
+
+    fix: center BottomNavigation label on web (#2074)
+
+[33mcommit b693b1cc6674f1b701d2f25f58e863bd6ae40181[m
+Author: Anthony Chuinard <tony@twansoftware.com>
+Date:   Wed Aug 5 09:58:25 2020 -0500
+
+    feat: add support for long press to FAB (#2072)
+
+[33mcommit 0b73cbcca18432fd8d98e55d2552a1b976ba3109[m
+Author: Asharam Seervi <asharamseervi@users.noreply.github.com>
+Date:   Wed Aug 5 20:26:52 2020 +0530
+
+    docs: updated latest reference URL & improved TS code highlight (#2095)
+
+[33mcommit 6f78dc32514967b766d029f103636b0b63e950f2[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Wed Aug 5 16:50:57 2020 +0200
+
+    chore: bump elliptic from 6.5.2 to 6.5.3 in /example (#2091)
+
+[33mcommit 4e77fcd40b7c1a8e42eaae57ca32b092d6455801[m
+Author: Michał Żuk <me@michalzuk.dev>
+Date:   Wed Aug 5 16:05:39 2020 +0200
+
+    docs: fix component order (#2106)
+
+[33mcommit 8b073d0b1073803bb2e3da63be26de7040dabb27[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Jul 30 10:59:03 2020 +0200
+
+    chore: check versions after issue was edited
+
+[33mcommit bb22a8f039ad349b04b5b9803095a5c4d8931f74[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Tue Jul 28 09:04:36 2020 -0300
+
+    feat: improve accessibility around dismissing modal (#2070)
+
+[33mcommit a7038ed56dab2c80f1353ef96dd34d58eecf0ccf[m
+Author: Derk-Jan Karrenbeld <derk-jan+github@karrenbeld.info>
+Date:   Tue Jul 28 13:56:58 2020 +0200
+
+    fix: ensure compatible animation driver for cards in dark mode (#2068)
+
+[33mcommit d963fc7c34eb932f5f711f5e5e029062cf95e3bd[m
+Author: imgbot[bot] <31301654+imgbot[bot]@users.noreply.github.com>
+Date:   Tue Jul 28 13:55:15 2020 +0200
+
+    docs: optimize images (#2086)
+
+[33mcommit 11e17aa78a9b75f2e42f3b14028254bca03da2b2[m
+Author: Alex Fournier <alex-fournier@users.noreply.github.com>
+Date:   Tue Jul 28 13:51:51 2020 +0200
+
+    docs: add Lyra Collect app to showcase page (#2083)
+
+[33mcommit 2ce47a149215bfe6c7c6cb8391a5096faf8a1266[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Fri Jul 17 12:33:09 2020 +0200
+
+    chore: release 4.0.1
+
+[33mcommit d8590187f2c3b8577a80c9677fedcd7f99ee16a1[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Fri Jul 17 12:32:07 2020 +0200
+
+    fix: handle appearance module being null (#2062)
+
+[33mcommit 08771dd68a29cd6a07840717325cf9f498ace806[m
+Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Date:   Thu Jul 16 15:15:55 2020 +0200
+
+    chore: bump lodash from 4.17.11 to 4.17.19 in /docs (#2058)
+
+[33mcommit 212aa73715f157e1a77f8738859a608a543ba04c[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Thu Jul 16 13:01:41 2020 +0200
+
+    chore: release 4.0.0
+
+[33mcommit 3ecd20a32168e8f213bccba51bba1b446d08d3fc[m
+Author: Alireza Ghamkhar <mra.ghamkhar@gmail.com>
+Date:   Thu Jul 16 12:56:17 2020 +0430
+
+    fix: fix showing unwanted rotations in header back button (#2051)
+
+[33mcommit 87fb26e348c5105c883722f1f97faa407970f607[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Thu Jul 16 10:00:09 2020 +0200
+
+    chore: bump rn web and add async storage that supports web (example app) (#2057)
+
+[33mcommit a25397b553fdeb7926ed3fffd20211918b632a5d[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Thu Jul 16 04:24:41 2020 -0300
+
+    fix: improve accessibility around Menu dismissing (#2028)
+
+[33mcommit e0d76f068c1143937b7466cbb1f33ee7d22e07c6[m
+Author: jbinda <jakub.binda@gmail.com>
+Date:   Mon Jul 13 10:43:54 2020 +0200
+
+    refactor: change condition to set default theme (#2055)
+
+[33mcommit b9c03a3974d5598a38dcdb988b0ffd62a5c05e6c[m
+Author: jbinda <jakub.binda@gmail.com>
+Date:   Mon Jul 13 10:37:35 2020 +0200
+
+    fix: assume Appearance module is always available in Provider (#2054)
+
+[33mcommit 1b5396719ef54c90b449930ad90651f4f63cdf59[m
+Author: jbinda <jakub.binda@gmail.com>
+Date:   Mon Jul 13 10:36:36 2020 +0200
+
+    fix: remove warnings in tests (#2053)
+
+[33mcommit 9868af4ebc4c36f6612a8c19ea188c210ea3b200[m
+Author: jbinda <jakub.binda@gmail.com>
+Date:   Thu Jul 9 13:03:50 2020 +0200
+
+    fix: allow auto change theme (#2049)
+    
+    * fix: allow auto change theme in example app
+    
+    * fix: dark mode switch
+
+[33mcommit 62c88d3d0427100a5423c6aa98e9ec22c8043ecb[m
+Author: Alireza Ghamkhar <mra.ghamkhar@gmail.com>
+Date:   Thu Jul 9 02:50:19 2020 +0430
+
+    fix: fix the bug of overlap of placeholder and label when error is true (#2032)
+
+[33mcommit bfafcf92a64daeeca137c870bcb9b5fc320253e6[m
+Author: Aviran Katz <42338902+avirankatzsofi@users.noreply.github.com>
+Date:   Fri Jul 3 18:05:31 2020 +0300
+
+    fix: always display RadioButtonIOS icon in "ltr" direction (#2034)
+
+[33mcommit b366d31ee60f532a2cf095bd43822b305ef8c9d9[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Tue Jun 30 23:01:04 2020 +0200
+
+    chore: release 4.0.0-alpha.2
+
+[33mcommit 22f801aec4c5824b2dee2cf09eeaf94f2fbbbd28[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Tue Jun 30 13:52:48 2020 +0200
+
+    fix: fix example app on web (#2030)
+
+[33mcommit b8d5760147a400e797e073c2a501122a4f0d10e0[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Tue Jun 30 13:21:15 2020 +0200
+
+    fix: catch empty touches in TouchableRipple on web (#2029)
+
+[33mcommit e8b6ea7bd7aed67f90c3d7f98f928841a797390e[m
+Author: Mohaimin Islam <mohaiminislam94@gmail.com>
+Date:   Tue Jun 30 15:14:51 2020 +0600
+
+    docs: fix broken Appbar example (#2025)
+
+[33mcommit f6f79d42974abfff0ec261b80aadab0e22b9a4a4[m
+Author: Alireza Ghamkhar <mra.ghamkhar@gmail.com>
+Date:   Tue Jun 30 14:38:11 2020 +0430
+
+    feat: enforce import type for the type imports (#2026)
+
+[33mcommit 7d4e006f71908420a66335802d8218242a15e6d4[m
+Author: troZee <12766071+troZee@users.noreply.github.com>
+Date:   Mon Jun 29 16:08:12 2020 +0200
+
+    feat: handle theme change based on device preferences (#2016)
+
+[33mcommit 78a33b7bb7428d9e662dfac0819a0cba3204b2e8[m
+Author: Alireza Ghamkhar <mra.ghamkhar@gmail.com>
+Date:   Sun Jun 28 12:28:19 2020 +0430
+
+    refactor: update prettier to 2.0.5 and refactor the whole project for it
+
+[33mcommit 9b74586e065137f8a13910da41a805dac49f1d7e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Jun 26 18:56:43 2020 +0200
+
+    chore: upgrade bob
+
+[33mcommit d5db5041cb72a5f7020b712a86cba72ebb9cfd2d[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Fri Jun 26 16:28:46 2020 +0200
+
+    chore: upgrade example app to expo38 (#2019)
+
+[33mcommit 2a265872ed89e23e1a5dacc890009098b777c1d2[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Jun 26 16:16:29 2020 +0200
+
+    docs: simplify bottom navigation example (#2018)
+
+[33mcommit 6439033d6dcd998b1c5337a23067bc4666e53cc6[m
+Author: Nick Foden <nickfoden@gmail.com>
+Date:   Fri Jun 26 09:45:24 2020 -0400
+
+    docs: Update class component examples to functions with hooks (#1998)
+
+[33mcommit 5636e41cf378f76122d87ce455c66dc1b3d50ba5[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Jun 26 16:03:40 2020 +0200
+
+    fix: disable tab switching animation by default in bottom navigation (#2017)
+
+[33mcommit b367993c25b1f332f613b02ba937fef02aeb54c6[m
+Author: Vamshi krishna <vamshi9666@riseup.net>
+Date:   Fri Jun 26 18:20:57 2020 +0530
+
+    feat: add proper TS type for TextInput style prop (#1933)
+
+[33mcommit 6ea81dbdd0c4be1553e9ebc31d00f76b122bf3bb[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Fri Jun 26 09:41:02 2020 -0300
+
+    feat: add prop accessibilityLabel to RadioButtonItem (#1955)
+
+[33mcommit d6e9c3b7518444bc784efe4a312d8b558d8029d8[m
+Author: imgbot[bot] <31301654+imgbot[bot]@users.noreply.github.com>
+Date:   Fri Jun 26 14:03:47 2020 +0200
+
+    docs: Optimize images (#2013)
+
+[33mcommit 08306447544f049c563cf998c138ea997ca5aecb[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Fri Jun 26 13:59:56 2020 +0200
+
+    feat: breaking use src as an entry point for react-native
+
+[33mcommit 6980f9cc68073c8fd1f91eada808042993cc6f8d[m
+Author: Josep Vidal <josepvidalvidal@gmail.com>
+Date:   Wed Jun 24 13:09:22 2020 +0200
+
+    docs: Add a new app and new github icon to showcase page (#2011)
+
+[33mcommit 0f8644aae55c3a9c3487e2ae2ad44d218fb92238[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Fri Jun 26 13:49:39 2020 +0200
+
+    feat: add ability to extend theme TS type with custom properties (#2002)
+
+[33mcommit 4bc030b8cbae28de5ac86e2d04aa25ebfd0b1a04[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jun 16 22:31:29 2020 +0200
+
+    chore: improve check versions action
+
+[33mcommit 256e2823686799d04994fcbf91fa6a55f6a6e472[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Sun Jun 21 13:27:35 2020 +0200
+
+    chore: release 4.0.0-alpha.1
+
+[33mcommit ac3824e307d89934ddc464cc3cd2a411a49866ac[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Sun Jun 21 12:57:52 2020 +0200
+
+    chore: upgrade rn ts types to 0.62.0
+
+[33mcommit 05504b2d523b7975e04545359e2022947ad199d2[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Thu Jun 18 15:25:22 2020 +0200
+
+    fix: fix menu example
+
+[33mcommit 49324a0135f1a570bd1535ea7394ce774439cff8[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Thu Jun 18 10:24:27 2020 -0300
+
+    fix: fix memory leak in Menu hide animation (#1965)
+
+[33mcommit 03572acac736eec1eaea35167671b0151ad4b1e3[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Tue Jun 16 09:33:38 2020 +0200
+
+    feat: add info about figma and sketch to the readme (#1988)
+
+[33mcommit 47a6cb3995b1157b14f1543cc1761017fdac3969[m
+Author: Maria Marchenkova <35371977+marchenk0va@users.noreply.github.com>
+Date:   Thu Jun 4 10:06:17 2020 +0200
+
+    docs: paper logo favicon, upgraded components-docs to 0.23.0 (#1964)
+    
+    * docs: added favicon
+    
+    * docs: changed favicon
+
+[33mcommit 12e802102f272a00c527dfa8279253033da872fc[m
+Author: Maria Marchenkova <35371977+marchenk0va@users.noreply.github.com>
+Date:   Wed Jun 3 11:55:07 2020 +0200
+
+    docs: added lib name in title (#1948)
+    
+    * docs: added lib name in title
+    
+    * revert: url-loader version
+
+[33mcommit 6b6fa7b8adeae022684b47997ca42a9ae5149037[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Tue Jun 2 15:10:13 2020 +0200
+
+    chore: use correct content of the bug report md file (#1960)
+
+[33mcommit e352f67b67e00210282535218837ff4b57339c20[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Tue Jun 2 14:52:40 2020 +0200
+
+    chore: update bug report issue template
+
+[33mcommit a92037deea492e03f228ea68be48dd63d6fbb83e[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Tue Jun 2 14:42:43 2020 +0200
+
+    chore: update bug_report issue template (#1959)
+
+[33mcommit 2927881751042a6350b8ff8fb6ade20b2a9cfa84[m
+Author: Paweł Szymański <3x4to9@gmail.com>
+Date:   Tue Jun 2 14:39:52 2020 +0200
+
+    docs: fix dark mode colors for icons (#1958)
+
+[33mcommit efad4b188469a5573347cd3052ba220947e2d216[m
+Author: jbinda <jakub.binda@gmail.com>
+Date:   Tue Jun 2 14:39:13 2020 +0200
+
+    docs: add docs header to js sections (#1932)
+
+[33mcommit f53064d795379e3e6173e5023b31fabd1e2cc653[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Tue Jun 2 14:28:15 2020 +0200
+
+    chore: fix bug report issue template file name
+
+[33mcommit 949df3e9b53b09486fd54e7fb6fcfa25d0dbfba9[m
+Author: jbinda <jakub.binda@gmail.com>
+Date:   Tue Jun 2 14:07:49 2020 +0200
+
+    chore: bump component docs version, remove restore cache step (#1950)
+
+[33mcommit 691376bfcf144480c3d9d12ecd797607f9e417e4[m
+Author: jbinda <jakub.binda@gmail.com>
+Date:   Tue Jun 2 14:04:11 2020 +0200
+
+    feat: add action to check versions of library (#1947)
+
+[33mcommit e76e589f9e5db985afed1ed29ae46234b5230128[m
+Author: Geoffrey Hunt <geoffrey.hunt.10@gmail.com>
+Date:   Mon May 25 11:47:45 2020 +0200
+
+    fix: fix activityindictor crash on android (#1935)
+
+[33mcommit 856e84c7eab69324bef967d33d52479af73dd946[m
+Author: Nick Foden <nickfoden@gmail.com>
+Date:   Mon May 25 05:46:27 2020 -0400
+
+    docs: update getting started code snippet
+
+[33mcommit 710d36436997b0db2fd2249e04d9a19caef8c037[m
+Author: Marek Majchrzak <44026723+mMajch@users.noreply.github.com>
+Date:   Mon May 25 11:32:49 2020 +0200
+
+    fix: fix CrossFadeIcon animation when icon passed as a function  (#1896)
+
+[33mcommit 87fcb507fffedcee963f85f7b7ee6815f9622789[m
+Author: Paweł Szymański <3x4to9@gmail.com>
+Date:   Mon May 25 13:21:04 2020 +0200
+
+    feat: change acccessibilityStates to accessibilityState (#1938)
+
+[33mcommit 9e2e7f6b63dc87bf66e611b1b4910770c3414282[m
+Author: Mateusz Kosoń <41837132+matkoson@users.noreply.github.com>
+Date:   Mon May 25 11:23:06 2020 +0200
+
+    feat: focus TextInput on icon/affix press (#1850)
+
+[33mcommit 49b327134ff9d7bb0a511f33df6a453814a5d34c[m
+Author: imgbot[bot] <31301654+imgbot[bot]@users.noreply.github.com>
+Date:   Fri May 22 13:11:46 2020 +0200
+
+    docs: optimize images (#1942)
+
+[33mcommit 7552059afec0f75969c58044c8f6c8eaa1a71240[m
+Author: Mateusz Kosoń <41837132+matkoson@users.noreply.github.com>
+Date:   Fri May 22 12:57:40 2020 +0200
+
+    docs: add missing screenshots (#1909)
+
+[33mcommit 8461098a07fef12ac14b027ed86b46d379530efa[m
+Author: Petr Leo Compel <petrleocompel@gmail.com>
+Date:   Wed May 13 22:51:08 2020 +0200
+
+    docs: ✨ Dark mode 🌚 (#1690)
+
+[33mcommit c17e6114b03cb6b64fbf6949c95b3c3f0593598a[m
+Author: M4gie <33150916+M4gie@users.noreply.github.com>
+Date:   Mon May 11 09:50:24 2020 +0200
+
+    docs: add useTheme exemple (#1895)
+
+[33mcommit 50742da39efe567025f77507383f47a91ce03c51[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat May 9 22:01:46 2020 +0200
+
+    chore: update project configurations
+    
+    - Simplify metro config and webpack configs for linking the project
+    - Update circleci config to 2.1
+
+[33mcommit faf6a530f45888573908fa7522a50d485edaeec5[m
+Author: Mateusz Kosoń <41837132+matkoson@users.noreply.github.com>
+Date:   Fri May 22 15:53:59 2020 +0200
+
+    feat: automatically handle reduce motion device settings (#1937)
+
+[33mcommit bf2d7f3420dd2878d18886266a44441e3d143486[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri May 8 15:21:21 2020 +0200
+
+    fix: pass route prop to the touchable (#1904)
+
+[33mcommit 3c8a33924d70f74195b0b42198356d300be1813c[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Fri May 8 14:52:49 2020 +0200
+
+    fix: use same color for button text and icon (#1894)
+
+[33mcommit e5b232557dd066a73786e2fc458eda0c734d414d[m
+Author: Marek Majchrzak <44026723+mMajch@users.noreply.github.com>
+Date:   Fri May 8 14:42:12 2020 +0200
+
+    feat: add `disable` prop to RadioButton.Item (#1900)
+
+[33mcommit e11a51a9da14e8babdf56a59459c338b9266ecd9[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri May 8 14:33:41 2020 +0200
+
+    feat: add renderTouchable prop to BottomNavigation (#1901)
+
+[33mcommit ce7ad22dd78419baa3e023340b997a51af54621b[m
+Author: Joonmo Yang <8017201+Remagpie@users.noreply.github.com>
+Date:   Tue May 5 21:15:37 2020 +0900
+
+    feat: add color and uncheckedColor prop to RadioButton.Item (#1892)
+
+[33mcommit 132570c3697b4f8b3b214b6add35579037b96d89[m
+Author: Vincent <7737876+Anapher@users.noreply.github.com>
+Date:   Tue May 5 13:01:55 2020 +0200
+
+    fix: use colors.text for RadioButton.Item label (#1871)
+
+[33mcommit acc3df01fed0735171b6d82961fb995e7bdec674[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Tue May 5 11:26:30 2020 +0200
+
+    chore: bump react-native-safe-area-view version (#1890)
+
+[33mcommit ecb6215f22bbf325d97265572d38731eec9e7cdc[m
+Author: imgbot[bot] <31301654+imgbot[bot]@users.noreply.github.com>
+Date:   Tue May 5 10:50:19 2020 +0200
+
+    docs: optimize size of the images (#1889)
+
+[33mcommit b600ea8faf0013f9213498517dc36c9ea701c0b8[m
+Author: Marek Majchrzak <44026723+mMajch@users.noreply.github.com>
+Date:   Tue May 5 10:39:09 2020 +0200
+
+    docs: add missing components screenshots (#1886)
+
+[33mcommit cebf3da5ef75b9827984fd7bf0c687bf0c9ed1f3[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue May 5 10:29:42 2020 +0200
+
+    fix: don't set statusbar style in Appbar.Header (#1873)
+
+[33mcommit 47d7a21c2982514fa95827a44edf2fcbeaf3be9c[m
+Author: Mateusz Kosoń <41837132+matkoson@users.noreply.github.com>
+Date:   Mon May 4 13:13:21 2020 +0200
+
+    chore: upgrade react-native-safe-area-view (#1884)
+
+[33mcommit a9454c1c1f41edd916b474f457f4953eade247fa[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Mon May 4 10:26:53 2020 +0200
+
+    chore: release 4.0.0-alpha.0
+
+[33mcommit 66b06b7ad7b582ef4f5d161fdf6c20c0de5e8c17[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri May 1 01:09:59 2020 +0200
+
+    chore: fix release it config
+    
+    Version number in commit message was broken after upgrade
+
+[33mcommit 6f4588b09a9f89c97ab8a0ff216afcf8cd4c7ddd[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri May 1 01:07:52 2020 +0200
+
+    chore: upgrade react navigation
+
+[33mcommit 3a002344b92f93f3fd556f1816e37af0e752fcd2[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Thu Apr 30 09:50:19 2020 +0200
+
+    fix: add wrapperStyle to Snackbar (#1865)
+    
+    * fix: add wrapperStyle
+    
+    * style: fix lint
+    
+    * style: fix lint
+    
+    * test: update snapshots
+
+[33mcommit ac3d8ac3b6ed4f76b6d72edad8a0d81d2fab1cd7[m
+Author: Aviran Katz <42338902+avirankatzsofi@users.noreply.github.com>
+Date:   Mon Apr 27 10:59:16 2020 +0300
+
+    fix: always display checkbox icon in LTR direction (#1864)
+
+[33mcommit f2c67f9f6eb06cb7a08e4a379f41a5a77a4876a7[m
+Author: marchenk0va <35371977+marchenk0va@users.noreply.github.com>
+Date:   Fri Apr 24 12:39:10 2020 +0200
+
+    chore: migrate example to functional components
+
+[33mcommit 2900b04190e3ca8ec2ecc14a00c7628fead6d81b[m
+Author: Stheffany Santos Hadlich <stheffanyhadlich@gmail.com>
+Date:   Fri Apr 24 04:37:20 2020 -0300
+
+    feat: create Checkbox.Item component
+
+[33mcommit bc95ae111293fbe74f0b7413efac0e49e4fd236f[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Fri Apr 24 09:32:14 2020 +0200
+
+    feat: add support for affix and icon in textinput (#1651)
+
+[33mcommit cc144798a4b382a5a94b240c5305659a001ac1f6[m
+Author: Vojtech Novak <vonovak@gmail.com>
+Date:   Mon Apr 20 11:43:38 2020 +0200
+
+    fix: fix menu item height (#1847)
+
+[33mcommit df28d87384a317439a9e993956dab03847966493[m
+Author: jbinda <jakub.binda@gmail.com>
+Date:   Mon Apr 20 05:31:51 2020 +0200
+
+    fix: prevent FABGroup click when its hidden (#1845)
+
+[33mcommit 4b400d695a46a69ae1005d655e95a98a5235a234[m
+Author: Faizal Andyka <logustra@gmail.com>
+Date:   Fri Apr 17 18:22:53 2020 +0700
+
+    fix: fix warning thrown on button animation (#1769)
+
+[33mcommit ef98d6b668113ca33384729867032c5d455ff7ab[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Fri Apr 17 13:21:45 2020 +0200
+
+    fix: pass useNativeDriver to all animations (#1787)
+
+[33mcommit 037bb32156ae96fb0f1f445075e7f9bb8e683326[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Fri Apr 17 13:17:06 2020 +0200
+
+    fix: add ref typings  (#1791)
+
+[33mcommit a0b1a3eef9fc79e573790281580f076e33447faa[m
+Author: Diego Toro <diego.toro527@gmail.com>
+Date:   Fri Apr 17 04:54:54 2020 -0500
+
+    fix: card title with 1 line only (#1809)
+
+[33mcommit 91a0da48c788e813e87a66b2d5d0e6f06003e336[m
+Author: joshglenn <joshglenn@users.noreply.github.com>
+Date:   Fri Apr 17 04:53:41 2020 -0500
+
+    docs: fix the FAB.Group example in documentation (#1819)
+
+[33mcommit 123c83b117c909a7a87502ea29543e527a9aa698[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Fri Apr 17 09:47:58 2020 +0200
+
+    chore: upgrade react-native-screens in group default to the latest version 🚀 (#1839)
+    
+    * fix(package): update react-native-screens to version 2.5.0
+    
+    * chore(package): update lockfile example/yarn.lock
+    
+    Co-authored-by: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+
+[33mcommit 885470219c0ee265abc8807e0f90707532b69fc5[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Tue Apr 14 13:04:13 2020 +0200
+
+    chore: update @react-native-community/masked-view in group default to the latest version 🚀 (#1813)
+    
+    * fix(package): update @react-native-community/masked-view to version 0.1.8
+    
+    * chore(package): update lockfile example/yarn.lock
+    
+    Co-authored-by: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+
+[33mcommit f7ac1750925ad85d26f0692627b9ed84db59228a[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Tue Apr 14 13:00:31 2020 +0200
+
+    chore: update url-loader in group default to the latest version 🚀 (#1806)
+    
+    * chore(package): update url-loader to version 4.1.0
+    
+    * chore(package): update lockfile docs/yarn.lock
+    
+    Co-authored-by: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+
+[33mcommit f97f52fcaf655447d11f70d6e86aa115cbc907bf[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Wed Apr 8 13:20:30 2020 +0200
+
+    chore: update react-native-reanimated in group default to the latest version 🚀 (#1793)
+
+[33mcommit 7fa4904453b7faf28dec1c29b858f48cea1a1aa6[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Wed Apr 8 12:22:02 2020 +0200
+
+    chore: release %s
+
+[33mcommit bd4f8e189aeb1f9c21d65eef143446faef3c0a65[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Wed Apr 8 12:20:07 2020 +0200
+
+    fix: fix warning when animating without passing useNativeDriver (#1796)
+
+[33mcommit 9fc1ffe997554aa56e043c0218b4aa1fc60f8a44[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Wed Apr 8 11:42:48 2020 +0200
+
+    revert: revert accessibility related changes (#1789)
+
+[33mcommit 1604b56e724aa240126a3d344fbe816d56707bc4[m
+Author: Alejandro <alejandroce@lagash.com>
+Date:   Mon Apr 6 10:56:53 2020 -0400
+
+    feat: add titleStyle prop in MenuItem (#1664)
+
+[33mcommit 86ef0a5d96c5d1373b55b47b77048af8040ce1e3[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Mon Apr 6 15:38:56 2020 +0200
+
+    feat: upgrade example app to expo 37 and bump ts types (#1786)
+
+[33mcommit 73814f8bb4b0e75bafe5ad5a088962e3d6ef0480[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Fri Apr 3 10:44:46 2020 +0200
+
+    chore: release %s
+
+[33mcommit fc69c653feaad8c1c8a4dcea64ccd049099eb68c[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Fri Apr 3 09:51:30 2020 +0200
+
+    chore: update chalk to the latest version 🚀 (#1776)
+
+[33mcommit 01b632f354d72a3d1b4585448206158653a503a3[m
+Author: Matt Oliver <halfmatthalfcat@users.noreply.github.com>
+Date:   Fri Apr 3 03:46:24 2020 -0400
+
+    fix(radiobuttonitem): added label theming support (#1587) (#1778)
+
+[33mcommit b3d0d70d3f9244a39f5417093d4ad87afd77c77d[m
+Author: Willian Rodrigues <oredstonebr@gmail.com>
+Date:   Mon Mar 30 09:48:36 2020 -0300
+
+    docs: improve example code, fix code of conduct link (#1707)
+
+[33mcommit f66c2e896d31569bcf3c99113d887988f4f993c1[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Mon Mar 30 14:09:33 2020 +0200
+
+    fix: add flexShrink to inner Card container (#1691)
+
+[33mcommit 2f9dc13c12895435bcd955082326f1b767594500[m
+Author: Danilo Assis <daniloab@users.noreply.github.com>
+Date:   Mon Mar 30 09:06:21 2020 -0300
+
+    feat: add testID prop in button (#1704)
+
+[33mcommit 0980f5c02f8ada0986be4bf5ef3d9d53a9273039[m
+Author: James Hush <james.hush@system1.com>
+Date:   Mon Mar 30 04:43:05 2020 -0700
+
+    feat: add search and clear accessibility labels props in searchbar (#1600)
+
+[33mcommit 57040ffaceca3aa59dfcd7703d93f50d10b9c1d4[m
+Author: TVGSoft <itfgiap@gmail.com>
+Date:   Mon Mar 30 18:41:07 2020 +0700
+
+    feat: add a subtitleNumberOfLines prop in card (#1576)
+
+[33mcommit 17e030a9ee72da6ffcd47d8032eb34ce970d2785[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Mon Mar 30 11:04:31 2020 +0200
+
+    chore: upgrade react-native-gesture-handler in group default to the latest version 🚀 (#1671)
+
+[33mcommit 920b0a681a69d0c398a0337cc156cd50dd36490e[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Mon Mar 30 10:35:08 2020 +0200
+
+    chore: upgrade release-it to the latest version 🚀 (#1761)
+
+[33mcommit 2313c26b24da08d9a778d46608f9e9e6376fdc68[m
+Author: digorath <59824597+digorath@users.noreply.github.com>
+Date:   Fri Mar 27 15:05:07 2020 +0100
+
+    feat: add testID prop to FAB and FAB.Group (#1573)
+
+[33mcommit 94ddfb037e9f135b52aac18bc51895190a75c518[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Fri Mar 27 09:33:45 2020 -0300
+
+    refactor: remove unused variable in TextInputOutlined (#1673)
+
+[33mcommit 983287cf50bb8a28411d5d094a7b9af1a1663833[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Fri Mar 27 13:32:28 2020 +0100
+
+    chore: update @react-native-community/bob to the latest version 🚀 (#1714)
+
+[33mcommit b83b356518385f6c48e528c3c73cd1eae3dffc9e[m
+Author: Vojtech Novak <vonovak@gmail.com>
+Date:   Fri Mar 27 13:31:52 2020 +0100
+
+    fix: remove redundant setState in Menu component (#1734)
+
+[33mcommit a198b0343d7aa1c2fa838046ebbe9b7a5dff2637[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Fri Mar 27 13:29:20 2020 +0100
+
+    fix: expose ref on DrawerItem (#1760)
+
+[33mcommit 1afb8ee91c1de3f1ca3a0b548ebb102736da6056[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Fri Mar 27 13:00:44 2020 +0100
+
+    chore: update @react-native-community/masked-view in group default to the latest version 🚀 (#1708)
+
+[33mcommit a28bc38f859820539e353917d39817a39b9186fc[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Fri Mar 27 12:59:06 2020 +0100
+
+    chore: update react-native-reanimated in group default to the latest version 🚀 (#1749)
+
+[33mcommit 90c48278369df2aa707fa7c1c7427e22ca561a1c[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Fri Mar 27 12:58:39 2020 +0100
+
+    chore:update expo-font in group default to the latest version 🚀 (#1755)
+    
+    * fix(package): update expo-font to version 8.1.0
+    
+    * chore(package): update lockfile example/yarn.lock
+    
+    Co-authored-by: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+    Co-authored-by: Dawid Urbaniak <dawidu@onet.pl>
+
+[33mcommit 6465903e622b26a40e593f2dcd90255ed55a483a[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Fri Mar 27 11:02:23 2020 +0100
+
+    fix: expose ref on Surface (#1753)
+
+[33mcommit 26423f69504dbb6879e5320bcd9f5aedbf7fc45e[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Fri Mar 27 11:00:21 2020 +0100
+
+    chore: update expo-keep-awake in group default to the latest version 🚀 (#1756)
+    
+    * fix(package): update expo-keep-awake to version 8.1.0
+    
+    * chore(package): update lockfile example/yarn.lock
+    
+    Co-authored-by: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+
+[33mcommit 6746bf8281eebebf15f365b7b92bbf75ff238a9c[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Mar 26 16:53:21 2020 +0100
+
+    chore: fix path to vector icons
+
+[33mcommit 6e87ac1300e31d9aad63df966081824a712b9ae9[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Mar 26 15:29:26 2020 +0100
+
+    chore: remove .history files
+
+[33mcommit 63c5b834cc865be1dd8bf13ede6ba2edc08247c1[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Mar 26 15:26:46 2020 +0100
+
+    chore: install deps during deploying docs
+
+[33mcommit e8fec7120f002045c26dd7e98802bee6c0f09fb2[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Mar 26 15:19:30 2020 +0100
+
+    chore: update component-docs
+
+[33mcommit e397d0492a665aa8f9f95df4ec6899656395d252[m
+Author: haxonadora <42680223+haxonadora@users.noreply.github.com>
+Date:   Wed Mar 25 17:52:45 2020 +0100
+
+    chore: added missing react-native-vector-icons dep to docs (#1752)
+
+[33mcommit 16e884b9137b233812b1bb1d411496d00bf5730a[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Wed Mar 25 15:21:47 2020 +0100
+
+    Update react-native-safe-area-context in group default to the latest version 🚀 (#1646)
+    
+    * fix(package): update react-native-safe-area-context to version 0.7.0
+    
+    * chore(package): update lockfile example/yarn.lock
+    
+    Co-authored-by: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+
+[33mcommit 77fe132d5dbb220ebcac3ae0b83e6432ddfc12c3[m
+Author: LuckyLuke19 <45518626+LuckyLuke19@users.noreply.github.com>
+Date:   Sat Feb 29 19:46:05 2020 +0000
+
+    docs: clarify color prop for FAB (#1701)
+    
+    Explicitly mention that the color prop of FAB refers to its text color (and not the background color).
+
+[33mcommit 5a658a2d765cf8bf5e09594059faaa073dfb51da[m
+Author: Zhao Lei <firede@firede.us>
+Date:   Thu Feb 27 00:48:11 2020 +0800
+
+    fix: custom icons doesn't work in portal component (#1689)
+
+[33mcommit 2a29dc6d6bca0cb8f529b192d2af3a1794e61a2a[m
+Author: Zhao Lei <firede@firede.us>
+Date:   Mon Feb 17 23:41:11 2020 +0800
+
+    feat: add labelStyle prop & support theme in RadioButton.Item (#1674)
+
+[33mcommit 701b279c3b6eca0754a828a017013ffcebfef91d[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Mon Feb 10 13:50:50 2020 +0100
+
+    fix: disable Appbar Content when not pressable (#1653)
+
+[33mcommit 3794b7cc2cd5abcc189499275008403b4da12bee[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Mon Feb 10 13:49:31 2020 +0100
+
+    chore: update rimraf to the latest version 🚀 (#1654)
+
+[33mcommit a0da23f30f3fa7f40fdb118da8654ebb73a169ae[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Feb 10 09:51:43 2020 +0100
+
+    chore: add a GitHub action for triaging issues (#1660)
+
+[33mcommit 5a53c039579ae8da3f98ad3f0f8ac1554821a3df[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Feb 10 09:25:25 2020 +0100
+
+    chore: fix outdated contribution guidelines
+
+[33mcommit bf43deb910482f785cf85dfbdf71156334cc5196[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Feb 9 18:10:51 2020 +0100
+
+    chore(package): update @react-native-community/bob to version 0… (#1656)
+    
+    Closes #1655
+    
+    Co-authored-by: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+
+[33mcommit 5870fb3ef5fbb6aeb9aa95db942c1ac009e6a3b0[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Feb 5 15:13:00 2020 +0100
+
+    chore: upgrade react navigation to stable
+
+[33mcommit 5fcc43a674e0e54ec0b5e95035094e5c838e23be[m
+Author: Gabriel Reis <gabriel.oreis@gmail.com>
+Date:   Wed Feb 5 03:40:12 2020 -0500
+
+    feat: Add testID prop to ListAccordion (#1640)
+
+[33mcommit f8e2c9b7837999daea39a6e664692478a68182ca[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Wed Feb 5 09:26:52 2020 +0100
+
+    chore: update react-native-screens in group default to the latest version 🚀 (#1638)
+
+[33mcommit 93ccaf347ef358d655aa0f2c2f3cdc9c09c741b4[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Wed Jan 22 09:06:11 2020 +0100
+
+    fix: disable Modal background when not dismissable
+
+[33mcommit 886ff93bac31daecd15c680c70904075b3d44fff[m
+Author: Noemi Rozpara <nrozpara@gmail.com>
+Date:   Tue Feb 4 20:27:11 2020 +0700
+
+    feat: use scale on minor animations (#1594)
+
+[33mcommit f070408c36361496072c7635f34f459e190c630b[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Tue Feb 4 14:23:01 2020 +0100
+
+    chore: update react-native-screens in group default to the latest version 🚀 (#1631)
+
+[33mcommit b74852f3ec83631ad0b56781717d3bcf894750e8[m
+Author: Gabriel Reis <gabriel.oreis@gmail.com>
+Date:   Tue Feb 4 08:22:14 2020 -0500
+
+    feat: add testID prop to MenuItem (#1633)
+
+[33mcommit 780c7da78df858ce461560a92efe080ebb3e5c5b[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Feb 4 11:05:29 2020 +0100
+
+    chore: only publish to expo if PR is from a branch in the repo (#1637)
+
+[33mcommit 699d13ef08a77661bbe00eca73f226b863fdbe8c[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Tue Feb 4 10:21:12 2020 +0100
+
+    chore: release 3.6.0
+
+[33mcommit 65da79707999309810b817936a16b0a18e98cd72[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Feb 4 09:47:06 2020 +0100
+
+    chore: use higher quality qr and add link (#1632)
+
+[33mcommit 19664c43bcdd668ba4a0400c5193a29739955c31[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Tue Feb 4 09:12:57 2020 +0100
+
+    fix: use material community icon for hard coded names (#1630)
+
+[33mcommit d1596595de64b5cf7a715223ca9c331efb40d1f6[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Mon Feb 3 10:21:20 2020 +0100
+
+    chore: update react-native-screens in group default to the latest version 🚀 (#1629)
+
+[33mcommit 881cc365688f6d7b934154a2daaec5c5841278f0[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Feb 1 14:38:14 2020 +0100
+
+    chore: add QR code to expo preview messages (#1627)
+
+[33mcommit 8c563acbb7b46b06d738dd5b3588dc333356f7ca[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Fri Jan 31 15:41:09 2020 +0100
+
+    feat: add a gh action for publishing example on every PR
+
+[33mcommit 5ef67392c066d1a395ea3b11a26de4b5785a88d7[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Fri Jan 31 14:54:47 2020 +0100
+
+    chore: add deps caching to expo publish action
+
+[33mcommit 231188b8a461063b56a237338e75d3e3710c7338[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Fri Jan 31 14:39:46 2020 +0100
+
+    chore: fix issue with wrong path in expo publish action (#1625)
+
+[33mcommit e0b224d12274ed27db6dd4356b590bf6c0898b26[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Fri Jan 31 13:57:21 2020 +0100
+
+    chore: add expo publish action (#1624)
+
+[33mcommit fb6596723c47062b3d5a4224b65ca7fc7c945f43[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Fri Jan 31 06:21:51 2020 -0300
+
+    feat: add accessibilityLabel prop to DrawerItem (#1622)
+
+[33mcommit 87f15b507ba8fd8413ec291621812703c3418503[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Thu Jan 30 13:52:01 2020 +0100
+
+    Revert "chore: update react-native-web in group default to the latest version 🚀 (#1604)"
+    
+    This reverts commit 370752d5c21b53778971131c665c335230c83d67.
+
+[33mcommit 8161684581d3a9457d315372463746e5eb41c166[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Tue Jan 28 16:06:28 2020 +0100
+
+    chore: ignore dependencies - greenkeeper
+
+[33mcommit 1b95efda61925b3e555b7c37a1e95b3efbadf49a[m
+Author: imgbot[bot] <31301654+imgbot[bot]@users.noreply.github.com>
+Date:   Tue Jan 28 15:58:53 2020 +0100
+
+    docs: optimize images (#1595)
+
+[33mcommit 19a908b497727ed7a493700c3ddc0fa39fdb4dd5[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Tue Jan 28 15:58:12 2020 +0100
+
+    chore: update @types/node to the latest version 🚀 (#1543)
+
+[33mcommit 370752d5c21b53778971131c665c335230c83d67[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Tue Jan 28 15:55:30 2020 +0100
+
+    chore: update react-native-web in group default to the latest version 🚀 (#1604)
+
+[33mcommit 292c7467070fb9efe111c697e9a93c127a0ea1a1[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Tue Jan 28 15:52:59 2020 +0100
+
+    chore: update react-native-screens in group default to the latest version 🚀 (#1591)
+
+[33mcommit d8ba4771629f8ebfe39ed4cff4ceaf56b6ab97e9[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Fri Jan 24 14:29:49 2020 +0100
+
+    chore: release 3.5.1
+
+[33mcommit 2826d836ccbb3e93303b2a48ff61bd6608a3ba6c[m
+Author: chewy444 <59180630+chewy444@users.noreply.github.com>
+Date:   Fri Jan 24 08:27:59 2020 -0500
+
+    fix: appBar Accessibility Focus (#1544)
+
+[33mcommit dc7b47ef8fe03072f05339b6ad02299ddd5b80c3[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jan 22 21:44:41 2020 +0100
+
+    chore: release 3.5.0
+
+[33mcommit e87bb2d5987e92390193691e930a28667ca84d51[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jan 22 21:43:29 2020 +0100
+
+    chore: also publish src for easier debugging
+
+[33mcommit 81dc4cb5a3d75466323054a44c26ce6af58f4978[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jan 22 21:42:30 2020 +0100
+
+    feat: add preventDefault to onTabPress in BottomNavigation
+
+[33mcommit 5a60eb2bedfc2d52093a2a2a23a33ece8753559d[m
+Author: Noemi Rozpara <nrozpara@gmail.com>
+Date:   Tue Jan 21 14:34:36 2020 +0100
+
+    feat: support animation scale in FAB, Snackbar and Banner (#1593)
+
+[33mcommit e1a5f5a77283bce56b3866b9aff1755a62854f37[m
+Author: Michael Yin <layerssss@gmail.com>
+Date:   Wed Jan 22 02:32:16 2020 +1300
+
+    docs: add TracksNZ into Showcase (#1588)
+
+[33mcommit 353f377492356437edde66516b30ba6be4061e02[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Mon Jan 20 16:35:10 2020 +0100
+
+    chore: release 3.4.1
+
+[33mcommit c919fd2e0d214b8deb96aab87df1e8c71a6f130f[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Mon Jan 20 16:34:17 2020 +0100
+
+    fix: don't disable tabbar animation when sceneAnimationEnabled is false
+
+[33mcommit 8daede90760982a216a47de9a339e2a1cd888e2d[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Jan 20 06:04:10 2020 +0100
+
+    chore: upgrade react navigation in example
+
+[33mcommit 80730d95a93a59679a3bfb68ff21039e59fe1b55[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Sat Jan 18 22:56:52 2020 +0100
+
+    chore: update @react-native-community/bob to the latest version 🚀 (#1568)
+
+[33mcommit 3f458546005da3146483cc4299329ae151066bb0[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Thu Jan 16 23:55:27 2020 +0100
+
+    chore: update @react-native-community/masked-view in group default to the latest version 🚀 (#1569)
+
+[33mcommit e282c89a1deb2ad55e13d9505b515e7d2fb0347f[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Thu Jan 16 23:50:36 2020 +0100
+
+    chore: update react-native-screens in group default to the latest version 🚀 (#1579)
+
+[33mcommit 6e274f5654b79961c6e0748eeaaf5fcf882e4f78[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Wed Jan 8 09:41:58 2020 -0300
+
+    refactor: remove pointerEvents from ListItem description (#1513)
+
+[33mcommit 3cb67be7017d87dd0af23db0e223fda681dc341b[m
+Author: Mark Pollmann <MarkPollmann@users.noreply.github.com>
+Date:   Wed Jan 8 13:28:06 2020 +0100
+
+    docs: add react-native-datetimeepicker to recommended libraries (#1534)
+
+[33mcommit 8d2018b9a0a9c7eb2178ba1d4b718ba3d33f7327[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Wed Jan 8 13:14:28 2020 +0100
+
+    chore: update commitlint to the latest version 🚀 (#1557)
+
+[33mcommit 4c6ed6643d0ea1c1282ac8437e8d193cd31d3d95[m
+Author: imgbot[bot] <31301654+imgbot[bot]@users.noreply.github.com>
+Date:   Tue Jan 7 11:01:23 2020 +0100
+
+    docs: optimize images (#1548)
+
+[33mcommit 15bef05fe2e1c71080dbc272729f6f254e0a453b[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Mon Dec 23 13:36:16 2019 +0100
+
+    chore: Update @callstack/eslint-config to the latest version 🚀 (#1525)
+
+[33mcommit bf625a099c5a3abfdf024a10fa3fd8ed7bd1ba55[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Mon Dec 23 13:01:57 2019 +0100
+
+    chore: update react-native-screens in group default to the latest version 🚀 (#1539)
+
+[33mcommit 0e2e3efbae0d877ca60f464360b3c76262a5ebcd[m
+Author: Mozamel Anwary <mozamel.anwary1@gmail.com>
+Date:   Mon Dec 23 23:00:43 2019 +1100
+
+    docs: Add Unicore to showcase (#1537)
+
+[33mcommit 95e48983e728c246146c4dbb005f6d06d3c592fb[m
+Author: joshglenn <joshglenn@users.noreply.github.com>
+Date:   Thu Dec 19 03:53:00 2019 -0500
+
+    fix: fix icon names in AppbarHeader example (#1535)
+
+[33mcommit 0b83f86ce6c3b10e2302e540661465baf254e4a1[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Wed Dec 18 10:45:14 2019 +0100
+
+    chore: update babel-plugin-module-resolver in group default to the latest version 🚀 (#1518)
+
+[33mcommit d7b81dc84a46abd57f7b4612aca65e73268c8302[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Wed Dec 18 10:43:48 2019 +0100
+
+    chore: update react-native-screens in group default to the latest version 🚀 (#1531)
+
+[33mcommit 0a08a8b9ea687e1171e35b5933f017d8aa152fdf[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Tue Dec 17 14:07:42 2019 +0100
+
+    chore: release 3.4.0
+
+[33mcommit 61a6362ddc1d3d205697309bd1900907377e9300[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Tue Dec 17 14:05:40 2019 +0100
+
+    chore: bump react-native-safe-area-view version
+
+[33mcommit f0596db3b9a13cbc1204608b5427dbfb01740f53[m
+Author: Mark Pollmann <MarkPollmann@users.noreply.github.com>
+Date:   Tue Dec 17 14:00:11 2019 +0100
+
+    feat: add rtl support to ProgressBar (#1523)
+
+[33mcommit c3c8c5fd25079348fd8bca74c33fd51cbc5374ee[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Fri Dec 13 14:03:48 2019 +0100
+
+    chore(package): update react-native-screens in group default to the latest version  (#1524)
+
+[33mcommit 9da9a733a67f54f0487fae3859ceaef9c13b51d9[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Dec 12 19:21:29 2019 +0100
+
+    chore: update react navigation in the example
+
+[33mcommit 7e64c64a8ffab175923c7b87874efcdc2022543b[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Thu Dec 12 17:09:37 2019 +0100
+
+    chore(package): Update react-native-screens in group default to the latest version  (#1519)
+    
+    * fix(package): update react-native-screens to version 2.0.0-alpha.18
+    
+    * chore(package): update lockfile example/yarn.lock
+
+[33mcommit d7dee334002ce52542e99a516a17468effd41750[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Thu Dec 12 14:50:45 2019 +0100
+
+    chore: add github action for closing old issues and PRs (#1521)
+
+[33mcommit 95c5ea4aeeeefde033e52644ef2cfe1e69d4ddd1[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Wed Dec 11 13:46:02 2019 +0100
+
+    chore: uprade example app to expo 36 (#1517)
+
+[33mcommit c3e9b4f343fd59219860beadf0bf3c21ec195a2b[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Tue Dec 10 12:38:22 2019 +0100
+
+    chore: Update expo-font in group default to the latest version  (#1511)
+
+[33mcommit ed5b014be9499d502c922e7264dea62a0730ea97[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Tue Dec 10 12:16:49 2019 +0100
+
+    chore: Update expo-keep-awake in group default to the latest version (#1512)
+
+[33mcommit 94920c934964f767aa03f6d0054ad00a957b2635[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Tue Dec 10 12:16:03 2019 +0100
+
+    chore: Update babel-preset-expo in group default to the latest version (#1510)
+
+[33mcommit 7fc340185fbd5fd11ae6c08218f0f8f14525f498[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Tue Dec 10 12:11:06 2019 +0100
+
+    chore: Update @typescript-eslint/parser to the latest version (#1497)
+
+[33mcommit 2a1d398f4f00aea3b6cde61d20212971d610d982[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Tue Dec 3 09:49:41 2019 +0100
+
+    chore: update @typescript-eslint/eslint-plugin to the latest version 🚀 (#1498)
+
+[33mcommit e941d9e700067ac50fee1df88c2c6a44bab14af0[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Mon Dec 2 10:46:42 2019 +0100
+
+    chore: release 3.3.0
+
+[33mcommit e60dc8063ed1161ce84f4c598fce1b7599129ecf[m
+Author: greenkeeper[bot] <23040076+greenkeeper[bot]@users.noreply.github.com>
+Date:   Mon Dec 2 10:41:43 2019 +0100
+
+    chore: Update dependencies to enable Greenkeeper 🌴 (#906)
+
+[33mcommit 17aefb9090dbf8901841c971dd541c5c775d8e17[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Mon Dec 2 06:31:16 2019 -0300
+
+    refactor: reuse RadioButton context in RadioButton/Android/IOS/Item (#1223)
+
+[33mcommit d013e96ce7b4bc5a5fde7c213d2fd7d01c35d108[m
+Author: Richard Lindhout <richardlindhout96@gmail.com>
+Date:   Tue Nov 26 15:45:58 2019 +0100
+
+    fix: support backdrop dismiss (#1490)
+
+[33mcommit ba6ad1717c6a82b6573c487942a606f63c33d45b[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Wed Nov 20 14:43:11 2019 +0100
+
+    chore: add jbinda to all contributors
+
+[33mcommit e5cd6fb6029396f35c7a6ca0f6ded2bb6526b64b[m
+Author: mmarkusik <magdalena@markusik.com>
+Date:   Thu Nov 14 13:47:00 2019 +0100
+
+    feat: add RadioButton.Item to enable pressing the whole row (#1468)
+
+[33mcommit c669d51a21097875d854225bd7afb5962c7f63ca[m
+Author: mmarkusik <magdalena@markusik.com>
+Date:   Thu Nov 14 11:59:01 2019 +0100
+
+    fix: fix text input disappearing value on blur when in uncontrolled mode (#1434)
+
+[33mcommit 53e1eca810e24e7c8cd07416a7f7b4f790a229f0[m
+Author: Michael Sageryd <michael@sageryd.se>
+Date:   Thu Nov 14 11:47:10 2019 +0100
+
+    fix: animation speed for checkbox on Android (#1471)
+
+[33mcommit be296741295b135f21ecf0b4b56e77600135091b[m
+Author: 0xflotus <0xflotus@gmail.com>
+Date:   Sun Nov 10 20:53:58 2019 +0100
+
+    fix: fix typos in docs (#1462)
+
+[33mcommit 2a155eebbc67aeee4cf1371a512f5561855b7ec3[m
+Author: Phil <phil@capshake.com>
+Date:   Thu Nov 7 10:16:17 2019 +0100
+
+    fix: fix banner doc comment (#1456)
+
+[33mcommit 1eed3eda0f4c826666876ed4b7c540e4e6854e37[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Nov 6 06:33:19 2019 +0100
+
+    chore: release 3.2.1
+
+[33mcommit b45bca82bf54825202efbac47807b41191534ce9[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Nov 6 06:32:21 2019 +0100
+
+    fix: fix importing mappings. closes #1454
+
+[33mcommit 15ddc162b4a65cefe9cefe0ddb08b793c40f4873[m
+Author: satyajit.happy <satyajit.happy@gmail.com>
+Date:   Tue Nov 5 17:08:58 2019 +0100
+
+    refactor: use file path for index in mappings
+
+[33mcommit 0a65d1cb79ed5f456b2a338ae6e0a5f6a619f53e[m
+Author: satyajit.happy <satyajit.happy@gmail.com>
+Date:   Tue Nov 5 17:02:03 2019 +0100
+
+    chore: release 3.2.0
+
+[33mcommit 5c1cc8e8f6d6406469152cae172d4d6e7d3cf4d2[m
+Author: satyajit.happy <satyajit.happy@gmail.com>
+Date:   Tue Nov 5 15:56:00 2019 +0100
+
+    fix: make sure only one version of the library is imported
+    
+    closes #1432
+
+[33mcommit d2e56efa495a6c607a7d53503454b110bfc6d5ac[m
+Author: Michael Yin <layerssss@gmail.com>
+Date:   Mon Nov 4 23:17:23 2019 +1300
+
+    docs: add RaceCalendar into Showcase (#1421) (#1442)
+
+[33mcommit a33d999cdc633b215177ade30df5829720078936[m
+Author: Richard Lindhout <richardlindhout96@gmail.com>
+Date:   Fri Nov 1 00:44:30 2019 +0100
+
+    fix: fix initial label position when value is set on RN 0.61 (#1441)
+
+[33mcommit 2f25bfa7e47cd594ae75a016d090add831bfaae1[m
+Author: satyajit.happy <satyajit.happy@gmail.com>
+Date:   Thu Oct 31 23:10:21 2019 +0100
+
+    fix: fix initializing label state when defaultValue is given
+
+[33mcommit a06906272c7759080972ec446d481f4a1e8542e9[m
+Author: Noemi Rozpara <nrozpara@gmail.com>
+Date:   Tue Oct 29 12:25:26 2019 +0100
+
+    fix: fix  label behavior when TextInput is in error state (#1429)
+
+[33mcommit 9ac64078bf820c1a0b0256e34fbc62190cb85478[m
+Author: Mars Lan <mars.th.lan@gmail.com>
+Date:   Tue Oct 29 02:14:51 2019 -0700
+
+    feat: export overlay function (#1411)
+
+[33mcommit 6dfcdf41b98153e055c6b070185e07b3a231f198[m
+Author: satyajit.happy <satyajit.happy@gmail.com>
+Date:   Tue Oct 29 02:12:12 2019 +0100
+
+    chore: release 3.1.1
+
+[33mcommit 9b67a889f8f38ff26c403714c35e61f1def77d71[m
+Author: satyajit.happy <satyajit.happy@gmail.com>
+Date:   Tue Oct 29 02:11:28 2019 +0100
+
+    fix: don't disable interactions on the scene
+
+[33mcommit d53582e8aa242f37429d49d5bbce10891eec7d74[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Oct 29 02:08:48 2019 +0100
+
+    fix: tweak modal animation to match default android animations (#1428)
+
+[33mcommit 97a5a0aadcf3f053fe9396fe91530e91d42b7797[m
+Author: satyajit.happy <satyajit.happy@gmail.com>
+Date:   Mon Oct 28 23:22:32 2019 +0100
+
+    chore: release 3.1.0
+
+[33mcommit 72c40eb8f2e07b90b01a367a86f930ff069817f9[m
+Author: satyajit.happy <satyajit.happy@gmail.com>
+Date:   Mon Oct 28 23:21:42 2019 +0100
+
+    fix: start ripple from correct position in bottom navigation
+    
+    fixes #1207
+
+[33mcommit ee81d6bb2573a8caa8179696c87067027f94a446[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Oct 28 21:25:21 2019 +0100
+
+    feat: add an option to disable animation in bottom navigation (#1426)
+
+[33mcommit eab656c8fdf0c6d0ab00bf0638fa69fd9c0c3e12[m
+Author: forkandfix <57001408+forkandfix@users.noreply.github.com>
+Date:   Mon Oct 28 19:16:23 2019 +0300
+
+    fix: allow touch events to go through in PortalHost (#1422)
+
+[33mcommit 37183ecf254c2f61c58cc2a933c9adf87f710be2[m
+Author: Jesse Katsumata <niconico.clarinet@gmail.com>
+Date:   Mon Oct 28 23:30:47 2019 +0900
+
+    chore: improve style prop type in MenuItem (#1425)
+
+[33mcommit a306d2ef288f866f55042285afc9ec1012f380a0[m
+Author: Usama Liaquat <33973828+Usamaliaquat123@users.noreply.github.com>
+Date:   Fri Oct 25 15:34:07 2019 +0500
+
+    docs: mention users don't have to link vector icons on RN >= 0.60 (#1414)
+
+[33mcommit 43517dca3cbdb3f7f052d22c51d19e18049529f1[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Oct 24 13:29:51 2019 +0200
+
+    fix: mark methods as private (#1419)
+
+[33mcommit 03c9bfde19af139ca56ddcfb6e3f42f53b00c28a[m
+Author: Tomek Przybył <tomasz.przybyl.it@gmail.com>
+Date:   Thu Oct 24 13:28:27 2019 +0200
+
+    fix: align text to center in multiline TextInput (#1408)
+
+[33mcommit 44e1d8afe39902750dbdbb5d8044791f6d7567d6[m
+Author: satyajit.happy <satyajit.happy@gmail.com>
+Date:   Thu Oct 24 00:05:55 2019 +0200
+
+    fix: add additional check for browsers. fixes #1178
+
+[33mcommit 9b74d21709d430708d3f41723beb388f856c206e[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Wed Oct 23 18:38:33 2019 +0200
+
+    fix: add commonjs step to bob and configure main and module fields properly (#1415)
+
+[33mcommit 6234c9a08a8e7d630ba385d5beff46d7b771c845[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Oct 23 18:37:20 2019 +0200
+
+    chore: upgrade react navigation to v5 (#1417)
+
+[33mcommit 99d091b9e2e87e7a8aa8ffe060f80268eab9cd44[m
+Author: Marcin Miazga <radioactive.v@gmail.com>
+Date:   Tue Oct 22 10:01:38 2019 +0200
+
+    docs: add pandadeals app in the showcase (#1399)
+
+[33mcommit f68014311ffae6f7676714214f31095db26a8b88[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Tue Oct 22 09:18:01 2019 +0200
+
+    chore: release 3.0.0
+
+[33mcommit 758180d63cead0437a35864ebdf6163c113e813d[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Tue Oct 22 08:50:04 2019 +0200
+
+    fix: flatten styles to get horizontal padding (#1405)
+
+[33mcommit 911f1be6ac83f2d4198cd279753adea511210d62[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Mon Oct 21 15:17:06 2019 +0200
+
+    docs: fix links pointing to previous version of docs (#1402)
+
+[33mcommit 8c8db78d5067d9243caf55d870519f4623bdc40e[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Mon Oct 21 14:50:43 2019 +0200
+
+    chore: release 3.0.0-alpha.8
+
+[33mcommit fb439edaabfe55f1d9f7633d2ba6d13a0c825343[m
+Author: Tomek Przybył <tomasz.przybyl.it@gmail.com>
+Date:   Mon Oct 21 14:48:47 2019 +0200
+
+    fix: fix flat TextInput flex behaviour (#1401)
+
+[33mcommit 9f26bb4c99ab8c4c4ccd9a13351877775c1e5286[m
+Author: Paweł Szymański <3x4to9@gmail.com>
+Date:   Mon Oct 21 09:44:13 2019 +0200
+
+    fix: use custom color first in bottom navigation (#1398)
+
+[33mcommit 1abcfb5d848791cece865baeef320b7b40ee65d4[m
+Author: satyajit.happy <satyajit.happy@gmail.com>
+Date:   Thu Oct 17 22:48:34 2019 +0200
+
+    chore: release 3.0.0-alpha.7
+
+[33mcommit 7865e80f242b031064c03cc0fc78df1b46d4df15[m
+Author: satyajit.happy <satyajit.happy@gmail.com>
+Date:   Thu Oct 17 22:43:44 2019 +0200
+
+    fix: update bottom navigation types
+
+[33mcommit f43c1a815b10d599bf253fb5e988af34c9f7bd8a[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Thu Oct 17 16:53:00 2019 +0200
+
+    chore: release 3.0.0-alpha.6
+
+[33mcommit 708fdf3463c676507f64286bbf790f02c5426cf2[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Thu Oct 17 16:48:29 2019 +0200
+
+    fix: BREAKING remove padding prop from TextInput (#1394)
+
+[33mcommit 7f7b5d2b9f3bb92fad749b6ff2d1eb36c740c856[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Wed Oct 16 16:26:54 2019 +0200
+
+    feat: implements dropdown menu for changing docs version. (#1376)
+
+[33mcommit edfc64ab6bc2728fd8e08dce1c9cef8a1dfaa408[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Wed Oct 16 16:07:29 2019 +0200
+
+    chore: bump theme provider version
+
+[33mcommit 2a392b9a6bef45dcc2d59b995ce4eb120a224558[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Fri Oct 11 12:43:17 2019 +0200
+
+    fix: make ListIcon color optional (#1379)
+
+[33mcommit 189ae0281e127573857793c8cdea43f618791df6[m
+Author: Rajendran Nadar <raajnadar@gmail.com>
+Date:   Fri Oct 11 13:24:58 2019 +0530
+
+    chore: upgrade example app to expo sdk 35 (#1366)
+
+[33mcommit d39973342526587ab94cc573a8195a0f62190c85[m
+Author: Paweł Szymański <3x4to9@gmail.com>
+Date:   Fri Oct 11 09:33:56 2019 +0200
+
+    feat: adaptive and exact dark theme (#1367)
+
+[33mcommit abe187ec5b57a683b4b20312dff532df83cc510f[m
+Author: Wojtek Szafraniec <feelun132@gmail.com>
+Date:   Fri Oct 11 09:28:15 2019 +0200
+
+    docs: update font configuration (#1363)
+
+[33mcommit bd4296116d841ed355f3dbebb40cfbc3b87a79ff[m
+Author: Taym Haddadi <bentaimia.haddadi@signify.com>
+Date:   Thu Oct 3 10:55:45 2019 +0200
+
+    fix: fix RadioButton onPress (#1359)
+
+[33mcommit 1e4b623c510fa35be05a7f02bd85223b0a9f9f4d[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Thu Oct 3 09:55:28 2019 +0200
+
+    fix: omit ref in TextInput props type (#1361)
+
+[33mcommit 9f7bb6bc3afca01a3d329b035d06551975af9c31[m
+Author: Iyad Thayyil <iyadthayyil@gmail.com>
+Date:   Mon Sep 30 12:30:32 2019 +0300
+
+    fix: pass borderRadius to touchableStyle of button (#1343)
+
+[33mcommit fb5ef8345b59e87c8a1cd80111e3e90b0d6c899a[m
+Author: Yosmany Garcia <yosmanyga@gmail.com>
+Date:   Fri Sep 20 12:08:57 2019 -0700
+
+    fix: fix snackbar example (#1338)
+
+[33mcommit 818f73c848bc0b0888c918810e9099a5746a1cf2[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Tue Sep 17 09:05:58 2019 +0200
+
+    fix: allow changing progressBar progress when visible
+
+[33mcommit ca94a2304dc58166e1fe6ef3426e9066d57cc31e[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Tue Sep 17 08:48:55 2019 +0200
+
+    fix: fix issue with displaying text in rtl mode
+
+[33mcommit 9c8a916596e37abc920d3f32e30e38672d0e140b[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Thu Sep 12 15:18:35 2019 +0200
+
+    chore: improve deploy-docs script
+
+[33mcommit dc04d94ebac29278ddad3e27ae38ce1c33e11555[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Thu Sep 12 15:09:04 2019 +0200
+
+    chore: improve error handling in bash script
+
+[33mcommit 7f5c50cdaca923cef38b3ed24fc68f1f2791f3e9[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Thu Sep 12 14:58:59 2019 +0200
+
+    docs: generate docs for 2.0 version
+
+[33mcommit 0ad697dba5072e5b304d13e9178a41a4218c4ec8[m
+Author: Iyad Thayyil <iyadthayyil@gmail.com>
+Date:   Thu Sep 12 14:28:02 2019 +0300
+
+    feat: add support to anchor menu on x,y coordinates (#1208)
+
+[33mcommit ce0bd3e39960474bb7fc1ffc6ee92c9027c623b4[m
+Author: Kuba Mazurek <jakub_mazurek96@onet.pl>
+Date:   Thu Sep 12 13:11:06 2019 +0200
+
+    feat: add List.AccordionGroup component (#1307)
+
+[33mcommit 97494536ec3d0552525e288afdc77b636cec46bb[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Thu Sep 12 09:23:09 2019 +0200
+
+    docs: use cli to add contributors
+
+[33mcommit 842c52cd6c6ca4d255c2cd6be9a6731c52693f8e[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Wed Sep 11 18:27:03 2019 +0200
+
+    docs: add jay and pan-pawel as contributors (#1331)
+
+[33mcommit 57d5de61a98ef82d0056d183474c04ff430fc35a[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Wed Sep 11 16:45:59 2019 +0200
+
+    chore: release 3.0.0-alpha.5
+
+[33mcommit 3e07f7ad243e3b1c09802980d339419ce48612ec[m
+Author: Kuba <jakub_mazurek96@onet.pl>
+Date:   Wed Sep 11 16:41:47 2019 +0200
+
+    fix: fix babel plugin (#1330)
+
+[33mcommit 7332260dec70cb90eab10f0b0fdbb2becfa60a60[m
+Author: Paweł Szymański <3x4to9@gmail.com>
+Date:   Wed Sep 11 16:39:56 2019 +0200
+
+    docs: add dark theme examples (#1325)
+
+[33mcommit fa22a6854f80259bdca266b4725fd15e722c5c70[m
+Author: Iyad Thayyil <iyadthayyil@gmail.com>
+Date:   Mon Sep 9 14:28:58 2019 +0300
+
+    fix(Menu): wrap overflowing menu items in scrollView (#1084)
+
+[33mcommit 4858bffaa7cb6d97861c6682d5d1331cf472d39d[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Mon Sep 9 09:41:34 2019 +0200
+
+    chore: release 3.0.0-alpha.4
+
+[33mcommit 18cf9d0506456190a2d0a623f78da55c7748573c[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Mon Sep 9 09:32:53 2019 +0200
+
+    Revert "chore: release 3.0.0"
+    
+    This reverts commit 723919f2c6d45f4796c1789dc47da742d8b1f243.
+
+[33mcommit 723919f2c6d45f4796c1789dc47da742d8b1f243[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Mon Sep 9 09:26:41 2019 +0200
+
+    chore: release 3.0.0
+
+[33mcommit 403bfd30d8db58f4837245e4928856d69e814823[m
+Author: Paweł Szymański <3x4to9@gmail.com>
+Date:   Mon Sep 2 10:28:35 2019 +0200
+
+    fix: add elevation to wrapper style on Android (#1319)
+
+[33mcommit 5bbba8893e8b1bbb1eb6ae912d26fc955e9cf753[m
+Author: Kuba <jakub_mazurek96@onet.pl>
+Date:   Mon Sep 2 10:04:41 2019 +0200
+
+    BREAKING CHANGE: change banner icon prop instead of image (#1304)
+
+[33mcommit 508fab450ad2ab8b9be732924804dd325997ecf6[m
+Author: Paweł Szymański <3x4to9@gmail.com>
+Date:   Mon Sep 2 09:33:58 2019 +0200
+
+    feat: add button labelStyle (#1321)
+
+[33mcommit d644354d396ad8e765c85886ab3033b45f7a7c00[m
+Author: Kuba <jakub_mazurek96@onet.pl>
+Date:   Sat Aug 31 16:42:09 2019 +0200
+
+    chore: fix babel plugin import (#1305)
+
+[33mcommit ee40e580e0d4e28ebc650a97336837f9374a944a[m
+Author: doomsower <K.Kuznetcov@gmail.com>
+Date:   Fri Aug 30 15:08:06 2019 +0300
+
+    refactor: use textTransform to upperCase Button label (#1316)
+
+[33mcommit 6e7cd360c2c238e1cd1ce8a5716e97e6b038ecb9[m
+Author: Richard Lindhout <richardlindhout96@gmail.com>
+Date:   Thu Aug 29 11:33:06 2019 +0200
+
+    fix: update chip close icon to material community icon (#1295)
+
+[33mcommit 3782cf5c7805e6c86d1dcd9c4e863e6ad6ffc7c9[m
+Author: Dominic Ward <deeuu@users.noreply.github.com>
+Date:   Wed Aug 28 14:08:17 2019 +0100
+
+    feat: (title|description)numberOfLines props to ListItem and ListAccordion (#1245)
+
+[33mcommit 575fdecbd3a0355c05b890e60005fcad58430a77[m
+Author: Yajana N Rao <38914337+YajanaRao@users.noreply.github.com>
+Date:   Wed Aug 28 16:25:42 2019 +0530
+
+    fix: FAB - always display activity indicator if loading property is set to true (#11570)
+
+[33mcommit 52b2756c3c79d202948550c30e783bb6c2d3fcb7[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Fri Aug 23 14:14:32 2019 +0200
+
+    fix: fix typescript error when setting ref on textinput (#1218)
+
+[33mcommit 6e4afbbd729a5a5b1b222d95c18a9433970f320d[m
+Author: Akshay-Katariya <akshay.katariya1@gmail.com>
+Date:   Thu Aug 22 17:20:25 2019 +0530
+
+    docs: fix Surface component docs (#1253)
+
+[33mcommit 45b386aa3f06bce06f5e03fbde0aa52c4051c8bc[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Thu Aug 22 13:40:00 2019 +0200
+
+    fix: only start/stop progressBar animation if visible prop changes (#1294)
+
+[33mcommit 8767b76db43af475301ad1fa1ba15f3e8d769120[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Aug 19 13:36:08 2019 +0200
+
+    docs: update font section according to v3.0 (#1287)
+
+[33mcommit 2bb643652d5192d93de85f22ea1d652d2dd6b48d[m
+Author: jbinda <jakub.binda@gmail.com>
+Date:   Mon Aug 5 11:53:23 2019 +0200
+
+    feat: handle fontWeight style-prop
+
+[33mcommit 03e484abadf80638b4953650f9f12c9f59abcbdd[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Thu Aug 1 12:54:18 2019 +0200
+
+    fix: fix iconButton example
+
+[33mcommit 2ad667f8e38e3cc70d3adb700fe3f3d638bae0d0[m
+Author: ferrannp <fnp.developer@gmail.com>
+Date:   Thu Aug 1 12:18:17 2019 +0200
+
+    chore: release 3.0.0-alpha.3
+
+[33mcommit 756d5839a9e8e95724d97d90142109b1ab1830e9[m
+Author: Ferran Negre <fnp.developer@gmail.com>
+Date:   Thu Aug 1 12:07:44 2019 +0200
+
+    chore: update release-it dep from 7.x to 12.x (#1240)
+
+[33mcommit db98ef0cf4921a063975046e9edc0d8bfb49db80[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Thu Aug 1 12:06:57 2019 +0200
+
+    feat: add ability to use own icon component (#1210)
+
+[33mcommit ce5ac1ad438113604cc671a4c015fa65da2b1cf1[m
+Author: Ben Wildeman <wildeman.benjamin@gmail.com>
+Date:   Wed Jul 31 09:47:40 2019 +0100
+
+    docs: update font docs for RN 0.60 (#1246)
+
+[33mcommit 76d598654f3d656894cf2ee498d925265531d247[m
+Author: Louie Christie <6807448+louiechristie@users.noreply.github.com>
+Date:   Wed Jul 31 09:46:25 2019 +0100
+
+    docs: fix typos (#1249)
+
+[33mcommit 3839cfa6516a67a5449d7d390366fc73441d0e07[m
+Author: jbinda <jakub.binda@gmail.com>
+Date:   Wed Jul 31 10:45:37 2019 +0200
+
+    refactor: change outline textinput label behaviour (#1241)
+
+[33mcommit 2e7c88a9d16ee7d786a9e176eb5c476dcc49a914[m
+Author: Wojtek Szafraniec <feelun132@gmail.com>
+Date:   Tue Jul 23 16:09:34 2019 +0200
+
+    fix: add style prop to AvatarText
+
+[33mcommit 93195590f0bc46b2f10fd4cc13358a8aacab65c1[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Jul 23 11:30:05 2019 +0200
+
+    feat: extend chip with onLongPress functionality (#1211)
+
+[33mcommit de94b142c2bc7e12196c7e54d71dfc4f50f72498[m
+Author: Denis <denistsoi@gmail.com>
+Date:   Tue Jul 23 15:50:52 2019 +0800
+
+    docs: update fonts link (#1239)
+    
+    File extension from `.js` to `.tsx`
+
+[33mcommit 15951f7b38b7a1cfa6aac1aae8d3f912afc0edaf[m
+Author: Jason Cooke <Jason-Cooke@users.noreply.github.com>
+Date:   Mon Jul 22 23:12:59 2019 +1200
+
+    docs: fix typo on Snackbar component (#1237)
+
+[33mcommit 5013a896bf43eafc8bfe3d68b69c11f99fb63815[m
+Author: Cedric van Putten <me@bycedric.com>
+Date:   Mon Jul 22 11:48:25 2019 +0200
+
+    docs: add component group annotation for Typography (#1221)
+
+[33mcommit e2a057ce8f479a43aeefd9fa1e73040eb668aead[m
+Author: Wojtek Szafraniec <feelun132@gmail.com>
+Date:   Mon Jul 22 11:43:41 2019 +0200
+
+    fix: add testID to HelperText (#1236)
+
+[33mcommit c26ebd8b9d2b96f08b426893c32cc26e91285bc0[m
+Author: Rin <radysurya.agus@gmail.com>
+Date:   Sat Jul 20 03:09:09 2019 +0700
+
+    docs: update 2.theming.md (#1228)
+    
+    fixed: missing link (404 Not found) of `default theme`.
+
+[33mcommit 66a9fa5294781894539c94d1aeb03ff9040b1441[m
+Author: Paweł Szymański <3x4to9@gmail.com>
+Date:   Fri Jul 19 21:18:15 2019 +0200
+
+    docs: fix color version (#1233)
+
+[33mcommit 05eb8a5fad7df010ce29f6bb080e1ec4844c8209[m
+Author: Paweł Szymański <3x4to9@gmail.com>
+Date:   Fri Jul 19 16:12:43 2019 +0200
+
+    fix: upgrade color missing changes (#1230)
+
+[33mcommit 3cc119ba216bdf1f04a15b12579506113d08ff13[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Fri Jul 19 08:27:45 2019 -0300
+
+    fix: make allowed children to accept additional props (#1174)
+
+[33mcommit 69c239a39df00c4670cfd1e51643977861fee406[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Fri Jul 19 12:29:57 2019 +0200
+
+    chore: upgrade color to 3.0 (#1204)
+
+[33mcommit 183157294a7ec2db8678145d527e576cc4195567[m
+Author: Travis Lang <36346822+travislang@users.noreply.github.com>
+Date:   Fri Jul 19 05:25:39 2019 -0500
+
+    docs: update href for typescrpt extension (#1216)
+
+[33mcommit 16e35697140305e94d9019ddb6e44a1e575ae469[m
+Author: Paweł Szymański <3x4to9@gmail.com>
+Date:   Fri Jul 19 12:14:12 2019 +0200
+
+    fix: touchable-ripple-toggling-disable-prop (#1226)
+
+[33mcommit 0b033716a9c18548b8e1f8468b1215224af61633[m
+Author: Paweł Szymański <3x4to9@gmail.com>
+Date:   Fri Jul 19 12:11:19 2019 +0200
+
+    feat: new dark theme colors (#1219)
+
+[33mcommit 4fc1eb9b0e4bf418d6262d011e28fe215243aa3f[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Thu Jul 18 11:02:31 2019 +0200
+
+    fix: add contentStyle prop to Menu
+
+[33mcommit 3adc5493994f4940381a12a7069fb4a45dff3056[m
+Author: Paweł Szymański <3x4to9@gmail.com>
+Date:   Wed Jul 17 14:28:38 2019 +0200
+
+    fix: iconButton scaling
+
+[33mcommit 2769edcac82b3614b0fa7169380adfe05a42f10f[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jul 17 14:17:37 2019 +0200
+
+    feat: add character counter to text input example
+
+[33mcommit e034b69ba526e2354d0a41ad175113048e207244[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jul 17 14:12:22 2019 +0200
+
+    fix: wrap modal children in SafeAreaView
+
+[33mcommit 16fe177e2aba5a8d666bbbd40356e66eac330c31[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Jul 17 14:10:56 2019 +0200
+
+    refactor: specify the font from theme in chip
+
+[33mcommit 1899651cdc517a6996e228a4cf0d8962ae350f89[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Fri Jul 12 15:21:12 2019 +0200
+
+    fix: add animation scale to Menu (#1182)
+
+[33mcommit 09a793eceb19a28d828e6bfbff9050bdcbef5bf6[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Fri Jul 12 15:20:48 2019 +0200
+
+    fix: reduce delay of Menu (#1183)
+
+[33mcommit 7e1d5cdcbd60db5a5ef128e3d1210c509d56f2ad[m
+Author: Joseph Shearer <joseph@josephshearer.net>
+Date:   Fri Jul 12 09:20:13 2019 -0400
+
+    feat: export useTheme hook
+
+[33mcommit c55e3dc542fc7941fbab8ecc2a8b73d8e9e6008e[m
+Author: Ahmed T. Ali <ah.tajelsir@gmail.com>
+Date:   Thu Jul 11 13:38:41 2019 +0300
+
+    fix: add letter spacing for typography components (#1111)
+
+[33mcommit 7ac5d39fdb0802f175480e65b8f47418877b902a[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Wed Jul 10 17:51:03 2019 -0300
+
+    fix: properly render prop description in List.Item (#1199)
+
+[33mcommit 553fbfc9f5f20063b33d25087287ea8351b9728b[m
+Author: jbinda <jakub.binda@gmail.com>
+Date:   Wed Jul 10 10:16:43 2019 +0200
+
+    fix: placeholder disappears in react-native-web (#1152)
+    
+    * fix: fix disappears placeholder on web
+
+[33mcommit 44cd98db96df5ec0b34daaacca003cf9e27e1439[m
+Author: jbinda <jakub.binda@gmail.com>
+Date:   Wed Jul 10 08:57:47 2019 +0200
+
+    docs: add docs about custom Fonts (#1151)
+
+[33mcommit 1ab39eb577c8e71c2bd6efe4edd3966e46f8d0e2[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Mon Jul 8 10:02:34 2019 +0200
+
+    fix: consistent elevation behavior across platforms (#1176)
+
+[33mcommit fe3efaeedadc43fb14b9abb5f04c3fe5cbbedbee[m
+Author: Dawid Urbaniak <dawidu@onet.pl>
+Date:   Mon Jul 8 09:51:29 2019 +0200
+
+    feat: add ToggleButton.Row component (#1169)
+
+[33mcommit 12ed01e04c845bbf5e7bf4dfe72a431c01f6b9fa[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Mon Jul 8 09:45:55 2019 +0200
+
+    fix: add $Omit for lower Typescript versions (#1180)
+
+[33mcommit ae6258cf87de04fb88392e1df89b183eb9c4e97f[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Mon Jul 8 04:19:05 2019 -0300
+
+    test: add missing test to ListItem.test.js (#1191)
+
+[33mcommit f61393d79f59dbb52993da7f7029c3bd919cc623[m
+Author: Iyad Thayyil <iyadthayyil@gmail.com>
+Date:   Sat Jul 6 12:34:18 2019 +0530
+
+    fix: remove unused prop from Appbar.Header (#1187)
+    
+    Closes #1186
+
+[33mcommit 4e57e64cc3ca8d4df164f269bc173afa2d68dec6[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Fri Jul 5 13:15:27 2019 +0200
+
+    feat: add contentStyle prop to banner (#1143)
+
+[33mcommit 7212ed83a01d3b0a100354b442ba9fb7847cf7ce[m
+Author: satyajit.happy <satyajit.happy@gmail.com>
+Date:   Fri Jul 5 11:35:13 2019 +0200
+
+    chore: fix webpack config for TS and remove @flow annotations
+
+[33mcommit c07d629ed7e57872224df26a3dff8841cda81683[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jul 3 15:51:19 2019 +0200
+
+    fix: use Partial<Props> for type of defaultProps (#1170)
+
+[33mcommit c6d5e081a5807c3eb00f207d851c121a627fb405[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jul 3 15:50:29 2019 +0200
+
+    chore: migrate example to TS fully and suppress warnings (#1172)
+
+[33mcommit 95750486ab3dfcf5b447cb07eeee047ddf444682[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Wed Jul 3 09:59:04 2019 +0200
+
+    fix: adjustsFontSizeToFit does not exist on TextInput (#1131)
+
+[33mcommit 4e8622c38f6c20ca9c6a45ce7731748e5a800535[m
+Author: Iyad Thayyil <iyadthayyil@gmail.com>
+Date:   Mon Jul 1 18:15:16 2019 +0530
+
+    fix: disable menu interaction while hiding (#1166)
+
+[33mcommit 12f3cf109683d365e7c672d7df626b5900ee1e02[m
+Author: raajnadar <raajnadar@gmail.com>
+Date:   Wed Jun 26 19:31:53 2019 +0530
+
+    fix: optimize images to remove warning from expo cli
+
+[33mcommit 14bb16a6f39bc61154b0acb38658ed7639632b0b[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Thu Jun 27 11:55:29 2019 +0200
+
+    chore: release 3.0.0-alpha.2
+
+[33mcommit acdd012345ec0a48d2c8c1bc7339483623e064b9[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Thu May 23 14:32:51 2019 -0300
+
+    refactor: make ListItem accepts a custom description (#996)
+    
+    * refactor: make ListItem accepts a custom description
+    
+    * fix: update prop description type
+
+[33mcommit cce403fcfcd8681b1613cb555597e3abcbb8cc86[m
+Author: Taym Haddadi <haddadi.taym@gmail.com>
+Date:   Thu May 9 12:08:34 2019 +0200
+
+    fix: add contentContainerStyle type to ModalProps interface (#1052)
+
+[33mcommit ef00256abecaa22f3513b5edd2dc94d7772e5bee[m
+Author: Mike Stone <mike@gnar.dog>
+Date:   Wed May 8 11:01:56 2019 -0400
+
+    fix: correct Chip component typings (#1044)
+    
+    As of version 2.15.2 the Chip component accepts the prop `selectedColor`
+    which it defines as an optional string prop. Though this change was
+    introduced to the Chip component itself, the typings for the component
+    were not updated which causes Typescript to complain when using the
+    `selectedColor` prop. This change adds the missing type to appease
+    Typescript.
+
+[33mcommit 6d5345c1ebb211701c71f9471f84183a4700454f[m
+Author: Dizy <mhisf@vip.qq.com>
+Date:   Wed May 8 23:00:44 2019 +0800
+
+    fix: add inputStyle prop tying to Searchbar (#1049)
+
+[33mcommit ad3eb6284a1986f56b8d6172469fa76664da6770[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon May 6 10:26:05 2019 +0200
+
+    fix: make the menu keyboard-accessible in browser (#1046)
+    
+    This PR makes sure that
+    - The correct item is focused when showing/hiding the menu
+    - The menu can be dismissed by the keyboard
+    - The menu is not rendered when not visible
+
+[33mcommit 72da47ed2d2aba5696b8ff396d35fef90d013f44[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Tue Apr 30 08:06:02 2019 -0300
+
+    fix: warning in console when running tests (#1028)
+
+[33mcommit 72b201fbbdab5736f07be8187e617f429cfdaa71[m
+Author: Iyad Thayyil <iyadthayyil@gmail.com>
+Date:   Sun Apr 28 11:58:50 2019 +0300
+
+    fix: properly handle back button press in menu (#1032)
+
+[33mcommit 391fe53bab501e843f8e4440b284a859c687d328[m
+Author: Iyad Thayyil <iyadthayyil@gmail.com>
+Date:   Sat Apr 27 11:13:35 2019 +0300
+
+    fix: typo in menu component
+
+[33mcommit 17c1f81d94bc3213276d25f545895f27bf2eac75[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Apr 25 17:26:26 2019 +0200
+
+    fix: dismiss menu on window layout change. closes #1005 (#1026)
+
+[33mcommit 4974b8cf16bca22013e44246c1a4d4d74225e9ee[m
+Author: Kuba <jakub.mazurek.dev@gmail.com>
+Date:   Thu Apr 25 12:24:20 2019 +0200
+
+    feat: missing titleStyle and descriptionStyle for List.Accordion and List.Section (#997)
+    
+    This PR introduces missing style props:
+    List.Accordion:
+    - `titleStyle`
+    - `descriptionStyle`
+    
+    List.Section
+    - `titleStyle`
+    
+    Also improves `style` prop type and description in these components.
+    
+    Fixes #973
+
+[33mcommit b5b8ed107a72f173800d592710aa04e34401b1a4[m
+Author: David undefined <offantik@gmail.com>
+Date:   Thu Apr 25 13:17:27 2019 +0300
+
+    fix: fix Card flow type (#1012)
+
+[33mcommit 87855b86cf7b7a44d1e79c5cadd20ddd7037f13c[m
+Author: Taym Haddadi <haddadi.taym@gmail.com>
+Date:   Thu Apr 18 09:08:47 2019 +0200
+
+    fix: check if portal manager is not null for update and unmount and fix the modal doc example (#995)
+    
+    * fix(portal): check if a portal manager is not null for update and unmount
+    
+    * docs(portal): fix Modal example
+
+[33mcommit 446ad94cbd1370dd6bedd4df147b366b8ee0cad4[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Tue Apr 16 05:54:16 2019 -0300
+
+    fix(appbar): do not pass any additional props to custom children components (#972)
+
+[33mcommit cb9923bc090ddecaaf52a06d891c440203ae2c8f[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Mon Apr 15 07:28:32 2019 -0300
+
+    feat: add prop textStyle to Chip (#954)
+
+[33mcommit c23d4eb9e701c77021185693bb1374f43611848e[m
+Author: Rajendran Nadar <raajnadar@gmail.com>
+Date:   Mon Apr 15 15:50:11 2019 +0530
+
+    feat: custom icon for clear in seachbar (#965)
+
+[33mcommit adb3337fd6c7d1796325f303f41eee1ae7f1bb47[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jun 26 16:19:35 2019 +0200
+
+    chore: update bot comment
+
+[33mcommit d3db78f926eacb3c667846b7c9dcae8c5cdcf89e[m
+Author: Wojtek Szafraniec <feelun132@gmail.com>
+Date:   Wed Jun 26 14:55:22 2019 +0200
+
+    feat: migrate from Flow to TS (#1114)
+
+[33mcommit fcf3ec9f87f6d33bc2f64e9521cc7909c4457491[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Wed Jun 26 13:48:27 2019 +0200
+
+    fix: pass flattened styles to adjustPadding (#1132)
+
+[33mcommit cbfa18194c7548eb00cd842b4c5da69f6198e263[m
+Author: Vojtech Novak <vonovak@gmail.com>
+Date:   Fri Jun 21 00:37:32 2019 +0200
+
+    docs: fix typo in Menu docs (#1142)
+
+[33mcommit f266ca11560b418d578f2cbc650f86c17f8ba224[m
+Author: Rodrigo Vieira <rodriigovieira@gmail.com>
+Date:   Fri Jun 14 06:16:41 2019 -0300
+
+    docs: Adding <Text> to avoid errors (#1124)
+    
+    * Adding <Text> to avoid errors
+    
+    When copying the code and trying in the editor, an error is returning, demanding that the "This is a scrollable area" text be wrapped in a `<Text>` component.
+    
+    * docs: importing <Text> from react-native-paper
+
+[33mcommit 3b19f18822200bdbb33f4d8ff32faa525dc810b6[m
+Author: José Chaves Neto <netobac1@gmail.com>
+Date:   Thu Jun 13 15:17:58 2019 -0300
+
+    docs: fix example erros in docs (#1109)
+    
+    * docs: fix fab group example error
+    
+    * docs: fix modal example error
+
+[33mcommit 3349a4fc28596e75ab53fea6681a8cef6a0bcf58[m
+Author: Mars Lan <mars.th.lan@gmail.com>
+Date:   Thu Jun 13 11:12:59 2019 -0700
+
+    fix: disable interaction when fading out modal (#1116)
+    
+    While the animation only last < 300ms, it is possible for user to interact with the modal during the transition.
+    This is based on a fix suggested in https://github.com/facebook/react-native/issues/6732
+
+[33mcommit b5878741f2d3150ad2d531890a95b937c527e9d6[m
+Author: Jason Cooke <Jason-Cooke@users.noreply.github.com>
+Date:   Fri Jun 14 06:11:12 2019 +1200
+
+    docs: fix typo (#1121)
+
+[33mcommit eab6a0e61c1458e7bfa3effee11783b9c58f0011[m
+Author: Mark Murphy <MarkRMurphy37@gmail.com>
+Date:   Wed Jun 12 08:02:07 2019 -0400
+
+    docs: add Dark Hacker News to app showcase (#1125)
+
+[33mcommit 57393dc94a814e3ead69acdb1653e43b024f293f[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue May 28 23:20:13 2019 +0200
+
+    docs: add a page for recommended libraries (#1095)
+
+[33mcommit 635d647f46347a5cf014cc1ef9bbb5fc4f9eed98[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Mon Jun 3 13:35:09 2019 +0200
+
+    chore: bump component-docs version
+
+[33mcommit 8746abab9d26bb7eef76ec8f08648bb77d6fb04f[m
+Author: Mars Lan <mars.th.lan@gmail.com>
+Date:   Thu May 30 03:28:27 2019 -0700
+
+    fix: use "active" instead of "text" for ripple color (#1060)
+
+[33mcommit ffe8ce0477f0b6641ee561225ce661a133b19924[m
+Author: jbinda <jakub.binda@gmail.com>
+Date:   Thu May 30 12:25:39 2019 +0200
+
+    refactor: extract inputs label and clean code  (#1071)
+    
+    * initial refactor of label
+    
+    * refactor inputs and split label to separate components
+
+[33mcommit ac5912601222d9bb1ac5af3f2338cd5a9b113a00[m
+Author: Jose <jose96043@gmail.com>
+Date:   Thu May 30 06:24:22 2019 -0400
+
+    fix: move paddingHorizontal out from content style (#1078)
+
+[33mcommit cd1e414f550b2e078eb97f66acd3c0a971fd402c[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Thu May 30 07:10:21 2019 -0300
+
+    ci: cache jest tests and fix flaky tests (#1094)
+
+[33mcommit 93c3760e3ea78d59bd95c22958f8905862b72cc2[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Thu May 23 12:37:47 2019 +0200
+
+    chore: release 3.0.0-alpha.1
+
+[33mcommit 4d47b4e063127fc9873fa28b77a076cb25b056e0[m
+Author: Taym Haddadi <bentaimia.haddadi@signify.com>
+Date:   Thu May 23 12:14:00 2019 +0200
+
+    feat: aad scale property to control cross fade icon animation time (#1067)
+
+[33mcommit b852293f24f64278497b518fe0ce887dda7cec42[m
+Author: jbinda <jakub.binda@gmail.com>
+Date:   Thu May 16 11:40:57 2019 +0200
+
+    feat: add ability to change TextInput fontSize and height (#1020)
+
+[33mcommit 327749f0374eeb0947252bef27ffd5882cc9ca14[m
+Author: jbinda <jakub.binda@gmail.com>
+Date:   Thu May 16 09:42:56 2019 +0200
+
+    feat: allow to make inputs uncontrolled with defaultValue (#1068)
+
+[33mcommit 6a37dc9982477436a604c5aaa44149612519b840[m
+Author: jbinda <jakub.binda@gmail.com>
+Date:   Thu May 16 09:35:07 2019 +0200
+
+    fix: fix editable disable props on TextInput (#1069)
+
+[33mcommit 45b86446e36d1d38bdd0ab0151628be485ca8575[m
+Author: jbinda <jakub.binda@gmail.com>
+Date:   Wed May 15 17:29:17 2019 +0200
+
+    fix: remove duplicate type import
+
+[33mcommit fb2bacb3ba36d6074036cde0ad3b50e0c5370129[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Wed May 15 06:54:45 2019 -0300
+
+    fix: fix bug with applying backgroundColor to DrawerSection (#1063)
+
+[33mcommit 16b9dd13067785541bb150df51bd31e254a105fa[m
+Author: Taym Haddadi <haddadi.taym@gmail.com>
+Date:   Thu May 9 12:40:01 2019 +0200
+
+    fix: fix icon type for FABGroup actions (#1057)
+
+[33mcommit f6ac53fe4a69e8c657aeaa2b2b5283ded0ba4058[m
+Author: sritharan <sritharan@memorangapp.com>
+Date:   Thu May 9 15:53:34 2019 +0530
+
+    feat: support loading indicator for FAB (#985)
+
+[33mcommit fbade97eca7e04dc051623c42fb67ce8dad13c9a[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Thu May 9 12:25:45 2019 +0200
+
+    fix: use own ActivityIndicator in Button (#979)
+
+[33mcommit ffc0d5e2b4a7885c9f401f302d042bf42a991e17[m
+Author: Chad Lavimoniere <chad@chadlavimoniere.com>
+Date:   Thu May 9 06:18:32 2019 -0400
+
+    feat: add props `leftStyle` and `rightStyle` to `Card.Title` so devs can style the `left` and `right` independently (#1016)
+
+[33mcommit 79f98d9b6a183929a77f0302232fe4ef03ff93c9[m
+Author: Jordy Wijman <jordywijman@gmail.com>
+Date:   Thu May 9 12:15:02 2019 +0200
+
+    fix: elevation being applied after mode changes on a button while it shouldn't (#1037)
+
+[33mcommit 77da065dc582e49885a4f4b9d60ca4d68a070592[m
+Author: Taym Haddadi <haddadi.taym@gmail.com>
+Date:   Thu May 9 12:16:34 2019 +0200
+
+    fix: remove StatusBar from FAB Group (#1027)
+
+[33mcommit e3dd1abcffeae80d1e9d38fdcb3cfb3f58e59b9f[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Tue Apr 30 08:02:46 2019 -0300
+
+    fix: fix RadioGroup animation (#982)
+
+[33mcommit 0872144dc8349c23b346cbc1ff0d775524e2eae9[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Wed Apr 24 13:03:30 2019 +0200
+
+    fix: fix use theme font in TextInputFlat (#1014)
+
+[33mcommit 9e30fc9837d13da10267b0a9538d720d0dcefb3b[m
+Author: jbinda <jakub.binda@gmail.com>
+Date:   Wed Apr 24 11:52:56 2019 +0200
+
+    fix: fix listitem icon spacing (#1017)
+
+[33mcommit 8a9a6a9d534d3e9d3b972c1fb65cbede3373a95f[m
+Author: jbinda <jakub.binda@gmail.com>
+Date:   Wed Apr 24 11:51:43 2019 +0200
+
+    feat: add padding prop to TextInput (#1018)
+
+[33mcommit eab40ec54cee2f60092625cd5d5ef50d34c60760[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Mon Apr 15 14:11:54 2019 +0200
+
+    chore: release 3.0.0-alpha.0
+
+[33mcommit 61047c4fa7a495e2e0ff40c50901c4f23424049b[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Mon Apr 15 14:07:27 2019 +0200
+
+    fix: upgrade failing snapshot tests
+
+[33mcommit 9eeb8e246ce98438b1b67cccb16e9e3fa49a2242[m
+Author: jbinda <jakub.binda@gmail.com>
+Date:   Fri Apr 12 09:31:55 2019 +0200
+
+    fix: list item height and margins
+    
+    fixes #914
+
+[33mcommit c73cf153b66694bef1074cd0c38a2c1a75b40a4f[m
+Author: Taym Haddadi <haddadi.taym@gmail.com>
+Date:   Thu Apr 11 11:25:22 2019 +0200
+
+    docs: fix edit pencil button (#981)
+    
+    fixes #980
+
+[33mcommit 3c0c2d8c3e99cac630c540c9e22c9fbbb7c85fd6[m
+Merge: 3fd48777 5947be9d
+Author: NoemiRozpara <nrozpara@gmail.com>
+Date:   Thu Apr 11 15:47:20 2019 +0200
+
+    Merge branch 'feat/theme-fonts' into 3.0
+
+[33mcommit 5947be9d94f5c0863213fc70fd3e69b9043a7945[m
+Author: Julian Hundeloh <julian@hundeloh-consulting.ch>
+Date:   Wed Jan 30 11:24:51 2019 +0100
+
+    test: update snapshots
+
+[33mcommit d2b78c6f9c1f37af6476a396ae425df91004351b[m
+Author: Julian Hundeloh <julian@hundeloh-consulting.ch>
+Date:   Wed Jan 30 10:30:56 2019 +0100
+
+    feat: allow granular font definitions in theme
+
+[33mcommit 3fd4877751085c1a9c4a9fb219f146ea43a9cf59[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Thu Apr 11 11:13:59 2019 +0200
+
+    feat: BREAKING CHANGE replace any with proper types (#915)
+
+[33mcommit b3df217e61fb36aeafe55cb7c8f7e2ccc56b7962[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Thu Apr 11 11:03:08 2019 +0200
+
+    feat: refactor of ProgressBar component (#735)
+
+[33mcommit 8c41503c180ae7718671e5c077c41f42152c0c2d[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Thu Apr 11 10:50:46 2019 +0200
+
+    feat: add scale property to control modal animation speed (#942)
+
+[33mcommit 60f1e9c32c0467bf6cba61b0c24c1836c15619cc[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Tue Apr 9 16:08:30 2019 +0200
+
+    chore: release 2.15.2
+
+[33mcommit cf6cc3d2970228fb3f5059a5937487e946f10b16[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Tue Apr 9 16:05:58 2019 +0200
+
+    fix: refactor of menu component (#976)
+
+[33mcommit 826e7e6200833d4f90a1a8342f3dcbe14d289128[m
+Author: Ferran Negre <fnp.developer@gmail.com>
+Date:   Thu Apr 4 10:07:21 2019 +0200
+
+    docs: add reactnativepaper.com in the README (#971)
+
+[33mcommit e4fa828d635565d90e04859ac30bb2fce9eabf1e[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Thu Apr 4 09:27:13 2019 +0200
+
+    chore: release 2.15.1
+
+[33mcommit dc89eb67c07bbd3a87086129fe1d51cecf12fd5f[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Mon Apr 1 12:29:53 2019 +0300
+
+    fix: issue with TextInput animation on iOS (#968)
+
+[33mcommit 35c56fb8853cf6003938147cf1c7be76f56f5829[m
+Author: Anthony Garant <anthony.garant@keenoa.co>
+Date:   Sun Mar 31 10:06:33 2019 -0400
+
+    fix: fix borderRadius support for the Chip component (#962)
+
+[33mcommit 8b8741c6ebb3fe88c7bde3dbcc2683918602f85b[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Tue Mar 26 11:05:33 2019 +0100
+
+    chore: release 2.15.0
+
+[33mcommit f23811bdfd3817827408521d4853a70839a3fef2[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Mon Mar 25 16:33:28 2019 +0100
+
+    fix: fix issue with jumping label in TextInput on iOS
+
+[33mcommit 64c553e3d2afcd9729be4049ed146709015f58e7[m
+Author: Przemysław Bitkowski <prz.bitkowski@gmail.com>
+Date:   Mon Mar 25 16:24:58 2019 +0100
+
+    fix: pass ref to child components, move API to parent TextInput (#949)
+
+[33mcommit 59b53e07754d4f8e6f6e0ab8096f4ecfb78a3b43[m
+Author: Zhe Wang <auzwang@gmail.com>
+Date:   Mon Mar 25 20:30:39 2019 +1100
+
+    feat: use native driver in Modal (#946)
+    
+    * feat: add useNativeDriver prop to Modal component
+    
+    * mock NativeAnimatedHelper in ActivityIndicator test
+    
+    * enforce useNativeDriver in Modal animations
+
+[33mcommit 2124a8176018516313bcd7953b349989b47f473a[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Mar 25 08:59:03 2019 +0100
+
+    feat: support accessibility label for Snackbar button (#951)
+
+[33mcommit 00457a956774d1e15b7509df0a615acc4211fc2a[m
+Author: Darkmyr <Darkmyr@users.noreply.github.com>
+Date:   Fri Mar 22 06:06:39 2019 -0500
+
+    feat: add ellipsize props to ListItem (#944)
+
+[33mcommit e899c5528015a2f89f6dbef920d017b4c5a12670[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Fri Mar 22 13:01:05 2019 +0200
+
+    fix: hide banner when visible prop is false (#934)
+
+[33mcommit 1a4af746d29f0c748935d24a576f2a17026a9ead[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Thu Mar 21 15:53:03 2019 +0100
+
+    fix: Searchbar TS types (#943)
+
+[33mcommit 0c5371adb3ac3ab2c37227307f83b570d9518aad[m
+Author: Iyad Thayyil <iyadthayyil@gmail.com>
+Date:   Thu Mar 21 15:36:48 2019 +0300
+
+    feat: add Menu component (#485)
+
+[33mcommit 117fe476d3a22656119539601176eebe9f3e6c2d[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Tue Mar 19 16:21:12 2019 +0100
+
+    chore: release 2.14.0
+
+[33mcommit 6143dd505307c3bf75372b86c30cf40cdc8c2c6a[m
+Author: Przemysław Bitkowski <prz.bitkowski@gmail.com>
+Date:   Tue Mar 19 13:34:08 2019 +0100
+
+    refactor: refactor TextInput to make it more maintainable (#882)
+
+[33mcommit bc7dbe818a0e6a856db60d465fa17c164c90e018[m
+Author: Przemysław Bitkowski <prz.bitkowski@gmail.com>
+Date:   Tue Mar 19 10:26:11 2019 +0100
+
+    chore: improve typescript tests running (#936)
+
+[33mcommit 0402e7482438b854a0f58c457fe3e227762a72f5[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Fri Mar 15 18:33:32 2019 +0200
+
+    fix: modal example (#925)
+    
+    * fix: modal example
+    
+    * fix: use existing func
+
+[33mcommit 4a28c3e8a54b475c822634090abf2c3938506c23[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Fri Mar 15 11:17:11 2019 +0100
+
+    feat: expose new prop to add custom color in Chip component (#729)
+
+[33mcommit 1262d01c7fdd4b0186ded547c60c330324310a52[m
+Author: Ali Kazemkhanloo <alikazemkhanloo@gmail.com>
+Date:   Thu Mar 14 14:26:26 2019 +0330
+
+    added iconColor to searchbar (#907)
+
+[33mcommit 30fed6f3668bef1c75c69761137cce1fd581b1eb[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Thu Mar 14 12:53:56 2019 +0200
+
+    feat: add titleStyle and descriptionStyle props to List.Item (#911)
+
+[33mcommit 2bbc33c3dda006fc0936e676eafef59aee923cd0[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Tue Mar 12 10:55:59 2019 +0100
+
+    fix: add flexGrow and flexShrink to Dialog.ScrollArea (#835)
+    
+    * fix: limit Dialog.ScrollArea height
+    
+    * fix: update example
+    
+    * fix: reduce height
+
+[33mcommit e9cef2a71b61d6d16548e12fa06c0ba3a34f6d98[m
+Author: ferrannp <fnp.developer@gmail.com>
+Date:   Mon Mar 11 14:52:05 2019 +0100
+
+    chore: release 2.13.0
+
+[33mcommit 2ca0b6079a160d8f79ce5f9eb3f29139805a1877[m
+Author: Ferran Negre <fnp.developer@gmail.com>
+Date:   Mon Mar 11 14:27:18 2019 +0100
+
+    fix: make sure to remove BackHandler listener on Modal (#912)
+
+[33mcommit 503223b5ca6a7c847d0074066ce9358a164f50b4[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Mar 8 14:34:58 2019 +0100
+
+    chore: ignore some deps for greenkeeper
+
+[33mcommit 0acc5e48dabb47ac32bbd20c18199699fd96fb4a[m
+Author: Taym Haddadi <haddadi.taym@gmail.com>
+Date:   Thu Mar 7 16:05:52 2019 +0100
+
+    fix: makes Snackbar handle Infinity duration properly. (#901)
+    
+    * fix: do not add a setTimeout if Infinity is passed as duration
+    
+    * fix: check positive and negative infinity
+    
+    * fix: fix lint
+
+[33mcommit 8042c309e66aba8305cead56f65ac70dba58929a[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Thu Mar 7 13:14:50 2019 +0200
+
+    docs: improve contentStyle prop description in Button (#900)
+    
+    Adds info about customizing height and width of button via contentStyle prop to prop description.
+
+[33mcommit 27c77a333070371d0b9130e7bc286d87fef66261[m
+Author: Ferran Negre <fnp.developer@gmail.com>
+Date:   Thu Mar 7 11:40:03 2019 +0100
+
+    docs: unify code of conduct (#899)
+
+[33mcommit 390981fd98957a7e98f8039f9f19cc6da9ac79ca[m
+Author: Ferran Negre <fnp.developer@gmail.com>
+Date:   Thu Mar 7 11:39:50 2019 +0100
+
+    docs: update Callstack links (#898)
+
+[33mcommit 908fe6b444db485c0ddf905b9a0fa8ed0ad99bfe[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Thu Mar 7 11:24:40 2019 +0100
+
+    fix: make onDismiss optional for Dialog and Modal (#890)
+
+[33mcommit d8171c750b807156b8fbe43ed35a5b32f3daed27[m
+Author: Michał Pierzchała <thymikee@gmail.com>
+Date:   Wed Mar 6 19:51:26 2019 +0100
+
+    docs: add callstack-badge and note to readme (#895)
+    
+    Giving more recognition to Callstack
+
+[33mcommit d81de729385db1e4a5f3670f7c82f20784ccb151[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Tue Mar 5 17:16:59 2019 +0100
+
+    fix: add onLongPress prop to typescript types (Card) (#892)
+
+[33mcommit d387aab9e28a75c8ed07965a160c174658c159a1[m
+Author: Richard Lindhout <richardlindhout96@gmail.com>
+Date:   Mon Mar 4 19:56:45 2019 +0100
+
+    feat: add option to change input style in searchbar (#884)
+    
+    https://www.slashgear.com/gmail-app-android-ios-material-design-update-released-21566652/
+    ```
+    <Searchbar
+      placeholder={'Zoeken'}
+      onChangeText={this.props.onSearch}
+      style={{
+        shadowOpacity: 0.07,
+        elevation: 2,
+      }}
+      inputStyle={{
+        fontSize: 16,
+      }}
+      value={value}
+      icon={icon}
+      onIconPress={this._onMenu}
+    />
+    ```
+    
+    
+    Before:
+    ![9219e44b-52f7-4f5a-b017-62d0b578d9c5](https://user-images.githubusercontent.com/6492229/53686058-f62f7b00-3d22-11e9-9ee3-6c21005e75e1.jpeg)
+    
+    After:
+    ![e77f1c71-b3af-451a-af15-b9a43992c1be](https://user-images.githubusercontent.com/6492229/53686050-dbf59d00-3d22-11e9-9b82-3718cde31b51.jpeg)
+    
+    
+    Related pull request:
+    https://github.com/callstack/react-native-paper/pull/861
+
+[33mcommit 19238824a8ebf6fe43554b5e13e2e881416e21f6[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Mar 1 15:07:53 2019 +0100
+
+    chore: upgrade component-docs
+
+[33mcommit e2b4ba4da7ad8a5fedcb46a88d32738fa240afc2[m
+Author: Óscar Carretero <ocarreterom@users.noreply.github.com>
+Date:   Fri Mar 1 11:48:17 2019 +0100
+
+    feat: add ListSubheader component (#739)
+    
+    * feat: add ListSubheader component
+    
+    * feat: update ListSection in order to use ListSubheader
+    
+    The `title` property is set as deprecated.
+    
+    * test: update ListSection tests
+    
+    * docs: update ListSection example
+    
+    * feat: add ListSubheader typings
+    
+    * docs: add ListSubheader usage example
+    
+    * test: update snapshot
+    
+    * refactor: remove  warning
+    
+    * fix: revert styles
+
+[33mcommit 3765a079c82da022be8302d356a7d7ab73abc74f[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Feb 27 01:10:02 2019 +0100
+
+    chore: release 2.12.0
+
+[33mcommit 4754e098ec62645188da16968ab048b72b5477c9[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Feb 26 13:35:09 2019 +0100
+
+    chore: upgrade component-docs
+
+[33mcommit ee7cc5d5a940fba774e715b1f029c6361110b108[m
+Author: Raphael Araújo <raphox.araujo@gmail.com>
+Date:   Tue Feb 26 09:19:27 2019 -0300
+
+    docs: add documentation to use react-native-paper with CRA (#874)
+
+[33mcommit 53e3bae7e3891249a724f63cfea41ec549ca26dd[m
+Author: R M <mrasikh88@yahoo.com>
+Date:   Tue Feb 19 17:31:27 2019 +0500
+
+    feat: add a `contentStyle` prop to `Button`
+
+[33mcommit c17f477df3663f54f49e8b06977f12c4e45750e1[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Feb 24 22:43:57 2019 +0100
+
+    chore: upgrade component-docs
+
+[33mcommit f9a094918b62534614c47aa8a13f33aec751a1e0[m
+Author: Taym Haddadi <haddadi.taym@gmail.com>
+Date:   Fri Feb 22 17:10:35 2019 +0100
+
+    feat: add numberOfLines prop to DataTableTitle (#863)
+    
+    Closes #848
+
+[33mcommit 8afb7d68c1f56a6c8c34b88b8a1674b6f1067ce7[m
+Author: Taym Haddadi <haddadi.taym@gmail.com>
+Date:   Fri Feb 22 15:46:23 2019 +0100
+
+    docs: add onLongPress to TouchableRipple (#862)
+    
+    Closes #849
+
+[33mcommit 224cdbcc8e3a441fbd83cb1ece55f4dddbbfd30f[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Feb 22 02:54:48 2019 +0100
+
+    chore: upgrade component-docs
+
+[33mcommit f7d370f3de91125623b7d252485efe14205f74ce[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Thu Feb 21 14:57:43 2019 +0100
+
+    fix: fix visiblity prop in SNackbar and Modal
+
+[33mcommit d29eb93d028360f0f78209fa3f546684d4b44146[m
+Author: Travis Collins <trc229@gmail.com>
+Date:   Thu Feb 21 08:21:43 2019 -0500
+
+    fix: pass down accessible from Card props to Touchable for Appium tests (#812)
+
+[33mcommit ade8d27a1ef48caea55e00383e34db95105a69c5[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Thu Feb 21 15:13:52 2019 +0200
+
+    fix: makes FAB not pressable when initialy not visible (#858)
+
+[33mcommit 7a4966dfed51d39e184129036a16a1f8250aa821[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Feb 19 23:08:47 2019 +0100
+
+    docs: update instructions for running the example app
+
+[33mcommit c108aafa6d155fc9b2d331db24c9aeccd36e65d9[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Feb 19 00:28:00 2019 +0100
+
+    docs: upgrade component docs and redesign landing page
+
+[33mcommit 0780e9b3c1aa1d99f5941b809a4bf874fd05cc1a[m
+Author: Pedro Henrique <pedrosobralxv@gmail.com>
+Date:   Mon Feb 18 07:38:51 2019 -0300
+
+    fix: update typescript types for button (#847)
+    
+    Add uppercase property
+
+[33mcommit 75e7c529912ac4a3b50c75533bcdeb7a412aba16[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Sun Feb 17 12:27:44 2019 +0100
+
+    fix: fix typescript types (Avatar, ProgressBar) (#842)
+    
+    * fix: update types
+    
+    * fix: fix typo
+
+[33mcommit 3e915be824c5ed575fdc24e1f6ec505fc309af3a[m
+Author: Trancever <dawidu@onet.pl>
+Date:   Thu Feb 14 20:05:18 2019 +0100
+
+    chore: release v2.11.1
+
+[33mcommit e171acdc275712e69a37df4be75f61098f718b94[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Thu Feb 14 19:45:19 2019 +0100
+
+    fix: Add SafeAreaView to FAB Group (#831)
+
+[33mcommit 7fbd6b7902120b9dc7cf60e870da2d1afd579912[m
+Author: Guilherme Lisboa <guilhermeslisboa92@gmail.com>
+Date:   Thu Feb 14 12:01:32 2019 -0500
+
+    fix: fix typings for cards.d.ts (#840)
+
+[33mcommit 45a1e5ca554e6fc97f322cd640680e81118051da[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Feb 14 17:02:47 2019 +0100
+
+    chore: use commitlint for validating commit message
+
+[33mcommit 3983edd0bf349c1688e180b0950b5516aff465b7[m
+Author: buncis <buncismamen@gmail.com>
+Date:   Wed Feb 13 02:22:00 2019 +0700
+
+    fix: update TextInput Typing (#833)
+
+[33mcommit b4490cfda0553b73f4930345ad2761e22006d4d7[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Mon Feb 11 16:06:14 2019 +0100
+
+    fix: set number of lines to 1 in Card.Title (#821)
+
+[33mcommit 13d51c0b47947a7baa5c55c29ab36e47c4bc537f[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Sat Feb 9 13:56:34 2019 +0100
+
+    docs: Add new showcase project (#829)
+
+[33mcommit 287d25a9a9a6a2484efa7c738d045f0f8d64f1d1[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Feb 9 02:10:19 2019 +0100
+
+    docs: update contributors list
+
+[33mcommit fd553585b91b3c8421a1d041c9cdd69c4bcf6dbb[m
+Author: allcontributors[bot] <allcontributors[bot]@users.noreply.github.com>
+Date:   Sat Feb 9 00:54:37 2019 +0000
+
+    docs: update .all-contributorsrc
+
+[33mcommit ccce6f447a14f86b1140b2671f0e53ddec46b9de[m
+Author: allcontributors[bot] <allcontributors[bot]@users.noreply.github.com>
+Date:   Sat Feb 9 00:54:36 2019 +0000
+
+    docs: update README.md
+
+[33mcommit 4bdd0ca546efe533bab6a68e652208500ea7ec70[m
+Author: allcontributors[bot] <allcontributors[bot]@users.noreply.github.com>
+Date:   Sat Feb 9 01:53:51 2019 +0100
+
+    docs: add jaulz as a contributor (#824)
+
+[33mcommit baaf3694f2aeeb5fee08f43a0457b4469d53dcd1[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Fri Feb 8 22:13:58 2019 +0100
+
+    fix: optimize Avatar.Icon look (#817)
+    
+    * fix: optimize Avatar.Icon look
+    
+    * fix: reduce icon size to 60%
+
+[33mcommit beb37a2739eafb18f96b0b800208df5e421e543c[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Fri Feb 8 11:45:18 2019 +0100
+
+    fix: textinput label position. (#822)
+
+[33mcommit d7f1a790acf6e93f6ae55996210895742e502957[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Feb 6 20:33:15 2019 +0100
+
+    chore: release 2.11.0
+
+[33mcommit 699ee6c2501bc9833ba8ffe37f9fc0e4a18a2876[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Feb 6 20:27:55 2019 +0100
+
+    fix: fix applying elevation to Appbar
+
+[33mcommit cfd08988ad199910e07b070add1e96b2b190b66c[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Feb 6 20:16:42 2019 +0100
+
+    fix: properly center arrow in accordion. fixes #763
+
+[33mcommit ca9fef071d6bbd190f256a97ffb58696c90339b2[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Feb 6 20:10:57 2019 +0100
+
+    fix: ignore pointer events on input outline. fixes #765
+
+[33mcommit 5258ac131e8b1cbf80fc5e52ba55e6b9e91ae448[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Feb 6 19:42:16 2019 +0100
+
+    feat: add a selectionColor prop to TextInput
+
+[33mcommit bd512f3bbc4e87da4424b50c098234bc2a4178fe[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Feb 6 18:25:33 2019 +0100
+
+    fix: only log icon load error when trying to use an icon. closes #818
+
+[33mcommit 8d48402f855a0c51ddb5bdc3a4d2c62ddd37bc03[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Wed Feb 6 16:15:05 2019 +0100
+
+    fix: collapsed content in DataTable (#816)
+
+[33mcommit 3df26e4d51d6a141e753c344c4cdf539cdbad303[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Wed Feb 6 15:16:04 2019 +0100
+
+    fix: disable unpressable DataTable title (#756)
+
+[33mcommit ad6f253df89c6b3318a3a140bc5e0956bdb78a73[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Wed Feb 6 10:21:01 2019 +0100
+
+    feat: add card title component (#796)
+    
+    * feat: card title
+    
+    * fix: add action prop
+    
+    * fix: harmonize props with List.Item
+    
+    * fix: set fixed width of left element
+    
+    * fix: optimize height
+
+[33mcommit 6c2837d5ada3193834b374a69de0e1e4c3e88aa0[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Feb 4 21:56:57 2019 +0100
+
+    chore: release 2.10.1
+
+[33mcommit 5ea17b84a394c40973b2c3b110c3ee608648af5d[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Feb 4 21:56:34 2019 +0100
+
+    fix: make activity indicator methods private
+
+[33mcommit e11a293f303638a2802ad4d7cf2217adaf287276[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Feb 4 21:52:47 2019 +0100
+
+    chore: release 2.10.0
+
+[33mcommit 6415ba54d1e5d19a47473eb6a60fed5921927ecf[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Feb 4 21:49:45 2019 +0100
+
+    fix: fix dialog closes even if you tap inside. fixes #809
+
+[33mcommit 5ac1daf425ef515700892f2fcf798af6fec3a171[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Feb 4 21:48:34 2019 +0100
+
+    docs: fix instructions for web
+
+[33mcommit 852ed3eb79c6a886b39e7e2a3b8de68c04f53cf4[m
+Author: Lukas Kurucz <usrbowe@users.noreply.github.com>
+Date:   Tue Feb 5 04:42:18 2019 +0800
+
+    fix: fix ToggleButton value change with ToggleButton.Group (#805)
+
+[33mcommit c552f000e3ebc5092adef3dab1455a0a17457c9d[m
+Author: Rajendran Nadar <raajnadar@gmail.com>
+Date:   Tue Feb 5 02:10:25 2019 +0530
+
+    docs: fix broken image link activity indicator (#811)
+    
+    <!-- Please provide enough information so that others can review your pull request. -->
+    <!-- Keep pull requests small and focused on a single change. -->
+    
+    ### Motivation
+    
+    https://callstack.github.io/react-native-paper/activity-indicator.html
+    
+    Gif not showing up in activity indicator example.
+    <!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
+    
+    ### Test plan
+    
+    Fixed the name of the gif file.
+    
+    <!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
+
+[33mcommit f79c00d83545e83a798e0d58fbafec6f9c02be02[m
+Author: Lukas Kurucz <usrbowe@users.noreply.github.com>
+Date:   Tue Feb 5 04:39:58 2019 +0800
+
+    docs: remove whitespace around selection (#810)
+
+[33mcommit cf79f65c42f71ac4a6533ce62ef11276d10d80a8[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Mon Feb 4 12:08:49 2019 +0100
+
+    fix: fix path to ToggleButtonGroup component. (#806)
+
+[33mcommit fb6762ee10ed72b51b0f871e535ed119c3ebe212[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Mon Feb 4 08:34:56 2019 +0100
+
+    feat: ActivityIndicator component (#723)
+    
+    This component serves as a drop-in replacement for the component that is delivered by React Native out of the box. It's design tries to imitate the indeterminate circular progress indicator from the Material guidelines:
+    https://material.io/design/components/progress-indicators.html#circular-progress-indicators
+
+[33mcommit 428b5c5199b5fa36d2dd55121a65dd9e9b22982a[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Feb 2 14:32:04 2019 +0100
+
+    chore: release 2.9.1
+
+[33mcommit 22514d6f93eac531ef1271f3f7b62599e4b02e0b[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Feb 2 14:25:02 2019 +0100
+
+    fix: hide banner if visible=false before height is measured. fixes #803
+
+[33mcommit c9a89efa524f9c27a1872eec7094053c9cc3c868[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Feb 1 23:14:14 2019 +0100
+
+    chore: release 2.9.0
+
+[33mcommit a07962638be6e5629de84385cd3520583f9e19fe[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Feb 1 23:13:01 2019 +0100
+
+    fix: fix random onLayout events in Bottom Navigation. fixes #800
+
+[33mcommit c5ab9a3430ac4c77d4ee5cd94ae446990ea2f36b[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Feb 1 21:37:06 2019 +0100
+
+    feat: add ripple effect on the web (#793)
+    
+    ![kapture 2019-01-31 at 21 00 58](https://user-images.githubusercontent.com/1174278/52082231-8b144c80-259c-11e9-8753-2df5f98e9ef4.gif)
+
+[33mcommit 550213b7606b6f466060595f4eb29b68af7dfa7d[m
+Author: Luís <luis_m_gouveia@hotmail.com>
+Date:   Fri Feb 1 14:54:59 2019 +0000
+
+    docs: adjust gestures distance for iOS on example app (#797)
+    
+    ### Motivation
+    
+    Fixes #282 in example app. It gives extra space for gestures in `react-navigation`.
+    This is also a fix for the previous PR #754
+    
+    ### Test plan
+    
+    Open the example app, change screen and test the gestures in iOS.
+
+[33mcommit 195d6bcb21fb77862e0f92bb544605678ee6a96b[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Feb 1 12:14:02 2019 +0100
+
+    chore: release 2.8.0
+
+[33mcommit 492230cb990043c033a7986440b7816613db6efc[m
+Author: Ferran Negre <fnp.developer@gmail.com>
+Date:   Thu Jan 31 17:14:57 2019 +0100
+
+    fix: Android P ripple effect using overflow hidden and useForeground (#788)
+    
+    * fix: Android P ripple effect using overflow hidden and useForeground
+    
+    * fix: simplify condition
+    
+    * fix: IconButton when borderless on Android P.
+
+[33mcommit 7cf91296b3e361ba40216e7d2ce5663dbd6029c6[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Thu Jan 31 12:17:26 2019 +0100
+
+    fix: limit search bar width (#790)
+
+[33mcommit b3293059096495d5c262832cda41c1c36bac3526[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jan 30 21:20:26 2019 +0100
+
+    docs: fix documentation for react-native-web
+
+[33mcommit 8fbe72561049258e7d94fb98caf174c7b350c722[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jan 30 01:25:20 2019 +0100
+
+    docs: fix typo
+
+[33mcommit 77936b8d17823c781389e581abbbcbcac3093c33[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jan 29 20:56:54 2019 +0100
+
+    chore: release 2.7.0
+
+[33mcommit 0bad9af2aef97f2708666ada69f3c76554467088[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jan 29 20:56:38 2019 +0100
+
+    test: fix snapshots
+
+[33mcommit 3600cad667bcabd39252a960e24b048ca7f3917c[m
+Author: jaulz <jhundeloh@yahoo.de>
+Date:   Wed Jan 23 10:21:41 2019 +0100
+
+    fix: prevent changing width of search bar on web
+
+[33mcommit 2bca3d827891f0466ebbc724e454baab63cad280[m
+Author: Julian Hundeloh <julian.hundeloh@novartis.com>
+Date:   Tue Jan 29 15:45:47 2019 +0100
+
+    feat: introduce animated property on IconButton
+
+[33mcommit 1cf11798347608699175fb2fef39137e4c19d7fa[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jan 29 20:45:24 2019 +0100
+
+    chore: make it possible to run "yarn example start" etc.
+
+[33mcommit ec872a5c6188d8fdded269ac2e98f4ba5881e679[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jan 29 20:28:14 2019 +0100
+
+    fix: handle animated value in the shadow helper
+
+[33mcommit 99b33ece80c9ef1b2b5bbfe8597c17a47e251617[m
+Author: jaulz <jhundeloh@yahoo.de>
+Date:   Tue Jan 29 08:05:36 2019 +0100
+
+    fix: improve fonts on web
+
+[33mcommit eefcff37b56c12213c50d48b89d2fccc92de5d70[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jan 29 01:19:37 2019 +0100
+
+    fix: support image URLs as icons on web
+
+[33mcommit 90450fc0d293ffe21ad4c38687e30d1e6dff736e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jan 29 01:15:30 2019 +0100
+
+    chore: fix errors in web configuration
+
+[33mcommit 163aa29d65210cccb8e48c3dcc2548e9d8eb6a28[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jan 29 01:07:31 2019 +0100
+
+    docs: add react-native-paper dep when opening the snacks
+
+[33mcommit 4a882594e7eb2462e3a12084809af103eb57da72[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Jan 27 17:34:06 2019 +0100
+
+    docs: add instructions for react-native-web
+
+[33mcommit 5246ad04d5be281d2129648517ee2db70db751e8[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Mon Jan 28 17:53:54 2019 +0100
+
+    docs: FAB.Group should use padding instead of margin (#755)
+
+[33mcommit b799a1e5f8e59e7afab1a04a2da6eabaad07f98a[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Mon Jan 28 12:13:43 2019 +0100
+
+    feat: allow to change background for FAB Group (#758)
+    
+    ### Motivation
+    
+    It's currently possible to change the background color for FAB and also items within FAB.Group components. Changing the background color in FAB Group causes the overlay background to change.
+    
+    This PR makes it possible to change the background for the FAB Group main button.
+    
+    Current behavior:
+    <img width="377" alt="screen shot 2019-01-25 at 17 41 56" src="https://user-images.githubusercontent.com/7827311/51761486-797b0280-20cd-11e9-93de-1eaf1ba64ff8.png">
+    
+    ### Test plan
+    
+    https://snack.expo.io/ryjNEaO7E
+
+[33mcommit e08eb2ba1fe63acd129e6b2d30df7c3869cf9a60[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Jan 27 17:57:42 2019 +0100
+
+    fix: delay portal rendering to avoid infinite loop
+
+[33mcommit 28762277bf2c5b32a46ca0ccb3af8b19be3dbfae[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Jan 27 16:08:04 2019 +0100
+
+    chore: use css grid in the examples
+
+[33mcommit 2d0a1c3f53d1092751163c52e1f25b9eab6451ff[m
+Author: Robert Collins <roberto.tomas.cuentas@gmail.com>
+Date:   Sun Jan 27 09:43:30 2019 -0500
+
+    fix: makes icon load errors more informative (#769)
+
+[33mcommit 22ffb9ae73d53f8643daae6516a8af3ba0468da6[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Jan 27 13:55:04 2019 +0100
+
+    chore: add react-native-web example. closes #671
+    
+    This example is missing the drawer, but all other examples are there. There are rendering issues with few components on the web. Hopefully this example will make it easier to identify these issues and fix them in future.
+
+[33mcommit 4cfc1e6af453d614b0240c465f2fdb765513c981[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Jan 27 14:00:13 2019 +0100
+
+    chore: release 2.6.3
+
+[33mcommit 81827f602891d9a2a9c68bf8d838d634dbb0ac14[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Jan 27 13:59:48 2019 +0100
+
+    fix: fix flow errors and snapshots
+
+[33mcommit bf992597a54745fa588d46dd94762fd6f963ebe7[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Jan 27 13:29:41 2019 +0100
+
+    fix: fix bottom navigation layout on web
+
+[33mcommit c2980c5a9f97b2a614d4ca7aa12bb71a777751d1[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Jan 27 12:44:35 2019 +0100
+
+    fix: fix fonts and some warnings when using with react-native-web
+
+[33mcommit 34aff3a91b0e2770b18cac6291cd6588c577ab42[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Jan 27 10:56:41 2019 +0100
+
+    chore: release 2.6.2
+
+[33mcommit 4c918ffb9b8daa93a068f64e44a596d974237d85[m
+Author: Yukiya Nakagawa <y.nakagawa@water-cell.jp>
+Date:   Thu Jan 24 18:59:28 2019 +0900
+
+    fix: fix TypeScript typings for TextInput methods (#753)
+    
+    ### Motivation
+    
+    * paper version: v2.6.1
+    * typescript version: v3.2.2
+    
+    The `TextInput` class has public methods `isFocused`, `clear`, `focus`, `blur`.
+    
+    https://github.com/callstack/react-native-paper/blob/v2.6.1/src/components/TextInput.js#L348-L374
+    
+    However, they are not declared in d.ts as below.
+    
+    ![2019-01-24 17 51 02](https://user-images.githubusercontent.com/434227/51666158-ab726300-2000-11e9-9da1-b5a8be0ad32d.png)
+    
+    ### Test plan
+    
+    Typecheck for below function.
+    
+    ```typescript
+    import { TextInput } from "react-native-paper";
+    
+    function doAnything(textInput: TextInput) {
+      textInput.isFocused();
+      textInput.clear();
+      textInput.focus();
+      textInput.blur();
+    }
+    ```
+
+[33mcommit 02a9a0e7b04f119fbcbff9bea3194d2827788612[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jan 23 18:28:34 2019 +0100
+
+    chore: release 2.6.1
+
+[33mcommit 844daf35015ae98af17a681c49da90167d34928d[m
+Author: Jose G <josegranafdez@gmail.com>
+Date:   Wed Jan 23 14:54:12 2019 +0100
+
+    fix: replace 'orderRadius' with 'borderRadius' in Snackbar component (#750)
+
+[33mcommit 8184d26d2516f36711b7c74b53d7df5e361a0966[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Wed Jan 23 11:10:34 2019 +0100
+
+    fix: add progressBarComponent as fallback for generic platforms. (#749)
+
+[33mcommit e1dcfbd7e0adc3522354e52000371a00ed140f6c[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jan 23 10:58:04 2019 +0100
+
+    chore: release 2.6.0
+
+[33mcommit 83f61585e8374a271b6088dd045cdf3f2b22f76c[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jan 23 10:57:15 2019 +0100
+
+    fix: fix badge border radius on iOS
+
+[33mcommit e55f6cc205566c993036f8c9f3d5d6dae22ed1a8[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jan 23 10:48:08 2019 +0100
+
+    fix: update typescript types for bottom navigation
+
+[33mcommit e1102a6385a5ca08681a99067cad03fc2964119a[m
+Author: napolev <rosycgrshare@gmail.com>
+Date:   Wed Jan 23 03:40:26 2019 -0600
+
+    fix: fix parenthesis locations in example app (#747)
+    
+    * fixing parenthesis locations
+    
+    * fix: fixing parenthesis locations
+
+[33mcommit ac5fe1668d80864694b66bf27d24cddcd0ffe4ad[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jan 22 16:59:16 2019 +0100
+
+    feat: add badge support in bottom navigation. closes #288
+
+[33mcommit 1de5095d1349147e0098cd00ce3424e88eabedb6[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Tue Oct 23 07:39:03 2018 +0200
+
+    feat: add Badge component
+
+[33mcommit fa1fd5e16fcdb7a039ce45a56ed4c1217e756389[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jan 22 13:02:00 2019 +0100
+
+    docs: fix edit link and try on snack link
+
+[33mcommit b68fac70b0b77a1338ff80ed69e8c1cb293c6337[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Thu Sep 6 17:36:00 2018 +0200
+
+    feat: add Avatar component
+
+[33mcommit c3cfb3189458922e3a88c82b28ddb40198778a03[m
+Author: Chris Zelenak <3809+netshade@users.noreply.github.com>
+Date:   Tue Jan 22 06:00:37 2019 -0500
+
+    feat: allow Chip to expand to font size changes (#697)
+    
+    ### Motivation
+    
+    The `Chip` component had a strict height on its `Text` component, which would clip the text internally if the user had adjusted the font size of the application.
+    
+    ### Test plan
+    
+    1. Create an app with a `Chip` component
+    1. Adjust your font size in the device's Accessibility settings to the largest possible font size
+    1. Start the app
+    1. Observe that the text is not clipped inside the `Chip` component
+
+[33mcommit d969f021c6d734a34cba0e07c782592c46e5d99d[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jan 22 11:57:34 2019 +0100
+
+    fix: make type optional for helper text in TS definitions
+
+[33mcommit 2618c067f6e9ffdeed17ce7b12d2b54b06bee105[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Jan 21 18:17:53 2019 +0100
+
+    fix: fix elevation not animating in some components
+    
+    On Android P, if a view with elevation is inside another view which animates the opacity, the elevation doesn't animate when the opacity changes.
+    This PR refactors components to animate opacity on the same views those have elevation to workaround this behaviour
+
+[33mcommit 4572af2bea4f922423197dd0c840237c4a0c118e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Jan 21 18:38:19 2019 +0100
+
+    chore: add a comment regarding ripple effect on Android P
+
+[33mcommit d49e41badcae3c28dd19c2befe6f1dbfc6a096e9[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Jan 21 12:53:37 2019 +0100
+
+    fix: disable ripple when not supported in bottom navigation
+
+[33mcommit c863e4c756d78633f0ace2abe735bf94bccd8ddf[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 26 14:41:48 2018 +0100
+
+    feat: hide bottom navigation when keyboard is shown. closes #676
+
+[33mcommit 65fc420c35c45dcd3c02117f24bab598b18ee0c9[m
+Author: raajnadar <raajnadar@gmail.com>
+Date:   Mon Jan 21 17:11:04 2019 +0530
+
+    fix: typo in bottom navigation example
+
+[33mcommit bcef4a60ba72669d51cd9418a341193c9bb0cfc8[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Jan 18 10:52:59 2019 +0100
+
+    chore: release 2.5.0
+
+[33mcommit e4ca933f386d7b485f6580c332f0638a55dfe2db[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Jan 14 14:42:02 2019 +0100
+
+    docs: don't use a form for icon list
+
+[33mcommit f261f36b60c53c5e751e079685997f87ae39f897[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Jan 14 14:28:03 2019 +0100
+
+    docs: show a message when no matching icon was found
+
+[33mcommit a35e3e03803d61907e918e838655633d647b84ab[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Jan 14 13:49:17 2019 +0100
+
+    chore: upgrade component-docs
+
+[33mcommit 7313202436beb67637e86b360ce27aad7a7266ef[m
+Author: lukewalczak <lukasz.walczak@callstack.io>
+Date:   Sun Jan 13 22:36:30 2019 +0100
+
+    docs: add a list of icons in the Icons page
+
+[33mcommit bcb8702600ae6809bcef41c982a065d86510a38b[m
+Author: Hasan Hejdari Nasab <hsn6@tuta.io>
+Date:   Tue Jan 8 18:56:07 2019 +0330
+
+    fix: use fontFamily of theme for Searchbar (#724)
+
+[33mcommit 6a065c7ef0b0c5b48504bed5346c0321dae4b09c[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jan 8 01:15:32 2019 +0100
+
+    chore: fix building docs for 1.0
+
+[33mcommit f1be44bb101367be8ef2761e616461051844a10e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jan 8 00:41:14 2019 +0100
+
+    chore: update component-docs and linaria
+
+[33mcommit e4e8d6ccd6b13655ea82bd392dd8e6650dc6d8cb[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jan 8 00:42:22 2019 +0100
+
+    chore: fix snapshots
+
+[33mcommit 54f1ece31cacb7e74b7730ebb428923fa3a9ac60[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Mon Jan 7 13:18:29 2019 +0100
+
+    feat: add smooth icon change in `IconButton` component (#672)
+    
+    * feat: smooth icon change in `IconButton`
+    
+    * test: update snapshots
+
+[33mcommit 1059b50d124b11ba522a6eb758f68c97d0572ce7[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Mon Jan 7 12:35:55 2019 +0100
+
+    feat: add animated visibility for FAB (#720)
+    
+    * feat: animated FAB
+    
+    * feat: animated FAB
+    
+    * fix: decrease hide animation duration.
+
+[33mcommit 00cc57502035bb747b1bc9328f7e0daf0291a8a9[m
+Author: Hamdi Wanis <hamdiwanis@gmail.com>
+Date:   Mon Jan 7 11:35:50 2019 +0200
+
+    fix: textInput label wrong position in RTL (#721)
+
+[33mcommit 38b729597a9bbf1721b4d9b5e8ec47a4dba2a8f5[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Dec 19 13:38:51 2018 +0100
+
+    chore: release 2.4.0
+
+[33mcommit 23cdb3cd20c105a0a41b0c51bedc6aef11435355[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Dec 19 13:37:58 2018 +0100
+
+    fix: disable ripple effect on Android P
+    
+    Ripple effect has a lot of issues on Android P https://github.com/facebook/react-native/issues/6480
+    
+    Let's disable it for now and figure out how to fix/workaround it
+
+[33mcommit 79e1ef22820d6243eb093f6796e821ea46d007f7[m
+Author: Rajendran Nadar <raajnadar@gmail.com>
+Date:   Tue Dec 18 13:46:04 2018 +0530
+
+    feat: add onpress prop for appbar content (#700)
+
+[33mcommit c80ca3fa260c8bbcf49c024e9177b177f834f94e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Dec 17 17:58:06 2018 +0100
+
+    chore: use babel-test for testing the babel plugin
+
+[33mcommit b859cb28f7466524f2b6d4fa54ded2cbefe25827[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Dec 10 12:56:17 2018 +0100
+
+    chore: release 2.3.0
+
+[33mcommit 23b963b3d63b4c22584fa4c3f65e5f6bd219fe77[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Dec 10 12:54:26 2018 +0100
+
+    fix: rename right to numeric for tables
+
+[33mcommit 3a8ca8811302cb64443c4a9e805011fef72a3af9[m
+Author: Erkan Ertürk <erkanerturk@pm.me>
+Date:   Mon Dec 10 14:28:32 2018 +0300
+
+    docs: fix typo in AppbarContent.js (#692)
+
+[33mcommit b0e9261a13c274e188c85ed5a3dcfd27ef46e8a1[m
+Author: Rajendran Nadar <raajnadar@gmail.com>
+Date:   Mon Dec 10 11:27:39 2018 +0000
+
+    chore: ask for expo sdk ver and repro (#685)
+
+[33mcommit ae9cc91fbf320a76dc7972b14a02fd8ec093bc2c[m
+Author: Rajendran Nadar <raajnadar@gmail.com>
+Date:   Mon Dec 10 11:23:09 2018 +0000
+
+    feat: ability to change button text case (#674)
+
+[33mcommit c0f7f90e67a45a075d296f04a2412a600e309969[m
+Author: Antonio Moreno Valls <amorenovalls@gmail.com>
+Date:   Mon Dec 10 12:17:18 2018 +0100
+
+    feat: ToggleButton component (#575)
+
+[33mcommit 0ad98f3bf2c397c12e258927b5bdd504ebf9f275[m
+Author: KevinG <kguljajev@gmail.com>
+Date:   Tue Nov 27 13:29:34 2018 +0200
+
+    fix: pass down testID from Card props to Touchable for Detox tests (#683)
+
+[33mcommit 68a5b78ac17527d3614295e45b8eb6e0bc6a6793[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Tue Nov 27 12:29:01 2018 +0100
+
+    feat: DataTable component (#446)
+
+[33mcommit 3bcda083ba75673a9dd85bff6494f7aeb142152d[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Nov 23 16:21:06 2018 +0100
+
+    chore: release 2.2.8
+
+[33mcommit 268b7bb56a8d35dac755b75444c5047234bc5632[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Nov 23 16:18:48 2018 +0100
+
+    docs: fix vector icons on snack.expo.io. fixes #675
+
+[33mcommit da9f234343c405ee6871cad3e0a45269b2b4f0fd[m
+Author: KevinG <kguljajev@gmail.com>
+Date:   Thu Nov 22 19:19:27 2018 +0200
+
+    fix: pass down testID from chip props to touchable for Detox tests. (#661)
+
+[33mcommit 903afcca712fec9d68f2c567bab501d331846f53[m
+Author: ferrannp <fnp.developer@gmail.com>
+Date:   Thu Nov 22 16:54:32 2018 +0100
+
+    chore: release 2.2.7
+
+[33mcommit 7b528327027ce054d893e4be10808155620589fb[m
+Author: ferrannp <fnp.developer@gmail.com>
+Date:   Thu Nov 22 16:47:45 2018 +0100
+
+    fix: fix flow errors
+
+[33mcommit 47d9b0ddfa74adbe8943ff7fb149493b0456dd80[m
+Author: Ferran Negre <fnp.developer@gmail.com>
+Date:   Thu Nov 22 16:24:41 2018 +0100
+
+    Update types.js
+
+[33mcommit 57fc5ecaab9d4f0c3febc2d0fff957c55d1eba07[m
+Author: Rajendran Nadar <raajnadar@gmail.com>
+Date:   Thu Nov 22 11:14:45 2018 +0000
+
+    chore: fix ambiguous resolution (#654)
+    
+    * chore: upgrade expo-cli to v2.3.8
+    
+    * fix :ambiguous module resolution
+    
+    * fix: normal-regex to escape-string-regex
+
+[33mcommit a3c3a9dfe05040838a024c79d748ac316575273d[m
+Author: aaska <aaska@users.noreply.github.com>
+Date:   Thu Nov 22 12:12:02 2018 +0100
+
+    updating typescript definition for Drawer.Item (#667)
+
+[33mcommit 1d9340954fe7be000606798d7720fcffd6b538d7[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Nov 21 11:49:34 2018 +0100
+
+    chore: release 2.2.6
+
+[33mcommit e1b81c2f4215545ca29fcf990dffd3ecc1ae8cfa[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Wed Nov 21 11:25:18 2018 +0100
+
+    fix: do not pass on elevation as property (#664)
+    
+    ### Motivation
+    
+    Otherwise the `elevation` prop will be passed on to `Animated.View` in `Surface` component and cause this warning on web: You are setting the style `{ elevation: ... }` as a prop. You should nest it in a style object. E.g. `{ style: { elevation: ... } }`
+    
+    ### Test plan
+    
+    n/a
+
+[33mcommit eb153f9840ccdcc64f85f679514c46f5461e85a7[m
+Author: Shen Junru <shenjunru@gmail.com>
+Date:   Wed Nov 21 00:06:35 2018 +0800
+
+    fix: fix TouchableRipple props types for typescript (#662)
+    
+    Fix TouchableRipple props types
+
+[33mcommit ef674181cdd751f4ac01dd00f5371a270c32506e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 18 08:33:49 2018 +0100
+
+    chore: release 2.2.5
+
+[33mcommit 60afd02df0a825c57bdebed870e881e357d92e13[m
+Author: Luís <luis_m_gouveia@hotmail.com>
+Date:   Tue Nov 13 13:32:16 2018 +0000
+
+    fix: TextInput align top with multiline (#651)
+
+[33mcommit 50cd9f69eed25f5841948cf851cda504c1f16f19[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Nov 8 17:26:44 2018 +0100
+
+    chore: release 2.2.4
+
+[33mcommit dec191f5c714a223fca43fd4fd3cd064971d9db5[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Nov 8 16:53:56 2018 +0100
+
+    refactor: export types from the main entry instead of /types
+
+[33mcommit f295272bf870e478bc9a2a21dacd7dd17bd95398[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Nov 8 16:21:36 2018 +0100
+
+    fix: use exact types when possible
+
+[33mcommit 02942095041def57e420fbacc1191342f71cf01e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Nov 8 16:04:19 2018 +0100
+
+    fix: merge types with the props of the component used internally
+
+[33mcommit aee06f3638428f8841cbd12dde0fe3b906404229[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Nov 8 16:36:43 2018 +0100
+
+    fix: fix chip snapshot tests
+
+[33mcommit a95eb10a482a1c6b644067c1586e302574f58f00[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Nov 8 16:33:09 2018 +0100
+
+    fix: don't pass all props down to Text
+
+[33mcommit a87c1dd85bd19e2a83c76d0729053d5b846b10a6[m
+Author: Shen Junru <shenjunru@gmail.com>
+Date:   Thu Nov 8 17:32:53 2018 +0800
+
+    fix: connect ts declaration with @types/react-native (#627)
+    
+    * fix: connect ts declaration with @types/react-native
+    
+    * fix: ts declaration
+    
+    * fix: ts declaration
+
+[33mcommit 466c2fc2f462e5756be60c2674b6d4ba917b4877[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Nov 7 12:39:31 2018 +0100
+
+    chore: release 2.2.3
+
+[33mcommit 38b14c1bf21a53d3081000ca60b4051d0c83ed20[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Nov 7 12:38:35 2018 +0100
+
+    fix: add a check to ensure Jest doesn't throw error. closes #644
+
+[33mcommit 2e23161ea3d10e3523523816ea445ba7931e5742[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Nov 6 15:41:08 2018 +0100
+
+    chore: release 2.2.2
+
+[33mcommit e31a33e92d07b9296d7c104d9a14fdb5501cdb74[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Nov 6 15:40:25 2018 +0100
+
+    fix: fix textinput not animating on changing error. fixes #611
+
+[33mcommit 77fb950de31447d09a57bf2e32a48c0cc99b668b[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Nov 6 15:34:22 2018 +0100
+
+    docs: update the guides for latest React Native
+
+[33mcommit caa63a7d67e1710d304808fedbc10346faf9dc39[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Nov 6 12:14:25 2018 +0100
+
+    chore: release 2.2.1
+
+[33mcommit 0f52b7c3fb8f48fec861ffaec7faf9b8e133ff9a[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Nov 6 12:13:56 2018 +0100
+
+    fix: get version from native modules instead of haste. closes #642
+
+[33mcommit 9eb0c4ade0ab9330e83f54f254f33fee1148b8f4[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Nov 6 00:32:21 2018 +0100
+
+    chore: fix rendering the logo on npm
+
+[33mcommit e541704e5d43350ea97ba6055f88cf4fca2378e3[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 5 23:26:06 2018 +0100
+
+    chore: release 2.2.0
+
+[33mcommit 4aa7addb87ed129e546974f6ebf6dee549bb4d90[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 5 23:23:47 2018 +0100
+
+    fix: use new Switch API from RN >= 0.57. fixes #571
+
+[33mcommit dcc5bf12d74bf7ba0ff6975a805dd499fc29078c[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 5 23:24:38 2018 +0100
+
+    test: fix list accordion snapshot
+
+[33mcommit 124f52f59850101d13cb8e89a1d64cf7e769469d[m
+Author: Dylan Companjen <info@dylancompanjen.com>
+Date:   Mon Nov 5 22:23:45 2018 +0100
+
+    fix: change the keyboard appearance according to theme (#593)
+    
+    If the dark theme is active, currently there is still a light keyboard shown (iOS).
+
+[33mcommit aed0bfd4c9ba81100fbe34c5b3a555eaddc2b330[m
+Author: Iyad Thayyil <iyadthayyil@gmail.com>
+Date:   Tue Nov 6 00:22:17 2018 +0300
+
+    fix: add RTL support to searchbar(#565)
+
+[33mcommit decbedbd82a182fecc208afa9ab4e4f58cf830d7[m
+Author: Lucas Vieira <vieiralucas4@gmail.com>
+Date:   Mon Nov 5 19:13:41 2018 -0200
+
+    feat: allow List.Accordion to behave as a controlled component (#638)
+    
+    fixes #616, #635
+    closes #618
+
+[33mcommit 8764f60370e0adfd0c07705e1cebdaf0f7e1459b[m
+Author: Andrei Barabas <andrei.barabas@argentumapp.com>
+Date:   Fri Oct 19 23:25:53 2018 +0300
+
+    fix: add tests for snackbar visibility on mount
+
+[33mcommit e4a48ba7dcbbe0ed992855bba29fcd6607f44a7b[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 5 15:28:10 2018 +0100
+
+    test: fix bottom navigation tests
+
+[33mcommit 627aa90c2b1d71b316b8be4726bce4c5ce60a043[m
+Author: Brent Vatne <brentvatne@gmail.com>
+Date:   Mon Nov 5 06:23:19 2018 -0800
+
+    Fix tab focus animation bug from react-native@~0.57 on Android (#637)
+    
+    * Fix tab focus animation bug from react-native@~0.57
+    https://github.com/react-navigation/react-navigation-material-bottom-tabs/issues/22
+    
+    * Add a comment to provide context for the change
+
+[33mcommit 5265fb4e523b4b092890668f64184c9d02680a93[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 5 14:47:48 2018 +0100
+
+    chore: upgrade deps
+
+[33mcommit 37d911118deddf30cfc369abca6d30bfc8c84b24[m
+Author: doomsower <K.Kuznetcov@gmail.com>
+Date:   Wed Oct 24 14:03:31 2018 +0300
+
+    fix: ts declaration of TouchableRipple (#615)
+    
+    * fix: ts declaration of TouchableRipple
+
+[33mcommit 8c13f84387919bd43b111899ed4acb1791b0c057[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Wed Oct 24 12:30:38 2018 +0200
+
+    feat: provide nice error message for users that use Portal without Provider. (#622)
+    
+    ### Motivation
+    
+    This PR makes clear what is the cause of app crash when user doesn't wrap his components' tree with Provider component.
+    
+    ### Test plan
+    
+    Render Portal component without wrapping components' tree with Provider component.
+    Nice error message with link to our docs will be presented.
+
+[33mcommit d3d17e7f5a648802317822ca7c0e60e07ff97279[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Tue Oct 23 18:08:48 2018 +0200
+
+    fix: make example typescript compatible (#623)
+    
+    ### Motivation
+    
+    Other PRs break because of this (e.g. see `typescript` deploy script at https://github.com/callstack/react-native-paper/pull/620)
+    
+    ### Test plan
+    
+    Run `yarn typescript` and it should not break anymore.
+
+[33mcommit a4579bdb4c473d6736a488e8c15ee122b9301d0e[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Tue Oct 23 14:13:10 2018 +0200
+
+    fix: hidden snackbar if initially visible (#621)
+    
+    Problem: snackbar stays hidden if the `visible` property is initially `true`
+
+[33mcommit 706c13d888fb4acbdb88d0a6ca6434b6c1a1564e[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Tue Oct 23 03:56:57 2018 -0300
+
+    fix: TextInput example (accept upperCase and lowerCase letters) (#619)
+    
+    It should accept both uppercase and lowercase letters
+
+[33mcommit b980c365f762f1f147132834a8f4023c6d9cf546[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Oct 18 16:56:58 2018 +0200
+
+    fix: grow text input to fill available space. fixes #612
+
+[33mcommit 5a51af4378a5a46070a061e74020af66fc35d96a[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Oct 18 16:41:39 2018 +0200
+
+    fix: fix helper text not shown the first time it's visible
+
+[33mcommit 56840ee6bf1ff3e5e8df9f352f4994de171e899d[m
+Author: Bruno Castro <bruno.castro@codeminer42.com>
+Date:   Thu Oct 18 11:20:47 2018 -0300
+
+    fix: don't update TextInput content if it's not editable (#608)
+    
+    Prevent component to update current value when it isn't editable
+    
+    Resolves #589
+
+[33mcommit 39ceec618c22c34971f5a5c3400c2e5282385ddb[m
+Author: Rajendran Nadar <raajnadar@gmail.com>
+Date:   Thu Oct 18 19:32:43 2018 +0530
+
+    docs: add keyboardavoidingview to text input example (#588)
+    
+    Added KeyBoardAvoidingView because it is hard to check the last TextInput in the example
+
+[33mcommit 2969b1d0627bc98828d0a201a041dcb0e1a4ea88[m
+Author: Yukiya Nakagawa <y.nakagawa@water-cell.jp>
+Date:   Thu Oct 18 21:17:46 2018 +0900
+
+    fix: fix Snackbar static constants type for typescript (#609)
+    
+    ### Motivation
+    
+    Below `Snackbar` usage has error.
+    
+    <img width="332" alt="2018-10-18 20 18 21" src="https://user-images.githubusercontent.com/434227/47150896-19790100-d313-11e8-8794-256703ab654b.png">
+    
+    And error message:
+    
+    ```
+    path/to/my/component.tsx:131:17 - error TS2322: Type 'string' is not assignable to type 'number | undefined'.
+    
+    131                 duration={Snackbar.DURATION_SHORT}
+                        ~~~~~~~~
+    
+      node_modules/react-native-paper/typings/components/Snackbar.d.ts:10:3
+        10   duration?: number;
+             ~~~~~~~~
+        The expected type comes from property 'duration' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<Snackbar> & Readonly<{ children?: ReactNode; }> & Readonly<SnackbarProps>'
+    ```
+    
+    Because `duration` was defined as a `string` in the type definition file. I fixed it.
+    
+    ### Test plan
+    
+    Typecheck for below jsx.
+    
+    ```jsx
+    <Snackbar
+        visible={true}
+        duration={Snackbar.DURATION_SHORT}>
+        Foo
+    </Snackbar>
+    ```
+
+[33mcommit 0697fb6ee215ee28949d005376327a063510b039[m
+Author: Andrew Durber <aidurber@gmail.com>
+Date:   Sat Oct 13 18:24:55 2018 +0100
+
+    fix: Always show error outline when including when unfocused (#595) (#598)
+    
+    ### Motivation
+    
+    TextInput with outline in an error state should correctly indicate an error when unfocused. This would also close #595
+    
+    ### Test plan
+    
+    It could also be possible to add a different prop `keepOutline` (not 100% on the name) instead of relying on the error state. However I'm unsure how that might be useful.
+    
+    ![focused-cropped](https://user-images.githubusercontent.com/5732291/46907418-eea13e00-cf09-11e8-8a16-725ef016f88c.png)
+    ![unfocused-cropped](https://user-images.githubusercontent.com/5732291/46907419-eea13e00-cf09-11e8-9539-95020b73ec71.png)
+
+[33mcommit ee954e8a8d41e4590d86844523db8d9c829d56e0[m
+Author: Altaf Shaikh <altaf933@gmail.com>
+Date:   Fri Oct 12 11:53:04 2018 +0530
+
+    fix: RadioButton dialog example should use status props. (#592)
+    
+    * fix: use correct props in radio button dialog example
+    
+    * fix: use correct props in radio button dialog example
+
+[33mcommit ec19ad1a0597c1ca27f0ad87de3f84b9e4f38c72[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Oct 11 14:29:30 2018 +0200
+
+    chore: release 2.1.3
+
+[33mcommit 1cf7ae9b1a7103bed547c86a69f2a4b4de956d13[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Oct 11 14:18:53 2018 +0200
+
+    chore: fix publishing to npm
+
+[33mcommit b21596c51c11189c10da40c968f530dee60cf8c0[m
+Author: Kacper Wiszczuk <kacperwiszczuk@gmail.com>
+Date:   Tue Oct 9 12:04:26 2018 +0200
+
+    fix: upgrade react-theme-provider (#584)
+
+[33mcommit e8ac8051869118656d1a6020b9d72a276bc4a9e5[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Mon Oct 8 10:58:17 2018 +0200
+
+    chore: update expo to latest version. (#580)
+    
+    This PR upgrades expo in example app to latest version.
+    
+    Actually, there is no issue for that, but It's good to use latest stable version of libraries.
+
+[33mcommit 295a7719c5b4ecb56bafdb09798a39188d137b59[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Oct 8 03:33:37 2018 +0200
+
+    chore: generate changelog with conventional-changelog
+
+[33mcommit 10cb0b201c70a1487af7e537bda26bbc51e3ce67[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Oct 8 03:29:29 2018 +0200
+
+    chore: release 2.1.2
+
+[33mcommit 53b5c0f6810702a4c5762ab2d0a20ca575e4b4b4[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Oct 8 02:38:41 2018 +0200
+
+    chore: automate release with relase-it. fixes #275
+
+[33mcommit 0837f8c2e8a2efed1d6b4aef6ed33b1820005ba4[m
+Author: Kacper Wiszczuk <kacperwiszczuk@gmail.com>
+Date:   Sun Oct 7 21:56:31 2018 +0200
+
+    fix: fix Typescript withTheme return type (#582)
+    
+    Fix Typescript type for `withTheme`.
+    
+    ```typescript
+    const Wrapped = withTheme(Component);
+    render = () => <Wrapped theme={somePartialTheme} />
+    ```
+
+[33mcommit 4e9056286b9b8362e7c70ca4e08c00b70d8ac32c[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Sun Oct 7 19:55:25 2018 +0200
+
+    fix: fix small issue in docs (Showcase section). (#581)
+    
+    While i was trying to update React and Flow versions, i found a small issue in docs.  We were trying to access `android` and `ios` properties on wrong object.
+
+[33mcommit 0a2349ad9c27933b4172b73c838b1fd90a726726[m
+Author: Kacper Wiszczuk <kacperwiszczuk@gmail.com>
+Date:   Sun Oct 7 13:41:49 2018 +0200
+
+    fix: fix types for component wrapping other components (#579)
+    
+    Fixes #578
+
+[33mcommit 6a334ad21290a13a3f418f4a63897aa4472fc999[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Oct 5 17:00:12 2018 +0200
+
+    chore: release 2.1.1
+
+[33mcommit 6b6a3d13831a8459dace05a32f87bd2f13af5fff[m
+Author: Kacper Wiszczuk <kacperwiszczuk@gmail.com>
+Date:   Fri Oct 5 16:52:01 2018 +0200
+
+    fix: fix withTheme typescript type (#577)
+
+[33mcommit 0c40b6e511fd98472b77df458aedb40598f3e30a[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Oct 4 17:24:16 2018 +0200
+
+    chore: release 2.1.0
+
+[33mcommit 23d2761bbe39771e7c6449af1c1737592e90aa04[m
+Author: Lucas Vieira <vieiralucas4@gmail.com>
+Date:   Thu Oct 4 10:13:36 2018 -0300
+
+    fix: fix caption font size (#572)
+    
+    Fixes #563
+
+[33mcommit b4fe2b5f7da2f2b4c3af459dfed6f26e78dd2f0b[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Thu Oct 4 14:25:31 2018 +0200
+
+    fix: Card action buttons alignment (#559)
+    
+    ### Motivation
+    
+    Fixes #556. It appears like the default card actions padding is slightly wrong. The issue affects buttons as well.
+    
+    This is somehow a possibly minor, but breaking change for existing projects, so I'll try to explain what's going on.
+    
+    ### Resources
+    
+    Cards
+    ![screen shot 2018-09-27 at 22 50 47](https://user-images.githubusercontent.com/7827311/46173876-d2659600-c2a7-11e8-8506-1b95d17a58c2.png)
+    According to MD guidelines the card actions padding is 8. The content's padding is 16. Cards use the "compact" buttons with smaller padding - 8 instead of standard 16.
+    
+    Buttons
+    ![screen shot 2018-09-27 at 22 09 27](https://user-images.githubusercontent.com/7827311/46172613-3d14d280-c2a4-11e8-8f7d-502c4f007cf8.png)
+    The standard horizontal padding is 16. Although it's different for card action buttons. Notice the min-width value, which is 64, but the buttons section doesn't really describe the compact buttons.
+    
+    ### Solution
+    
+    The example provided by @brunohkbx presented a case where it got caught into the min-width trap. The text was too small and caused a larger button padding. If you run this [expo snack](https://snack.expo.io/HyqcT35KX), it presents the same case, just with different button text. First goes too far to the right, second goes too far to the left.
+    
+    The first thing to fix was the card actions padding - switch from 4 to 8. It results in:
+    <img width="377" alt="screen shot 2018-09-27 at 22 21 01" src="https://user-images.githubusercontent.com/7827311/46172934-2a4ecd80-c2a5-11e8-9364-17911a79cce3.png">
+    So it works for the expo examples case, but not really for the [mentioned issue](#556). It still gives an extra button padding due to too short text (min-width).
+    
+    After removing the min-width from compact buttons, it seems like it's finally there:
+    <img width="376" alt="screen shot 2018-09-27 at 22 13 03" src="https://user-images.githubusercontent.com/7827311/46173141-b95be580-c2a5-11e8-88dd-82a15f5981a5.png">
+    
+    Finally, it also switches the dialog actions to 8 padding, since that's basically the same thing.
+    
+    ### Test plan
+    
+    https://snack.expo.io/HydBnn5t7
+    Snapshot tests updated
+
+[33mcommit 526b8c1544df4a958136be07cd9c9fcc35e53f40[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Thu Oct 4 12:19:25 2018 +0200
+
+    fix: Fix flow issues with ref (#551)
+
+[33mcommit 60e078298140bd05a72d48eb40cce990b16f5c76[m
+Author: Waquid Valiya Peedikakkal <waquidvp@gmail.com>
+Date:   Thu Oct 4 11:08:24 2018 +0100
+
+    feat: RTL usage for icons (#566)
+
+[33mcommit 9e0fe32e14cc9fd8ccc785d0200c814765301aed[m
+Author: Kacper Wiszczuk <kacperwiszczuk@gmail.com>
+Date:   Thu Oct 4 12:04:10 2018 +0200
+
+    feat: add typescript support (#561)
+
+[33mcommit 224d473e514a4fc03e5bc57302e1fbd705b964dd[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Wed Oct 3 11:52:55 2018 +0200
+
+    docs: improve docs for fab component by adding styles. (#568)
+    
+    * docs: improve docs for fab component by adding styles.
+    
+    * refactor: remove unecessary white space.
+    
+    * refactor: improve fab docs.
+
+[33mcommit ce97029dc900f51b2c3f42335c20459e3688c5fe[m
+Author: Kacper Wiszczuk <kacperwiszczuk@gmail.com>
+Date:   Thu Sep 27 22:31:00 2018 +0200
+
+    fix: Update test snapshots (#558)
+
+[33mcommit d3a7c48eee085a3bd86dca6bc589ae41d551f188[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Thu Sep 27 13:58:08 2018 +0200
+
+    Add implementation of banner component. (#441)
+    
+    * feat: initial implementation of banner component.
+    
+    * feat: add props description.
+    
+    * refactor: Change the way banner is structured.
+    
+    * refactor: small refactor of banner component and example.
+    
+    * refactor: remove some not needed logic from banner and add example.
+    
+    * refactor: refactor of banner props description and little clean up in component.
+    
+    * refactor: simplify implementation of banner
+    
+    * feat: add snapshot tests for banner.
+    
+    * feat: add banner gif.
+    
+    * fix: fix example.
+    
+    * fix: reduce banner gif size.
+    
+    * fix: reduce gif size even more.
+
+[33mcommit de7b124922ce3416f01b195f2331fd0a850e7843[m
+Author: Iyad Thayyil <iyadthayyil@gmail.com>
+Date:   Wed Sep 26 23:15:37 2018 +0300
+
+    fix: Surface View to Animated.View (#557)
+
+[33mcommit 768094119c38b5a37261e84e06faaf1ef11c77bc[m
+Author: Kacper Wiszczuk <kacperwiszczuk@gmail.com>
+Date:   Fri Sep 14 23:09:35 2018 +0200
+
+    feat: add custom render to TextInput component
+
+[33mcommit 9966be7704bbf3c58572eedd12f0dd5c507dd1de[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Sep 26 15:51:10 2018 +0200
+
+    chore: fix lint
+
+[33mcommit 2397715aa4cede583688156ec98ddd880934afc1[m
+Author: Drew Rothstein <drew.rothstein@gmail.com>
+Date:   Tue Sep 25 00:49:58 2018 -0700
+
+    feat: add onLongPress to Card (#538)
+    
+    * feat: add onLongPress to Card
+    
+    * feat: add onLongPress to Card: disable correction
+    
+    * Update CONTRIBUTING.md
+    
+    * Update CONTRIBUTING.md
+
+[33mcommit 41cb7165dd5fe1b6caf59cd83e93a905d3576ddf[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Sep 21 13:55:06 2018 +0200
+
+    fix: StatusBar.currentHeight is Android-only
+
+[33mcommit f145b98eab5b8ca63a93d93991c7a3e2846a973f[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Thu Sep 20 12:45:25 2018 +0200
+
+    fix: Remove style prop from touchable (#550)
+
+[33mcommit 81b0177f0ba9d736d03755fa1c213d786f66232f[m
+Author: Tomasz Czajęcki <tomek.czajecki@gmail.com>
+Date:   Thu Sep 13 12:52:07 2018 +0200
+
+    docs: fix wrong URL to 'getting started' (#545)
+    
+    I've noticed that link to the _getting started_ page in the docs seems to not working as expected since `*.html` extension is added anyway and it makes the link broken:
+    `https://callstack.github.io/react-native-paper/getting-started.html.html`.
+    
+    ### Motivation
+    
+    The documentation is important part of the library and should be working properly.
+    
+    ### Test plan
+    
+    Enter `/docs`, install using `yarn` and run it with `yarn start`.
+    
+    > **NOTE:** _the current version works on localhost and breaks only in the prod env. Suggested change will probably work in both, but needs to be verified by someone who knows the deployment process._
+
+[33mcommit 241ddb3e8ccf7a0e65e2968a277d3e2932e0f540[m
+Author: Antonio Moreno Valls <amorenovalls@gmail.com>
+Date:   Tue Sep 11 17:18:09 2018 +0200
+
+    docs: update RadioButton docs with new version 2.0.1 (#542)
+    
+    ### Motivation
+    
+    Update documentation with new version `2.0.1` of `react-native-paper`. RadioButton props are quite different from version 1 to 2, so docs needed an update.
+    ### Test plan
+    
+    See docs.
+
+[33mcommit 7b27b7cde79410d05b0a2836f5e3a92297599873[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Sep 5 11:02:21 2018 +0200
+
+    chore: release v2.0.1
+
+[33mcommit 70f37b8785be25fc17bccd6bb9f3f5db31ddf56e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Sep 4 19:57:59 2018 +0200
+
+    fix: get label's background color from backgroundColor style of input
+
+[33mcommit b82f1831781f4f28bda86aff689e15bfe0cc931e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Sep 4 19:41:37 2018 +0200
+
+    docs: add more screenshots
+
+[33mcommit 6afc38e8b16bd37ac61ec96bf8f9ff91b8483c0b[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Tue Sep 4 16:15:02 2018 +0200
+
+    fix: fix issue with sibling components being clipped. fixes #527
+
+[33mcommit abb71cb00821f00ced5082faf447251534dc2199[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Sep 4 15:34:21 2018 +0200
+
+    chore: upgrade component-docs
+
+[33mcommit 2d7f50ce08732f4d44887421347fe05efc53989e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Sep 4 15:00:53 2018 +0200
+
+    BREAKING: rename tintColor to color in bottom navigation
+
+[33mcommit 137124da8579b4696089c84e067ba2f4f3469290[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Sep 4 14:54:46 2018 +0200
+
+    feat: pass color prop to left and right items
+
+[33mcommit 6785992d8f1c3003e213a6aab33fd1b579cbd93a[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Sep 4 13:39:16 2018 +0200
+
+    docs: improve examples
+
+[33mcommit 0da377684a02ac134c638ebe0b55a9f1963c3c19[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Sep 4 13:16:43 2018 +0200
+
+    chore: wrap dialogs in example with portal
+
+[33mcommit 1b6e652e7fea1a928a9cd1e70ba3201d1b4c7e59[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Sep 4 13:10:02 2018 +0200
+
+    fix: fix dismissable prop of modal which broke in 7b0cd50
+
+[33mcommit 68ff8e48a25043e8d4c7167ce92c24d95bc9d4e8[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Sep 3 22:09:13 2018 +0200
+
+    docs: remove outdated slack link
+
+[33mcommit f1522237bab6b47ac35ecc2924f96f6a0808ac85[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Sep 3 17:20:53 2018 +0200
+
+    docs: update examples to be runnable
+
+[33mcommit 06f929bd5c000c6c30f6f6460c6dc5d6dc5b5ab7[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Sep 3 17:04:58 2018 +0200
+
+    BREAKING: change left and right props to render callbacks
+
+[33mcommit 6cc83d2be2f67485c69c05cc2e886231f4961586[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Sep 3 13:20:41 2018 +0200
+
+    docs: add link to try examples on snack
+
+[33mcommit 389163200cdd86c33308bad9d4608519d5ffd6d4[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Sep 3 00:06:09 2018 +0200
+
+    fix: remove flex: 1 from input, it messes up height
+
+[33mcommit 00361a063c500f76967d6f3415cbee0f6df6c360[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Sep 2 21:13:27 2018 +0200
+
+    chore: release v2.0.0-alpha.9
+
+[33mcommit e3ee3a28bffde4880e01c8ecc21452ca5ff9331c[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Sep 2 20:46:07 2018 +0200
+
+    docs: update link to the snack in README
+
+[33mcommit 3128ee7be8283d6190735bfd9134bf630ea45343[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Sep 2 20:24:12 2018 +0200
+
+    chore: update branding in the documentation
+
+[33mcommit d9e1739fd0dadafd8b5eed0939ed4bcd43fe50c1[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Sep 2 19:29:30 2018 +0200
+
+    chore: also build docs for 1.0
+
+[33mcommit 61c6fef2640a622aa43fe54833fbcd8d5e592480[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Sep 2 03:46:33 2018 +0200
+
+    BREAKING: replace ListSection.* and DrawerSection.* with List.* and Drawer.* (#524)
+
+[33mcommit f6e42f363c8557057ac20ecbb56bde0e1940b7f9[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Sep 2 03:41:27 2018 +0200
+
+    chore: upgrade component-docs
+
+[33mcommit 27c196fad261167608ccc66abff86b5a1db6077a[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Sep 2 03:00:12 2018 +0200
+
+    BREAKING: replace icon and avatar props of ListItem with left and right
+    Fixes #365
+
+[33mcommit 4de442d67089a44b5a103c691de4c4ac11b94aab[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Sep 1 14:08:09 2018 +0200
+
+    chore: fix example app
+
+[33mcommit e0086991a7e2b07b3f9abace8a201ada4ed08cc0[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Sep 1 14:01:10 2018 +0200
+
+    chore: release v2.0.0-alpha.8
+
+[33mcommit a25b33a7e609db93d15aa919206f576057de2cf3[m
+Author: Lucas Vieira <vieiralucas4@gmail.com>
+Date:   Thu Aug 16 07:22:03 2018 -0300
+
+    docs: add onDismiss to Modal Usage docs (#489)
+
+[33mcommit a44a67998703251f06ffe4f8b5c3cc38bb7a50b3[m
+Author: Travis Nuttall <Traviskn@users.noreply.github.com>
+Date:   Thu Aug 16 04:23:31 2018 -0600
+
+    docs: fix link to platform adaptation guidelines (#479)
+
+[33mcommit 4fd0442482b4e96d7a26e09bb63b6515f923699b[m
+Author: Lawrence Cheuk <shcheuklogin@gmail.com>
+Date:   Thu Aug 16 18:23:04 2018 +0800
+
+    fix: fixed android flash crash when subtitle =' ' (empty string) (#469)
+    
+    reference: https://github.com/wix/react-native-navigation/issues/2892
+    in short, javascript  A && B syntax will return A if A is false. if A is empty string, it will return empty string (which is false if evaluated as boolean) this most of the time works but not here. {A && `<Text>sth</Text>`}, will return "" when A is empty string. This have no problem in iPhone, but returning an empty string to rn component other that` <Text> `will crash in android. The fatal error message can only be viewed using android device monitor or logcat, no message will show in console (as it is a flash crash).
+    To reproduce, put an empty string in subtitle. the double !! first turn empty string '' to true and then false. return false or null is save within JSX
+    
+    
+    
+    07-26 21:07:41.735: E/AndroidRuntime(16154): java.lang.RuntimeException: abi26_0_0.com.facebook.react.uimanager.IllegalViewOperationException: Trying to add unknown view tag: 1472
+    07-26 21:07:41.735: E/AndroidRuntime(16154):  detail: View tag:1479
+    07-26 21:07:41.735: E/AndroidRuntime(16154):   children(2): [
+    07-26 21:07:41.735: E/AndroidRuntime(16154): 1468,1470,
+    07-26 21:07:41.735: E/AndroidRuntime(16154):  ],
+    07-26 21:07:41.735: E/AndroidRuntime(16154):   viewsToAdd(1): [
+    07-26 21:07:41.735: E/AndroidRuntime(16154): [2,1472],
+    07-26 21:07:41.735: E/AndroidRuntime(16154):  ],
+    07-26 21:07:41.735: E/AndroidRuntime(16154):    at abi26_0_0.com.facebook.react.bridge.ReactContext.handleException(ReactContext.java:313)
+    07-26 21:07:41.735: E/AndroidRuntime(16154):    at abi26_0_0.com.facebook.react.uimanager.GuardedFrameCallback.doFrame(GuardedFrameCallback.java:33)
+    
+    <!-- Please provide enough information so that others can review your pull request. -->
+    <!-- Keep pull requests small and focused on a single change. -->
+    
+    ### Motivation
+    
+    <!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
+    
+    ### Test plan
+    
+    <!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
+
+[33mcommit 7d11a8ef07bbc0fc25709380ad922db8e82dc5a6[m
+Author: Max <max.doerfler@gmail.com>
+Date:   Thu Aug 16 12:18:04 2018 +0200
+
+    fix: pass rest props into button (#488)
+    
+    I had the same issue described in #477 where I need to pass testID and/or accessibilityLabel to buttons to find them in e2e tests.
+    The same behaviour is implemented in other components such as [FAB](https://github.com/callstack/react-native-paper/blob/master/src/components/FAB.js#L97)
+    
+    Create a button and pass a testID
+    ```
+    function testID(id) {
+      return Platform.OS === 'android' ? { accessible: true, accessibilityLabel: id } : { testID: id }
+    }
+    
+    <Button
+      {...testID('skip-button')}
+      onPress={async () => {
+        // ...
+      }}
+    >
+      Skip
+    </Button>
+    ```
+    
+    This works now in appium tests with wd
+    ```
+    const skipButton = await client.elementByAccessibilityId('skip-button')
+    await skipButton.click()
+    ```
+
+[33mcommit da9abc48bae3230aad76f7f90e660b4cdccde84b[m
+Author: Gabriel Rubens <grsabreu@gmail.com>
+Date:   Fri Aug 3 19:40:54 2018 -0300
+
+    docs: minor english fix in snackbar actions doc (#482)
+
+[33mcommit 0e7d0cd88daea696d5ab2f679ff7a5504413c928[m
+Author: Kacper <kacperwiszczuk@gmail.com>
+Date:   Fri Aug 17 22:32:45 2018 +0200
+
+    BREAKING: TextInput RTL support (#499)
+    
+    - [x] - [Working RTL](https://i.imgur.com/sXYWKZi.png)
+    - [x] - [Working LTR](https://i.imgur.com/SjV0k8Z.png)
+
+[33mcommit ce97d1558b5cb352c65d370cd9150a09f88d77a8[m
+Author: iyad <iyadthayyil@gmail.com>
+Date:   Wed Aug 29 12:29:40 2018 +0300
+
+    chore: add RTL toggle to example app. closes #503
+
+[33mcommit 0c98a1eecbd754722887f8d4f30bb39177e4470e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Sep 1 01:32:28 2018 +0200
+
+    feat: use new accessibility APIs
+    http://facebook.github.io/react-native/blog/2018/08/13/react-native-accessibility-updates
+
+[33mcommit 8b9176b44bb01a1eef497a403b0304bc389c9aee[m
+Author: Thanos Korakas <thanoskorakas@gmail.com>
+Date:   Tue Jul 31 15:58:10 2018 +0300
+
+    feat: add style prop to FAB group action items. closes #475
+
+[33mcommit 89db7c14ab1cc4cc0181d1a8fa7f739a92177395[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Fri Jul 6 10:53:15 2018 +0200
+
+    feat: disabled FAB. closes #445
+
+[33mcommit f31f25ec0250942985b7c8e21a726040b7d0c23a[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Sep 1 01:04:36 2018 +0200
+
+    Revert "fix: FAB elevation to match material design (#497)"
+    
+    This reverts commit 640c7dda1de081da3ef75ed941f57953f6d00ff5.
+
+[33mcommit 3b09171aff76baddcb86f0c46685a913a4b7946d[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Fri Jul 6 08:46:19 2018 +0200
+
+    BREAKING: add status prop to checkbox and radio
+
+[33mcommit f1cde8a3fc7277a28ea9d74107075545f6fe5b8a[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Sep 1 00:31:40 2018 +0200
+
+    BREAKING: TextInput redesign (#522)
+
+[33mcommit 13140943ca98100fb9baaf1db0cf7bdc79923f50[m
+Author: KevinG <kguljajev@gmail.com>
+Date:   Fri Aug 31 13:44:35 2018 +0300
+
+    fix: Make desktop builds runnable by adding required files (#515)
+    
+    * Disabled SnackBar content rendering when SnackBar is not visible
+    
+    * Added windows and macOS ProgressBarComponents so that the build would not fail
+
+[33mcommit 4a7d2e64660e4b1b9f4dc1d06ae284a7604cf8d4[m
+Author: Iyad Thayyil <iyadthayyil@gmail.com>
+Date:   Wed Aug 29 12:43:28 2018 +0300
+
+    fix: broken menu button of example app (#510)
+    
+    <!-- Please provide enough information so that others can review your pull request. -->
+    <!-- Keep pull requests small and focused on a single change. -->
+    
+    ### Motivation
+    
+    <!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
+    
+    ### Test plan
+    
+    <!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
+
+[33mcommit c63f9dba78a965f4113fc2b74333152d590a003e[m
+Author: Ferran Negre <fnp.developer@gmail.com>
+Date:   Wed Aug 29 09:56:34 2018 +0200
+
+    fix: Snapshot tests
+
+[33mcommit 206c1b39a3bf6a4a14d8cf1bf7dd617f79b43c26[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Tue Aug 28 12:17:22 2018 +0200
+
+    feat: allow themeable backdrop (#507)
+
+[33mcommit 33cbd34682bc11e251649ba0738b78b80feae7ff[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Mon Aug 27 10:45:39 2018 +0200
+
+    fix: justify content centered in Modals (#506)
+    
+    Since #491 the content is not centered automatically anymore because the children take up 100% and `justifyContent` on the parent container has no effect.
+
+[33mcommit eaf684a5046405650bfb3df8cd65e2ee5cb642b1[m
+Author: KevinG <kguljajev@gmail.com>
+Date:   Fri Aug 24 09:24:45 2018 +0300
+
+    Disabled SnackBar content rendering when SnackBar is not visible (#502)
+
+[33mcommit e9236b355c473fd3f7eac58258fab340130e3dc5[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Thu Aug 23 12:11:08 2018 +0200
+
+    fix: set proper elevation for Card and decease a bit animation time. (#498)
+
+[33mcommit 640c7dda1de081da3ef75ed941f57953f6d00ff5[m
+Author: Luís <luis_m_gouveia@hotmail.com>
+Date:   Tue Aug 21 12:18:28 2018 +0100
+
+    fix: FAB elevation to match material design (#497)
+
+[33mcommit 141142caa9c3900a5f250bd7064d220e1503f546[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Fri Aug 17 15:06:15 2018 +0200
+
+    feat: fix issue with card showing above dialog. (#496)
+
+[33mcommit 6b41e63eea69678739d3115a01f338184fb5df50[m
+Author: Iyad Thayyil <iyadthayyil@gmail.com>
+Date:   Thu Aug 16 13:23:59 2018 +0300
+
+    fix: button borderWidth (#481)
+    
+    ### Motivation
+    `borderWidth: StyleSheet.hairlineWidth` is only needed for outlined buttons, it is causing unwanted white bottom border on contained buttons.
+    
+    ### Screenshots
+    #### before:
+    ![screenshot_20180803-143947](https://user-images.githubusercontent.com/11161020/43641826-c1a0bffc-972d-11e8-9c47-1618a57d9493.png)
+    #### expected:
+    ![screenshot_20180803-143727](https://user-images.githubusercontent.com/11161020/43641858-df31ffc2-972d-11e8-98b5-90ccdc135394.png)
+    
+    
+    
+    <!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
+    
+    ### Test plan
+    
+    <!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
+
+[33mcommit 7b0cd50daca34a1ed3327b47b7ef43f23cac535a[m
+Author: fzyzcjy <turtlegood@163.com>
+Date:   Thu Aug 16 18:19:43 2018 +0800
+
+    fix: fix issue that `Modal` children cannot grow (#491)
+    
+    Add `flex:1` to Modal to fix the issue that `Modal` children cannot grow. fixes #471
+
+[33mcommit 53960896cc30fd26aed77a1053aa808ef79624f8[m
+Author: Iyad Thayyil <iyadthayyil@gmail.com>
+Date:   Mon Aug 13 11:32:16 2018 +0300
+
+    fix: dialog borderRadius (#472)
+    
+    Dialog borderRadius was explicitly set 2, I have updated it to get the roundness from theme prop.
+
+[33mcommit f5ed1df475a7b7917cbf7854e54e197010ab5056[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Sat Aug 11 11:18:13 2018 +0200
+
+    fix: disable Touchable if no press handler was passed
+
+[33mcommit e49ba4e661c4e7de0da82ff5e283a16cb3a0b179[m
+Author: iyad <iyadthayyil@gmail.com>
+Date:   Wed Jun 27 21:22:32 2018 +0300
+
+    feat: RTL support. closes #434, #375
+
+[33mcommit 787379005a0b22240062965564d524e80a083b0b[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jul 25 15:04:01 2018 +0200
+
+    chore: release v2.0.0-alpha.7
+
+[33mcommit 2c273219686b3a14a020995159d34b9b1a957851[m
+Author: Jakub Kłobus <souhepend@hotmail.com>
+Date:   Tue Jun 12 18:28:05 2018 +0200
+
+    refactor: use @callstack/react-theme-provider
+
+[33mcommit b573ea228bbb2150bb716a848de1642988e4b5da[m
+Author: Óscar Carretero <ocarreterom@users.noreply.github.com>
+Date:   Wed Jul 25 13:23:23 2018 +0200
+
+    fix: Searchbar TextInput whole clickable
+
+[33mcommit c5db9204c6c78a3f11b9e5632bcc0277e91ff74c[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Jul 19 14:22:25 2018 +0200
+
+    fix: remove hardcoded drawer item height (#461)
+
+[33mcommit 1c8cf5c7328f67dde7b9dd8f9b12b3f6cf500aa8[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Jul 6 12:21:09 2018 +0200
+
+    BREAKING: remove Portal wrapper from components (#439)
+    
+    Currently, we wrap certain components such as FAB.Group and Snackbar in Portal by default.
+    This means they are always rendered on top of everything and there's no way to control it.
+    This makes it hard to integrate with navigation libraries such as React Navigation.
+    The PR removes the Portal wrapper by default and exports PortalHost so users can control where the components are rendered.
+    
+    In future React Navigation could provide an API to render things on top of the screen and users would be able to take advantage of it.
+
+[33mcommit b9631580b5db79ce84d6b360a177d4c37414b36f[m
+Author: Julian Hundeloh <hennes_88-mailbox@yahoo.de>
+Date:   Fri Jun 29 10:32:20 2018 +0200
+
+    feat: export platform dependent CheckBox and RadioButton
+
+[33mcommit 1e3ddc4d6396a0dab026cb57f2ce7ab32d32050c[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Fri Jun 29 15:02:25 2018 +0200
+
+    docs: document disabling of AppbarAction (#435)
+
+[33mcommit db4befec6b5726a12fec3bc74cb167d8a4c1041f[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Jun 28 15:00:45 2018 +0200
+
+    docs: fix description for accessibility label
+
+[33mcommit 1795dc255359dc9859c3f70eac535cfebb6dcdde[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Thu Jun 28 14:32:58 2018 +0200
+
+    fix: prevent focus and blur if disabled (#431)
+
+[33mcommit 0108b23d33f9d215f83414f7aa289bb8d7a0bc83[m
+Author: Julian Hundeloh <hennes_88-mailbox@yahoo.de>
+Date:   Fri Jun 22 14:11:41 2018 +0200
+
+    feat: rename TouchableIcon to IconButton and export it
+
+[33mcommit ed05a65d3fb1080648482121f81584e29853b2f5[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Jun 28 13:04:27 2018 +0200
+
+    docs: update chat link in README
+
+[33mcommit bf354528f84335df6d2fa3763b0a9af6becaae18[m
+Author: Eric <bosung90@gmail.com>
+Date:   Thu Jun 28 03:43:56 2018 -0700
+
+    fix: fix snackbar blocks touch at the bottom of the screen (#427)
+    
+    If you have a tabbar or anything at the bottom, and you move the snackbar up, snackbar will block all pointer events at the bottom of the screen. `pointerEvents="box-none"` on both SafeAreaView and `Animated.View` will fix this issue and still allow you to add buttons within Snackbar component
+
+[33mcommit 2209d7c9c5b34e4f3f89392415308d1674bb9a44[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jun 12 11:37:09 2018 +0200
+
+    docs: fix docs on components as static property
+
+[33mcommit 091938ca13c3769e1fe85ed487cdb7e4d010ddca[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jun 12 11:17:28 2018 +0200
+
+    chore: release v2.0.0-alpha.6
+
+[33mcommit 9b21e4264b65c4fd8db237a9e4f8af0b26c3ef1b[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Tue Jun 12 11:06:40 2018 +0200
+
+    feat: add style prop to FABGroup component. (#419)
+    
+    This PR makes it possible to pass style prop to FABGroup component and for example change it's position.
+
+[33mcommit befa1b0e29a3b135e2d7dc1665960f0e680f8560[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jun 6 13:38:36 2018 +0200
+
+    chore: release v2.0.0-alpha.5
+
+[33mcommit 243104c5c5ae245aabc953c0cb54d992ba529411[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Wed Jun 6 21:01:13 2018 +0200
+
+    fix: handle empty string in description (#413)
+
+[33mcommit 773c4f5da15da204968a4681aeba93feccd9b7b7[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jun 6 13:17:53 2018 +0200
+
+    docs: point to snack to try the example app
+
+[33mcommit 42325501e8ed002ededbaf4193cd57afeae5b8d2[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jun 6 13:08:44 2018 +0200
+
+    chore: updates to make it work with Snack git import
+
+[33mcommit a218aa023520ade5a6819e639ec5edd1f56de797[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jun 6 13:07:58 2018 +0200
+
+    fix: publish types to npm
+
+[33mcommit 63349a727dedd9913f2bf28812b2cb84087fcfef[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Wed Jun 6 13:10:33 2018 +0200
+
+    fix: ref set to null on updates (#410)
+    
+    ### Motivation
+    
+    The ref function is called twice on updates (see https://reactjs.org/docs/refs-and-the-dom.html#caveats-with-callback-refs). This behaviour causes the variable `this._manager` sometimes to be null during rendering and in that case actions are pushed to the queue again. Since the queue is only processed once (during componentDidMount), somes changes will never be visible. The simple solution is to bind the ref-function as mentioned in the link above.
+    
+    ### Test plan
+    
+    Dynamically change `visible` parameter of Modal. The Modal won't be visible on the second time.
+
+[33mcommit adb970d968befe44dc880c48e722015a9618a136[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jun 5 14:23:20 2018 +0200
+
+    chore: release v2.0.0-alpha.4
+
+[33mcommit e09b7429e7d504367f1bdd329ecdf2b202dc42ca[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jun 5 14:22:32 2018 +0200
+
+    fix: properly center icons in bottom navigation
+
+[33mcommit 7e1938e1de66f510734c2f5ecb681a88b61d692e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jun 5 14:15:56 2018 +0200
+
+    fix: accessibility improvements (#411)
+
+[33mcommit c0f0a2a86502eac92972e9015f14dda9a5ee7f7f[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Jun 4 23:47:46 2018 +0200
+
+    fix: hide icon from screen readers
+
+[33mcommit 7f887ecd361b583b6fab99a298fd1a7b7c2affd1[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Jun 4 17:02:34 2018 +0200
+
+    chore: persist navigation state in example app
+
+[33mcommit ecf30e4c7e1a05e843680680351311c599f06029[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Jun 4 17:01:55 2018 +0200
+
+    fix: disable chip elevation on iOS
+    Animating the elevation for Chip looks glitchy on iOS
+
+[33mcommit d131912533802feef600cba1eb963fa2d67b81b7[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Jun 4 16:36:26 2018 +0200
+
+    chore: release v2.0.0-alpha.3
+
+[33mcommit 233bf45244aec060fa2f25c1e88b22977baeedff[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Jun 4 16:35:58 2018 +0200
+
+    fix: vertically center label on iOS
+
+[33mcommit a5a01e27d90885f78c30e406c41f16c50b6ead70[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Jun 4 15:47:43 2018 +0200
+
+    chore: release v2.0.0-alpha.2
+
+[33mcommit 1d3276a2abc219f542677a1c8f9437b64ea5e8a9[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Sun May 13 02:51:58 2018 +0200
+
+    BREAKING: Redesign Chips. Closes #369
+
+[33mcommit 2688e0bbe22860608cf3a134281985081e611dfb[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Jun 4 11:52:32 2018 +0200
+
+    docs: update docs regarding babel and flow. fixes #392
+
+[33mcommit 302f4e220a6b00f2b17b25a91102aeb71956341e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu May 31 07:37:39 2018 +0200
+
+    fix: close speed dial on pressing action in FABGroup
+
+[33mcommit 3b18d4cefbb14130f96174f51ac5bb9a86cd4f85[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Jun 4 11:36:47 2018 +0200
+
+    fix: fix flow error in FABGroup
+
+[33mcommit bad3c543296cc8e72149db9ec44d19e3cf3241c1[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Jun 4 01:38:31 2018 +0200
+
+    feat: make bottom navigation accessible
+
+[33mcommit e7393aff8c662b2b4c64c1d51ea47b766f0c5d69[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Jun 3 23:47:48 2018 +0200
+
+    chore: release v2.0.0-alpha.1
+
+[33mcommit 3dc48719f303f1b5472c92f5afe4dc7f6a7bbc57[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Jun 3 23:47:22 2018 +0200
+
+    fix: make sure tabs are vertically centered
+    https://github.com/react-navigation/react-navigation-material-bottom-tab-navigator/issues/4
+
+[33mcommit c4e5582adff285c6a1e5a9e70ae3a8e6305c8e83[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Jun 3 23:34:10 2018 +0200
+
+    feat: support using BottomNavigation.SceneMap inside component's render
+
+[33mcommit d8182b48f2040a27c6c520f6f00632275db94a25[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Jun 3 17:55:39 2018 +0200
+
+    refactor: simplify dialog logic
+
+[33mcommit b6bc327e39dd34d2e68024929a3798076c48325f[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Jun 3 17:08:16 2018 +0200
+
+    refactor: simplify appbar logic
+
+[33mcommit a2a3bc34d51c41c1e8e04c7e7fe9deaba9a0ffc6[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Sun Jun 3 17:34:29 2018 +0300
+
+    fix: show ripple in same position where user touched (#394)
+
+[33mcommit bedfd24bfa9e1e7cbb69cd60e250162b2fb8fd7e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Jun 3 16:17:04 2018 +0200
+
+    refactor: remove extra view wrapper from portal
+
+[33mcommit 397da928cba56538254c3b4ed194fd8069374fd9[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Sun Jun 3 16:14:19 2018 +0200
+
+    fix: make Modal nestable (#398)
+
+[33mcommit b838b40cf866c7add1d6add8031264c3b9dafbe5[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Jun 3 16:11:13 2018 +0200
+
+    fix: check if component is valid before cloning. fixes #407
+
+[33mcommit d9a3d77d3407b3ec399116b8523d416a8c79d5bc[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed May 30 18:16:27 2018 +0200
+
+    BREAKING: rename Toolbar to Appbar and add Appbar.Header
+
+[33mcommit 5fc7f3333193db14afaf59305169708e3d16a4d5[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu May 31 08:19:00 2018 +0200
+
+    chore: use latest node image on ci
+
+[33mcommit 8959640f563a3f3d2d49defeb762c194719faf7d[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat May 26 14:17:46 2018 +0200
+
+    chore: upgrade deps
+
+[33mcommit 2f5154f4d3f8c7fe1ae1ba43928033b8681bcfa4[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed May 30 16:27:50 2018 +0200
+
+    BREAKING: update toolbar design on iOS
+
+[33mcommit 651e3e1b23c8fa4130e83cf233a3875a754c744a[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat May 26 23:06:02 2018 +0200
+
+    fix: faster tab switching for bottom navigation
+
+[33mcommit bc5d967772dff02e40d5414692cf389bf9624cd9[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Tue May 15 21:12:47 2018 +0200
+
+    BREAKING: redesign Snackbar
+
+[33mcommit 54660ef0b87ac64afae4b1dfc04b4aebcc9746e4[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat May 26 02:22:59 2018 +0200
+
+    chore: update drawer item snapshot
+
+[33mcommit 1d511ccfc7b6a58073e9f696a76bff6e1858120d[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri May 25 14:45:51 2018 +0200
+
+    BREAKING: use static properties for related components
+
+[33mcommit c3bf6b09aebb32ae4780920a13edf40da7c3c7ab[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri May 25 13:11:29 2018 +0200
+
+    BREAKING: drop dark prop in favor of color prop in various components
+
+[33mcommit 160e36d1d257b6d595b987d150aad257e6c3e8f1[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu May 24 19:38:05 2018 +0200
+
+    chore: release v2.0.0-alpha.0
+
+[33mcommit a522b60c5f95846932d7d0fea1a128d8c3952c97[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu May 24 22:07:13 2018 +0200
+
+    refactor: remove elevation handling from Portal implementation
+
+[33mcommit 734cd9892a8e65512dc296cf78219677be940502[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Sun May 20 18:53:36 2018 +0200
+
+    BREAKING: Drawer redesign (#377)
+    
+    Drawer redesign for 2.0. Changes:
+    - changed the active state styling
+    - colors are now theme based, not fixed
+    - theme based roundness
+    - removed the "color" prop - it can be now controller with the primaryColor (see [the expo app example](https://github.com/callstack/react-native-paper/pull/377/files#diff-cf8d6e3323746c5c486de08cb0c333c3R59))
+    - added snapshot tests
+    
+    <img width="248" alt="screen shot 2018-05-16 at 23 59 54" src="https://user-images.githubusercontent.com/7827311/40146708-e58bf92c-5966-11e8-8916-e76cb42e2f86.png">
+    <img width="248" alt="screen shot 2018-05-17 at 00 00 02" src="https://user-images.githubusercontent.com/7827311/40146727-f26662a4-5966-11e8-9cee-dc01e3cd5599.png">
+    
+    Fixes #358.
+    
+    Snapshot tests added. Run `yarn test`.
+
+[33mcommit c696883da4ff70a0b50a161e612c3f9474be4267[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Wed May 16 14:43:51 2018 +0200
+
+    refactor: use touchable disabled prop (#372)
+
+[33mcommit 951572fb0720e99a1ea20949c24d5a7767da35f6[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon May 14 22:05:29 2018 +0200
+
+    feat: add ability to hide tab labels in bottom navigation
+
+[33mcommit fa694fbf8027bb5fe7d109bf01cd2cc5e1ec4431[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon May 14 21:54:49 2018 +0200
+
+    feat: add support for active and inactive tint color in bottom navigation
+
+[33mcommit 9ad9532051e6277588f6c782ff33da45f1434682[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun May 13 19:58:49 2018 +0200
+
+    BREAKING: remove default margins. fixes #334
+
+[33mcommit 991ac5e6ce85cf6846ca9bbe49e70f807722e5ec[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun May 13 15:58:21 2018 +0200
+
+    BREAKING: simplify bottom navigation design
+    https://material.io/design/components/bottom-navigation.html
+
+[33mcommit 37091c7616ffa738b700d443f777b50bb9721be4[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri May 11 14:36:38 2018 +0200
+
+    BREAKING: redesign button. fixes #356
+
+[33mcommit fb361299e48bd3e637869f6576fc7898b3195a35[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri May 11 14:53:59 2018 +0200
+
+    BREAKING: change default theme colors
+
+[33mcommit 8fede4a086b632e94e4f17d7769e4888efbd32b8[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu May 10 15:19:48 2018 +0200
+
+    BREAKING: Change default roundness and error color
+
+[33mcommit 3485402a1f7e9f2954f3bcb02373e0007939407f[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu May 10 14:52:56 2018 +0200
+
+    BREAKING: rename Paper to Surface
+
+[33mcommit 65ad2a04571d20524bc4f9ae1c19fe99c8c42e2c[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu May 10 14:32:25 2018 +0200
+
+    BREAKING: Remove support for React elements for icon prop
+    Use render callback instead
+
+[33mcommit 8c5bc5165bbbb2c6ef2c3295db731f9e491d6a5f[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu May 10 14:15:14 2018 +0200
+
+    BREAKING: remove SearchBar export
+
+[33mcommit 1924945f9ffebcdbfc688f20b1363805fb255f0e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat May 26 02:04:29 2018 +0200
+
+    chore: release v1.9.1
+
+[33mcommit 5525f55d6dcf7c44f860dce34412510f48eb7593[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat May 26 02:04:06 2018 +0200
+
+    fix: fix statusbar style in FABGroup
+
+[33mcommit 204604aa7e48586595a04dac565abf5eeb547e5b[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat May 26 02:00:01 2018 +0200
+
+    chore: release v1.9.0
+
+[33mcommit 880aba2a3db568ebf33b8ceb1b542ece356d12a3[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Sat May 26 01:59:18 2018 +0200
+
+    docs: fix typos (#385)
+
+[33mcommit 5a6524169121672eaeeab35cb997ec6d4c4e8ef8[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Sat May 26 01:58:39 2018 +0200
+
+    fix: use paper's typography for drawer (#387)
+
+[33mcommit c8472ce6fce9c95f7e1d3f04d09c8edba38d1d11[m
+Author: Julian Hundeloh <jaulz@users.noreply.github.com>
+Date:   Thu May 24 20:26:25 2018 +0200
+
+    fix: avoid "this" in static properties in snackbar. fixes #383
+
+[33mcommit cc6408b88246f20c62884a5892a6276baf7c3920[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat May 26 01:47:25 2018 +0200
+
+    fix: properly respect value and focused state. fixes #388
+
+[33mcommit f3260036c6c61b756aff23d453903daab861c089[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat May 26 00:48:12 2018 +0200
+
+    fix: fix drawer icon styling. fixes #386
+
+[33mcommit e1c795e7de2aa706b267598b77d9eeed95f9a6fe[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu May 24 18:58:37 2018 +0200
+
+    feat: add FABGroup component for FAB with speed dial (#218)
+    
+    Fixes #210
+
+[33mcommit 0feb270b58dc62d2e088ec2d58df9a712da46078[m
+Author: Ferran Negre <fnp.developer@gmail.com>
+Date:   Fri May 18 15:12:41 2018 +0200
+
+    docs: add paper logo (#378)
+
+[33mcommit bdf7e7579241e4dbe0cf5128811a7ad48a664693[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed May 16 14:45:20 2018 +0200
+
+    chore: release v1.8.0
+
+[33mcommit 70742a0235626cbbb39d286c9573bac5296b6c73[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed May 16 14:41:55 2018 +0200
+
+    fix: call onTabPress before navigating in bottom navigation
+
+[33mcommit c9515219c3074688a36b95ac32b4faf8a44888ad[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Wed May 16 11:42:02 2018 +0200
+
+    docs: Improve the DrawerSection example (#363)
+
+[33mcommit 41ef933aec8289264562b92a283ed1182f99a83b[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Sun May 13 20:20:35 2018 +0200
+
+    docs: support components exposed as static properties in docs(#368)
+
+[33mcommit 743821d709074c6176dc9e51df1f1cdfc75ee6f1[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat May 12 17:32:30 2018 +0200
+
+    chore: use babel-preset-env for docs
+
+[33mcommit dfeb23b8e5e874009348526314c79c54742fda1f[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat May 12 16:17:38 2018 +0200
+
+    chore: upgrade component-docs
+
+[33mcommit 629b57aed208d62aab64e4fc9ddfe3ffcca11b13[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri May 11 15:43:43 2018 +0200
+
+    feat: add extended FAB according to material design
+    https://material.io/design/components/buttons-floating-action-button.html\#extended-fab
+
+[33mcommit faca4bc1e08aac993840d2312d2524a61faff27b[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed May 9 15:06:07 2018 +0200
+
+    docs: update component-docs
+
+[33mcommit 0692bd97ba06c9367928659d7c3361becfe4f130[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed May 9 14:44:36 2018 +0200
+
+    docs: use -webkit-overflow-scrolling: touch for safari
+
+[33mcommit 2291d52a76d9073c71e043bc8240a3f88bbc6894[m
+Author: Michał Pierzchała <thymikee@gmail.com>
+Date:   Wed May 9 11:58:32 2018 +0200
+
+    docs: add iOS safari fix for "hijacked" scroll (#323)
+
+[33mcommit 20843efa3dd633782e6ba1e8d72b7233ff3e7603[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Wed May 9 11:56:05 2018 +0200
+
+    docs: fix Text imports (#353)
+
+[33mcommit 9ccf641eb4f47654268e4c5673e551a365529434[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon May 7 11:57:13 2018 +0200
+
+    chore: release v1.7.0
+
+[33mcommit b9aa79503c1aa8779ebd08190fc71d64fe93d0bf[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Sat May 5 21:59:45 2018 +0200
+
+    feat: add Chip component
+
+[33mcommit 9fd6db4ec7c958259f23860b9ff6c227728f645b[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Sun May 6 17:23:53 2018 +0200
+
+    refactor: change the flow typing for functions (#351)
+
+[33mcommit 772b82ac36892e0ea5f724cd54801e1cce30606e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun May 6 17:05:20 2018 +0200
+
+    fix: center icon in button along with text
+
+[33mcommit 85cb5bdb48d2d7ea9e20d580c98f849dff21acb3[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun May 6 14:50:28 2018 +0200
+
+    fix: fix visibility and touch target of action in Snackbar
+    - Animate the Snackbar on layout instead of on mount because we need the layout for animation, this fixes snackbar not being visible on initial mount if visible=true.
+    - Fix the touch target of the action button to be larger. Previously the touch target was as small as the action text and it was difficult to tap on it.
+
+[33mcommit 720f9b235d95f4331dfc5bda40bc040623663ec1[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat May 5 18:07:40 2018 +0200
+
+    chore: release v1.6.0
+
+[33mcommit 7c054c00284819cfeec19ae737d59b5a892bebc7[m
+Author: K. P. Sroka <kpsroka@users.noreply.github.com>
+Date:   Sat May 5 18:06:14 2018 +0200
+
+    feat: implement helper and error text support in TextInput (#243)
+
+[33mcommit d3e7beb786ba78b79ae84cca9cde86de144548fd[m
+Author: Peter Piekarczyk <peterpme@users.noreply.github.com>
+Date:   Sat May 5 10:46:38 2018 -0500
+
+    docs: add Babel example with env setting from CRNA (#337)
+
+[33mcommit b6462b7a4fdd1629c737e1ea50376e1ee5b8ee2a[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Fri Apr 20 01:47:59 2018 +0200
+
+    feat: add ListAccordion component
+
+[33mcommit 174af0debb211576171a5f625bf0bb6e3cdc3cdd[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat May 5 17:05:10 2018 +0200
+
+    chore: use ListItem in example
+
+[33mcommit 9fb3df0504ddecf2f28d1d52050f492148b80466[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat May 5 16:46:54 2018 +0200
+
+    fix: fix icon styling in Searchbar
+
+[33mcommit 19e4ce5cec7e64370b46ca960a385012293c2324[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat May 5 16:22:39 2018 +0200
+
+    refactor: rework toolbar actions
+
+[33mcommit 9167db25ea960f99a34d9020daea670ed46a1abd[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat May 5 14:59:56 2018 +0200
+
+    docs: update bottom navigation docs for react-navigation
+
+[33mcommit d04d09dadbf238e8f406340b431e4b51c48a3f2f[m
+Author: Taym95 <haddadi@codeyellow.nl>
+Date:   Mon Apr 30 19:37:10 2018 +0200
+
+    feat: support custom icon color for ToolbarAction
+
+[33mcommit df7fcd248e67c52a666753f3da54d54659a7dcf4[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat May 5 15:55:08 2018 +0200
+
+    feat: support render function for icon prop
+
+[33mcommit 0faee986a5f8e3922c005a027a861978f50c5444[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat May 5 14:53:36 2018 +0200
+
+    fix: add back the peer dependency on vector icons
+    The peerDependency on vector icons was removed in #303 to support optional usage of vector icons. This was mostly due to people using react-navigation wanting to remove the dependency. However, React Navigation moved it to a separate package: https://github.com/react-navigation/react-navigation-material-bottom-tab-navigator, so the case no longer holds.
+    
+    Removing the peerDependency also had the effect of removing support for vector-icons on our build on Snack since Snackager relies on peerDependencies to figure out what to install before bundling.
+    
+    Adding it back to the peerDependency also means that people who use expo will get the warning since they don't need to install it. However they already get this error from any package that uses react-native-vector-icons and there's no good way to handle it.
+    
+    Another effect is that people who use babe-plugin-optional-require to exclude vector icons will still get the warning for peer dependency. They could, however, install the package and use the 'blacklist' option to exclude it from the bundle.
+
+[33mcommit 729a694149735dae87ec966ddfbdb77e07318aa6[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri May 4 14:55:17 2018 +0200
+
+    fix: add sideEffects: false for better tree-shaking with webpack
+
+[33mcommit 2af23ded98eece2a02f59dcae51b5e060f609e05[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue May 1 11:37:59 2018 +0200
+
+    chore: release v1.5.0
+
+[33mcommit 870a4570e3a6b7dac9923648a54b15ea5e7e26cd[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Mon Apr 2 18:12:49 2018 +0200
+
+    feat: add snackbar component
+
+[33mcommit 1dbe3e2dea6d171c5e3f90a289a30f7963ede5d2[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Apr 30 14:27:43 2018 +0200
+
+    docs: document methods on TextInput and Searchbar
+
+[33mcommit 89fd20e22099efc0ef23faafb9faea8cddc2e57d[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Apr 30 14:06:53 2018 +0200
+
+    docs: update bottom navigation docs. fixes #270
+
+[33mcommit f1a5e819b3b0aa61bcf9aee184a41edb21f19960[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Apr 30 14:01:47 2018 +0200
+
+    chore: upgrade component-docs
+
+[33mcommit 4ad50ce57b68b939fac77582d8bbe0dd3979e683[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Apr 28 01:33:04 2018 +0200
+
+    fix: make flow play well with the theme prop
+
+[33mcommit 27bc0e67dc0d28ee96401b7d0411cd71102e7a0b[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Fri Apr 27 15:07:44 2018 +0200
+
+    fix: add elevation prop to newly created PortalGroups.
+
+[33mcommit 2f8e59b098e34086a485734f655d4fd815ba79ce[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Apr 27 11:44:45 2018 +0200
+
+    fix: support function components in withTheme
+
+[33mcommit 5748ff57ebafe94c4979eafa790d9a84812ca440[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Apr 11 17:37:56 2018 +0200
+
+    feat: save memory usage for inactive routes in bottom navigation
+
+[33mcommit bb845c0e4653821046504174c35fa5c47f3c7e89[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Apr 24 12:52:20 2018 +0200
+
+    chore: upgrade component-docs
+
+[33mcommit e6ce1c4f0f34d1dda0ae7b0434abd16363cc2609[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Apr 23 16:46:17 2018 +0200
+
+    chore: release v1.4.1
+
+[33mcommit c89920d60e5caaf6d52946daa31407c2a335d8d8[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Apr 23 16:41:00 2018 +0200
+
+    docs: fix Searchbar docs
+
+[33mcommit 30ed1473defc25b534f4ab1293ce78573d207299[m
+Author: Ferran Negre <fnp.developer@gmail.com>
+Date:   Fri Apr 20 17:06:32 2018 +0200
+
+    fix: hide checkbox on iOS instead of removing it (#333)
+
+[33mcommit 4e3e9290bb72512dccf75f8d36dc770534627da3[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Apr 19 20:44:36 2018 +0200
+
+    refactor: rename SearchBar -> Searchbar for consistency
+
+[33mcommit 70cb8aa0dd98c7d253bc097522968c41df6718f0[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Apr 19 17:55:44 2018 +0200
+
+    docs: fix Paper and Switch docs
+
+[33mcommit 0f97677ff83048dcccecf2a5243ea3612e5d37c7[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Apr 19 15:57:19 2018 +0200
+
+    chore: release v1.4.0
+
+[33mcommit 7018472968744c36b11a662ff5eaf262b96d5951[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Apr 19 15:46:36 2018 +0200
+
+    feat: make vector-icons optional. fixes #303 (#327)
+
+[33mcommit d90cd76cb9081cbde9225990bc5acac217e25877[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Apr 19 00:34:09 2018 +0200
+
+    fix: allow using TextInput as uncontrolled component
+
+[33mcommit 0d915596e87bfcfd0a94bc2db80e8530657c3db2[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Apr 18 17:41:32 2018 +0200
+
+    chore: release v1.3.1
+
+[33mcommit f50fccaadce0d5fa95bccaf8a4a49459294692ad[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Apr 18 17:41:03 2018 +0200
+
+    fix: fix importing color with babel plugin
+
+[33mcommit db26d6c9fdc2b610e79b5f09e31fa57949a65d84[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Apr 18 10:53:25 2018 +0200
+
+    chore: release v1.3.0
+
+[33mcommit 1fabaae6f589b28413ff2fdcead3a81b7aa8ce0d[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Apr 18 10:38:58 2018 +0200
+
+    refactor: flow tweaks
+
+[33mcommit b58b46b835b19544e3d1bc186e5157f095138e77[m
+Author: Lawrence Cheuk <shcheuklogin@gmail.com>
+Date:   Wed Apr 18 16:33:16 2018 +0800
+
+    feat: add helper methods to SearchBar (#326)
+
+[33mcommit b548111f13b6c073ad9fc5a59475c87270849f0b[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Wed Apr 18 10:24:29 2018 +0200
+
+    test: Add snapshot tests for ListItem and ListSection component (#322)
+
+[33mcommit 851d998a04bf82f2e330958f980aa0ebe1a82d6c[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Wed Apr 18 10:21:15 2018 +0200
+
+    chore: Ignore the __tests__ directory when publishing to npm (#324)
+
+[33mcommit 61e745a519139389412dbea1230944a86baad06f[m
+Author: Lawrence Cheuk <shcheuklogin@gmail.com>
+Date:   Wed Apr 18 16:19:05 2018 +0800
+
+    fix: fix no render function in CardCover (#325)
+
+[33mcommit 6842e4bbf442bcaab72fd366522417e2e939f190[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Apr 17 14:46:25 2018 +0200
+
+    chore: release v1.2.8
+
+[33mcommit 59fefc23c5c01d6d9c76d7415e104584251de9ca[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Apr 17 14:41:28 2018 +0200
+
+    chore: fix deploying docs
+
+[33mcommit 090ce9484d825057c81e0b287c6d5dac63d753a6[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Apr 17 14:39:44 2018 +0200
+
+    fix: loosen flow types of bottom navigation
+
+[33mcommit 4ce565bf23c3e7764bf6f89c4e931caa417b94c4[m
+Author: Ferran Negre <fnp.developer@gmail.com>
+Date:   Tue Apr 17 14:08:59 2018 +0200
+
+    fix: reduce non-shifting animation duration and background color for bottom navigation (#319)
+
+[33mcommit b544a42e2d1b5ef10492fc6487d82568ef1a83c4[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Apr 17 13:59:38 2018 +0200
+
+    feat: add babel plugin for modular imports (#309)
+
+[33mcommit 7ce8eb841ce9cdf14f52eca3896f6a09e5a6103b[m
+Author: Nazar Yablonskyi <nazaryablonskiy@gmail.com>
+Date:   Tue Apr 17 12:41:20 2018 +0300
+
+    feat: add uncheckedColor prop for Checkbox and RadioButton  (#313)
+
+[33mcommit ba57bc0d051cc5763fa1ce809803c5a746c6a681[m
+Author: Lawrence Cheuk <shcheuklogin@gmail.com>
+Date:   Tue Apr 17 17:33:42 2018 +0800
+
+    fix: respect icon prop when onIconPress is not passed in SearchBar (#315)
+
+[33mcommit d1a0acaff5bafba3bd78d78b7ca5cea405191d3f[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Apr 17 09:25:48 2018 +0200
+
+    chore: use [untyped] section to ignore modules in flow
+
+[33mcommit 43c00be9fd70cc2a5a9432f3ee5961121a13d453[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Apr 17 09:10:42 2018 +0200
+
+    fix: don't animate checkbox when state is not changed
+
+[33mcommit a3bbb4e9345d9a014d39a79151669faee8cb2d1d[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Apr 17 07:44:18 2018 +0200
+
+    chore: update dependencies and fix flow
+
+[33mcommit 85decc73b00d0099636c58b5537e1ecd65b268c4[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Apr 16 18:41:36 2018 +0200
+
+    fix: support static properties in withTheme HOC
+
+[33mcommit 888efd71f9e842e1e0babf8aae3567a860a59ebc[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Apr 15 21:02:38 2018 +0200
+
+    chore: release  v1.2.7
+
+[33mcommit f9d86030ce4c649e1ad3ce7f7d5b0aa6ad2c3d9d[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Apr 15 19:32:59 2018 +0200
+
+    fix: fix typo
+
+[33mcommit 5ee4160890d82d7d29019a2e5a51e10b4405ba25[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Apr 15 18:44:29 2018 +0200
+
+    fix: use text color for ripples and selection controls
+
+[33mcommit ba4046964fe7223292655315fb1b28bc91645ecd[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Apr 12 17:39:58 2018 +0200
+
+    docs: optimize screenshots
+
+[33mcommit 7b2948f570faa2a6c8dbb32a1f7ba6a08d8531f4[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Fri Apr 6 00:20:45 2018 +0200
+
+    feat: Add ListSection and ListItem components
+
+[33mcommit 5e38f9ccd87c5bed9c2e8529ea6cdfe7684e493b[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Apr 12 12:13:32 2018 +0200
+
+    fix: support dynamically changing routes in bottom navigation
+
+[33mcommit fa352f3148084494ea89c293b335ddabf6b4a731[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Apr 11 15:15:19 2018 +0200
+
+    fix: properly add element to queue
+
+[33mcommit 262b4d41fcf1f991b5964dcdb3d09847022574b5[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Apr 11 12:36:48 2018 +0200
+
+    docs: clarify that TouchableRipple falls back to TouchableHighlight
+
+[33mcommit 490d7071e1508797dcd9ae5bf99fd23eca943e45[m
+Author: ferrannp <fnp.developer@gmail.com>
+Date:   Wed Mar 28 14:46:27 2018 +0200
+
+    docs: add Showcase page
+
+[33mcommit 84a80532c5d4c834d9a20e1c475e0e8742ee8b6e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Apr 5 13:40:42 2018 +0200
+
+    chore: release  v1.2.6
+
+[33mcommit a8137337ac458817dda91324d20f95190304b8b0[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Apr 4 18:06:29 2018 +0200
+
+    refactor: don't use deprecated React lifecycles. closes #285
+
+[33mcommit 860a5348df7e10af850641eb32c572860977cec2[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Apr 4 12:08:43 2018 +0200
+
+    fix: use color prop instead of style in Icon. closes #291, #294
+
+[33mcommit 56b7315b5d55638f9bc8e9c3da49c8145d2ce00a[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Tue Apr 3 17:48:25 2018 +0200
+
+    docs: fix dialog component typo (#297)
+
+[33mcommit b1d38e739bc347f17a539ee84fa6b6dae8c8dcd9[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Mar 29 15:37:47 2018 +0200
+
+    chore: release v1.2.5
+
+[33mcommit 51fafaa63bd716572f1555f39f08d028992cfc5c[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Mar 29 12:13:11 2018 +0200
+
+    refactor: tweak portals
+
+[33mcommit 23a1f3cad30f5f273f9b70ae14fa3cc071bb44cc[m
+Author: Anton Mishyn <aaxmshn@gmail.com>
+Date:   Thu Mar 29 11:45:00 2018 +0200
+
+    fix: linting issue
+
+[33mcommit 3a0e8c19d599b5262214a9e5fe8c9a85789487d1[m
+Author: Anton Mishyn <aaxmshn@gmail.com>
+Date:   Thu Mar 29 11:29:45 2018 +0200
+
+    added nested property check to withTheme
+
+[33mcommit b136cbaac9bf6f3849abcbf6232660f49ae34d79[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Mar 29 11:28:28 2018 +0200
+
+    chore: run yarn in root folder on bootstrap
+
+[33mcommit ab42b415acb140cb52005249554fa9ce87fab98f[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Mar 23 16:58:24 2018 +0100
+
+    docs: simplify contribution guidelines (#283)
+    
+    It's still pretty big, but all the important stuff about setting up the environment is on the top. Rest is verified by the pre-commit hook, so not a big deal if people don't read them.
+
+[33mcommit a28d93590b9b7e34a455f6f3d92866c8a6e8152b[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Mar 22 15:50:54 2018 +0100
+
+    fix: fix statusbar height on old versions of ios (#281)
+
+[33mcommit 8a5ccde22d050cf65e6bc2e54a2845d8568c3304[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Mar 19 11:39:25 2018 +0100
+
+    chore: release v1.2.4
+
+[33mcommit 1cb795852b746047596cc269010422e322b0cb67[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Mar 19 11:25:42 2018 +0100
+
+    chore: remove stale files when deploying docs
+
+[33mcommit 3259fbbf8e56e4cd1c87f329bef945fd5a103c05[m
+Author: Brent Vatne <brentvatne@gmail.com>
+Date:   Mon Mar 19 01:51:34 2018 -0400
+
+    fix: only import ProgressViewIOS and ProgressBarAndroid in .ios/.android files
+    - react-native-web does not export them so these imports break web support
+
+[33mcommit 505d58d65d4cbfa4deca49aec84c753187bc7114[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Mar 18 18:44:30 2018 +0100
+
+    docs: rename RadioGroup to RadioButtonGroup and fix docs
+
+[33mcommit 959582ed9e67c6555d906fedf4b1cc7da67e4b26[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Mar 18 18:27:12 2018 +0100
+
+    docs: add section about customizing components
+
+[33mcommit 29f21bc029754b2b222f518a4ca86aab956b8e30[m
+Author: Dawid <dawidu@onet.pl>
+Date:   Fri Mar 16 00:45:29 2018 +0100
+
+    feat: Implements radio group component. (#214)
+    
+    * feat: Implements radio group component.
+    
+    * Removes stylesheet import and change flow props types.
+    
+    * Feat: Change RadioGroup to pass props using context.
+    
+    * Feat: Adds example.
+    
+    * Fix flow errors in withRadioGroup component.
+    
+    * feat: Add docs to withRadioGroup component.
+    
+    * feat: Add comment to withRadio prop.
+    
+    * Change RadioGroup to use create-react-context.
+    
+    * refactor: small changes in radioGroup component api.
+
+[33mcommit 16c6de4dfe160cb343a4fcac43fe0efb48456829[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Mar 15 17:31:52 2018 +0100
+
+    docs: fix typo
+
+[33mcommit f8eec8e84f6d0ba3ec4848e6f2ae79837104b71a[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Mar 15 17:08:06 2018 +0100
+
+    chore: release v1.2.3
+
+[33mcommit da0c5181c649894b2d1518f9a373347aa07d9ec6[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Mar 15 17:01:52 2018 +0100
+
+    fix: don't render all tabs in advance to improve initial load time
+
+[33mcommit bd6b7a9879844f1995e95d9d8886f950503d3715[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Mar 14 15:00:43 2018 +0100
+
+    docs: fix badges in README
+
+[33mcommit 81c887ad1dccbafd33230f564b29b334a214a6f8[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Mar 14 14:55:35 2018 +0100
+
+    chore: release v1.2.2
+
+[33mcommit 090f6fbde07013ebe60c15440d119bc37ff50b98[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Mar 14 14:55:08 2018 +0100
+
+    chore: run yarn test on pre-commit hook
+
+[33mcommit cb876a38569e7ecf76a7ccb368faff4a70ef3c3d[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Mar 14 14:54:19 2018 +0100
+
+    docs: update README to point to docs page
+
+[33mcommit 2bafaf9d1d7cd05d6c675213265bd2119348d68a[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Mar 14 13:47:13 2018 +0100
+
+    fix: copy public methods from component in HOC. fixes #254
+
+[33mcommit 87427fe39d165bee2acedde8dbaa237cca3fb61e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Mar 14 14:00:49 2018 +0100
+
+    chore: fix unit tests
+
+[33mcommit bae40c8fb9aa66ee332f8be71843ad0839f96b19[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Mar 13 20:37:28 2018 +0100
+
+    chore: release v1.2.1
+
+[33mcommit ded26d768ff432ad3bde3c0aa1e95ce50726100a[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Mar 13 20:36:25 2018 +0100
+
+    feat: add props to get color and label from a route
+
+[33mcommit 87349c112a72be4658bcefa194fd5d81db4d8fd6[m
+Author: Mateusz Zatorski <mateuszzatorski@gmail.com>
+Date:   Wed Mar 7 14:13:01 2018 +0100
+
+    docs: fix instructions for expo (#271)
+
+[33mcommit 316f3f53ca790568bcf906f482c86bd70090ce23[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Mar 7 13:38:29 2018 +0100
+
+    chore: tweak how vector icons are imported
+
+[33mcommit 27f0a60cc275453eaf1ec9688d63d27900b1626d[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Mar 6 16:21:39 2018 +0100
+
+    chore: release v1.1.1
+
+[33mcommit 50c82f19e678551dd60b8da96822a25c165d245d[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Mar 6 16:04:08 2018 +0100
+
+    fix: handle status bar properly on iOS
+
+[33mcommit 97eb2a3d6455036dcc0c3c287be4a1a3e45be72e[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Mon Mar 5 15:45:10 2018 +0100
+
+    fix: do not require the TextInput numberOfLines prop
+
+[33mcommit adb97b3e9b9886b1669d16c2f47f34e90ac0766f[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Mon Mar 5 14:26:03 2018 +0100
+
+    fix: do not require the TextInput multiline prop
+
+[33mcommit 74e3228facf3d9b6df6fa23259edff4ec97ce131[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Mar 5 14:46:20 2018 +0100
+
+    chore: release 1.1.0
+
+[33mcommit c48ba8a1c475443be16b67a29f787c3cfaaf9e7d[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Mar 5 13:47:05 2018 +0100
+
+    feat: add bottom navigation component (#258)
+
+[33mcommit 5411620ec9f0cdf61142be20cf97f7f635e5e46c[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Mar 4 21:06:51 2018 +0100
+
+    fix: make properties in theme prop optional
+    this doesn't work right now, but should work from flow 0.57 onwards
+
+[33mcommit 8542439e9fa84269b5301dcca378ee4ea8a51de1[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Mar 4 17:30:30 2018 +0100
+
+    refactor: remove screen props from example
+
+[33mcommit 09e64d811ef04480f8969ae32e0f8e565d2b10ac[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Mar 3 23:16:44 2018 +0100
+
+    docs: add description for various properties in the theme
+
+[33mcommit 872efda86741a347829006677226c8c19fd09a7f[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Mar 3 14:39:17 2018 +0100
+
+    chore: release 1.0.2
+
+[33mcommit 1766fd10b61200895287470eb617dbd12bb8503b[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Mar 3 14:22:19 2018 +0100
+
+    refactor: use create-react-context for theming
+
+[33mcommit e54ba172573cda33d0c515fcbff54860a9f16a0b[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Mar 3 13:16:49 2018 +0100
+
+    chore: fix card example
+
+[33mcommit 865ca05f19e062962a079062a06631dfbca9bb31[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Mar 3 13:07:19 2018 +0100
+
+    fix: handle status bar automatically on Expo. fixes #251
+
+[33mcommit 4b4492831d5f76a6478665b52a87b83c6da3f8d8[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Mar 3 12:37:59 2018 +0100
+
+    fix: fix toolbar issues with dark prop
+
+[33mcommit 3a2f3f8e3ccdfd6dec6b7a901a8bb8a326e466eb[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Sat Mar 3 12:16:32 2018 +0100
+
+    fix: align card actions to the left (#262)
+
+[33mcommit 228749346c4d877545d05938040b248409473d55[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Mar 3 12:14:15 2018 +0100
+
+    fix: rework portal to isolate rendering of portals. fixes #216 (#261)
+
+[33mcommit 96c061ce6aa0074f69748f8896eb0c259059f1d8[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Sat Mar 3 12:13:50 2018 +0100
+
+    chore: update the lockfile (#263)
+
+[33mcommit 5a67be9a2f1e429dc4eae654efba6a579f5c1a83[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Mar 2 21:54:18 2018 +0100
+
+    chore: setup jest
+
+[33mcommit c3fedbd51bf25e97cc5e5047089d8780f4426313[m
+Author: Clayton Ray <iamclaytonray@gmail.com>
+Date:   Fri Mar 2 09:35:37 2018 -0500
+
+    docs: add imports to doc examples - closes #223 (#256)
+
+[33mcommit 442653cdb117e9ca1376a551d8b3b8bf479d37bc[m
+Author: Grzegorz Gawrysiak <grzegorz@appsolutions.pl>
+Date:   Fri Mar 2 11:41:34 2018 +0100
+
+    docs: add the missing CardCover props (#260)
+
+[33mcommit 3e1cfa8e9335a7ff6d59defdefad4e91edc4192a[m
+Author: Michał Pierzchała <thymikee@gmail.com>
+Date:   Mon Feb 26 13:17:25 2018 +0100
+
+    chore: use eslint-config-callstack-io (#250)
+
+[33mcommit 58f2e0f49d99c44b8c3667f92fd89ca37dc668de[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Feb 26 12:40:25 2018 +0100
+
+    chore: add issue and pr templates
+
+[33mcommit 827d87415e1fdf20edd4eb21d8517c5fe9cd62d5[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Feb 24 17:56:55 2018 +0100
+
+    chore: release 1.0.1
+
+[33mcommit 665f8fd801021819b2c2fffb1e4f8cceb110fc8c[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Feb 24 17:56:05 2018 +0100
+
+    fix: use hoist-non-react-statics
+
+[33mcommit 887b3ec6ceb5a8acac25745a34a4db64f5a16a58[m
+Author: Jakub Beneš <jukben@gmail.com>
+Date:   Fri Feb 23 12:27:36 2018 +0100
+
+    docs: fix the copy-paste (#253)
+
+[33mcommit 4c9c5ad0a1624b6bb5995b8ad0b126d65971ade9[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Feb 23 11:50:01 2018 +0100
+
+    Add LICENSE. Fixes #252
+
+[33mcommit 21f0140b49c1c7237e51e724254aa2f5fd2bcd0b[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Feb 22 16:46:14 2018 +0100
+
+    chore: release 1.0.0 🎉
+
+[33mcommit d8e7c171783acfef7ff741723f3cfb1d2ea4b35c[m
+Author: ferrannp <fnp.developer@gmail.com>
+Date:   Thu Feb 22 13:33:23 2018 +0100
+
+    docs: make screenshots for Dialog
+
+[33mcommit 72f7567a08172717476d0124c73d2a8fed996c94[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Feb 22 13:45:55 2018 +0100
+
+    docs: add screenshots for radio, checkbox and toolbar
+
+[33mcommit cf5c9b9a435df1f2942fbe30c7116ac54570f754[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Feb 22 12:29:47 2018 +0100
+
+    BREAKING: remove GridView for now
+
+[33mcommit 91bf179df0d68b60af4095c9a06c98c9998542e0[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Feb 21 15:40:25 2018 +0100
+
+     docs: Improvements to the documentation
+
+[33mcommit 59de0c99ff4ae6d698f06fd68008579fd57cbf6e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Feb 21 13:31:49 2018 +0100
+
+    fix: fix typo
+
+[33mcommit 4c842341d1d862f2766b9fe76d399c61d52dca28[m
+Author: Ferran Negre <fnp.developer@gmail.com>
+Date:   Tue Feb 20 15:33:07 2018 +0100
+
+    fix: properly align icon in back button on iOS (#242)
+
+[33mcommit 83b9e3641d05c31e541ffd89d2edcf7c15f4b759[m
+Author: Ferran Negre <fnp.developer@gmail.com>
+Date:   Tue Feb 20 15:25:31 2018 +0100
+
+    fix: use correct color for TouchableRipple in dark theme (#244)
+
+[33mcommit 1185c0df7a5c863528b507f610a20ff3598f18ad[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Feb 20 15:21:57 2018 +0100
+
+    docs: add screenshots for Card and Typography (#236)
+
+[33mcommit 7c426f9efc3561e5b1f36b137621228664f179dc[m
+Author: K. P. Sroka <kpsroka@users.noreply.github.com>
+Date:   Fri Feb 16 12:36:01 2018 +0100
+
+    fix: disabling Touchables if onPress was not set to allow event handling in parent components
+
+[33mcommit c6ae995e8af26ce062958fb36771569ccd464de3[m
+Author: Manjula Subhashchandra Dube <dube.manjula668@gmail.com>
+Date:   Wed Feb 14 16:15:41 2018 +0530
+
+    docs: add test commit type to guidelines (#240)
+
+[33mcommit 88c522d3a18e01098e803d0d06d989149c4eb4cc[m
+Author: Manjula Subhashchandra Dube <dube.manjula668@gmail.com>
+Date:   Sat Feb 10 22:30:17 2018 +0530
+
+    chore: add bootstrap script to run yarn (#239)
+
+[33mcommit 144388439d64e049cbed4e37659e819856d6987f[m
+Author: K. P. Sroka <kpsroka@users.noreply.github.com>
+Date:   Tue Feb 6 16:56:26 2018 +0100
+
+    docs: Adding screenshots for TextInput (#233)
+
+[33mcommit 7b08554fd8c364903de2fedc88eb806f1c54254f[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Feb 6 10:00:29 2018 +0100
+
+    chore: release 0.0.9
+
+[33mcommit e4ff9c8950672a71a9807d349e7b1213bc7f1a43[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Feb 5 16:28:22 2018 +0100
+
+    docs: rework ripple example
+
+[33mcommit 38bfe108caf2a3b045e13de0951ce3e2fe4a2820[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Feb 5 16:20:46 2018 +0100
+
+    docs: fix spacing in radio button example
+
+[33mcommit 4b61f4ffe63c69c32b481acfffdadcb3af6a0a99[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Feb 5 16:02:09 2018 +0100
+
+    docs: rework toolbar example
+
+[33mcommit 1c19f02a026b89fbedc5bad7a61f2baa5da97a41[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Feb 5 16:01:39 2018 +0100
+
+    docs: animate progressbar in example
+
+[33mcommit 710d25e40353ab180e3ef0b1a6978b1137e10c9c[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Feb 5 15:23:34 2018 +0100
+
+    fix: various fixes to dark theme
+
+[33mcommit b9cdbe43fe14ba2b110f95f73307754d9a470316[m
+Author: K. P. Sroka <kpsroka@users.noreply.github.com>
+Date:   Mon Feb 5 13:08:04 2018 +0100
+
+    docs: add screenshots of FAB, Paper, ProgressBar and Switch components (#227)
+
+[33mcommit 1ddd529313dfcb774ca9022855be2497a847c209[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Feb 2 22:04:20 2018 +0100
+
+    chore: update the comment script
+
+[33mcommit 913d7c1291cb2b1c687bbfc360b99c299db957f1[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Feb 2 17:03:00 2018 +0100
+
+    chore: link to docs in the branch in pr comment (#229)
+
+[33mcommit 0edfdc6393856b985efc7a3e75582760fad9617c[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Feb 1 18:38:40 2018 +0100
+
+    fix: fix padding in drawer item
+
+[33mcommit f58ae2e4008816e5500067d9aaf5c06ebdf711d4[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Feb 1 18:33:43 2018 +0100
+
+    fix: avoid setState after update in Portal
+
+[33mcommit 105d337a19dadafb7a83b2916da6574ec25ae3b0[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Feb 1 16:28:10 2018 +0100
+
+    docs: update documentation (#228)
+
+[33mcommit a2f83734e08e1fa4cfbb06d61bfe45cc7f1a5873[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jan 31 17:55:34 2018 +0100
+
+    docs: tweak screenshot sizes
+
+[33mcommit fdb426f211eabac555f04186a81d42546d9e0724[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jan 31 17:31:32 2018 +0100
+
+    docs: setup screenshots (#224)
+
+[33mcommit b4e4de4b20b7f7551e5b7de33f74574e4c8b70e7[m
+Author: TAKAHASHI Shuuji <shuuji3@gmail.com>
+Date:   Wed Jan 31 19:51:48 2018 +0900
+
+    docs: fix a link to default theme file (#215)
+
+[33mcommit 5d67167a4006cc090a5d8ad9aeed585863ab13bc[m
+Author: K. P. Sroka <kpsroka@users.noreply.github.com>
+Date:   Wed Jan 31 11:39:34 2018 +0100
+
+    Fixing 'remote image' button example (#221)
+    
+    * fix: Updating uri link in ButtonExample (the current one gives 404 and no image displayed).
+    
+    * fix: Updating uri link in ButtonExample (svg doesn't work well).
+
+[33mcommit 18e079498a8cef41b27495ba5d87d5b6584b0853[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jan 31 11:38:41 2018 +0100
+
+    docs: add a simple landing page (#220)
+
+[33mcommit f624c2b41f3f3eeb4245f6057c10170a91f437ff[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Jan 28 04:27:09 2018 +0100
+
+    fix: return correct key for portal
+
+[33mcommit 1ea7def251a80d8bed72ce242eb47c8120492d48[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Dec 20 16:27:24 2017 +0530
+
+    fix: fix flow typing with withTheme (#213)
+    
+    There seems to be some issue with defaultProps after this change, but it's better than not typechecking props at all
+
+[33mcommit 1f3cedb62b7d47b7484a93587c94bbb8a5d5ad55[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Dec 12 14:26:33 2017 +0100
+
+    fix: components color style refactor (#212)
+
+[33mcommit fe2123bc5e4c35fc356aebc4cacfd9ead68b0ead[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Dec 11 23:06:39 2017 +0100
+
+    fix: correct components using dark theme (#203)
+
+[33mcommit 9bf90601de303d6e86fd50ba2072d945aa7fe3fd[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Dec 5 23:55:37 2017 +0530
+
+    docs: add expo link to README
+
+[33mcommit 60160f998c31ca73b97f8bfc207dffc7f21e44e1[m
+Author: ferrannp <fnp.developer@gmail.com>
+Date:   Tue Dec 5 11:40:10 2017 +0100
+
+    chore: release 0.0.8
+
+[33mcommit d21b4cbbe3c5f6d0de913ecb73775a8e9b23b75f[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Dec 1 05:57:51 2017 +0530
+
+    chore: upgrade component-docs
+
+[33mcommit b0d49c7815924a716355e1cac36845110015f98b[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Nov 30 18:51:03 2017 +0530
+
+    docs: support custom pages in docs (#211)
+
+[33mcommit f9e4d8ddd07366c911b8335309b266cbf605c2d3[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Nov 29 14:57:14 2017 +0100
+
+    docs: Fix component usage (#209)
+    
+    * chore: upgrade dependencies
+    
+    * docs: fix components usage
+
+[33mcommit 206963adc9e3fca6a534492b0bad268f180cb46c[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Nov 24 17:32:13 2017 +0530
+
+    chore: upgrade dependencies
+
+[33mcommit de7b88d8fcce3872ac24ff5c355299510763a497[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Nov 8 05:49:47 2017 +0530
+
+    chore: upgrade component-docs
+
+[33mcommit 230f8ca2efb2d2a436824bf1f24d16988a6ea1f8[m
+Author: lukewalczak <lukasz.walczak@callstack.io>
+Date:   Tue Nov 7 22:58:24 2017 +0100
+
+    docs: set js inside component for proper highlight
+
+[33mcommit 89ec2efa42187613af99d383390f016726fc80a6[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Nov 7 17:23:57 2017 +0530
+
+    chore: upgrade component-docs
+
+[33mcommit 2dfa9b73b3860df33966796a953cdb7090f36b36[m
+Author: Ferran Negre <fnp.developer@gmail.com>
+Date:   Tue Nov 7 11:57:32 2017 +0100
+
+    docs: Fix README badges and links (#204)
+    
+    * Fix README badges and links
+    
+    * Update README.md
+    
+    * Less badges
+
+[33mcommit aa829bab42b69f4047f4feb565da8c4618674468[m
+Author: Ferran Negre <fnp.developer@gmail.com>
+Date:   Tue Nov 7 11:38:38 2017 +0100
+
+    docs: update README (#199)
+
+[33mcommit bb5158635107bc1e379714086accb415349d1ee7[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Nov 7 15:51:17 2017 +0530
+
+    chore: upgrade flow and dependencies (#200)
+
+[33mcommit 4ba4f279b11d025b7fb2bd8f832e59fc95c8c630[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 6 15:06:09 2017 +0530
+
+    docs: add a doc on theming (#201)
+
+[33mcommit f75e004a453a7696b21acfa4340aa3afee369bf8[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 6 14:31:35 2017 +0530
+
+    chore: configure circle ci (#202)
+    
+    Replace TravisCI with CircleCI for consistency across all callstack repos
+
+[33mcommit c552aa0951ac43cabc9f43f79f64c1fc95ca27fa[m
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Fri Nov 3 17:36:25 2017 +0200
+
+    style: Adapt dialog to the dark theme (#196)
+    
+    * style: Adapt dialog to the dark theme
+    
+    * chore:  Remove unused default prop & set correct elevation style & rename import
+    
+    * style: Fix textinput background color
+    
+    * chore: Add missing proptypes
+    
+    * chore: Update with latest master
+
+[33mcommit bf0d65a17f7bd5deb1a7ab2fb1022b467c8129c3[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Tue Oct 24 21:16:25 2017 +0200
+
+    docs: sort components alphabetically (#190)
+
+[33mcommit 8ce0a18b7fb8cb19bb10d41bd844959a6d77fa83[m
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Tue Oct 24 10:50:43 2017 +0200
+
+    fix: Buttons shadow (#195)
+
+[33mcommit 3410a6b5d4a4629b5c8b0cd05abde1ab389c620b[m
+Author: Paul Brewczynski <pbbluesm@gmail.com>
+Date:   Thu Oct 19 22:18:22 2017 +0200
+
+    Closed xml tags for card element example (#194)
+
+[33mcommit 288ca9d22268106c70bb881e792702107d0f214d[m
+Author: Krzysztof Karol <Krzysztof.Karol@gmail.com>
+Date:   Thu Oct 19 22:06:21 2017 +0200
+
+    Remove checkAnim (#193)
+
+[33mcommit 48892440eb69e2b685c0447d69815bbe3a71c4cd[m
+Author: hasparus <hasparus@gmail.com>
+Date:   Thu Oct 19 22:04:32 2017 +0200
+
+    feat: add hamburger to RootNavigator (#192)
+
+[33mcommit 95b2c7e2ba4b73b60ec272673c4d031c2f3f5775[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Oct 19 15:44:33 2017 +0200
+
+    docs: add info on running the docs and example (#187)
+
+[33mcommit 2dac4f606e61af34b16797b0d4e28eb9e69a29aa[m
+Author: Ferran Negre <fnp.developer@gmail.com>
+Date:   Thu Oct 19 14:49:09 2017 +0200
+
+    docs: update toolbar example. (#186)
+
+[33mcommit 497ae55256a82140cb5044c6a215babddf9f2146[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Oct 19 14:29:17 2017 +0200
+
+    docs: Add missing example usage
+    
+    * docs: documented modal and switch usage
+    
+    * docs: documented checkbox
+    
+    * docs: documented checkbox
+    
+    * docs: documented radio button
+    
+    * docs: refactor component usage description
+    
+    * docs: documented typography styles
+    
+    * docs: documented search bar
+    
+    * docs: documented fab
+    
+    * docs: documented divider
+    
+    * docs: documented icon
+    
+    * docs: documented paper
+    
+    * docs: documented toolbar
+    
+    * docs: documented card
+    
+    * docs: proptypes refactor
+    
+    * docs: documented drawer section
+    
+    * docs: fix state in drawer section
+    
+    * docs: documented drawer item
+    
+    * docs: documented grid view
+    
+    * docs: documented touchable ripple
+    
+    * docs: remove static proptypes
+    
+    * docs: fix typography
+    
+    * docs: update icon component
+
+[33mcommit 9a38816107eb20932809d6f086ea7dfcdfe8fa3d[m
+Author: ferrannp <fnp.developer@gmail.com>
+Date:   Thu Oct 19 13:21:05 2017 +0200
+
+    docs: Rewrite contributing guide.
+
+[33mcommit 3070020fc83485d89782de6d2c7b3070808a89d6[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Thu Oct 19 12:46:59 2017 +0200
+
+    feat: add ripple example (#183)
+    
+    * feat: add ripple example
+    
+    * feat: extend ripple example
+    
+    * docs: refactor ripple example
+
+[33mcommit 04d1836fc18d1a869a38c8ce8f896ff41132c462[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Wed Oct 18 13:46:14 2017 +0200
+
+    refactor: disable shadow on ios toolbar (#176)
+    
+    * refactor: disable shadow on ios toolbar
+    
+    * Update toolbar.js
+
+[33mcommit c6a59d3cac0b32ab621bae5682d63ef546820c7a[m
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Wed Oct 18 11:33:03 2017 +0200
+
+    feat: add TextInput component (#85)
+
+[33mcommit 3e7e59b977dae89b1502484479d589a98a9cbebb[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Oct 17 23:19:25 2017 +0200
+
+    fix: don't do unnecessary merges for theme when not needed
+
+[33mcommit 879571ead0b88d9a43f68c45fb598878b2fee7f2[m
+Author: ferrannp <fnp.developer@gmail.com>
+Date:   Tue Oct 17 16:18:28 2017 +0200
+
+    fix: Be able to override nested theme component.
+
+[33mcommit 386a7c0a9bafa5c23c72e8c5d10b0c23f3b9dc64[m
+Author: ferrannp <fnp.developer@gmail.com>
+Date:   Tue Oct 17 16:01:14 2017 +0200
+
+    fix: Remove flex: 1 for ListView on example and set up light theme as default again.
+
+[33mcommit d4f1149f6417b07e9e0ad106c9e84a9936b67080[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Oct 17 15:14:36 2017 +0200
+
+    chore: update yarn.lock
+
+[33mcommit 70427a8df7c4a2d9be171be6ad33e098a1fe5548[m
+Author: Jakub Beneš <jukben@gmail.com>
+Date:   Mon Oct 16 11:26:30 2017 +0200
+
+    feat: GridView: ListView upgraded to VirtualizedList (#150)
+    
+    * feat(gridView): use VirtualizedList
+    
+    * feat(gridView): orientation should work. start with public API.
+    
+    * feat(gridView): polished code, added public API
+    
+    * fix(gridView): removed comments which broke the CI
+    
+    * docs(gridView): updated documentation
+    
+    * refactor(gridView): better distinguish between private / public method in the example
+    
+    * docs(gridView): fixed comments
+    
+    * fix(gridView): round the layout width
+    
+    * chore(docs): fixed docs generation. When you use flow you have to use named arguments of function
+    
+    * refactor(gridView): renderItem shoud return valid react element
+    
+    * BREAKING: migrate GridView to use VirtualizedList
+    
+    * fix(gridView): we can use flewWrap. YEY!
+    
+    * feat(gridView): use Animated.Value
+    
+    * fix(gridView): polished code
+    
+    * refactor(gridViewExample): polished code
+    
+    * fix(gridView): unused variable
+
+[33mcommit 2637403c3d31f9b87e4d5c3c725f809aba35bac6[m
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Fri Oct 13 16:35:59 2017 +0200
+
+    fix: Fix packger module resolution problem
+
+[33mcommit 8adfa6751ec34bbc84803ffd23fdd46bccbc1b74[m
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Fri Oct 13 15:29:28 2017 +0200
+
+    feat: Dark Theme (#131)
+    
+    * refactor: Add DarkTheme, new colors in theme & update components to use it
+    
+    * chore: Remove 'console.log' statements
+    
+    * chore: Change dark theme property from string to boolean
+    
+    * feat: Add ability to toggle the theme from the drawer
+    
+    * fix: Wrap typography example screen with 'withTheme'
+    
+    * style: Update components to use correct dark theme colors
+    
+    * style: Update dark theme primary color and rn-navigation toolbar now gets the color from the theme
+    
+    * style: Add color prop to DrawerItem and update the example
+    
+    * style: Change the unchecked color in both Checkbox and RadioButton
+    
+    * chore: Add `yarn-error.log` to `.gitignore`
+    
+    * chore: Use lodash instead of lodash.merge
+    
+    * chore: Address PR comments
+
+[33mcommit bd1d481f58c9a0b701c5dd83d81ba2bcc398d494[m
+Author: lukewalczak <lukasz.walczak@callstack.io>
+Date:   Fri Oct 13 15:23:39 2017 +0200
+
+    fix: wrap icon in view
+
+[33mcommit 05c8d10817c0e6f44b13a476ea56dff53bacff4d[m
+Author: lukewalczak <lukasz.walczak@callstack.io>
+Date:   Fri Oct 13 14:38:39 2017 +0200
+
+    fix: fix checkbox container dimensions
+
+[33mcommit 3f88a6e53aacf11acb276ef8f42ed347df648bdc[m
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Wed Oct 11 14:53:06 2017 +0200
+
+    feat: add dialog component (#98)
+    
+    * Add dialog component
+    
+    * Fix: fix back button not functioning right
+    
+    * Fix: fix action btns get added to the scrollview
+    
+    * Fix: match the MD guidelines for margins
+    
+    * Visual enhancements to the dialog example scene
+    
+    * Fix: fix flow errors
+    
+    * :art: Fix prettier errors
+    
+    * Enhancements to the dialog component
+    
+    * More enhancements to the dialog component
+    
+    * :tada: Introduce Modal component and refactor Dialog to use it
+    
+    * Remove ThemedPortal from exported components
+    
+    * :bug: Fix shadow cutoff on Android
+    
+    * Add a comment about a regression that is caused by a fix that was done for Android
+    
+    * chore: Seperate example dialog components into their own files
+    
+    * chore: Rename Dialog components to be prefixed with 'Dialog'
+    
+    * chore: change DialogTitle color prop to style
+    
+    * chore: Replace AnimatedPaper to Paper.Animated
+    
+    * fix: Replace BackAndroid with BackHandler
+    
+    * chore: Merge master with `dialog`
+    
+    * chore: Addressed comments
+
+[33mcommit 129a4e4a9ac112382a3d24f658f2944bff7eec4e[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 9 16:47:22 2017 +0200
+
+    refactor: use own toolbar in examples (#159)
+    
+    * refactor: use own toolbar in examples
+    
+    * refactor: fix missing space
+    
+    * refactor: remove useless code line
+
+[33mcommit 658a8aeab8b4ce2cc7b0f77cdafbe2bfb22e1f71[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Oct 2 15:14:59 2017 +0200
+
+    chore: release 0.0.7
+
+[33mcommit 153130093a153ff9fa2a37ee899f7b48f909ada8[m
+Author: Ferran Negre <fnp.developer@gmail.com>
+Date:   Mon Oct 2 15:10:37 2017 +0200
+
+    feat: Toolbar platform adaptation for iOS (#146)
+    
+    * feat: Toolbar platform adaptation for iOS: Title centered depending on the number of Actions.
+    
+    * feat: Fix ToolbarAction when using TouchableRipple.
+    
+    * feat: Use 'ios' for platform check.
+
+[33mcommit 8cd3e75cbee5e7107c16c0e48930455789a700cb[m
+Author: Krzysztof Borowy <Krizzu@users.noreply.github.com>
+Date:   Mon Oct 2 15:08:54 2017 +0200
+
+    fix: Remove elevation prop, use styles instead (#153)
+
+[33mcommit f201e1f7eacd064d3ff537d90df23628421335c2[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Oct 2 14:59:06 2017 +0200
+
+    feat: Controls adaptation to IOS (#155)
+    
+    * feat: checkbox ios adaptation
+    
+    * feat: switch component
+    
+    * feat: radio button ios adaptation
+    
+    * feat: refactor control components
+
+[33mcommit 547b14ad5ebcce2769735f990af64b5d55ee6edc[m
+Author: lukewalczak <lukasz.walczak@callstack.io>
+Date:   Tue Sep 26 14:40:19 2017 +0200
+
+    refactor: checkbox as a part of a list item
+
+[33mcommit 1981048ff5706936b21267762bd843bf7bda82e3[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Sep 26 15:17:33 2017 +0200
+
+    chore: upgrade component-docs
+
+[33mcommit d02205e23a403b28a536dfc77d882e07646e94fc[m
+Author: Krzysztof Borowy <Krizzu@users.noreply.github.com>
+Date:   Tue Sep 26 13:35:11 2017 +0200
+
+    Do not add 'ref' to functional Components (#147)
+    
+    * fix: add refs only to non-functional components
+    
+    * feat: mention supported RN version
+
+[33mcommit 812825646ffcd7159d6709632180ec4a283cf389[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Sep 26 12:59:13 2017 +0200
+
+    fix: fix error with checkbox component (#149)
+
+[33mcommit 6b71968b2ecbae97a51aa80a324fb764b8757890[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Sep 26 12:46:56 2017 +0200
+
+    chore: upgrade expo and react native (#148)
+
+[33mcommit bbdf9f04238663977580e4008f97210b01af2d90[m
+Author: Luke Walczak <lukasz.walczak.pwr@gmail.com>
+Date:   Mon Sep 25 11:53:05 2017 +0200
+
+    Progress bar component (#144)
+    
+    * feat: progress bar component
+    
+    * feat: update progress bar example
+    
+    * feat: refactor progress bar component
+    
+    * feat: progress bar component finished
+
+[33mcommit 572aa8ea1eb9853cc9985b4e99fb6327f2c56ad5[m
+Author: Adam Trzciński <trzcinski.adam@gmail.com>
+Date:   Tue Aug 22 10:31:04 2017 +0200
+
+    feat: enhance  Icon component (#125)
+
+[33mcommit ca30661038ee70c999fc6ec69035e8c762e3e8fc[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Aug 19 07:11:03 2017 +0200
+
+    chore: remove design references
+    Nobody ever uses them and they take up unnecessary space
+
+[33mcommit 5b797a9ea5f352555521887ed1a955eb6af496c9[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Aug 19 07:08:40 2017 +0200
+
+    chore: upgrade dependencies and fix flow errors
+
+[33mcommit 75c672628a0b9bdb5abe7d89f00bf90d999d88f5[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Aug 11 23:10:44 2017 +0200
+
+    fix: fix ToolbarContent proptypes
+
+[33mcommit 624bdc3d1cdb042d33730aba52f734311f854e97[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Aug 9 16:33:01 2017 +0200
+
+    chore: release 0.0.6
+
+[33mcommit b0d1dce696dfc139689503a31d58a8af58a08c8b[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Aug 9 16:32:24 2017 +0200
+
+    fix: fix icon component
+
+[33mcommit 27e5b5dc3cbe36c6d73d613a2a762be5797b7f89[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Aug 9 12:54:34 2017 +0200
+
+    chore: release 0.0.5
+
+[33mcommit 97e1fd88b78fa4dec9b2fae3724caffae0833386[m
+Author: Michał Pierzchała <thymikee@gmail.com>
+Date:   Mon Aug 7 12:49:32 2017 +0200
+
+    chore(deploy): Adjust path to deploy_key (#130)
+
+[33mcommit 3b779c6c0465b36238f1c4c9069f36998ff7c39c[m
+Author: Michał Pierzchała <thymikee@gmail.com>
+Date:   Mon Aug 7 12:41:01 2017 +0200
+
+    chore(deploy): fix travis globals; move deployment_key to docs (#129)
+
+[33mcommit 2abd6792fde0b703cc305865142fbdde00f683df[m
+Author: Michał Pierzchała <thymikee@gmail.com>
+Date:   Mon Aug 7 12:01:12 2017 +0200
+
+    chore(deploy): Setup auto deployment to gh-pages (#128)
+
+[33mcommit 73cdf8937841c2152c2b6e1b96f7cf5c39a6f100[m
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Wed Jul 26 17:49:23 2017 +0200
+
+    Drawer removal (#123)
+    
+    * breaking: Delete the drawer component and export DrawerItem and DrawerSection
+    
+    * fix: Eslint errors
+    
+    * fix: Eslint errors
+
+[33mcommit aa6271ddd6fd0a6f55aa78e752a383659b0bd47f[m
+Author: Ferran Negre <fnp.developer@gmail.com>
+Date:   Wed Jul 26 17:10:40 2017 +0200
+
+    feat: SearchBar - Add ability to use the left icon as a button (#121)
+
+[33mcommit c23d5d3ff949b4cc6f4591021709bd2041f06c75[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jul 19 04:11:22 2017 +0530
+
+    chore: use CRNA for the example
+
+[33mcommit d8bb183be360ba5db7e6686fed23b25e3b01833d[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Jul 16 03:44:14 2017 +0530
+
+    chore: upgrade component-docs
+
+[33mcommit 6a4bb7d6a4783ffd0cece24d6c86bb295bac1893[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jul 5 22:47:59 2017 +0530
+
+    fix: fix searchbar
+
+[33mcommit 201702408fb8b9edb93e0b9bbcb9b13812f6171c[m
+Author: Raúl Gómez Acuña <rauliyohmc@users.noreply.github.com>
+Date:   Wed Jul 5 19:11:04 2017 +0200
+
+    chore: add Git Hook to validate commit messages (#118)
+
+[33mcommit 79cf42aaf1d8e06affa174b6efebc2098900d604[m
+Author: Ferran Negre <fnp.developer@gmail.com>
+Date:   Wed Jul 5 19:03:33 2017 +0200
+
+    feat: add a Toolbar component (#112)
+
+[33mcommit 1479c76f776f0a4cc7513121964928b91cf4b60e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Jul 5 01:22:12 2017 +0530
+
+    chore: upgrade to React Native 0.45 (#120)
+
+[33mcommit 05455b1140c6f3df25e69358855a31db44945c99[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jul 4 18:09:17 2017 +0530
+
+    chore: use gh-pages branch for deploying docs
+
+[33mcommit c0f4341c76a5f02b0de4d145553d1d3408e0ff2d[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jul 4 18:00:30 2017 +0530
+
+    chore: use yarn on travis (#116)
+
+[33mcommit c3dba49d8aaa5deb332286b2cdcd5fa03c4f3740[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jul 4 16:34:20 2017 +0530
+
+    fix: use TouchableHighlight on Android < Lollipop (#115)
+    
+    Earlier, older Android versions used a ugly blue highlight for touchable items. This commit changes it to a `TouchableHighlight`, which uses the appropriate highlight color. Merged it with the iOS version for now since they have the same behaviour.
+
+[33mcommit 07d52d49ebf4874a775fbd8a5051bb82e23ceb40[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Jul 4 16:17:01 2017 +0530
+
+    chore: add jsconfig.json to .gitignore
+
+[33mcommit d82e1a0d4fac156370f1d243a85fa0e4f4c3745e[m
+Author: Raúl Gómez Acuña <rauliyohmc@users.noreply.github.com>
+Date:   Tue Jul 4 12:17:53 2017 +0200
+
+    chore: fix linting errors + add precommit hook for flow and lint (#114)
+
+[33mcommit 16c3ea2f606259b4ab999bd8211b3b910ce1cb32[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Jun 26 21:27:16 2017 +0530
+
+    feat: add a FAB component (#109)
+
+[33mcommit 8af755191428b87b0b8fefd63613e22842717485[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Jun 26 21:17:06 2017 +0530
+
+    fix: fix searchbar styles (#110)
+
+[33mcommit d117bb95c0d0ad3f26e3326b060bc14734084b53[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Jun 26 19:57:37 2017 +0530
+
+    chore: fix prettier error
+
+[33mcommit c1bd408bb3dbc827b3df0630b4340cebb7472b97[m
+Merge: 0a203079 b68f446f
+Author: Ferran Negre <fnp.developer@gmail.com>
+Date:   Fri Jun 23 06:19:31 2017 -0400
+
+    Merge pull request #106 from callstack-io/@satya164/theming
+    
+    refactor: rework theme provider and HOC
+
+[33mcommit b68f446f09306d305cea8ec86d05e99ca11bdf20[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed May 31 17:48:36 2017 +0530
+
+    fix typo
+
+[33mcommit f58315775a93319f42bdf55fa38d33d9a98640d6[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed May 31 17:05:05 2017 +0530
+
+    refactor: rework theme provider and HOC
+
+[33mcommit 0a203079f590eec2e33ed005fad18bd10e950c00[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed May 17 17:28:36 2017 +0530
+
+    chore: use es5 trailing commas
+
+[33mcommit 2e49f5e9577bdbbdbe41752113dbe140746f11c8[m
+Author: ferrannp <fnp.developer@gmail.com>
+Date:   Tue May 16 23:36:13 2017 +0200
+
+    fix: fix flow issues for withTheme and dependencies
+
+[33mcommit eee9b0372bdb497142b3e2f2470a185fbae6ec18[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue May 16 21:24:53 2017 +0530
+
+    chore: use prop-types package from npm
+
+[33mcommit ebada8fd6d5e5cce3b0698555add4947c831b88a[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue May 16 21:18:24 2017 +0530
+
+    chore: setup prettier
+
+[33mcommit fc1d59e44ca907ba8310fff4a64cb2ef5c65c92c[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue May 16 21:13:02 2017 +0530
+
+    chore: switch to react navigation
+
+[33mcommit c468b029e9a48fb60d63cd0cd2090ce7c2ae5d9a[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue May 16 21:12:49 2017 +0530
+
+    chore: improve dev workflow and upgrade deps
+
+[33mcommit 8f75241a3cb13280b4c9ed1a1661b158b7efc3ab[m
+Author: Ferran Negre <fnp.developer@gmail.com>
+Date:   Tue Feb 14 02:19:58 2017 +0100
+
+    feat: add searchBar component (#97)
+
+[33mcommit bb0e3c5d99b86b89c0d5125ec42550b638e297d2[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Dec 7 05:17:50 2016 +0530
+
+    fix: fix building docs
+
+[33mcommit a467848f86478be60c4926bc1436ba61efb87bef[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Dec 6 04:54:42 2016 +0530
+
+    Use component-docs for documentation (#96)
+
+[33mcommit a34c81d11220a0e9cddc344e92f0b1ba4de87169[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Dec 4 14:53:00 2016 +0530
+
+    docs: fix mobile view
+
+[33mcommit 696cdd90fdcf8f2ca1a4059b39ec3fbebe7101f2[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Dec 4 04:39:21 2016 +0530
+
+    docs: tweak styling
+
+[33mcommit 9b7cd02fb5e4e6f833773fb37678f4796cc9e21e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Dec 4 03:47:19 2016 +0530
+
+    feat: add get started page
+
+[33mcommit 70b17c153a19babb8bfcbb8af3b9dd7aa80d31a2[m
+Author: Sreejith R <sreejith.r44@gmail.com>
+Date:   Wed Nov 30 15:50:40 2016 +0530
+
+    fix: use `flexGrow` instead of `flex` to avoid collapsing (#95)
+
+[33mcommit 66e9fe7c7303f7c69bdcdcc68481ebb1ad0e6cec[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Nov 30 14:32:07 2016 +0530
+
+    fix: fix button's children
+
+[33mcommit 25cd68146655321a31aaf725e7f8f06071bcc658[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Nov 29 08:09:30 2016 +0530
+
+    fix: fix portal props
+
+[33mcommit ba6ee19eb59c139307f76e39f79cb59b1014cb38[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Nov 29 06:06:41 2016 +0530
+
+    feat: add checkbox and radio animations on Android (#89)
+    
+    Border animations aren't very nice on iOS, so I disabled animations on iOS for now. Let's add animations when we find a better way.
+    Also native animations don't support borders as of now, so can't enables native animations either, probably can enable in future
+
+[33mcommit 26ea691541df46774196715c518df4ad52a5a69a[m
+Author: Sreejith R <sreejith.r44@gmail.com>
+Date:   Mon Nov 28 20:37:04 2016 +0530
+
+    Removed 'export * as' syntax in 'src/index.js' (#93)
+    
+    Changed 'export * as' syntax to 'import * as ...; export { ... }' since former needs extra babel plugin to function
+    
+    * Moved the import of Colors to the top to pass Linter
+
+[33mcommit 6165252485bab0acacf697700346e963fac8fa6a[m
+Merge: 113e3cbd ce255594
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 28 20:17:18 2016 +0530
+
+    Merge branch 'master' of github.com:react-native-paper/react-native-paper
+
+[33mcommit 113e3cbd8fc692eac8322d26fedef99649cbfbd3[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 28 20:03:52 2016 +0530
+
+    fix: fix flex in <PortalHost />
+
+[33mcommit ce2555940b94603b00a58322838116e9691005b7[m
+Author: Sreejith R <sreejith.r44@gmail.com>
+Date:   Mon Nov 28 19:55:39 2016 +0530
+
+    Exported DefaultTheme (#92)
+
+[33mcommit a5519eefbd6b5ccd66ea2661fad110aef2a455cb[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 28 11:27:31 2016 +0530
+
+    feat: improvements to portal (#90)
+    
+    - layer management according to position
+    - preserve theme context via ThemedPortal
+
+[33mcommit 4732b02a0fac5ece92335594954ebd51b1e6ddf0[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 27 03:49:53 2016 +0530
+
+    feat: add portal component (#86)
+    
+    * Initial commit
+    
+    * Fix incorrect flow type
+    
+    * refactor: tweak portal component
+    
+    * fix: update portal's children when they update
+
+[33mcommit b4a97323fcb4945c7c991ba2283b2e7b38d07e6b[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Nov 25 12:09:38 2016 +0530
+
+    docs: add a pure css menu button
+
+[33mcommit 70cf03b4d9a44391f9d15a116b17f8ac0c524bb9[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Nov 25 11:00:16 2016 +0530
+
+    docs: fix deploy
+
+[33mcommit 0ae917bccc0a7b58e5d588f5ff89b30d5ed398ea[m
+Merge: c5b8f2c8 8f13e29c
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Nov 25 10:42:45 2016 +0530
+
+    Merge pull request #83 from react-native-paper/extra-props
+    
+    docs: add a way to specify extra props
+
+[33mcommit 8f13e29c115e40ea893bb0636b095d1c4a69fbe0[m
+Merge: 70a20bbb c5b8f2c8
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Nov 25 10:36:40 2016 +0530
+
+    Merge branch 'master' into extra-props
+
+[33mcommit c5b8f2c8499c6d6a55eb0ca22d0b8f011ff9cfb2[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Nov 25 10:32:46 2016 +0530
+
+    docs: update page title when route changes (#84)
+
+[33mcommit 70a20bbbca0b0a8f2475a8ef56059c04e84b7578[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Nov 25 09:33:12 2016 +0530
+
+    docs: update page title when route changes
+
+[33mcommit 0c0b053946c2ababe46bbe8de362af566a70499a[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Nov 25 09:25:13 2016 +0530
+
+    docs: support markdown in docs
+
+[33mcommit aafadc9016cafa8d21f7532080cf2ca866b1bb60[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Nov 25 07:42:16 2016 +0530
+
+    docs: add a way to specify extra props
+
+[33mcommit b13159a7e7a6eb6f0b6c1301591077c138af93e1[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Nov 25 06:23:29 2016 +0530
+
+    chore: tweak styling for docs
+
+[33mcommit 958f2cbfee54fbb6a8466743f56deafb911d18f2[m
+Merge: 8387dd66 68418b7d
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Wed Nov 23 23:35:06 2016 +0200
+
+    Merge pull request #82 from react-native-paper/docs-improv
+    
+    docs: mark required prop in docs
+
+[33mcommit 8387dd660e67f45159985056d18ee896cd7020a0[m
+Merge: de250d89 01850e1b
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Wed Nov 23 22:55:30 2016 +0200
+
+    Merge pull request #81 from react-native-paper/docs
+    
+    docs: improvements to docs generation
+
+[33mcommit 01850e1bb7d2f841dcf03cf3bd0e8cc196b396aa[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Nov 23 16:56:53 2016 +0530
+
+    docs: improvements to docs generation
+    
+    - Generate a single bundle
+    - Implement routing which works with/without JS
+    - Enable HMR for function components as well as documentation
+
+[33mcommit 68418b7db32b40ff78095d4cb4e68bb126b6f395[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Nov 23 10:41:42 2016 +0530
+
+    docs: mark required prop in docs
+
+[33mcommit de250d89f4470ad8ae2600c9fa1cc3aab8bb89d5[m
+Merge: 4612e5bd 32c3ed8f
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Wed Nov 23 02:39:21 2016 +0200
+
+    Merge pull request #80 from react-native-paper/button
+    
+    BREAKING: rename shrink to compact for Button
+
+[33mcommit 32c3ed8f384ea2c1826081acdd7f0dee1c1034b2[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Nov 23 06:02:37 2016 +0530
+
+    BREAKING: rename shrink to compact for Button
+
+[33mcommit 4612e5bd81d96766762cbcfa5bf19011ba110d99[m
+Merge: e6af55b8 060e0a38
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Tue Nov 22 23:28:39 2016 +0200
+
+    Merge pull request #79 from react-native-paper/docs
+    
+    docs: enable JavaScript in documentation
+
+[33mcommit e6af55b858057e78fcf75b4f3099193168eedb6c[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Nov 23 02:39:12 2016 +0530
+
+    Update commit email
+
+[33mcommit 060e0a38eaf929f4d066d3b772114c3b28edcff9[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Nov 23 01:19:39 2016 +0530
+
+    docs: enable JavaScript in documentation
+
+[33mcommit 31675d01e2848e19de5a7d20c1e9134b6142ef62[m
+Author: Travis CI <satya@Satyajits-MacBook-Air.local>
+Date:   Tue Nov 22 05:20:59 2016 +0530
+
+    chore: change commit email
+
+[33mcommit 78251e34bfb388ea7fbd1a26215aaddf92e8d5d9[m
+Merge: 8e4243e0 1e984375
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Nov 22 05:14:52 2016 +0530
+
+    Merge pull request #78 from react-native-paper/docs
+    
+    docs: generate static html pages
+
+[33mcommit 1e98437543afc2fbdca38fe7f8ef553de302c4ee[m
+Author: Travis CI <satya@Satyajits-MacBook-Air.local>
+Date:   Tue Nov 22 05:14:13 2016 +0530
+
+    chore: setup deployment
+
+[33mcommit d5122f831153964884fe9b5632ad0323fd6bbf33[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Nov 22 02:53:03 2016 +0530
+
+    chore: fix flow errors
+
+[33mcommit c46312999c4652ee908cb5525b3c5260cbf8f89f[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Nov 22 01:34:15 2016 +0530
+
+    docs: generate static html pages
+
+[33mcommit 8e4243e07f0a02343d3a22ea1d7f3be158b51dae[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Nov 22 00:34:08 2016 +0530
+
+    docs: add docs specific deps to docs folder
+
+[33mcommit 83f00ac4502de466773c65e7a46108501184a0d3[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 21 20:51:41 2016 +0530
+
+    docs: make props linkable
+
+[33mcommit 1fd17b71627638ee9193887a08770a5bb5f72db8[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 21 20:02:29 2016 +0530
+
+    docs: tweak sidebar styling
+
+[33mcommit 1b804d4c7bd2b76ea71981afbf596ed060fd6ff8[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 21 19:58:51 2016 +0530
+
+    docs: use components for typography elements
+
+[33mcommit c83ffdfeafc73518282c9d7b09b7e633ec465ff4[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 21 19:58:44 2016 +0530
+
+    docs: sort components alphabatically
+
+[33mcommit 2fa8e91c532c1155e65dcf8127ca3ae021937588[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 21 19:40:12 2016 +0530
+
+    fix: parse files under directories
+
+[33mcommit 3a9f2e5259c83ee0771802dd960c9e3f0504b730[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 21 19:30:54 2016 +0530
+
+    fix: fix extracting gridview props
+
+[33mcommit b83dcc4c45a75f5d2ff2d800868ac721e92bf53d[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 21 19:20:19 2016 +0530
+
+    chore: use semantically correct tags for docs
+
+[33mcommit 414ca296e3982b8c32244bffcea2c831f493d012[m
+Merge: 0c84a871 39d6fdd4
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Mon Nov 21 15:15:37 2016 +0200
+
+    Merge pull request #73 from react-native-paper/gridview
+    
+    feat: add GridView component. fixes #44
+
+[33mcommit 0c84a871a6cd0a03ee9392c16bbaeeefe0b17d1e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 21 18:38:32 2016 +0530
+
+    Add docs generator (#75)
+    
+    * docs: start working on docs generator
+    
+    * docs: add a sidebar listing components
+    
+    * docs: use next/css instead of styled components
+    
+    * docs: properly setup routing
+    
+    * refactor: rework styling
+    
+    * docs: improve props styling
+    
+    * chore: fix flow errors
+    
+    * chore: styling tweaks
+
+[33mcommit 57ca9aa2e5390ab311f7e7a9a1746318d9163353[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 21 01:39:17 2016 +0530
+
+    chore: use ListView for example list
+
+[33mcommit 39d6fdd49b1fb556cd0c348e080e36cee0d08a75[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 21 01:21:35 2016 +0530
+
+    feat: add <GridView /> component. fixes #44
+
+[33mcommit e5697ccda38f07dedcb62d62966d357628e12dd9[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Nov 21 01:20:00 2016 +0530
+
+    chore: don't lock orientation for example
+
+[33mcommit d0c9a4ad4e4ecdb652afb1f9aad3d182da2e2718[m
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Sun Nov 20 20:28:47 2016 +0200
+
+    feat: add <Drawer /> component (#72)
+
+[33mcommit c3a3e21196de8ac18d891f960d7b37be2e3ba704[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 20 22:43:01 2016 +0530
+
+    chore: move index.js to src/
+
+[33mcommit 09df41c1e76f592d3c77b3149cdf1cb0f06c13f9[m
+Merge: 4880cc6e 5a964b32
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Sun Nov 20 18:09:17 2016 +0200
+
+    Merge pull request #71 from react-native-paper/card-examples
+    
+    docs: add more card examples
+
+[33mcommit 5a964b32348308cebd62830869d965715640a9d4[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 20 21:30:59 2016 +0530
+
+    docs: add more card examples
+
+[33mcommit 4880cc6e37b51c5b993cfbc2712218d5d3823820[m
+Merge: c4488f8a e1db4e51
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Sun Nov 20 17:08:31 2016 +0200
+
+    Merge pull request #69 from react-native-paper/styling
+    
+    fix: adjust button and card styling
+
+[33mcommit e1db4e51a0eb47307af31b812f86120591eab9b3[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 20 20:30:42 2016 +0530
+
+    fix: add minWidth of 64 to button
+
+[33mcommit c927a8b5d86846e66205ae5de3a16d1d7c4eec42[m
+Merge: 1ff90500 c4488f8a
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 20 20:15:49 2016 +0530
+
+    Merge branch 'master' into styling
+
+[33mcommit 1ff905001aa541fb6e2d895372bce1488958ceb2[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 20 20:13:50 2016 +0530
+
+    fix: shrink buttons in cards
+
+[33mcommit c2ffc56135a7a54c44c5431a1c51db893dea070a[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 20 19:52:46 2016 +0530
+
+    fix: fix roundness for card cover
+
+[33mcommit c4488f8a2acaf30c5d9e551983e3102b76cf5d03[m
+Merge: 3a47f5ce 49776eca
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Sun Nov 20 16:12:49 2016 +0200
+
+    Merge pull request #68 from react-native-paper/theme
+    
+    feat: support theme overrides for themed components
+
+[33mcommit f32a55f96b2ab83fed930e8ca4076f2ed0370ab2[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 20 19:33:44 2016 +0530
+
+    fix: adjust button and card styling
+
+[33mcommit 49776eca7f2dbd88d59d59de72438fba6c81a2e3[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 20 19:30:52 2016 +0530
+
+    feat: support theme overrides for themed components
+    
+    For example, this will allow you to do <Button theme={{ roundess: 3 }}>Hello world</Button>
+
+[33mcommit 3a47f5ce7a3706d2867f00049720bb9e5d028f85[m
+Merge: db46d1f9 b0f93c20
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Sun Nov 20 15:07:43 2016 +0200
+
+    Merge pull request #67 from react-native-paper/roundness
+    
+    Roundness
+
+[33mcommit b0f93c20e9f4f99e6664159479de2cbcdf329588[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 20 18:34:29 2016 +0530
+
+    feat: add roundness to theme
+
+[33mcommit db46d1f9d725ecb960bc61d695902290d85bbe8e[m
+Merge: bcea65ad 0f3e1420
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Sun Nov 20 14:58:47 2016 +0200
+
+    Merge pull request #66 from react-native-paper/card
+    
+    Add Card.Cover, Card.Actions and Card.Content
+
+[33mcommit 0f3e1420a49ac31b5e8cc030e47c023ec03b102c[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 20 17:48:14 2016 +0530
+
+    feat: add Card.Cover, Card.Actions and Card.Content
+    These components can adjust their styling automatically based on their siblings without any extra work on user's end. For example, the cover adjusts it's border radius, content adjusts it's padding, etc.
+
+[33mcommit bcea65ad3206d09c90ec78bcd66743881d452f88[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 20 17:45:55 2016 +0530
+
+    chore: don't cache node_modules
+
+[33mcommit 260df2cb17aee078bad30150be8eb3f915a5010e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 20 17:45:42 2016 +0530
+
+    chore: fix devDependencies
+
+[33mcommit 93334f79bd82caa32b24e1fec77f12fd729b3a27[m
+Merge: 873161e5 0a73f77f
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Sun Nov 13 21:44:16 2016 +0200
+
+    Merge pull request #65 from react-native-paper/revert-64-revert-63-check
+    
+    Revert "Revert "Add radio and check buttons""
+
+[33mcommit 0a73f77f2b779aa8cf51aeb4b1dd8fd409c91bed[m
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Sun Nov 13 21:41:16 2016 +0200
+
+    Revert "Revert "Add radio and check buttons""
+
+[33mcommit 873161e597ac510dd0ced57cf0693cd591f74779[m
+Merge: 9e3ec649 47efa8eb
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Sun Nov 13 21:28:39 2016 +0200
+
+    Merge pull request #64 from react-native-paper/revert-63-check
+    
+    Revert "Add radio and check buttons"
+
+[33mcommit 47efa8eb863666b20dbc9b98db69eba5ba09a0f0[m
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Sun Nov 13 21:25:35 2016 +0200
+
+    Revert "Add radio and check buttons"
+
+[33mcommit 9e3ec6495a5e5d4eb6b0b27d085f9b0835c56c68[m
+Merge: fe0d9ccb ac76dc0a
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Sun Nov 13 21:25:25 2016 +0200
+
+    Merge pull request #63 from react-native-paper/check
+    
+    Add radio and check buttons
+
+[33mcommit fe0d9ccb60aae7300f59a46c69bf596e98bd97e3[m
+Merge: f9405567 4a7788e3
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Sun Nov 13 21:15:06 2016 +0200
+
+    Merge pull request #62 from react-native-paper/pure
+    
+    fix: use pure components
+
+[33mcommit ac76dc0a1c09bb55c23a728d22d8b9e8307a88ac[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 13 23:59:53 2016 +0530
+
+    chore: fix flow errors
+
+[33mcommit eeb8210ab9db15af360c506895f6f2cfffe80d4e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 13 23:50:58 2016 +0530
+
+    feat: add <RadioButton /> component. fixes #13
+
+[33mcommit 7264166463300e7ec81674b63e9bce63e1333bcd[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 13 23:09:36 2016 +0530
+
+    feat: add <Checkbox /> component. fixes #12
+
+[33mcommit 4a7788e300c777a0662498ff0e578e45c8234789[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 13 23:06:13 2016 +0530
+
+    fix: use pure components
+
+[33mcommit f9405567fd868cb2bf513e725d997d3e0b6e9abb[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 13 12:05:37 2016 +0530
+
+    fix: fix missing ripple color
+
+[33mcommit 1ab565fa4386412b3993d2dc8f05e988ce894802[m
+Merge: 342c8bb6 7c67a80a
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 13 11:59:06 2016 +0530
+
+    Merge pull request #58 from react-native-paper/divider
+    
+    feat: Add divider
+
+[33mcommit 7c67a80ad6de29464d05a64f8e472d86628cdc2f[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 13 11:57:31 2016 +0530
+
+    refactor: move static styles out
+
+[33mcommit 9054c8c782007605fc5fd8961b26fa991e5b6fa1[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 13 11:53:53 2016 +0530
+
+    docs: update divider example
+
+[33mcommit 00edf6e16ef2d689842f10e1a094c20e5496b1eb[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 13 11:31:46 2016 +0530
+
+    chore: switch to npm on travis
+
+[33mcommit a25b2c0dd379cd8b7f4f23c1602abe8243d7ff27[m
+Merge: ec714d42 94d18ccc
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Nov 13 11:29:21 2016 +0530
+
+    Merge branch 'master' into divider
+
+[33mcommit 342c8bb6509be4e9cd904fafca7461323313079e[m
+Merge: 94d18ccc 88f0bdd4
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Sat Nov 12 20:48:44 2016 +0200
+
+    Merge pull request #61 from react-native-paper/under-development
+    
+    Update README.md
+
+[33mcommit 94d18cccefa94339bb89bb608e8a9f3a1e02e78c[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Nov 12 23:52:24 2016 +0530
+
+    fix: fix background color of button
+
+[33mcommit ec0d69effa06a45c1e326372ce9d86c4835111d7[m
+Merge: 3a51b425 088887d8
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Sat Nov 12 20:01:08 2016 +0200
+
+    Merge pull request #60 from react-native-paper/button
+    
+    feat: add color prop, don't add bg for non-raised button
+
+[33mcommit ec714d42c750e87090645e1b19b66e5882ef7d72[m
+Merge: 335fd6a6 3a51b425
+Author: ferrannp <fnp.developer@gmail.com>
+Date:   Sat Nov 12 13:44:40 2016 +0100
+
+    Merge branch 'master' into divider
+    
+    Conflicts:
+            example/src/ExampleList.js
+
+[33mcommit 335fd6a626c2e92111e5d1cfcd8ea90c5718d821[m
+Author: ferrannp <fnp.developer@gmail.com>
+Date:   Sat Nov 12 13:42:08 2016 +0100
+
+    #8: Use hairlineWidth instead of 1, allow only inset prop + style prop for full customization.
+
+[33mcommit 88f0bdd422d7a4fae80d8975995f435bd8e4f855[m
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Sat Nov 12 11:51:08 2016 +0200
+
+    Update README.md
+
+[33mcommit 088887d80d684a10ff16019a62a316a9f90869aa[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Nov 12 15:18:26 2016 +0530
+
+    fix: limit numberOfLines in button
+
+[33mcommit 07bca5a54bffdc39a79ce9ec3cf90a765f239369[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Nov 12 15:14:11 2016 +0530
+
+    feat: add color prop, don't add bg for non-raised button
+
+[33mcommit 3a51b42576a8e08b6d032d433265997557686c2c[m
+Merge: f91a448c b5879609
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Sat Nov 12 11:41:12 2016 +0200
+
+    Merge pull request #57 from react-native-paper/button
+    
+    feat: add icon and loading support to <Button />
+
+[33mcommit b587960951ee220776b6637814d88a58fc0888e1[m
+Merge: 3ef48d65 f91a448c
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Nov 12 12:18:24 2016 +0530
+
+    Merge branch 'master' into button
+
+[33mcommit f91a448c5b3c1725f2348862285b8abdd2f17338[m
+Author: Sreejith R <sreejith.r44@gmail.com>
+Date:   Sat Nov 12 12:17:04 2016 +0530
+
+    Fixed Flow Errors (#52)
+
+[33mcommit 3ef48d65fdc1f5477d85c1c24a1bff4f8b3a51fb[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Nov 12 11:34:02 2016 +0530
+
+    fix: pressOut should be faster
+
+[33mcommit a9da6fbea4ad78a501abd98a5816f05a0695424a[m
+Author: ferrannp <fnp.developer@gmail.com>
+Date:   Fri Nov 11 23:45:41 2016 +0100
+
+    feat: Add divider. #8.
+
+[33mcommit 1557aa58a76f2ca1af31b48836414f299d2def27[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Nov 12 02:01:06 2016 +0530
+
+    feat: add disabled button style
+
+[33mcommit 1271d66292f6ae689b450fca26e2085b72e1ff59[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sat Nov 12 01:02:12 2016 +0530
+
+    feat: add icon and loading support to <Button />
+
+[33mcommit 34a8b9f0d489bcd104bbae759f3fdbeeff8ef35e[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Nov 11 23:50:32 2016 +0530
+
+    chore: add missing dependency
+
+[33mcommit 4afa48a7de8eb9ae055fad6e8185a5b669bd3fee[m
+Merge: 5f456fa9 ecc481f9
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Fri Nov 11 20:17:10 2016 +0200
+
+    Merge pull request #56 from react-native-paper/exponent
+    
+    chore: update dependencies
+
+[33mcommit 5f456fa94230c7484766a8b0edacc7a0d0425de3[m
+Merge: 2df45e33 c717bbff
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Fri Nov 11 20:16:54 2016 +0200
+
+    Merge pull request #55 from react-native-paper/typography
+    
+    fix: add vertical margin to typography elements
+
+[33mcommit 2df45e3398df3de02d2f78ccc88db0f15cc4a82e[m
+Merge: 28e43434 d1536d6b
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Fri Nov 11 20:08:51 2016 +0200
+
+    Merge pull request #54 from react-native-paper/card
+    
+    feat: add <Card /> component
+
+[33mcommit d1536d6b2ce4ed902957570ac0e38c5f6d73f63d[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Nov 11 23:13:32 2016 +0530
+
+    feat: add <Card /> component
+
+[33mcommit 28e43434cd940d1593a2bc5e6f74c67f720cab18[m
+Merge: 7d75a7fc 9e9c9e13
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Fri Nov 11 19:40:57 2016 +0200
+
+    Merge pull request #53 from react-native-paper/button
+    
+    feat: add <Button /> component
+
+[33mcommit ecc481f9f501aa34b41e06e7bbdde6e79f8ca1bb[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Nov 11 21:37:05 2016 +0530
+
+    chore: update dependencies
+
+[33mcommit c717bbff43d1bf818dd3bde2fb304c9ba5db9620[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Nov 11 21:30:19 2016 +0530
+
+    fix: add vertical margin to typography elements
+
+[33mcommit 9e9c9e131013b41a63e53ae4f75d6f1a9cc2737d[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Nov 11 20:29:37 2016 +0530
+
+    fix: make TouchableHighlight underlay lighter
+
+[33mcommit 74c9f8b6131462d7264f3f17beacf3cd59e7cdc3[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Nov 11 20:22:34 2016 +0530
+
+    feat: add buttons
+
+[33mcommit 7d75a7fc045b7cd251495a0206b4b0e09df11ac8[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Fri Nov 11 18:18:28 2016 +0530
+
+    fix: fix typo
+
+[33mcommit 834adea3042cbf136d6150dcc772bd3aa985e4e2[m
+Merge: 1cc7ef08 b725648d
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Nov 10 22:41:39 2016 +0530
+
+    Merge pull request #49 from react-native-paper/typography
+    
+    fix: follow line height and opacity guidelines for text
+
+[33mcommit 1cc7ef08a8ca1e2bea6e344b54f0434ec60c649f[m
+Merge: f28c3359 d7f4dc32
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Thu Nov 10 22:41:23 2016 +0530
+
+    Merge pull request #48 from react-native-paper/statics
+    
+    fix: copy static properties in HOC
+
+[33mcommit b725648d73af6ca272ab72051bf3ad1aea9cdc61[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Nov 2 07:35:01 2016 +0530
+
+    fix: follow line height and opacity guidelines for text
+
+[33mcommit a32d2c2f4e5ed5d8cc9c34f5e64efae9ccc98370[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Nov 2 06:54:54 2016 +0530
+
+    fix: copy static properties in HOC
+
+[33mcommit f28c3359b91e81ca023446765878424ed33d742c[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Nov 2 06:57:16 2016 +0530
+
+    feat: add a paper component. fixes #42 (#47)
+    
+    Since Google doesn't document the shadow values anywhere (it was documented earlier, but only upto 5dp), this is an approximation.
+
+[33mcommit d7f4dc32bea743a618af339fc147345e13fb8be9[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Wed Nov 2 06:54:54 2016 +0530
+
+    fix: copy static properties in HOC
+
+[33mcommit 3015cd7bf347d05434194ef27ebd6517713ec1de[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Oct 31 06:39:59 2016 +0530
+
+    core: move Typography to components (#45)
+
+[33mcommit 96d93ba202aeac3a7d7e7eceb160267688c61cc5[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Oct 31 06:39:09 2016 +0530
+
+    chore: add travis config (#46)
+
+[33mcommit 470a904d43d15433161241f856acb0ed8cd16665[m
+Merge: 980e1f11 dcc39883
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Tue Oct 25 20:49:20 2016 +0200
+
+    Merge pull request #40 from ahmedlhanafy/icons
+    
+    Add vector-icons as peerDep and internal component exposing MaterialDesign icons
+
+[33mcommit dcc3988334f69cf11483781a0d28292d4837ecea[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Tue Oct 25 23:09:24 2016 +0530
+
+    Use exponent's fork of vector icons
+
+[33mcommit c0628fa44ec2b3849df4221c1d523202cd7b8caf[m
+Author: Ahmed Magdy <ahmed.elhanafy95@gmail.com>
+Date:   Mon Oct 24 23:35:23 2016 +0200
+
+    Add vector-icons as peerDep and add an internal component that exposes MaterialDesign icons
+
+[33mcommit 980e1f110493a89e7c27ec689281f964bdf2d2ee[m
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Mon Oct 24 16:04:30 2016 +0200
+
+    Add contributing guidelines (#39)
+
+[33mcommit 28313b2b85ce1058d6739b128f79847197756e5e[m
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Mon Oct 24 16:04:18 2016 +0200
+
+    Add different text components and add them in the example app (#38)
+    
+    * Add different text components and add them in the example app
+    
+    * Rename textWithProps to createStyledText and change isAndroid to isIOS in fonts
+    
+    * Rename primaryText to text and disabled
+
+[33mcommit dbad643722847498addf2eb2db32a3a19dd8026d[m
+Merge: bb319e55 12848b5f
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Mon Oct 24 01:19:08 2016 +0200
+
+    Merge pull request #37 from ahmedlhanafy/theme
+    
+    Add HOC for theme
+
+[33mcommit 12848b5fbd5969803eb5cdabb72bfa8d409b291b[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Oct 24 04:22:58 2016 +0530
+
+    Add HOC for theme
+
+[33mcommit bb319e5510c8f18ecd75ae4fa01ba748c3a9ba75[m
+Merge: 065e6f08 9ddb159f
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Mon Oct 24 00:28:39 2016 +0200
+
+    Merge pull request #36 from ahmedlhanafy/example
+    
+    Setup example app
+
+[33mcommit 9ddb159f7dbdd0c2e7aaa8024c4d32c651809efe[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Oct 24 03:43:56 2016 +0530
+
+    Setup example app
+
+[33mcommit 065e6f08cea56159418e208bb776ad5380a99fc9[m
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Sun Oct 23 23:54:12 2016 +0200
+
+    Add better way of exporting touchable module (#35)
+    
+    * Add better way of exporting touchable module
+    
+    * Rename TouchableRipple.ios.js to TouchableRipple.js to make flow happy
+
+[33mcommit bd2f2a1b66ea311aec28c1cee6be5439a5c344d4[m
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Sun Oct 23 23:09:34 2016 +0200
+
+    Touchable component (#34)
+    
+    * Initial implementation of Touchable component
+    
+    * Export touchable component
+    
+    * Fix export statement
+    
+    * Edit Touchable Component
+    
+    * Fix export statement
+    
+    * Update example app with usage of touchable component
+    
+    * Make eslint happy
+    
+    * Change style propType
+    
+    * Change Touchable name => TouchableRipple, add check on older versions of Android and change borderLess prop to borderless
+    
+    * Remove usage of TouchableRipple from example app
+
+[33mcommit deca4be4bb0750144dc25923015887353727fb84[m
+Merge: 30a7a796 1506c838
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Sun Oct 23 21:47:27 2016 +0200
+
+    Merge pull request #33 from ahmedlhanafy/exp
+    
+    Migrate example app to exponent
+
+[33mcommit 1506c838b84be8e4953955de68ee1fb50a017056[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Oct 24 00:59:07 2016 +0530
+
+    Fix typo
+
+[33mcommit 016dd6c922de1f558073143ecbc5565225e801d2[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Mon Oct 24 00:47:53 2016 +0530
+
+    Migrate example app to exponent
+
+[33mcommit 30a7a796c6656a58795be00f00d8e1b2ef9d9eed[m
+Merge: 17ec0e39 fe622111
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Sun Oct 23 20:45:34 2016 +0200
+
+    Merge pull request #32 from ahmedlhanafy/tweaks
+    
+    Tweaks to project setup
+
+[33mcommit fe6221111196adceea0840b21b7cb4581925abb1[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Oct 23 23:59:20 2016 +0530
+
+    Include only src/ in published package
+
+[33mcommit 06aed55bc4d326c45fa8acdc55d160f2ebebd958[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Oct 23 23:56:56 2016 +0530
+
+    Setup ESLint and Flow
+
+[33mcommit 5963ff982d6d490fcf86daabfe64be1256fd83c1[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Oct 23 23:36:39 2016 +0530
+
+    Rename example app folder
+
+[33mcommit 80f7612f26c79923081d9aee001f1abb486ecb92[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Oct 23 23:16:08 2016 +0530
+
+    Update .gitignore
+
+[33mcommit 740a0a4d341691509f42208597ef2b7538c954f0[m
+Author: Satyajit Sahoo <satyajit.happy@gmail.com>
+Date:   Sun Oct 23 23:15:53 2016 +0530
+
+    Made React and React Native peer deps
+
+[33mcommit 17ec0e395eaa718428f5f20e16b948726b1f065e[m
+Merge: 1b139805 ab3f0416
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Sat Oct 22 16:42:56 2016 +0200
+
+    Merge pull request #31 from ahmedlhanafy/theme-provider
+    
+    Theme provider
+
+[33mcommit ab3f041611d400d954e508412e91a226874e93c9[m
+Author: Ahmed Magdy <ahmed.elhanafy95@gmail.com>
+Date:   Fri Oct 21 02:53:50 2016 +0200
+
+    export ThemeProvider and change ThemeProvider and DefaultTheme dir
+
+[33mcommit 9ea9bb980127afc160a6688f2fc83abf08bc84e4[m
+Author: Ahmed Magdy <ahmed.elhanafy95@gmail.com>
+Date:   Fri Oct 21 01:42:43 2016 +0200
+
+    Create simple ThemeProvider and Default Theme
+
+[33mcommit 1b139805612b0a00e72f16a4d8f55182724ff6a2[m
+Author: Ahmed Magdy <ahmed.elhanafy95@gmail.com>
+Date:   Fri Oct 21 01:28:25 2016 +0200
+
+    Add example app
+
+[33mcommit 5c3363068b0bc53c9e74458ee652b8f845b9aad2[m
+Author: Ahmed Magdy <ahmed.elhanafy95@gmail.com>
+Date:   Fri Oct 21 01:22:37 2016 +0200
+
+    Add react and react-native deps in package.json
+
+[33mcommit d238e381cef79579e1767865b4d24018798a845f[m
+Author: Ahmed Magdy <ahmed.elhanafy95@gmail.com>
+Date:   Fri Oct 21 01:21:25 2016 +0200
+
+    Add Material design palette colors
+
+[33mcommit 9974814e09e7b8b379312b33a941429189a96615[m
+Author: Ahmed Magdy <ahmed.elhanafy95@gmail.com>
+Date:   Fri Oct 21 01:19:22 2016 +0200
+
+    Create .flowconfig file and ignore example app folder
+
+[33mcommit 92776a273b195f942cae2c342f14822bbb23631c[m
+Author: Ahmed Magdy <ahmed.elhanafy95@gmail.com>
+Date:   Fri Oct 21 01:05:28 2016 +0200
+
+    Create package.json and add flow command
+
+[33mcommit c4a57476f20aaa98b0a12efe0349c67306a6b40c[m
+Author: Ahmed Magdy <ahmed.elhanafy95@gmail.com>
+Date:   Wed Oct 19 08:02:09 2016 +0200
+
+    Add some design references
+
+[33mcommit c752a96f6d712eedbb9ab6f2bb2a1c797fe11ccb[m
+Author: Ahmed Elhanafy <ahmed.elhanafy95@gmail.com>
+Date:   Wed Oct 19 07:56:53 2016 +0200
+
+    Initial commit

--- a/example/src/Examples/ListAccordionExample.tsx
+++ b/example/src/Examples/ListAccordionExample.tsx
@@ -15,14 +15,14 @@ const ListAccordionExample = () => {
     <ScreenWrapper>
       <List.Section title="Expandable list item">
         <List.Accordion
-          left={(props) => <List.Icon size={32}  {...props} icon="folder" />}
+          left={(props) => <List.Icon iconSize={32}  {...props} icon="folder" />}
           title="Expandable list item"
         >
           <List.Item title="List item 1" />
           <List.Item title="List item 2" />
         </List.Accordion>
         <List.Accordion
-          left={(props) => <List.Icon size={32}  {...props} icon="folder" />}
+          left={(props) => <List.Icon iconSize={32}  {...props} icon="folder" />}
           title="Start expanded"
           expanded={expanded}
           onPress={_handlePress}
@@ -43,15 +43,15 @@ const ListAccordionExample = () => {
       <Divider />
       <List.Section title="Expandable list with icons">
         <List.Accordion
-          left={(props) => <List.Icon size={32}  {...props} icon="star" />}
+          left={(props) => <List.Icon iconSize={32}  {...props} icon="star" />}
           title="Accordion item 1"
         >
           <List.Item
-            left={(props) => <List.Icon size={32}  {...props} icon="thumb-up" />}
+            left={(props) => <List.Icon iconSize={32}  {...props} icon="thumb-up" />}
             title="List item 1"
           />
           <List.Item
-            left={(props) => <List.Icon size={32}  {...props} icon="thumb-down" />}
+            left={(props) => <List.Icon iconSize={32}  {...props} icon="thumb-down" />}
             title="List item 2"
           />
         </List.Accordion>

--- a/example/src/Examples/ListAccordionExample.tsx
+++ b/example/src/Examples/ListAccordionExample.tsx
@@ -15,14 +15,14 @@ const ListAccordionExample = () => {
     <ScreenWrapper>
       <List.Section title="Expandable list item">
         <List.Accordion
-          left={(props) => <List.Icon iconSize={32}  {...props} icon="folder" />}
+          left={(props) => <List.Icon iconSize={32} {...props} icon="folder" />}
           title="Expandable list item"
         >
           <List.Item title="List item 1" />
           <List.Item title="List item 2" />
         </List.Accordion>
         <List.Accordion
-          left={(props) => <List.Icon iconSize={32}  {...props} icon="folder" />}
+          left={(props) => <List.Icon iconSize={32} {...props} icon="folder" />}
           title="Start expanded"
           expanded={expanded}
           onPress={_handlePress}
@@ -43,15 +43,19 @@ const ListAccordionExample = () => {
       <Divider />
       <List.Section title="Expandable list with icons">
         <List.Accordion
-          left={(props) => <List.Icon iconSize={32}  {...props} icon="star" />}
+          left={(props) => <List.Icon iconSize={32} {...props} icon="star" />}
           title="Accordion item 1"
         >
           <List.Item
-            left={(props) => <List.Icon iconSize={32}  {...props} icon="thumb-up" />}
+            left={(props) => (
+              <List.Icon iconSize={32} {...props} icon="thumb-up" />
+            )}
             title="List item 1"
           />
           <List.Item
-            left={(props) => <List.Icon iconSize={32}  {...props} icon="thumb-down" />}
+            left={(props) => (
+              <List.Icon iconSize={32} {...props} icon="thumb-down" />
+            )}
             title="List item 2"
           />
         </List.Accordion>

--- a/example/src/Examples/ListAccordionExample.tsx
+++ b/example/src/Examples/ListAccordionExample.tsx
@@ -15,14 +15,14 @@ const ListAccordionExample = () => {
     <ScreenWrapper>
       <List.Section title="Expandable list item">
         <List.Accordion
-          left={(props) => <List.Icon {...props} icon="folder" />}
+          left={(props) => <List.Icon size={32}  {...props} icon="folder" />}
           title="Expandable list item"
         >
           <List.Item title="List item 1" />
           <List.Item title="List item 2" />
         </List.Accordion>
         <List.Accordion
-          left={(props) => <List.Icon {...props} icon="folder" />}
+          left={(props) => <List.Icon size={32}  {...props} icon="folder" />}
           title="Start expanded"
           expanded={expanded}
           onPress={_handlePress}
@@ -43,15 +43,15 @@ const ListAccordionExample = () => {
       <Divider />
       <List.Section title="Expandable list with icons">
         <List.Accordion
-          left={(props) => <List.Icon {...props} icon="star" />}
+          left={(props) => <List.Icon size={32}  {...props} icon="star" />}
           title="Accordion item 1"
         >
           <List.Item
-            left={(props) => <List.Icon {...props} icon="thumb-up" />}
+            left={(props) => <List.Icon size={32}  {...props} icon="thumb-up" />}
             title="List item 1"
           />
           <List.Item
-            left={(props) => <List.Icon {...props} icon="thumb-down" />}
+            left={(props) => <List.Icon size={32}  {...props} icon="thumb-down" />}
             title="List item 2"
           />
         </List.Accordion>

--- a/example/src/Examples/ListAccordionGroupExample.tsx
+++ b/example/src/Examples/ListAccordionGroupExample.tsx
@@ -19,7 +19,7 @@ const ListAccordionGroupExample = () => {
       <List.AccordionGroup>
         <List.Section title="Uncontrolled Accordion Group example">
           <List.Accordion
-            left={(props) => <List.Icon {...props} icon="folder" />}
+            left={(props) => <List.Icon size={32}  {...props} icon="folder" />}
             title="Expandable list item"
             id="1"
           >
@@ -27,14 +27,14 @@ const ListAccordionGroupExample = () => {
             <List.Item title="List item 2" />
           </List.Accordion>
           <List.Accordion
-            left={(props) => <List.Icon {...props} icon="folder" />}
+            left={(props) => <List.Icon size={32}  {...props} icon="folder" />}
             title="Expandable list item 2"
             id="2"
           >
             <List.Item title="List item 1" />
           </List.Accordion>
           <List.Accordion
-            left={(props) => <List.Icon {...props} icon="folder" />}
+            left={(props) => <List.Icon size={32}  {...props} icon="folder" />}
             title="Expandable list item 2"
             id="3"
           >
@@ -48,7 +48,7 @@ const ListAccordionGroupExample = () => {
       >
         <List.Section title="Controlled Accordion Group example">
           <List.Accordion
-            left={(props) => <List.Icon {...props} icon="folder" />}
+            left={(props) => <List.Icon size={32}  {...props} icon="folder" />}
             title="Expandable list item"
             id="1"
           >
@@ -56,14 +56,14 @@ const ListAccordionGroupExample = () => {
             <List.Item title="List item 2" />
           </List.Accordion>
           <List.Accordion
-            left={(props) => <List.Icon {...props} icon="folder" />}
+            left={(props) => <List.Icon size={32}  {...props} icon="folder" />}
             title="Expandable list item 2"
             id="2"
           >
             <List.Item title="List item 1" />
           </List.Accordion>
           <List.Accordion
-            left={(props) => <List.Icon {...props} icon="folder" />}
+            left={(props) => <List.Icon size={32}  {...props} icon="folder" />}
             title="Expandable list item 2"
             id="3"
           >

--- a/example/src/Examples/ListAccordionGroupExample.tsx
+++ b/example/src/Examples/ListAccordionGroupExample.tsx
@@ -19,7 +19,9 @@ const ListAccordionGroupExample = () => {
       <List.AccordionGroup>
         <List.Section title="Uncontrolled Accordion Group example">
           <List.Accordion
-            left={(props) => <List.Icon iconSize={32}  {...props} icon="folder" />}
+            left={(props) => (
+              <List.Icon iconSize={32} {...props} icon="folder" />
+            )}
             title="Expandable list item"
             id="1"
           >
@@ -27,14 +29,18 @@ const ListAccordionGroupExample = () => {
             <List.Item title="List item 2" />
           </List.Accordion>
           <List.Accordion
-            left={(props) => <List.Icon iconSize={32}  {...props} icon="folder" />}
+            left={(props) => (
+              <List.Icon iconSize={32} {...props} icon="folder" />
+            )}
             title="Expandable list item 2"
             id="2"
           >
             <List.Item title="List item 1" />
           </List.Accordion>
           <List.Accordion
-            left={(props) => <List.Icon iconSize={32}  {...props} icon="folder" />}
+            left={(props) => (
+              <List.Icon iconSize={32} {...props} icon="folder" />
+            )}
             title="Expandable list item 2"
             id="3"
           >
@@ -48,7 +54,9 @@ const ListAccordionGroupExample = () => {
       >
         <List.Section title="Controlled Accordion Group example">
           <List.Accordion
-            left={(props) => <List.Icon iconSize={32}  {...props} icon="folder" />}
+            left={(props) => (
+              <List.Icon iconSize={32} {...props} icon="folder" />
+            )}
             title="Expandable list item"
             id="1"
           >
@@ -56,14 +64,18 @@ const ListAccordionGroupExample = () => {
             <List.Item title="List item 2" />
           </List.Accordion>
           <List.Accordion
-            left={(props) => <List.Icon iconSize={32}  {...props} icon="folder" />}
+            left={(props) => (
+              <List.Icon iconSize={32} {...props} icon="folder" />
+            )}
             title="Expandable list item 2"
             id="2"
           >
             <List.Item title="List item 1" />
           </List.Accordion>
           <List.Accordion
-            left={(props) => <List.Icon iconSize={32}  {...props} icon="folder" />}
+            left={(props) => (
+              <List.Icon iconSize={32} {...props} icon="folder" />
+            )}
             title="Expandable list item 2"
             id="3"
           >

--- a/example/src/Examples/ListAccordionGroupExample.tsx
+++ b/example/src/Examples/ListAccordionGroupExample.tsx
@@ -19,7 +19,7 @@ const ListAccordionGroupExample = () => {
       <List.AccordionGroup>
         <List.Section title="Uncontrolled Accordion Group example">
           <List.Accordion
-            left={(props) => <List.Icon size={32}  {...props} icon="folder" />}
+            left={(props) => <List.Icon iconSize={32}  {...props} icon="folder" />}
             title="Expandable list item"
             id="1"
           >
@@ -27,14 +27,14 @@ const ListAccordionGroupExample = () => {
             <List.Item title="List item 2" />
           </List.Accordion>
           <List.Accordion
-            left={(props) => <List.Icon size={32}  {...props} icon="folder" />}
+            left={(props) => <List.Icon iconSize={32}  {...props} icon="folder" />}
             title="Expandable list item 2"
             id="2"
           >
             <List.Item title="List item 1" />
           </List.Accordion>
           <List.Accordion
-            left={(props) => <List.Icon size={32}  {...props} icon="folder" />}
+            left={(props) => <List.Icon iconSize={32}  {...props} icon="folder" />}
             title="Expandable list item 2"
             id="3"
           >
@@ -48,7 +48,7 @@ const ListAccordionGroupExample = () => {
       >
         <List.Section title="Controlled Accordion Group example">
           <List.Accordion
-            left={(props) => <List.Icon size={32}  {...props} icon="folder" />}
+            left={(props) => <List.Icon iconSize={32}  {...props} icon="folder" />}
             title="Expandable list item"
             id="1"
           >
@@ -56,14 +56,14 @@ const ListAccordionGroupExample = () => {
             <List.Item title="List item 2" />
           </List.Accordion>
           <List.Accordion
-            left={(props) => <List.Icon size={32}  {...props} icon="folder" />}
+            left={(props) => <List.Icon iconSize={32}  {...props} icon="folder" />}
             title="Expandable list item 2"
             id="2"
           >
             <List.Item title="List item 1" />
           </List.Accordion>
           <List.Accordion
-            left={(props) => <List.Icon size={32}  {...props} icon="folder" />}
+            left={(props) => <List.Icon iconSize={32}  {...props} icon="folder" />}
             title="Expandable list item 2"
             id="3"
           >

--- a/example/src/Examples/ListItemExample.tsx
+++ b/example/src/Examples/ListItemExample.tsx
@@ -39,34 +39,34 @@ const ListItemExample = () => {
       <List.Section title="With icon">
         <List.Item
           title="Headline"
-          left={(props) => <List.Icon size={32}  {...props} icon="account-outline" />}
+          left={(props) => <List.Icon iconSize={32}  {...props} icon="account-outline" />}
         />
         <List.Item
           title="Headline"
           description="Supporting text"
-          left={(props) => <List.Icon size={32}  {...props} icon="account-outline" />}
+          left={(props) => <List.Icon iconSize={32}  {...props} icon="account-outline" />}
         />
         <List.Item
           title="Headline"
           description="Supporting text that is long enough to fill up multiple lines in the item"
-          left={(props) => <List.Icon size={32}  {...props} icon="account-outline" />}
+          left={(props) => <List.Icon iconSize={32}  {...props} icon="account-outline" />}
         />
         <Divider />
         <List.Item
           title="Headline"
-          left={(props) => <List.Icon size={32}  {...props} icon="account-outline" />}
+          left={(props) => <List.Icon iconSize={32}  {...props} icon="account-outline" />}
           right={() => <CenteredCheckbox />}
         />
         <List.Item
           title="Headline"
           description="Supporting text"
-          left={(props) => <List.Icon size={32}  {...props} icon="account-outline" />}
+          left={(props) => <List.Icon iconSize={32}  {...props} icon="account-outline" />}
           right={() => <CenteredCheckbox />}
         />
         <List.Item
           title="Headline"
           description="Supporting text that is long enough to fill up multiple lines in the item"
-          left={(props) => <List.Icon size={32}  {...props} icon="account-outline" />}
+          left={(props) => <List.Icon iconSize={32}  {...props} icon="account-outline" />}
           right={() => <Checkbox status="checked" />}
         />
         <Divider />
@@ -276,19 +276,19 @@ const ListItemExample = () => {
         <Divider />
         <List.Item
           title="Headline"
-          left={(props) => <List.Icon size={32}  {...props} icon="account-outline" />}
+          left={(props) => <List.Icon iconSize={32}  {...props} icon="account-outline" />}
           right={() => <Switch disabled style={styles.centered} />}
         />
         <List.Item
           title="Headline"
           description="Supporting text"
-          left={(props) => <List.Icon size={32}  {...props} icon="account-outline" />}
+          left={(props) => <List.Icon iconSize={32}  {...props} icon="account-outline" />}
           right={() => <Switch disabled style={styles.centered} />}
         />
         <List.Item
           title="Headline"
           description="Supporting text that is long enough to fill up multiple lines in the item"
-          left={(props) => <List.Icon size={32}  {...props} icon="account-outline" />}
+          left={(props) => <List.Icon iconSize={32}  {...props} icon="account-outline" />}
           right={() => <Switch disabled />}
         />
         <Divider />

--- a/example/src/Examples/ListItemExample.tsx
+++ b/example/src/Examples/ListItemExample.tsx
@@ -39,34 +39,46 @@ const ListItemExample = () => {
       <List.Section title="With icon">
         <List.Item
           title="Headline"
-          left={(props) => <List.Icon iconSize={32}  {...props} icon="account-outline" />}
+          left={(props) => (
+            <List.Icon iconSize={32} {...props} icon="account-outline" />
+          )}
         />
         <List.Item
           title="Headline"
           description="Supporting text"
-          left={(props) => <List.Icon iconSize={32}  {...props} icon="account-outline" />}
+          left={(props) => (
+            <List.Icon iconSize={32} {...props} icon="account-outline" />
+          )}
         />
         <List.Item
           title="Headline"
           description="Supporting text that is long enough to fill up multiple lines in the item"
-          left={(props) => <List.Icon iconSize={32}  {...props} icon="account-outline" />}
+          left={(props) => (
+            <List.Icon iconSize={32} {...props} icon="account-outline" />
+          )}
         />
         <Divider />
         <List.Item
           title="Headline"
-          left={(props) => <List.Icon iconSize={32}  {...props} icon="account-outline" />}
+          left={(props) => (
+            <List.Icon iconSize={32} {...props} icon="account-outline" />
+          )}
           right={() => <CenteredCheckbox />}
         />
         <List.Item
           title="Headline"
           description="Supporting text"
-          left={(props) => <List.Icon iconSize={32}  {...props} icon="account-outline" />}
+          left={(props) => (
+            <List.Icon iconSize={32} {...props} icon="account-outline" />
+          )}
           right={() => <CenteredCheckbox />}
         />
         <List.Item
           title="Headline"
           description="Supporting text that is long enough to fill up multiple lines in the item"
-          left={(props) => <List.Icon iconSize={32}  {...props} icon="account-outline" />}
+          left={(props) => (
+            <List.Icon iconSize={32} {...props} icon="account-outline" />
+          )}
           right={() => <Checkbox status="checked" />}
         />
         <Divider />
@@ -276,19 +288,25 @@ const ListItemExample = () => {
         <Divider />
         <List.Item
           title="Headline"
-          left={(props) => <List.Icon iconSize={32}  {...props} icon="account-outline" />}
+          left={(props) => (
+            <List.Icon iconSize={32} {...props} icon="account-outline" />
+          )}
           right={() => <Switch disabled style={styles.centered} />}
         />
         <List.Item
           title="Headline"
           description="Supporting text"
-          left={(props) => <List.Icon iconSize={32}  {...props} icon="account-outline" />}
+          left={(props) => (
+            <List.Icon iconSize={32} {...props} icon="account-outline" />
+          )}
           right={() => <Switch disabled style={styles.centered} />}
         />
         <List.Item
           title="Headline"
           description="Supporting text that is long enough to fill up multiple lines in the item"
-          left={(props) => <List.Icon iconSize={32}  {...props} icon="account-outline" />}
+          left={(props) => (
+            <List.Icon iconSize={32} {...props} icon="account-outline" />
+          )}
           right={() => <Switch disabled />}
         />
         <Divider />

--- a/example/src/Examples/ListItemExample.tsx
+++ b/example/src/Examples/ListItemExample.tsx
@@ -39,34 +39,34 @@ const ListItemExample = () => {
       <List.Section title="With icon">
         <List.Item
           title="Headline"
-          left={(props) => <List.Icon {...props} icon="account-outline" />}
+          left={(props) => <List.Icon size={32}  {...props} icon="account-outline" />}
         />
         <List.Item
           title="Headline"
           description="Supporting text"
-          left={(props) => <List.Icon {...props} icon="account-outline" />}
+          left={(props) => <List.Icon size={32}  {...props} icon="account-outline" />}
         />
         <List.Item
           title="Headline"
           description="Supporting text that is long enough to fill up multiple lines in the item"
-          left={(props) => <List.Icon {...props} icon="account-outline" />}
+          left={(props) => <List.Icon size={32}  {...props} icon="account-outline" />}
         />
         <Divider />
         <List.Item
           title="Headline"
-          left={(props) => <List.Icon {...props} icon="account-outline" />}
+          left={(props) => <List.Icon size={32}  {...props} icon="account-outline" />}
           right={() => <CenteredCheckbox />}
         />
         <List.Item
           title="Headline"
           description="Supporting text"
-          left={(props) => <List.Icon {...props} icon="account-outline" />}
+          left={(props) => <List.Icon size={32}  {...props} icon="account-outline" />}
           right={() => <CenteredCheckbox />}
         />
         <List.Item
           title="Headline"
           description="Supporting text that is long enough to fill up multiple lines in the item"
-          left={(props) => <List.Icon {...props} icon="account-outline" />}
+          left={(props) => <List.Icon size={32}  {...props} icon="account-outline" />}
           right={() => <Checkbox status="checked" />}
         />
         <Divider />
@@ -276,19 +276,19 @@ const ListItemExample = () => {
         <Divider />
         <List.Item
           title="Headline"
-          left={(props) => <List.Icon {...props} icon="account-outline" />}
+          left={(props) => <List.Icon size={32}  {...props} icon="account-outline" />}
           right={() => <Switch disabled style={styles.centered} />}
         />
         <List.Item
           title="Headline"
           description="Supporting text"
-          left={(props) => <List.Icon {...props} icon="account-outline" />}
+          left={(props) => <List.Icon size={32}  {...props} icon="account-outline" />}
           right={() => <Switch disabled style={styles.centered} />}
         />
         <List.Item
           title="Headline"
           description="Supporting text that is long enough to fill up multiple lines in the item"
-          left={(props) => <List.Icon {...props} icon="account-outline" />}
+          left={(props) => <List.Icon size={32}  {...props} icon="account-outline" />}
           right={() => <Switch disabled />}
         />
         <Divider />

--- a/example/src/Examples/ListSectionExample.tsx
+++ b/example/src/Examples/ListSectionExample.tsx
@@ -10,17 +10,17 @@ const ListSectionExample = () => {
       <List.Section>
         <List.Subheader>Single line</List.Subheader>
         <List.Item
-          left={(props) => <List.Icon size={32}  {...props} icon="calendar" />}
+          left={(props) => <List.Icon iconSize={32}  {...props} icon="calendar" />}
           title="List item 1"
         />
         <List.Item
-          left={(props) => <List.Icon size={32}  {...props} icon="wallet-giftcard" />}
+          left={(props) => <List.Icon iconSize={32}  {...props} icon="wallet-giftcard" />}
           title="List item 2"
         />
         <List.Item
           title="List item 3"
-          left={(props) => <List.Icon size={32}  {...props} icon="folder" />}
-          right={(props) => <List.Icon size={32}  {...props} icon="equal" />}
+          left={(props) => <List.Icon iconSize={32}  {...props} icon="folder" />}
+          right={(props) => <List.Icon iconSize={32}  {...props} icon="equal" />}
         />
       </List.Section>
       <Divider />
@@ -45,7 +45,7 @@ const ListSectionExample = () => {
               accessibilityIgnoresInvertColors
             />
           )}
-          right={(props) => <List.Icon size={32}  {...props} icon="information" />}
+          right={(props) => <List.Icon iconSize={32}  {...props} icon="information" />}
           title="List item 2"
           description="Describes item 2"
         />
@@ -72,7 +72,7 @@ const ListSectionExample = () => {
               accessibilityIgnoresInvertColors
             />
           )}
-          right={(props) => <List.Icon size={32}  {...props} icon="star-outline" />}
+          right={(props) => <List.Icon iconSize={32}  {...props} icon="star-outline" />}
           title="List item 2"
           description="Describes item 2. Example of a very very long description."
         />
@@ -88,7 +88,7 @@ const ListSectionExample = () => {
               accessibilityIgnoresInvertColors
             />
           )}
-          right={(props) => <List.Icon size={32}  {...props} icon="star-outline" />}
+          right={(props) => <List.Icon iconSize={32}  {...props} icon="star-outline" />}
           title={({ ellipsizeMode, color: titleColor, fontSize }) => (
             <View style={[styles.container, styles.row, styles.customTitle]}>
               <Text

--- a/example/src/Examples/ListSectionExample.tsx
+++ b/example/src/Examples/ListSectionExample.tsx
@@ -10,17 +10,17 @@ const ListSectionExample = () => {
       <List.Section>
         <List.Subheader>Single line</List.Subheader>
         <List.Item
-          left={(props) => <List.Icon {...props} icon="calendar" />}
+          left={(props) => <List.Icon size={32}  {...props} icon="calendar" />}
           title="List item 1"
         />
         <List.Item
-          left={(props) => <List.Icon {...props} icon="wallet-giftcard" />}
+          left={(props) => <List.Icon size={32}  {...props} icon="wallet-giftcard" />}
           title="List item 2"
         />
         <List.Item
           title="List item 3"
-          left={(props) => <List.Icon {...props} icon="folder" />}
-          right={(props) => <List.Icon {...props} icon="equal" />}
+          left={(props) => <List.Icon size={32}  {...props} icon="folder" />}
+          right={(props) => <List.Icon size={32}  {...props} icon="equal" />}
         />
       </List.Section>
       <Divider />
@@ -45,7 +45,7 @@ const ListSectionExample = () => {
               accessibilityIgnoresInvertColors
             />
           )}
-          right={(props) => <List.Icon {...props} icon="information" />}
+          right={(props) => <List.Icon size={32}  {...props} icon="information" />}
           title="List item 2"
           description="Describes item 2"
         />
@@ -72,7 +72,7 @@ const ListSectionExample = () => {
               accessibilityIgnoresInvertColors
             />
           )}
-          right={(props) => <List.Icon {...props} icon="star-outline" />}
+          right={(props) => <List.Icon size={32}  {...props} icon="star-outline" />}
           title="List item 2"
           description="Describes item 2. Example of a very very long description."
         />
@@ -88,7 +88,7 @@ const ListSectionExample = () => {
               accessibilityIgnoresInvertColors
             />
           )}
-          right={(props) => <List.Icon {...props} icon="star-outline" />}
+          right={(props) => <List.Icon size={32}  {...props} icon="star-outline" />}
           title={({ ellipsizeMode, color: titleColor, fontSize }) => (
             <View style={[styles.container, styles.row, styles.customTitle]}>
               <Text

--- a/example/src/Examples/ListSectionExample.tsx
+++ b/example/src/Examples/ListSectionExample.tsx
@@ -10,17 +10,21 @@ const ListSectionExample = () => {
       <List.Section>
         <List.Subheader>Single line</List.Subheader>
         <List.Item
-          left={(props) => <List.Icon iconSize={32}  {...props} icon="calendar" />}
+          left={(props) => (
+            <List.Icon iconSize={32} {...props} icon="calendar" />
+          )}
           title="List item 1"
         />
         <List.Item
-          left={(props) => <List.Icon iconSize={32}  {...props} icon="wallet-giftcard" />}
+          left={(props) => (
+            <List.Icon iconSize={32} {...props} icon="wallet-giftcard" />
+          )}
           title="List item 2"
         />
         <List.Item
           title="List item 3"
-          left={(props) => <List.Icon iconSize={32}  {...props} icon="folder" />}
-          right={(props) => <List.Icon iconSize={32}  {...props} icon="equal" />}
+          left={(props) => <List.Icon iconSize={32} {...props} icon="folder" />}
+          right={(props) => <List.Icon iconSize={32} {...props} icon="equal" />}
         />
       </List.Section>
       <Divider />
@@ -45,7 +49,9 @@ const ListSectionExample = () => {
               accessibilityIgnoresInvertColors
             />
           )}
-          right={(props) => <List.Icon iconSize={32}  {...props} icon="information" />}
+          right={(props) => (
+            <List.Icon iconSize={32} {...props} icon="information" />
+          )}
           title="List item 2"
           description="Describes item 2"
         />
@@ -72,7 +78,9 @@ const ListSectionExample = () => {
               accessibilityIgnoresInvertColors
             />
           )}
-          right={(props) => <List.Icon iconSize={32}  {...props} icon="star-outline" />}
+          right={(props) => (
+            <List.Icon iconSize={32} {...props} icon="star-outline" />
+          )}
           title="List item 2"
           description="Describes item 2. Example of a very very long description."
         />
@@ -88,7 +96,9 @@ const ListSectionExample = () => {
               accessibilityIgnoresInvertColors
             />
           )}
-          right={(props) => <List.Icon iconSize={32}  {...props} icon="star-outline" />}
+          right={(props) => (
+            <List.Icon iconSize={32} {...props} icon="star-outline" />
+          )}
           title={({ ellipsizeMode, color: titleColor, fontSize }) => (
             <View style={[styles.container, styles.row, styles.customTitle]}>
               <Text

--- a/example/src/Examples/SegmentedButtonsExample.tsx
+++ b/example/src/Examples/SegmentedButtonsExample.tsx
@@ -28,7 +28,7 @@ const SegmentedButtonExample = ({ navigation }: Props) => {
           title="Single select"
           description="Go to the example"
           onPress={() => navigation.navigate('segmentedButtonRealCase')}
-          right={(props) => <List.Icon size={32}  {...props} icon="arrow-right" />}
+          right={(props) => <List.Icon iconSize={32}  {...props} icon="arrow-right" />}
         />
         <List.Item
           title="Multiselect select"
@@ -36,7 +36,7 @@ const SegmentedButtonExample = ({ navigation }: Props) => {
           onPress={() =>
             navigation.navigate('segmentedButtonMultiselectRealCase')
           }
-          right={(props) => <List.Icon size={32}  {...props} icon="arrow-right" />}
+          right={(props) => <List.Icon iconSize={32}  {...props} icon="arrow-right" />}
         />
       </List.Section>
       <SegmentedButtonDefault />

--- a/example/src/Examples/SegmentedButtonsExample.tsx
+++ b/example/src/Examples/SegmentedButtonsExample.tsx
@@ -28,7 +28,9 @@ const SegmentedButtonExample = ({ navigation }: Props) => {
           title="Single select"
           description="Go to the example"
           onPress={() => navigation.navigate('segmentedButtonRealCase')}
-          right={(props) => <List.Icon iconSize={32}  {...props} icon="arrow-right" />}
+          right={(props) => (
+            <List.Icon iconSize={32} {...props} icon="arrow-right" />
+          )}
         />
         <List.Item
           title="Multiselect select"
@@ -36,7 +38,9 @@ const SegmentedButtonExample = ({ navigation }: Props) => {
           onPress={() =>
             navigation.navigate('segmentedButtonMultiselectRealCase')
           }
-          right={(props) => <List.Icon iconSize={32}  {...props} icon="arrow-right" />}
+          right={(props) => (
+            <List.Icon iconSize={32} {...props} icon="arrow-right" />
+          )}
         />
       </List.Section>
       <SegmentedButtonDefault />

--- a/example/src/Examples/SegmentedButtonsExample.tsx
+++ b/example/src/Examples/SegmentedButtonsExample.tsx
@@ -28,7 +28,7 @@ const SegmentedButtonExample = ({ navigation }: Props) => {
           title="Single select"
           description="Go to the example"
           onPress={() => navigation.navigate('segmentedButtonRealCase')}
-          right={(props) => <List.Icon {...props} icon="arrow-right" />}
+          right={(props) => <List.Icon size={32}  {...props} icon="arrow-right" />}
         />
         <List.Item
           title="Multiselect select"
@@ -36,7 +36,7 @@ const SegmentedButtonExample = ({ navigation }: Props) => {
           onPress={() =>
             navigation.navigate('segmentedButtonMultiselectRealCase')
           }
-          right={(props) => <List.Icon {...props} icon="arrow-right" />}
+          right={(props) => <List.Icon size={32}  {...props} icon="arrow-right" />}
         />
       </List.Section>
       <SegmentedButtonDefault />

--- a/example/src/Examples/ThemeExample.tsx
+++ b/example/src/Examples/ThemeExample.tsx
@@ -24,7 +24,7 @@ const ThemeExample = ({ navigation }: Props) => {
             title="Themed Sport App"
             description="Go to the example"
             onPress={() => navigation.navigate('teamsList')}
-            right={(props) => <List.Icon {...props} icon="arrow-right" />}
+            right={(props) => <List.Icon size={32}  {...props} icon="arrow-right" />}
           />
         </List.Section>
       </ScreenWrapper>

--- a/example/src/Examples/ThemeExample.tsx
+++ b/example/src/Examples/ThemeExample.tsx
@@ -24,7 +24,9 @@ const ThemeExample = ({ navigation }: Props) => {
             title="Themed Sport App"
             description="Go to the example"
             onPress={() => navigation.navigate('teamsList')}
-            right={(props) => <List.Icon iconSize={32}  {...props} icon="arrow-right" />}
+            right={(props) => (
+              <List.Icon iconSize={32} {...props} icon="arrow-right" />
+            )}
           />
         </List.Section>
       </ScreenWrapper>

--- a/example/src/Examples/ThemeExample.tsx
+++ b/example/src/Examples/ThemeExample.tsx
@@ -24,7 +24,7 @@ const ThemeExample = ({ navigation }: Props) => {
             title="Themed Sport App"
             description="Go to the example"
             onPress={() => navigation.navigate('teamsList')}
-            right={(props) => <List.Icon size={32}  {...props} icon="arrow-right" />}
+            right={(props) => <List.Icon iconSize={32}  {...props} icon="arrow-right" />}
           />
         </List.Section>
       </ScreenWrapper>

--- a/src/components/List/ListIcon.tsx
+++ b/src/components/List/ListIcon.tsx
@@ -19,6 +19,10 @@ export type Props = {
    * @optional
    */
   theme?: ThemeProp;
+  /**
+   * Size of the icon.
+   */
+  iconSize?: number;
 };
 
 const ICON_SIZE = 24;
@@ -34,19 +38,21 @@ const ICON_SIZE = 24;
  * const MyComponent = () => (
  *   <>
  *     <List.Icon color={MD3Colors.tertiary70} icon="folder" />
- *     <List.Icon color={MD3Colors.tertiary70} icon="equal" />
- *     <List.Icon color={MD3Colors.tertiary70} icon="calendar" />
+ *     <List.Icon color={MD3Colors.tertiary70} icon="equal" iconSize={32} />  // 👈 NEW EXAMPLE
+ *     <List.Icon color={MD3Colors.tertiary70} icon="calendar" iconSize={18} />
  *   </>
  * );
- *
- * export default MyComponent;
  * ```
+ *
+ * @property iconSize Size of the icon.
  */
+
 const ListIcon = ({
   icon,
   color: iconColor,
   style,
   theme: themeOverrides,
+  iconSize,
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
 
@@ -55,7 +61,12 @@ const ListIcon = ({
       style={[theme.isV3 ? styles.itemV3 : styles.item, style]}
       pointerEvents="box-none"
     >
-      <Icon source={icon} size={ICON_SIZE} color={iconColor} theme={theme} />
+      <Icon
+        source={icon}
+        size={iconSize || ICON_SIZE}
+        color={iconColor}
+        theme={theme}
+      />
     </View>
   );
 };


### PR DESCRIPTION
### Summary
Adds a new `iconSize` prop to `List.Icon` allowing consumers to set a custom icon size instead of the fixed 24px default.

### Motivation
Previously, `List.Icon` always rendered at 24px, which limited flexibility. This change makes it possible to scale icons up or down based on design needs.

### Example
```tsx
<List.Icon icon="calendar" iconSize={32} />
<List.Icon icon="equal" iconSize={18} />
