### PR TITLE
docs(theme): improve icon search visibility in dark mode

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -182,6 +182,21 @@ html[data-theme='light'] .gallery-dark {
   }
 }
 
+[data-theme='dark'] .icons-list-searchbar {
+  background-color: var(--ifm-color-emphasis-200);
+  color: var(--ifm-font-color-base);
+}
+
+[data-theme='dark'] .icons-list-searchbar::placeholder {
+  color: var(--ifm-color-content-secondary);
+  opacity: 0.6;
+}
+
+[data-theme='dark'] .icons-list-searchbar:focus,
+[data-theme='dark'] .icons-list-searchbar:hover {
+  background-color: var(--ifm-color-emphasis-300);
+}
+
 @font-face {
   font-family: 'MaterialDesignIcons';
   src: url('../../node_modules/@react-native-vector-icons/material-design-icons/fonts/MaterialDesignIcons.ttf') format('truetype');


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The icon search input field in the documentation site was completely invisible in dark theme due to white text being rendered on a white background. This made it impossible for users to see what they were typing when searching for icons, significantly impacting the user experience in dark mode.

### Related issue

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

Fixes #4822

### Test plan

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

1. Navigate to the documentation site locally: `cd docs && npm start`
2. Go to the Icons page in the documentation
3. Toggle to dark theme using the theme switcher
4. Try typing in the "Find icon by name…" search input
5. Verify that:
   - Text is now visible while typing (white text on dark background)
   - Placeholder text is visible with appropriate contrast
   - Input background changes on hover/focus for better UX
   - All states work correctly in both light and dark themes

**Before**: Text was invisible (white on white)
**After**: Text is clearly visible with proper contrast using Infima CSS variables

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->