### PR TITLE
fix: fab size prop with label

### DIFF
--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -257,7 +257,7 @@ const FAB = forwardRef<View, Props>(
     const loadingIndicatorSize = isLargeSize ? 24 : 18;
     const font = isV3 ? theme.fonts.labelLarge : theme.fonts.medium;
 
-    const extendedStyle = getExtendedFabStyle({ customSize, theme });
+    const extendedStyle = getExtendedFabStyle({ customSize, size, theme });
     const textStyle = {
       color: foregroundColor,
       ...font,

--- a/src/components/FAB/utils.ts
+++ b/src/components/FAB/utils.ts
@@ -410,10 +410,16 @@ const extended = {
   height: 48,
   paddingHorizontal: 16,
 };
-
-const v3Extended = {
+const v3ExtendedSmallSize = {
+  height: 40,
+  paddingHorizontal: 16,
+};
+const v3ExtendedMediumSize = {
   height: 56,
-  borderRadius: 16,
+  paddingHorizontal: 16,
+};
+const v3ExtendedLargeSize = {
+  height: 96,
   paddingHorizontal: 16,
 };
 
@@ -424,16 +430,38 @@ const getExtendedFabDimensions = (customSize: number) => ({
 
 export const getExtendedFabStyle = ({
   customSize,
+  size,
   theme,
 }: {
   customSize?: number;
+  size: 'small' | 'medium' | 'large';
   theme: InternalTheme;
 }) => {
   if (customSize) return getExtendedFabDimensions(customSize);
 
-  const { isV3 } = theme;
+  const { isV3, roundness } = theme;
 
-  return isV3 ? v3Extended : extended;
+  if (isV3) {
+    switch (size) {
+      case 'small':
+        return {
+          ...v3ExtendedSmallSize,
+          borderRadius: 3 * roundness,
+        };
+      case 'medium':
+        return {
+          ...v3ExtendedMediumSize,
+          borderRadius: 4 * roundness,
+        };
+      case 'large':
+        return {
+          ...v3ExtendedLargeSize,
+          borderRadius: 7 * roundness,
+        };
+    }
+  }
+
+  return extended;
 };
 
 let cachedContext: CanvasRenderingContext2D | null = null;


### PR DESCRIPTION
FAB size prop doesn't work if label is provided. 

Resolves issue #4793

If I add FAB only with the icon and size props, the button displays correctly and works with small, medium, and large sizes. After adding the label prop, the size prop does not work, and the height of the button is always the same.
<img width="438" height="279" alt="Screenshot 2025-09-10 at 23 10 10" src="https://github.com/user-attachments/assets/1ea0ff49-9904-4c3a-a376-89d186f8b27d" />


I included size prop for FAB styles with labels. I set exactly the same heights as for FAB without labels.
<img width="436" height="297" alt="Screenshot 2025-09-10 at 23 10 20" src="https://github.com/user-attachments/assets/be24a949-c6a1-4646-86b8-9d16bc2b44c1" />


