### PR TITLE
fix: chip selected colors

### DIFF
--- a/example/src/Examples/ChipExample.tsx
+++ b/example/src/Examples/ChipExample.tsx
@@ -249,10 +249,10 @@ const ChipExample = () => {
             </Chip>
           </View>
         </List.Section>
-        <List.Section title="Custom chip">
-          <View style={styles.row}>
-            {isV3 && (
-              <>
+        <List.Section title="Custom chips">
+          {isV3 && (
+            <List.Section title="Custom border radius">
+              <View style={styles.row}>
                 <Chip
                   mode="outlined"
                   onPress={() => {}}
@@ -265,7 +265,7 @@ const ChipExample = () => {
                   }
                   style={[styles.chip, styles.customBorderRadius]}
                 >
-                  Compact with custom border radius
+                  Compact with custom border radius (outlined)
                 </Chip>
                 <Chip
                   mode="flat"
@@ -279,110 +279,219 @@ const ChipExample = () => {
                   }
                   style={[styles.chip, styles.customBorderRadius]}
                 >
-                  Compact with custom border radius
+                  Compact with custom border radius (flat)
                 </Chip>
-              </>
-            )}
+              </View>
+            </List.Section>
+          )}
+          <List.Section title="Custom background color">
+            <View style={styles.row}>
+              <Chip
+                selected
+                onPress={() => {}}
+                style={[
+                  styles.chip,
+                  {
+                    backgroundColor: color(customColor)
+                      .alpha(0.2)
+                      .rgb()
+                      .string(),
+                  },
+                ]}
+              >
+                Flat selected chip with custom background color
+              </Chip>
+              <Chip
+                selected={false}
+                onPress={() => {}}
+                style={[
+                  styles.chip,
+                  {
+                    backgroundColor: color(customColor)
+                      .alpha(0.2)
+                      .rgb()
+                      .string(),
+                  },
+                ]}
+              >
+                Flat unselected chip with custom background color
+              </Chip>
+              <Chip
+                disabled
+                onPress={() => {}}
+                style={[
+                  styles.chip,
+                  {
+                    backgroundColor: color(customColor)
+                      .alpha(0.2)
+                      .rgb()
+                      .string(),
+                  },
+                ]}
+              >
+                Flat disabled chip with custom background color
+              </Chip>
+            </View>
+          </List.Section>
+          <List.Section title="Custom selected color">
+            <View style={styles.row}>
+              <Chip
+                selected
+                onPress={() => {}}
+                style={[styles.chip]}
+                selectedColor={customColor}
+              >
+                Flat selected chip with custom selected color
+              </Chip>
+              <Chip
+                selected={false}
+                onPress={() => {}}
+                style={styles.chip}
+                selectedColor={customColor}
+              >
+                Flat unselected chip with custom selected color
+              </Chip>
+              <Chip
+                selected
+                showSelectedCheck={false}
+                onPress={() => {}}
+                style={[styles.chip]}
+                selectedColor={customColor}
+              >
+                Flat selected chip with custom selected color (no check)
+              </Chip>
+              <Chip
+                selected={false}
+                showSelectedCheck={false}
+                onPress={() => {}}
+                style={styles.chip}
+                selectedColor={customColor}
+              >
+                Flat unselected chip with custom selected color (no check)
+              </Chip>
+              <Chip
+                disabled
+                onPress={() => {}}
+                style={styles.chip}
+                selectedColor={customColor}
+              >
+                Flat disabled unselected chip with custom selected color
+              </Chip>
+              <Chip
+                selected
+                mode="outlined"
+                onPress={() => {}}
+                style={[
+                  styles.chip,
+                  {
+                    backgroundColor: color(customColor)
+                      .alpha(0.2)
+                      .rgb()
+                      .string(),
+                  },
+                ]}
+                selectedColor={customColor}
+              >
+                Outlined selected chip with custom color
+              </Chip>
+              <Chip
+                mode="outlined"
+                onPress={() => {}}
+                style={styles.chip}
+                selectedColor={customColor}
+              >
+                Outlined unselected chip with custom color
+              </Chip>
+            </View>
+          </List.Section>
+          <List.Section title="Custom styling">
+            <View style={styles.row}>
+              <Chip
+                selected
+                showSelectedCheck={false}
+                onPress={() => {}}
+                style={[styles.chip]}
+                selectedColor="rgba(255, 255, 255, 1)"
+                selectedBackgroundColor="rgba(0, 0, 0, 1)"
+              >
+                Flat selected chip with custom selected color & background color
+              </Chip>
+              <Chip
+                disabled
+                onPress={() => {}}
+                style={[styles.chip]}
+                selectedColor="rgba(255, 255, 255, 1)"
+                selectedBackgroundColor="rgba(0, 0, 0, 1)"
+              >
+                Flat disabled chip with custom selected & background color
+              </Chip>
+              <Chip
+                onPress={() => {}}
+                style={styles.chip}
+                textStyle={styles.tiny}
+              >
+                With custom size
+              </Chip>
+              <Chip
+                onPress={() => {}}
+                style={styles.chip}
+                textStyle={styles.tiny}
+              >
+                <Text variant="titleLarge">With custom text</Text>
+              </Chip>
+              <Chip
+                onPress={() => {}}
+                onClose={() =>
+                  setSnackbarProperties({
+                    visible: true,
+                    text: 'Custom icon close button pressed',
+                  })
+                }
+                closeIcon="arrow-down"
+                style={styles.chip}
+                closeIconAccessibilityLabel="Custom Close icon accessibility label"
+              >
+                With custom close icon
+              </Chip>
+              <Chip
+                mode="outlined"
+                onPress={() => {}}
+                onLongPress={() =>
+                  setSnackbarProperties({ visible: true, text: '' })
+                }
+                style={styles.chip}
+              >
+                With onLongPress
+              </Chip>
+            </View>
+          </List.Section>
+          <List.Section title="Full width & long text">
+            <View style={styles.row}>
+              <Chip
+                onPress={() => {}}
+                onClose={() =>
+                  setSnackbarProperties({
+                    visible: true,
+                    text: 'Close button pressed',
+                  })
+                }
+                style={styles.bigTextFlex}
+                textStyle={styles.bigTextStyle}
+                ellipsizeMode="middle"
+              >
+                With a very big text: React Native Paper is a high-quality,
+                standard-compliant Material Design library that has you covered
+                in all major use-cases.
+              </Chip>
+            </View>
             <Chip
               mode="outlined"
               onPress={() => {}}
-              onLongPress={() =>
-                setSnackbarProperties({ visible: true, text: '' })
-              }
-              style={styles.chip}
+              style={styles.fullWidthChip}
             >
-              With onLongPress
+              Full width chip
             </Chip>
-            <Chip
-              selected
-              onPress={() => {}}
-              style={[
-                styles.chip,
-                {
-                  backgroundColor: color(customColor).alpha(0.2).rgb().string(),
-                },
-              ]}
-              selectedColor={customColor}
-            >
-              Flat selected chip with custom color
-            </Chip>
-            <Chip
-              onPress={() => {}}
-              style={styles.chip}
-              selectedColor={customColor}
-            >
-              Flat unselected chip with custom color
-            </Chip>
-            <Chip
-              selected
-              mode="outlined"
-              onPress={() => {}}
-              style={[
-                styles.chip,
-                {
-                  backgroundColor: color(customColor).alpha(0.2).rgb().string(),
-                },
-              ]}
-              selectedColor={customColor}
-            >
-              Outlined selected chip with custom color
-            </Chip>
-            <Chip
-              mode="outlined"
-              onPress={() => {}}
-              style={styles.chip}
-              selectedColor={customColor}
-            >
-              Outlined unselected chip with custom color
-            </Chip>
-            <Chip
-              onPress={() => {}}
-              style={styles.chip}
-              textStyle={styles.tiny}
-            >
-              With custom size
-            </Chip>
-            <Chip
-              onPress={() => {}}
-              onClose={() =>
-                setSnackbarProperties({
-                  visible: true,
-                  text: 'Close button pressed',
-                })
-              }
-              style={styles.bigTextFlex}
-              textStyle={styles.bigTextStyle}
-              ellipsizeMode="middle"
-            >
-              With a very big text: React Native Paper is a high-quality,
-              standard-compliant Material Design library that has you covered in
-              all major use-cases.
-            </Chip>
-            <Chip
-              onPress={() => {}}
-              onClose={() =>
-                setSnackbarProperties({
-                  visible: true,
-                  text: 'Custom icon close button pressed',
-                })
-              }
-              closeIcon="arrow-down"
-              style={styles.chip}
-              closeIconAccessibilityLabel="Custom Close icon accessibility label"
-            >
-              With custom close icon
-            </Chip>
-            <Chip
-              onPress={() => {}}
-              style={styles.chip}
-              textStyle={styles.tiny}
-            >
-              <Text variant="titleLarge">With custom text</Text>
-            </Chip>
-          </View>
-          <Chip mode="outlined" onPress={() => {}} style={styles.fullWidthChip}>
-            Full width chip
-          </Chip>
+          </List.Section>
         </List.Section>
       </ScreenWrapper>
       <Snackbar

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -59,10 +59,14 @@ export type Props = $Omit<React.ComponentProps<typeof Surface>, 'mode'> & {
   selected?: boolean;
   /**
    * Whether to style the chip color as selected.
-   * Note: With theme version 3 `selectedColor` doesn't apply to the `icon`.
+   * Note: With theme version 3 `selectedColor` doesn't apply to the `icon`. Only text color is affected.
    *       If you want specify custom color for the `icon`, render your own `Icon` component.
    */
   selectedColor?: string;
+  /**
+   * Background color for the selected chip.
+   */
+  selectedBackgroundColor?: string;
   /**
    * @supported Available in v5.x with theme version 3
    * Whether to display overlay on selected chip
@@ -139,6 +143,25 @@ export type Props = $Omit<React.ComponentProps<typeof Surface>, 'mode'> & {
   hitSlop?: TouchableRippleProps['hitSlop'];
   /**
    * @optional
+   * Theme object containing styling properties. The following theme properties are used:
+   * **V3 Theme:**
+   * - `colors.onSurfaceDisabled` - Text and icon color when disabled
+   * - `colors.onSurfaceVariant` - Text/icon color for outlined mode, disabled border color, overlay mixing
+   * - `colors.outline` - Border color for outlined mode (when not disabled/selected)
+   * - `colors.surface` - Background color for outlined mode
+   * - `colors.secondaryContainer` - Background color for flat mode
+   * - `colors.onSecondaryContainer` - Text/icon color for flat mode, overlay mixing
+   * - `colors.primary` - Icon color when not disabled (for custom icons)
+   * **V2 Theme:**
+   * - `colors.disabled` - Text and icon color when disabled
+   * - `colors.text` - Base text and icon color (with alpha applied)
+   * - `colors.surface` - Background color for outlined mode
+   * **Common:**
+   * - `roundness` - Used to calculate default border radius (V3: roundness * 2, V2: roundness * 4)
+   * - `animation.scale` - Used for elevation animation timing
+   * - `fonts.labelLarge` (V3) / `fonts.regular` (V2) - Text typography
+   * - `dark` - Determines color calculations for V2 theme
+   * - `isV3` - Determines which theme version logic to apply
    */
   theme?: ThemeProp;
   /**
@@ -201,6 +224,7 @@ const Chip = ({
   theme: themeOverrides,
   testID = 'chip',
   selectedColor,
+  selectedBackgroundColor: customSelectedBackgroundColor,
   rippleColor: customRippleColor,
   showSelectedOverlay = false,
   showSelectedCheck = true,
@@ -259,22 +283,18 @@ const Chip = ({
     borderRadius = defaultBorderRadius,
   } = (StyleSheet.flatten(style) || {}) as ViewStyle;
 
-  const {
-    borderColor,
-    textColor,
-    iconColor,
-    rippleColor,
-    selectedBackgroundColor,
-    backgroundColor,
-  } = getChipColors({
-    isOutlined,
-    theme,
-    selectedColor,
-    showSelectedOverlay,
-    customBackgroundColor,
-    disabled,
-    customRippleColor,
-  });
+  const { borderColor, textColor, iconColor, rippleColor, backgroundColor } =
+    getChipColors({
+      isOutlined,
+      theme,
+      selectedColor,
+      showSelectedOverlay,
+      customBackgroundColor,
+      disabled,
+      customRippleColor,
+      selected,
+      customSelectedBackgroundColor,
+    });
 
   const accessibilityState: AccessibilityState = {
     selected,
@@ -306,7 +326,7 @@ const Chip = ({
           elevation: elevationStyle,
         },
         {
-          backgroundColor: selected ? selectedBackgroundColor : backgroundColor,
+          backgroundColor,
           borderColor,
           borderRadius,
         },

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -144,7 +144,9 @@ export type Props = $Omit<React.ComponentProps<typeof Surface>, 'mode'> & {
   /**
    * @optional
    * Theme object containing styling properties. The following theme properties are used:
+   *
    * **V3 Theme:**
+   *
    * - `colors.onSurfaceDisabled` - Text and icon color when disabled
    * - `colors.onSurfaceVariant` - Text/icon color for outlined mode, disabled border color, overlay mixing
    * - `colors.outline` - Border color for outlined mode (when not disabled/selected)
@@ -152,7 +154,9 @@ export type Props = $Omit<React.ComponentProps<typeof Surface>, 'mode'> & {
    * - `colors.secondaryContainer` - Background color for flat mode
    * - `colors.onSecondaryContainer` - Text/icon color for flat mode, overlay mixing
    * - `colors.primary` - Icon color when not disabled (for custom icons)
+   *
    * **V2 Theme:**
+   *
    * - `colors.disabled` - Text and icon color when disabled
    * - `colors.text` - Base text and icon color (with alpha applied)
    * - `colors.surface` - Background color for outlined mode

--- a/src/components/Chip/helpers.tsx
+++ b/src/components/Chip/helpers.tsx
@@ -13,6 +13,7 @@ type BaseProps = {
   theme: InternalTheme;
   isOutlined: boolean;
   disabled?: boolean;
+  selected?: boolean;
 };
 
 const getBorderColor = ({
@@ -61,6 +62,7 @@ const getTextColor = ({
   isOutlined,
   disabled,
   selectedColor,
+  selected,
 }: BaseProps & {
   selectedColor?: string;
 }) => {
@@ -70,7 +72,7 @@ const getTextColor = ({
       return theme.colors.onSurfaceDisabled;
     }
 
-    if (isSelectedColor) {
+    if (isSelectedColor && selected) {
       return selectedColor;
     }
 
@@ -119,6 +121,7 @@ const getBackgroundColor = ({
   theme,
   isOutlined,
   disabled,
+  selected,
   customBackgroundColor,
 }: BaseProps & {
   customBackgroundColor?: ColorValue;
@@ -136,26 +139,37 @@ const getBackgroundColor = ({
     }
   }
 
-  return getDefaultBackgroundColor({ theme, isOutlined });
+  return getDefaultBackgroundColor({ theme, isOutlined, selected });
 };
 
 const getSelectedBackgroundColor = ({
   theme,
   isOutlined,
   disabled,
+  selected,
   customBackgroundColor,
   showSelectedOverlay,
+  customSelectedBackgroundColor,
 }: BaseProps & {
   customBackgroundColor?: ColorValue;
   showSelectedOverlay?: boolean;
+  customSelectedBackgroundColor?: ColorValue;
 }) => {
+  // If customSelectedBackgroundColor is provided, use it as-is without processing
+  if (typeof customSelectedBackgroundColor === 'string') {
+    return customSelectedBackgroundColor;
+  }
+
+  // Get the base background color (which may be custom or theme-based)
   const backgroundColor = getBackgroundColor({
     theme,
     disabled,
     isOutlined,
     customBackgroundColor,
+    selected,
   });
 
+  // Process the background color to get the selected background color
   if (theme.isV3) {
     if (isOutlined) {
       if (showSelectedOverlay) {
@@ -237,6 +251,7 @@ const getRippleColor = ({
   theme,
   isOutlined,
   disabled,
+  selected,
   selectedColor,
   selectedBackgroundColor,
   customRippleColor,
@@ -255,6 +270,7 @@ const getRippleColor = ({
     disabled,
     selectedColor,
     isOutlined,
+    selected,
   });
 
   if (theme.isV3) {
@@ -280,14 +296,18 @@ export const getChipColors = ({
   customBackgroundColor,
   disabled,
   customRippleColor,
+  selected = false,
+  customSelectedBackgroundColor,
 }: BaseProps & {
   customBackgroundColor?: ColorValue;
   disabled?: boolean;
   showSelectedOverlay?: boolean;
   selectedColor?: string;
   customRippleColor?: ColorValue;
+  selected?: boolean;
+  customSelectedBackgroundColor?: ColorValue;
 }) => {
-  const baseChipColorProps = { theme, isOutlined, disabled };
+  const baseChipColorProps = { theme, isOutlined, disabled, selected };
 
   const backgroundColor = getBackgroundColor({
     ...baseChipColorProps,
@@ -298,6 +318,7 @@ export const getChipColors = ({
     ...baseChipColorProps,
     customBackgroundColor,
     showSelectedOverlay,
+    customSelectedBackgroundColor,
   });
 
   return {
@@ -320,7 +341,6 @@ export const getChipColors = ({
       selectedBackgroundColor,
       customRippleColor,
     }),
-    backgroundColor,
-    selectedBackgroundColor,
+    backgroundColor: selected ? selectedBackgroundColor : backgroundColor,
   };
 };

--- a/src/components/Chip/helpers.tsx
+++ b/src/components/Chip/helpers.tsx
@@ -216,6 +216,7 @@ const getIconColor = ({
   isOutlined,
   disabled,
   selectedColor,
+  selected,
 }: BaseProps & {
   selectedColor?: string;
 }) => {
@@ -225,7 +226,7 @@ const getIconColor = ({
       return theme.colors.onSurfaceDisabled;
     }
 
-    if (isSelectedColor) {
+    if (isSelectedColor && selected) {
       return selectedColor;
     }
 
@@ -240,7 +241,7 @@ const getIconColor = ({
     return theme.colors.disabled;
   }
 
-  if (isSelectedColor) {
+  if (isSelectedColor && selected) {
     return color(selectedColor).alpha(0.54).rgb().string();
   }
 

--- a/src/components/Chip/helpers.tsx
+++ b/src/components/Chip/helpers.tsx
@@ -22,6 +22,7 @@ const getBorderColor = ({
   disabled,
   selectedColor,
   backgroundColor,
+  selected,
 }: BaseProps & { backgroundColor: string; selectedColor?: string }) => {
   const isSelectedColor = selectedColor !== undefined;
 
@@ -35,7 +36,7 @@ const getBorderColor = ({
       return color(theme.colors.onSurfaceVariant).alpha(0.12).rgb().string();
     }
 
-    if (isSelectedColor) {
+    if (isSelectedColor && selected) {
       return color(selectedColor).alpha(0.29).rgb().string();
     }
 
@@ -43,7 +44,7 @@ const getBorderColor = ({
   }
 
   if (isOutlined) {
-    if (isSelectedColor) {
+    if (isSelectedColor && selected) {
       return color(selectedColor).alpha(0.29).rgb().string();
     }
 

--- a/src/components/Chip/helpers.tsx
+++ b/src/components/Chip/helpers.tsx
@@ -87,7 +87,7 @@ const getTextColor = ({
     return theme.colors.disabled;
   }
 
-  if (isSelectedColor) {
+  if (isSelectedColor && selected) {
     return color(selectedColor).alpha(0.87).rgb().string();
   }
 

--- a/src/components/Chip/helpers.tsx
+++ b/src/components/Chip/helpers.tsx
@@ -274,14 +274,14 @@ const getRippleColor = ({
   });
 
   if (theme.isV3) {
-    if (isSelectedColor) {
+    if (isSelectedColor && selected) {
       return color(selectedColor).alpha(0.12).rgb().string();
     }
 
     return color(textColor).alpha(0.12).rgb().string();
   }
 
-  if (isSelectedColor) {
+  if (isSelectedColor && selected) {
     return color(selectedColor).fade(0.5).rgb().string();
   }
 

--- a/src/components/__tests__/Chip.test.tsx
+++ b/src/components/__tests__/Chip.test.tsx
@@ -152,7 +152,7 @@ describe('getChipColors - text color', () => {
     });
   });
 
-  it('should return custom color, for theme version 3', () => {
+  it('should return custom color, for theme version 3, when selected', () => {
     expect(
       getChipColors({
         theme: getTheme(),
@@ -165,14 +165,41 @@ describe('getChipColors - text color', () => {
     });
   });
 
-  it('should return custom color, for theme version 2', () => {
+  it('should not return custom color, for theme version 3, when unselected', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+        selectedColor: 'purple',
+        isOutlined: false,
+        selected: false,
+      })
+    ).not.toMatchObject({
+      textColor: 'purple',
+    });
+  });
+
+  it('should return custom color, for theme version 2, when selected', () => {
     expect(
       getChipColors({
         theme: getTheme(false, false),
         selectedColor: 'purple',
         isOutlined: false,
+        selected: true,
       })
     ).toMatchObject({
+      textColor: color('purple').alpha(0.87).rgb().string(),
+    });
+  });
+
+  it('should not return custom color, for theme version 2, when unselected', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(false, false),
+        selectedColor: 'purple',
+        isOutlined: false,
+        selected: false,
+      })
+    ).not.toMatchObject({
       textColor: color('purple').alpha(0.87).rgb().string(),
     });
   });

--- a/src/components/__tests__/Chip.test.tsx
+++ b/src/components/__tests__/Chip.test.tsx
@@ -789,6 +789,7 @@ describe('getChipColor - border color', () => {
         theme: getTheme(false, false),
         selectedColor: 'purple',
         isOutlined: true,
+        selected: true,
       })
     ).toMatchObject({
       borderColor: color('purple').alpha(0.29).rgb().string(),

--- a/src/components/__tests__/Chip.test.tsx
+++ b/src/components/__tests__/Chip.test.tsx
@@ -158,6 +158,7 @@ describe('getChipColors - text color', () => {
         theme: getTheme(),
         selectedColor: 'purple',
         isOutlined: false,
+        selected: true,
       })
     ).toMatchObject({
       textColor: 'purple',
@@ -422,9 +423,10 @@ describe('getChipColor - selected background color', () => {
         theme: getTheme(),
         customBackgroundColor: 'purple',
         isOutlined: true,
+        selected: true,
       })
     ).toMatchObject({
-      selectedBackgroundColor: color('purple')
+      backgroundColor: color('purple')
         .mix(color(getTheme().colors.onSurfaceVariant), 0)
         .rgb()
         .string(),
@@ -437,9 +439,10 @@ describe('getChipColor - selected background color', () => {
         theme: getTheme(),
         customBackgroundColor: 'purple',
         isOutlined: false,
+        selected: true,
       })
     ).toMatchObject({
-      selectedBackgroundColor: color('purple')
+      backgroundColor: color('purple')
         .mix(color(getTheme().colors.onSecondaryContainer), 0)
         .rgb()
         .string(),
@@ -453,9 +456,10 @@ describe('getChipColor - selected background color', () => {
         customBackgroundColor: 'purple',
         showSelectedOverlay: true,
         isOutlined: true,
+        selected: true,
       })
     ).toMatchObject({
-      selectedBackgroundColor: color('purple')
+      backgroundColor: color('purple')
         .mix(color(getTheme().colors.onSurfaceVariant), 0.12)
         .rgb()
         .string(),
@@ -469,9 +473,10 @@ describe('getChipColor - selected background color', () => {
         customBackgroundColor: 'purple',
         showSelectedOverlay: true,
         isOutlined: false,
+        selected: true,
       })
     ).toMatchObject({
-      selectedBackgroundColor: color('purple')
+      backgroundColor: color('purple')
         .mix(color(getTheme().colors.onSecondaryContainer), 0.12)
         .rgb()
         .string(),
@@ -483,9 +488,10 @@ describe('getChipColor - selected background color', () => {
       getChipColors({
         theme: getTheme(),
         isOutlined: true,
+        selected: true,
       })
     ).toMatchObject({
-      selectedBackgroundColor: color(getTheme().colors.surface)
+      backgroundColor: color(getTheme().colors.surface)
         .mix(color(getTheme().colors.onSurfaceVariant), 0)
         .rgb()
         .string(),
@@ -497,9 +503,10 @@ describe('getChipColor - selected background color', () => {
       getChipColors({
         theme: getTheme(),
         isOutlined: false,
+        selected: true,
       })
     ).toMatchObject({
-      selectedBackgroundColor: color(getTheme().colors.secondaryContainer)
+      backgroundColor: color(getTheme().colors.secondaryContainer)
         .mix(color(getTheme().colors.onSecondaryContainer), 0)
         .rgb()
         .string(),
@@ -512,9 +519,10 @@ describe('getChipColor - selected background color', () => {
         theme: getTheme(false, false),
         customBackgroundColor: 'purple',
         isOutlined: true,
+        selected: true,
       })
     ).toMatchObject({
-      selectedBackgroundColor: color('purple').darken(0.08).rgb().string(),
+      backgroundColor: color('purple').darken(0.08).rgb().string(),
     });
   });
 
@@ -524,9 +532,10 @@ describe('getChipColor - selected background color', () => {
         theme: getTheme(false, false),
         customBackgroundColor: 'purple',
         isOutlined: false,
+        selected: true,
       })
     ).toMatchObject({
-      selectedBackgroundColor: color('purple').darken(0.2).rgb().string(),
+      backgroundColor: color('purple').darken(0.2).rgb().string(),
     });
   });
 
@@ -536,9 +545,10 @@ describe('getChipColor - selected background color', () => {
         theme: getTheme(true, false),
         customBackgroundColor: 'purple',
         isOutlined: true,
+        selected: true,
       })
     ).toMatchObject({
-      selectedBackgroundColor: color('purple').lighten(0.2).rgb().string(),
+      backgroundColor: color('purple').lighten(0.2).rgb().string(),
     });
   });
 
@@ -548,9 +558,10 @@ describe('getChipColor - selected background color', () => {
         theme: getTheme(true, false),
         customBackgroundColor: 'purple',
         isOutlined: false,
+        selected: true,
       })
     ).toMatchObject({
-      selectedBackgroundColor: color('purple').lighten(0.4).rgb().string(),
+      backgroundColor: color('purple').lighten(0.4).rgb().string(),
     });
   });
 
@@ -559,9 +570,10 @@ describe('getChipColor - selected background color', () => {
       getChipColors({
         theme: getTheme(false, false),
         isOutlined: true,
+        selected: true,
       })
     ).toMatchObject({
-      selectedBackgroundColor: color(getTheme(false, false).colors.surface)
+      backgroundColor: color(getTheme(false, false).colors.surface)
         .darken(0.08)
         .rgb()
         .string(),
@@ -573,9 +585,10 @@ describe('getChipColor - selected background color', () => {
       getChipColors({
         theme: getTheme(false, false),
         isOutlined: false,
+        selected: true,
       })
     ).toMatchObject({
-      selectedBackgroundColor: color('#ebebeb').darken(0.2).rgb().string(),
+      backgroundColor: color('#ebebeb').darken(0.2).rgb().string(),
     });
   });
 
@@ -584,9 +597,36 @@ describe('getChipColor - selected background color', () => {
       getChipColors({
         theme: getTheme(true, false),
         isOutlined: false,
+        selected: true,
       })
     ).toMatchObject({
-      selectedBackgroundColor: color('#383838').lighten(0.4).rgb().string(),
+      backgroundColor: color('#383838').lighten(0.4).rgb().string(),
+    });
+  });
+
+  it('should return custom selectedBackgroundColor when provided & chip is selected', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+        customSelectedBackgroundColor: 'red',
+        isOutlined: false,
+        selected: true,
+      })
+    ).toMatchObject({
+      backgroundColor: 'red',
+    });
+  });
+
+  it('should return custom selectedBackgroundColor for version 2 theme, when chip is selected', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(false, false),
+        customSelectedBackgroundColor: 'red',
+        isOutlined: false,
+        selected: true,
+      })
+    ).toMatchObject({
+      backgroundColor: 'red',
     });
   });
 });
@@ -673,15 +713,31 @@ describe('getChipColor - border color', () => {
     });
   });
 
-  it('should return custom color, for theme version 3', () => {
+  it('should return custom color, for theme version 3, when selected', () => {
     expect(
       getChipColors({
         theme: getTheme(),
         selectedColor: 'purple',
         isOutlined: false,
+        selected: true,
       })
     ).toMatchObject({
       borderColor: 'transparent',
+      textColor: 'purple',
+    });
+  });
+
+  it('should return theme color, for theme version 3, when unselected', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(false, true),
+        selectedColor: 'purple',
+        isOutlined: false,
+        selected: false,
+      })
+    ).toMatchObject({
+      borderColor: 'transparent',
+      textColor: getTheme(false, true).colors.onSecondaryContainer,
     });
   });
 

--- a/src/components/__tests__/Chip.test.tsx
+++ b/src/components/__tests__/Chip.test.tsx
@@ -272,6 +272,7 @@ describe('getChipColors - icon color', () => {
         theme: getTheme(),
         selectedColor: 'purple',
         isOutlined: false,
+        selected: true,
       })
     ).toMatchObject({
       iconColor: 'purple',
@@ -284,6 +285,7 @@ describe('getChipColors - icon color', () => {
         theme: getTheme(false, false),
         selectedColor: 'purple',
         isOutlined: false,
+        selected: true,
       })
     ).toMatchObject({
       iconColor: color('purple').alpha(0.54).rgb().string(),
@@ -326,6 +328,7 @@ describe('getChipColors - ripple color', () => {
         theme: getTheme(),
         selectedColor: 'purple',
         isOutlined: false,
+        selected: true,
       })
     ).toMatchObject({
       rippleColor: color('purple').alpha(0.12).rgb().string(),
@@ -338,6 +341,7 @@ describe('getChipColors - ripple color', () => {
         theme: getTheme(false, false),
         selectedColor: 'purple',
         isOutlined: false,
+        selected: true,
       })
     ).toMatchObject({
       rippleColor: color('purple').fade(0.5).rgb().string(),


### PR DESCRIPTION
### Motivation

This PR addresses a bug and adds a new feature to the Chip component:

1. **Bug fix**: The `selectedColor` prop was incorrectly applying to chips regardless of their selected state. This has been fixed by properly passing the `selected` state to the `getTextColor` helper function, so `selectedColor` now only applies when the chip is actually selected.

2. **New feature**: Added support for the `selectedBackgroundColor` prop. Previously, developers had to manually manage selected background colors by passing conditional styles like `style={{ backgroundColor: selected ? "black" : "white" }}`. Now the `selectedBackgroundColor` prop provides a declarative way to specify the background color for selected chips, making the API more consistent and easier to use.

Additionally, this PR improves documentation and examples:
- Added comprehensive JSDoc documentation for the `theme` prop, detailing which theme properties are used and for what purpose (separated by V3/V2 themes)
- Reorganized the ChipExample into logical subsections for better clarity and easier navigation
- Added examples demonstrating the new `selectedBackgroundColor` prop

### Related issue
Fixes `selectedColor` applying to unselected chips and adds the new `selectedBackgroundColor` prop for easier selected state styling.

### Test plan

**Functional changes:**
1. Run `yarn test` to verify all 67 tests pass, including 3 new tests for `selectedBackgroundColor`
2. Run `yarn typescript` to verify type safety
3. Run `yarn lint` to verify code style compliance

**Visual verification:**
1. Run the example app: `yarn example start`
2. Navigate to the Chip example screen
3. Verify the following behavior:
   - In "Custom selected color" section: Chips with `selectedColor` only show the custom color when `selected={true}`, not when `selected={false}`
   - In "Custom styling" section: Selected chip with `selectedBackgroundColor="rgba(0, 0, 0, 1)"` displays black background with white text (previously would have required conditional style prop)
   - Toggle chips between selected/unselected states to verify colors apply correctly

**Documentation:**
- Review JSDoc for `theme` prop in `Chip.tsx` - should document all theme properties used
- Review reorganized ChipExample sections for improved clarity

### Screenshot(s)
<img width="1266" height="728" alt="image" src="https://github.com/user-attachments/assets/a5acbd55-99ee-4bdc-b3ca-eaaf42753796" />