### PR TITLE
fix: textinput multiline hidden lable issue on ios and web

### DIFF
--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -466,10 +466,10 @@ const styles = StyleSheet.create({
   },
   patchContainer: {
     height: 24,
-    zIndex: 2,
+    zIndex: 0,
   },
   densePatchContainer: {
     height: 22,
-    zIndex: 2,
+    zIndex: 0,
   },
 });


### PR DESCRIPTION
### Problem

When a `TextInput` gains focus (particularly with `mode="flat"`), the label disappears. This issue does not occur when `multiline` is set to `false`, where the label behaves as expected.

### Motivation

A `patchContainer` was introduced to address an earlier issue ([#2799](https://github.com/callstack/react-native-paper/issues/2799)). However, the container was assigned a `zIndex` of `2`, which causes it to overlap and hide the actual label when the `TextInput` is focused.  
To fix this, the `zIndex` has been reduced to `0`. With this change, the label remains visible and functions correctly. The fix has been tested successfully on iOS, Android, and Web.

### Related Issue

- https://github.com/callstack/react-native-paper/issues/4756

### Test Plan

All existing tests pass successfully.