### PR TITLE
fix: use ReactElement | null for Text and AnimatedText return type (fixes #4871)

### DIFF
--- a/src/components/Typography/AnimatedText.tsx
+++ b/src/components/Typography/AnimatedText.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { ReactNode } from 'react';
 import {
   Animated,
   I18nManager,
@@ -103,6 +102,6 @@ const styles = StyleSheet.create({
 });
 
 export const customAnimatedText = <T,>() =>
-  AnimatedText as (props: Props<T>) => ReactNode;
+  AnimatedText as (props: Props<T>) => React.ReactElement | null;
 
 export default AnimatedText;

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { ReactNode } from 'react';
 import {
   I18nManager,
   StyleProp,
@@ -178,7 +177,7 @@ const styles = StyleSheet.create({
 
 type TextComponent<T> = (
   props: Props<T> & { ref?: React.RefObject<TextRef> }
-) => ReactNode;
+) => React.ReactElement | null;
 
 const Component = forwardRef(Text) as TextComponent<never>;
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

After upgrading to react-native-paper v5.15.0, consumers see TypeScript errors when using `Text` (and when using `styled(Text)`):

1. **`Text` as JSX:** `'Text' cannot be used as a JSX component. Its return type 'ReactNode' is not a valid JSX element.`
2. **`styled(Text)`:** `Argument of type 'TextComponent<never>' is not assignable to parameter of type 'NativeTarget' | 'WebTarget'.`

This happens because the exported component types declared a return type of `ReactNode`. In current React/TypeScript, a component used as JSX must return `React.ReactElement | null`. This change updates the `TextComponent` and `customAnimatedText` typings to return `React.ReactElement | null` so that `Text` and `AnimatedText` are valid JSX components and compatible with `styled()`.

### Related issue

Fixes #4871

### Test plan

- **TypeScript:** Run `yarn typescript` in the repo root (and in a consumer app using `Text` and optionally `styled(Text)`) and confirm no type errors.
- **Lint/tests:** Run `yarn lint` and `yarn test` to ensure nothing else is broken.
- **Usage:** Use `<Text>`, `<AnimatedText>`, and `styled(Text)` in a TypeScript project; `tsc --noEmit` (or `bun run tsc:check`) should pass.

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
