### PR TITLE
fix: android radio button off center dot

### DIFF
--- a/src/components/RadioButton/RadioButtonAndroid.tsx
+++ b/src/components/RadioButton/RadioButtonAndroid.tsx
@@ -153,17 +153,15 @@ const RadioButtonAndroid = ({
               ]}
             >
               {checked ? (
-                <View style={[StyleSheet.absoluteFill, styles.radioContainer]}>
-                  <Animated.View
-                    style={[
-                      styles.dot,
-                      {
-                        backgroundColor: selectionControlColor,
-                        transform: [{ scale: radioAnim }],
-                      },
-                    ]}
-                  />
-                </View>
+                <Animated.View
+                  style={[
+                    styles.dot,
+                    {
+                      backgroundColor: selectionControlColor,
+                      transform: [{ scale: radioAnim }],
+                    },
+                  ]}
+                />
               ) : null}
             </Animated.View>
           </TouchableRipple>
@@ -179,11 +177,9 @@ const styles = StyleSheet.create({
   container: {
     borderRadius: 18,
   },
-  radioContainer: {
+  radio: {
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  radio: {
     height: 20,
     width: 20,
     borderRadius: 10,


### PR DESCRIPTION
### Motivation

The android radio button dot was off-center so i fixed it.

### Related issue

callstack/react-native-paper#3628

### Test plan

Use the RadioButton component and run in android environment.

| Note | Preview |
| --- | --- |
| Before & After | <img width="1080" height="1080" alt="Screenshot_2026-04-18-19-33-07-616_host exp exponent" src="https://github.com/user-attachments/assets/abb55008-04fa-44a8-968c-973fb10ecf8b" /> |
| Video to prove animation is unhindered | https://github.com/user-attachments/assets/6ad7d834-3f01-43b7-be2c-ce88da783d81 |
