### PR TITLE
feat: add expandDirection prop to List.Accordion/Group (#4852)

### DIFF
--- a/example/src/Examples/ListAccordionExample.tsx
+++ b/example/src/Examples/ListAccordionExample.tsx
@@ -56,6 +56,17 @@ const ListAccordionExample = () => {
           />
         </List.Accordion>
       </List.Section>
+      <Divider />
+      <List.Section title="Expandable list item (upwards)">
+        <List.Accordion
+          left={(props) => <List.Icon {...props} icon="folder" />}
+          title="Expandable list item"
+          expandDirection="upwards"
+        >
+          <List.Item title="List item 1" />
+          <List.Item title="List item 2" />
+        </List.Accordion>
+      </List.Section>
     </ScreenWrapper>
   );
 };

--- a/example/src/Examples/ListAccordionGroupExample.tsx
+++ b/example/src/Examples/ListAccordionGroupExample.tsx
@@ -71,6 +71,25 @@ const ListAccordionGroupExample = () => {
           </List.Accordion>
         </List.Section>
       </List.AccordionGroup>
+      <List.AccordionGroup expandDirection="upwards">
+        <List.Section title="Accordion Group example (upwards)">
+          <List.Accordion
+            left={(props) => <List.Icon {...props} icon="folder" />}
+            title="Expandable list item"
+            id="1"
+          >
+            <List.Item title="List item 1" />
+            <List.Item title="List item 2" />
+          </List.Accordion>
+          <List.Accordion
+            left={(props) => <List.Icon {...props} icon="folder" />}
+            title="Expandable list item 2"
+            id="2"
+          >
+            <List.Item title="List item 1" />
+          </List.Accordion>
+        </List.Section>
+      </List.AccordionGroup>
     </ScreenWrapper>
   );
 };

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -138,7 +138,6 @@ export type Props = {
   hitSlop?: TouchableRippleProps['hitSlop'];
   /**
    * Sets expansion direction for the accordion.
-   * Can be 'downwards' (default) or 'upwards'.
    */
   expandDirection?: 'downwards' | 'upwards';
 };
@@ -240,7 +239,7 @@ const ListAccordion = ({
   titleMaxFontSizeMultiplier,
   descriptionMaxFontSizeMultiplier,
   hitSlop,
-  expandDirection: expandDirectionProp,
+  expandDirection = 'downwards',
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
   const [expanded, setExpanded] = React.useState<boolean>(
@@ -291,9 +290,6 @@ const ListAccordion = ({
     groupContext && id !== undefined
       ? () => groupContext.onAccordionPress(id)
       : handlePressAction;
-
-  const expandDirection =
-    expandDirectionProp || groupContext?.expandDirection || 'downwards';
 
   const expandedContent = getExpandedContent({
     isExpanded,

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -265,21 +265,21 @@ const ListAccordion = ({
   const expandedContent = isExpanded
     ? React.Children.map(children, (child) => {
         if (
-          left &&
-          React.isValidElement<ListChildProps>(child) &&
-          !child.props.left &&
-          !child.props.right
+          !left ||
+          !React.isValidElement<ListChildProps>(child) ||
+          child.props.left ||
+          child.props.right
         ) {
-          return React.cloneElement(child, {
-            style: [
-              theme.isV3 ? styles.childV3 : styles.child,
-              child.props.style,
-            ],
-            theme,
-          });
+          return child;
         }
 
-        return child;
+        return React.cloneElement(child, {
+          style: [
+            theme.isV3 ? styles.childV3 : styles.child,
+            child.props.style,
+          ],
+          theme,
+        });
       })
     : null;
 

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -136,6 +136,11 @@ export type Props = {
    * This can be used to enlarge the touchable area beyond the visible component.
    */
   hitSlop?: TouchableRippleProps['hitSlop'];
+  /**
+   * Sets expansion direction for the accordion.
+   * Can be 'downwards' (default) or 'upwards'.
+   */
+  expandDirection?: 'downwards' | 'upwards';
 };
 
 /**
@@ -202,6 +207,7 @@ const ListAccordion = ({
   titleMaxFontSizeMultiplier,
   descriptionMaxFontSizeMultiplier,
   hitSlop,
+  expandDirection: expandDirectionProp,
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
   const [expanded, setExpanded] = React.useState<boolean>(
@@ -252,8 +258,34 @@ const ListAccordion = ({
     groupContext && id !== undefined
       ? () => groupContext.onAccordionPress(id)
       : handlePressAction;
+
+  const expandDirection =
+    expandDirectionProp || groupContext?.expandDirection || 'downwards';
+
+  const expandedContent = isExpanded
+    ? React.Children.map(children, (child) => {
+        if (
+          left &&
+          React.isValidElement<ListChildProps>(child) &&
+          !child.props.left &&
+          !child.props.right
+        ) {
+          return React.cloneElement(child, {
+            style: [
+              theme.isV3 ? styles.childV3 : styles.child,
+              child.props.style,
+            ],
+            theme,
+          });
+        }
+
+        return child;
+      })
+    : null;
+
   return (
     <View>
+      {expandDirection === 'upwards' ? expandedContent : null}
       <View style={{ backgroundColor: theme?.colors?.background }}>
         <TouchableRipple
           style={[theme.isV3 ? styles.containerV3 : styles.container, style]}
@@ -339,26 +371,7 @@ const ListAccordion = ({
         </TouchableRipple>
       </View>
 
-      {isExpanded
-        ? React.Children.map(children, (child) => {
-            if (
-              left &&
-              React.isValidElement<ListChildProps>(child) &&
-              !child.props.left &&
-              !child.props.right
-            ) {
-              return React.cloneElement(child, {
-                style: [
-                  theme.isV3 ? styles.childV3 : styles.child,
-                  child.props.style,
-                ],
-                theme,
-              });
-            }
-
-            return child;
-          })
-        : null}
+      {expandDirection === 'downwards' ? expandedContent : null}
     </View>
   );
 };

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -18,7 +18,7 @@ import { ListAccordionGroupContext } from './ListAccordionGroup';
 import type { ListChildProps, Style } from './utils';
 import { getAccordionColors, getLeftStyles } from './utils';
 import { useInternalTheme } from '../../core/theming';
-import type { ThemeProp } from '../../types';
+import type { InternalTheme, ThemeProp } from '../../types';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
 import TouchableRipple, {
   Props as TouchableRippleProps,
@@ -180,6 +180,39 @@ export type Props = {
  * export default MyComponent;
  * ```
  */
+function getExpandedContent({
+  isExpanded,
+  children,
+  left,
+  theme,
+}: {
+  isExpanded: boolean;
+  children: React.ReactNode;
+  left?: Props['left'];
+  theme: InternalTheme;
+}) {
+  return isExpanded
+    ? React.Children.map(children, (child) => {
+        if (
+          !left ||
+          !React.isValidElement<ListChildProps>(child) ||
+          child.props.left ||
+          child.props.right
+        ) {
+          return child;
+        }
+
+        return React.cloneElement(child, {
+          style: [
+            theme.isV3 ? styles.childV3 : styles.child,
+            child.props.style,
+          ],
+          theme,
+        });
+      })
+    : null;
+}
+
 const ListAccordion = ({
   left,
   right,
@@ -262,26 +295,12 @@ const ListAccordion = ({
   const expandDirection =
     expandDirectionProp || groupContext?.expandDirection || 'downwards';
 
-  const expandedContent = isExpanded
-    ? React.Children.map(children, (child) => {
-        if (
-          !left ||
-          !React.isValidElement<ListChildProps>(child) ||
-          child.props.left ||
-          child.props.right
-        ) {
-          return child;
-        }
-
-        return React.cloneElement(child, {
-          style: [
-            theme.isV3 ? styles.childV3 : styles.child,
-            child.props.style,
-          ],
-          theme,
-        });
-      })
-    : null;
+  const expandedContent = getExpandedContent({
+    isExpanded,
+    children,
+    left,
+    theme,
+  });
 
   return (
     <View>

--- a/src/components/List/ListAccordionGroup.tsx
+++ b/src/components/List/ListAccordionGroup.tsx
@@ -15,7 +15,6 @@ export type Props = {
   children: React.ReactNode;
   /**
    * Sets expansion direction for all accordions in the group.
-   * Can be 'downwards' (default) or 'upwards'.
    */
   expandDirection?: 'downwards' | 'upwards';
 };
@@ -66,7 +65,7 @@ const ListAccordionGroup = ({
   expandedId: expandedIdProp,
   onAccordionPress,
   children,
-  expandDirection,
+  expandDirection = 'downwards',
 }: Props) => {
   const [expandedId, setExpandedId] = React.useState<
     string | number | undefined

--- a/src/components/List/ListAccordionGroup.tsx
+++ b/src/components/List/ListAccordionGroup.tsx
@@ -13,11 +13,17 @@ export type Props = {
    * React elements containing list accordions
    */
   children: React.ReactNode;
+  /**
+   * Sets expansion direction for all accordions in the group.
+   * Can be 'downwards' (default) or 'upwards'.
+   */
+  expandDirection?: 'downwards' | 'upwards';
 };
 
 export type ListAccordionGroupContextType = {
   expandedId: string | number | undefined;
   onAccordionPress: (expandedId: string | number) => void;
+  expandDirection?: 'downwards' | 'upwards';
 } | null;
 
 export const ListAccordionGroupContext =
@@ -60,6 +66,7 @@ const ListAccordionGroup = ({
   expandedId: expandedIdProp,
   onAccordionPress,
   children,
+  expandDirection,
 }: Props) => {
   const [expandedId, setExpandedId] = React.useState<
     string | number | undefined
@@ -76,6 +83,7 @@ const ListAccordionGroup = ({
       value={{
         expandedId: expandedIdProp || expandedId, // component can be controlled or uncontrolled
         onAccordionPress: onAccordionPress || onAccordionPressDefault,
+        expandDirection,
       }}
     >
       {children}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

upward-expanding-lists are common on the web.

### Related issue

https://github.com/callstack/react-native-paper/issues/4852

### Test plan

check out the last `List.Section` components of :
`example/src/Examples/ListAccordionExample.tsx` and `example/src/Examples/ListAccordionGroupExample.tsx`

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
