### PR TITLE
fix: switch state sync when used inside a Portal on iOS

### DIFF
--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -67,12 +67,32 @@ const Switch = ({
   ...rest
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
+
+  // Internal state is needed to fix #4789 where Switch is inside a Portal
+  const [internalValue, setInternalValue] = React.useState<boolean>(() =>
+    typeof value === 'boolean' ? value : false
+  );
+
+  React.useEffect(() => {
+    if (typeof value === 'boolean' && value !== internalValue) {
+      setInternalValue(value);
+    }
+  }, [value, internalValue]);
+
   const { checkedColor, onTintColor, thumbTintColor } = getSwitchColor({
     theme,
     disabled,
-    value,
+    value: internalValue,
     color,
   });
+
+  const handleValueChange = React.useCallback(
+    (newValue: boolean) => {
+      setInternalValue(newValue);
+      onValueChange?.(newValue);
+    },
+    [onValueChange]
+  );
 
   const props =
     version && version.major === 0 && version.minor <= 56
@@ -96,13 +116,15 @@ const Switch = ({
 
   return (
     <NativeSwitch
-      value={value}
+      value={internalValue}
       disabled={disabled}
-      onValueChange={disabled ? undefined : onValueChange}
+      onValueChange={disabled ? undefined : handleValueChange}
       {...props}
       {...rest}
     />
   );
 };
+
+Switch.displayName = 'Switch';
 
 export default Switch;


### PR DESCRIPTION
### Motivation

When a `<Switch />` is inside a `<Portal />` you must tap the switch component twice to visually toggle the state on iOS.

### Related issue

Fixes #4789

### Test plan

I updated the example app to Expo 54, and then added this code in the `SwitchExample.tsx` file and tried toggling with a single tap.

```tsx
<Portal>
  <View style={[styles.row, { top: 500 }]}>
    <TextComponent>Portal {checked ? 'on' : 'off'}</TextComponent>
    <Switch value={checked} onValueChange={setChecked} />
  </View>
</Portal>
```

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
