### PR TITLE
feat: add debounce functionality to TouchableRipple

### DIFF
--- a/example/src/Examples/TouchableRippleExample.tsx
+++ b/example/src/Examples/TouchableRippleExample.tsx
@@ -1,22 +1,108 @@
 import * as React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, ScrollView } from 'react-native';
 
-import { Text, TouchableRipple } from 'react-native-paper';
+import { Text, TouchableRipple, Button, Divider } from 'react-native-paper';
 
 import ScreenWrapper from '../ScreenWrapper';
 
 const RippleExample = () => {
+  const [pressCount, setPressCount] = React.useState(0);
+  const [debouncedPressCount, setDebouncedPressCount] = React.useState(0);
+  const [lastPressTime, setLastPressTime] = React.useState<number | null>(null);
+
+  const handleNormalPress = () => {
+    const now = Date.now();
+    setPressCount((prev) => prev + 1);
+    setLastPressTime(now);
+  };
+
+  const handleDebouncedPress = () => {
+    const now = Date.now();
+    setDebouncedPressCount((prev) => prev + 1);
+    setLastPressTime(now);
+  };
+
+  const resetCounters = () => {
+    setPressCount(0);
+    setDebouncedPressCount(0);
+    setLastPressTime(null);
+  };
+
   return (
-    <ScreenWrapper contentContainerStyle={styles.container}>
-      <TouchableRipple
-        style={styles.ripple}
-        onPress={() => {}}
-        rippleColor="rgba(0, 0, 0, .32)"
-      >
-        <View pointerEvents="none">
-          <Text variant="bodyMedium">Press anywhere</Text>
+    <ScreenWrapper>
+      <ScrollView contentContainerStyle={styles.container}>
+        <View style={styles.section}>
+          <Text variant="titleMedium" style={styles.sectionTitle}>
+            Basic TouchableRipple
+          </Text>
+          <TouchableRipple
+            style={styles.basicRipple}
+            onPress={() => {}}
+            rippleColor="rgba(0, 0, 0, .32)"
+          >
+            <View pointerEvents="none">
+              <Text variant="bodyMedium">Press anywhere</Text>
+            </View>
+          </TouchableRipple>
         </View>
-      </TouchableRipple>
+
+        <Divider style={styles.divider} />
+
+        <View style={styles.section}>
+          <Text variant="titleMedium" style={styles.sectionTitle}>
+            Debounce Test
+          </Text>
+          
+          <View style={styles.statsContainer}>
+            <Text variant="bodyLarge">Normal Presses: {pressCount}</Text>
+            <Text variant="bodyLarge">Debounced Presses: {debouncedPressCount}</Text>
+            {lastPressTime && (
+              <Text variant="bodyMedium" style={styles.timeText}>
+                Last Press: {new Date(lastPressTime).toLocaleTimeString()}
+              </Text>
+            )}
+          </View>
+
+          <Text variant="bodySmall" style={styles.instructionText}>
+            Try clicking rapidly on both buttons to see the difference:
+          </Text>
+
+          <TouchableRipple
+            onPress={handleNormalPress}
+            style={[styles.testButton, styles.normalButton]}
+            rippleColor="rgba(33, 150, 243, 0.32)"
+          >
+            <View style={styles.buttonContent}>
+              <Text variant="titleSmall" style={styles.normalButtonText}>
+                Normal Button
+              </Text>
+              <Text variant="bodySmall" style={styles.buttonSubtext}>
+                No debounce - all clicks counted
+              </Text>
+            </View>
+          </TouchableRipple>
+
+          <TouchableRipple
+            onPress={handleDebouncedPress}
+            debounce={500} // 500ms debounce
+            style={[styles.testButton, styles.debouncedButton]}
+            rippleColor="rgba(76, 175, 80, 0.32)"
+          >
+            <View style={styles.buttonContent}>
+              <Text variant="titleSmall" style={styles.debouncedButtonText}>
+                Debounced Button (500ms)
+              </Text>
+              <Text variant="bodySmall" style={styles.buttonSubtext}>
+                Rapid clicks ignored within 500ms
+              </Text>
+            </View>
+          </TouchableRipple>
+
+          <Button mode="outlined" onPress={resetCounters} style={styles.resetButton}>
+            Reset Counters
+          </Button>
+        </View>
+      </ScrollView>
     </ScreenWrapper>
   );
 };
@@ -25,12 +111,72 @@ RippleExample.title = 'TouchableRipple';
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
+    padding: 16,
   },
-  ripple: {
-    flex: 1,
+  section: {
+    marginBottom: 24,
+  },
+  sectionTitle: {
+    marginBottom: 16,
+    fontWeight: 'bold',
+  },
+  basicRipple: {
+    height: 150,
     alignItems: 'center',
     justifyContent: 'center',
+    backgroundColor: '#f5f5f5',
+    borderRadius: 8,
+  },
+  divider: {
+    marginVertical: 16,
+  },
+  statsContainer: {
+    padding: 16,
+    backgroundColor: '#f0f0f0',
+    borderRadius: 8,
+    marginBottom: 16,
+  },
+  timeText: {
+    marginTop: 8,
+    color: '#666',
+  },
+  instructionText: {
+    marginBottom: 16,
+    color: '#666',
+    textAlign: 'center',
+  },
+  testButton: {
+    padding: 20,
+    borderRadius: 8,
+    marginBottom: 12,
+    borderWidth: 1,
+  },
+  normalButton: {
+    backgroundColor: '#e3f2fd',
+    borderColor: '#2196f3',
+  },
+  debouncedButton: {
+    backgroundColor: '#e8f5e8',
+    borderColor: '#4caf50',
+  },
+  buttonContent: {
+    alignItems: 'center',
+  },
+  normalButtonText: {
+    color: '#1976d2',
+    fontWeight: 'bold',
+  },
+  debouncedButtonText: {
+    color: '#388e3c',
+    fontWeight: 'bold',
+  },
+  buttonSubtext: {
+    color: '#666',
+    marginTop: 4,
+    textAlign: 'center',
+  },
+  resetButton: {
+    marginTop: 8,
   },
 });
 

--- a/src/components/__tests__/TouchableRipple.test.tsx
+++ b/src/components/__tests__/TouchableRipple.test.tsx
@@ -29,6 +29,54 @@ describe('TouchableRipple', () => {
     expect(onPress).toHaveBeenCalledTimes(1);
   });
 
+  it('debounces onPress when debounce prop is provided', () => {
+    jest.useFakeTimers();
+    const onPress = jest.fn();
+    const { getByText } = render(
+      <TouchableRipple onPress={onPress} debounce={300}>
+        <Text>Button</Text>
+      </TouchableRipple>
+    );
+
+    const button = getByText('Button');
+    
+    // Press multiple times rapidly
+    fireEvent.press(button);
+    fireEvent.press(button);
+    fireEvent.press(button);
+
+    // Should only be called once due to debouncing
+    expect(onPress).toHaveBeenCalledTimes(1);
+
+    // Fast forward time past debounce window
+    jest.advanceTimersByTime(400);
+
+    // Now pressing should work again
+    fireEvent.press(button);
+    expect(onPress).toHaveBeenCalledTimes(2);
+
+    jest.useRealTimers();
+  });
+
+  it('does not debounce when debounce is not provided', () => {
+    const onPress = jest.fn();
+    const { getByText } = render(
+      <TouchableRipple onPress={onPress}>
+        <Text>Button</Text>
+      </TouchableRipple>
+    );
+
+    const button = getByText('Button');
+    
+    // Press multiple times rapidly
+    fireEvent.press(button);
+    fireEvent.press(button);
+    fireEvent.press(button);
+
+    // Should be called for each press
+    expect(onPress).toHaveBeenCalledTimes(3);
+  });
+
   it('disables the button when disabled prop is true', () => {
     const onPress = jest.fn();
     const { getByText } = render(


### PR DESCRIPTION
- Add optional debounce prop to prevent rapid successive presses
- Implement debounce logic in both web and native TouchableRipple components
- Add comprehensive test interface in TouchableRipple example
- Update documentation with usage examples
- Maintain backward compatibility with existing code

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Had to write extra code just to implement this in my apps


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add optional debounce to `TouchableRipple` (web/native), wire it to `onPress`, and update examples and tests.
> 
> - **Components**:
>   - Add optional `debounce` prop to `TouchableRipple` (web: `src/components/TouchableRipple/TouchableRipple.tsx`, native: `src/components/TouchableRipple/TouchableRipple.native.tsx`).
>   - Implement `debouncedOnPress` using `Date.now()` + ref; hook into `Pressable` via `onPress={debouncedOnPress}`.
>   - Minor typing adjustments for `PressableStateCallbackType` on web.
> - **Examples**:
>   - Revamp `example/src/Examples/TouchableRippleExample.tsx` with a scrollable demo showcasing basic ripple and a debounce test (normal vs debounced buttons, counters, reset).
> - **Tests**:
>   - Extend `src/components/__tests__/TouchableRipple.test.tsx` to cover debounced vs non-debounced presses and existing behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c77ad85a5b2e6df49beb392f4f8f6f99d9e9aca6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->