### PR TITLE
feat: allow custom Image component in Card.Cover

### DIFF
--- a/src/components/Card/CardCover.tsx
+++ b/src/components/Card/CardCover.tsx
@@ -21,6 +21,10 @@ export type Props = React.ComponentPropsWithRef<typeof Image> & {
    * @optional
    */
   theme?: ThemeProp;
+  /**
+   * Optional custom image component to replace default Image
+   */
+  imageComponent?: React.ComponentType<any>;
 };
 
 /**
@@ -47,6 +51,7 @@ const CardCover = ({
   total,
   style,
   theme: themeOverrides,
+  imageComponent: ImageComponent,
   ...rest
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
@@ -66,11 +71,18 @@ const CardCover = ({
 
   return (
     <View style={[styles.container, coverStyle, style]}>
-      <Image
-        {...rest}
-        style={[styles.image, coverStyle]}
-        accessibilityIgnoresInvertColors
-      />
+      {ImageComponent ? (
+        <ImageComponent
+          {...rest}
+          style={[styles.image, coverStyle]}
+        />
+      ) : (
+        <Image
+          {...rest}
+          style={[styles.image, coverStyle]}
+          accessibilityIgnoresInvertColors
+        />
+      )}
     </View>
   );
 };


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
The Image component from react-native doesn't pass headers in the http request (at least not on android in react-native version 0.83.1)
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### Related issue
Closes #4869
<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
