### PR TITLE
fix: Add aria-hidden to interior radio button in RadioButtonItem

### DIFF
--- a/src/components/RadioButton/RadioButtonItem.tsx
+++ b/src/components/RadioButton/RadioButtonItem.tsx
@@ -177,7 +177,7 @@ const RadioButtonItem = ({
   let radioButton: any;
 
   if (mode === 'android') {
-    radioButton = <RadioButtonAndroid {...radioButtonProps} />;
+    radioButton = <RadioButtonAndroid {...radioButtonProps} aria-hidden />;
   } else if (mode === 'ios') {
     radioButton = <RadioButtonIOS {...radioButtonProps} />;
   } else {

--- a/src/components/RadioButton/RadioButtonItem.tsx
+++ b/src/components/RadioButton/RadioButtonItem.tsx
@@ -177,6 +177,7 @@ const RadioButtonItem = ({
   let radioButton: any;
 
   if (mode === 'android') {
+    // aria-hidden ensures that Talkback does not read out the interior radio button as a separate element
     radioButton = <RadioButtonAndroid {...radioButtonProps} aria-hidden />;
   } else if (mode === 'ios') {
     radioButton = <RadioButtonIOS {...radioButtonProps} />;

--- a/src/components/__tests__/RadioButton/__snapshots__/RadioButtonItem.test.tsx.snap
+++ b/src/components/__tests__/RadioButton/__snapshots__/RadioButtonItem.test.tsx.snap
@@ -290,6 +290,7 @@ exports[`can render the Android radio button on different platforms 1`] = `
         }
       }
       accessible={true}
+      aria-hidden={true}
       collapsable={false}
       focusable={true}
       onBlur={[Function]}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

tl;dr - `RadioButton.Item` re-presents the interior `RadioButton` when using Android TalkBack.

Android Talkback is Android's screen-reader, and it behaves somewhat differently than iOS's VoiceOver (which is more commonly used for screen-reader auditing). Talkback allows access to buttons-within-buttons (iOS does not), which can be a confusing experience for Talkback users if both the outer and inner buttons on an element present themselves as distinct elements, when in fact it's just a button with an `onPress` on an outer container as well as the inner button.

In the case of `Radiobutton.Item`, which groups a radio button and a label, Talkback first presents the user with the pressable radio button + label, as intended. However, it then presents just the radio button, which is within the `RadioButton.Item`, as a separate element. This is confusing, and is never the intended behavior. 

This PR adds `aria-hidden`, which Talkback recognizes, to the inner `RadioButton` in `RadioButtonItem`, ensuring that Talkback does not read out the interior radio button as a separate element. It is still read out as part of the radio button + label group, as intended. 

This change has no effect on iOS, as iOS does not reveal child pressables to VoiceOver (precisely for this reason). 

It has no effect on the non screen-reader experience on any platform. 

### Related issue

https://github.com/callstack/react-native-paper/issues/4881

### Test plan

Attempt to navigate a `RadioButton.Item` with Android Talkback, iOS VoiceOver, and no screen reader. (I completed these tests locally.)
