### PR TITLE
fix: fix Menu briefly flashes on first open

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -345,23 +345,25 @@ const Menu = ({
     });
 
     attachListeners();
-    const { animation } = theme;
-    Animated.parallel([
-      Animated.timing(scaleAnimationRef.current, {
-        toValue: { x: menuLayoutResult.width, y: menuLayoutResult.height },
-        duration: ANIMATION_DURATION * animation.scale,
-        easing: EASING,
-        useNativeDriver: true,
-      }),
-      Animated.timing(opacityAnimationRef.current, {
-        toValue: 1,
-        duration: ANIMATION_DURATION * animation.scale,
-        easing: EASING,
-        useNativeDriver: true,
-      }),
-    ]).start(() => {
-      focusFirstDOMNode(menuRef.current);
-      prevRendered.current = true;
+    requestAnimationFrame(() => {
+      const { animation } = theme;
+      Animated.parallel([
+        Animated.timing(scaleAnimationRef.current, {
+          toValue: { x: menuLayoutResult.width, y: menuLayoutResult.height },
+          duration: ANIMATION_DURATION * animation.scale,
+          easing: EASING,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacityAnimationRef.current, {
+          toValue: 1,
+          duration: ANIMATION_DURATION * animation.scale,
+          easing: EASING,
+          useNativeDriver: true,
+        }),
+      ]).start(() => {
+        focusFirstDOMNode(menuRef.current);
+        prevRendered.current = true;
+      });
     });
   }, [anchor, attachListeners, measureAnchorLayout, theme]);
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

PR fixes an issue where the Menu component would briefly flash/flicker on the first interaction due to executing animation during calculation of initial position. 

### Related issue

https://github.com/callstack/react-native-paper/issues/4827


<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
       <video src="https://github.com/user-attachments/assets/cd2b1603-ef50-4679-a2e5-a447c519056d" />
    </td>
    <td>
        <video src="https://github.com/user-attachments/assets/330b3afc-85e3-4591-ab1c-15a340be214f" />
    </td>
</tr>
  <tr>
    <td>
       <video src="https://github.com/user-attachments/assets/a7c1971e-7d92-4821-b3ff-b978a56cbacb" />
    </td>
    <td>
        <video src="https://github.com/user-attachments/assets/dfe6a833-cb58-4979-8913-11794ebc95e8" />
    </td>
</tr>
<tr>
    <td>
       <video src="https://github.com/user-attachments/assets/0af606b0-1071-462b-9f1c-d77fb61e60e3" />
    </td>
    <td>
        <video src="https://github.com/user-attachments/assets/e8612d8b-01ea-4447-b7e2-42ad83c9ae97" />
    </td>
</tr>
</table>


### Test plan

I was able to reproduce mentioned issue on Menu Example screen in the example app.

1. Open Example app
2. Go to Menu screen
3. Tap on any button that opens Menu component.

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
