### PR TITLE
fix(animated-fab): correct Android shadow/content stacking

### DIFF
--- a/src/components/FAB/AnimatedFAB.tsx
+++ b/src/components/FAB/AnimatedFAB.tsx
@@ -130,6 +130,8 @@ export type Props = $Omit<$RemoveChildren<typeof Surface>, 'mode'> & {
 
 const SIZE = 56;
 const SCALE = 0.9;
+const SHADOW_LAYER_Z_INDEX = 1;
+const CONTENT_LAYER_Z_INDEX = 2;
 
 /**
  * An animated, extending horizontally floating action button represents the primary action in an application.
@@ -596,9 +598,19 @@ const styles = StyleSheet.create({
   innerWrapper: {
     flexDirection: 'row',
     overflow: 'hidden',
+    ...Platform.select({
+      android: {
+        zIndex: CONTENT_LAYER_Z_INDEX,
+      },
+    }),
   },
   shadowWrapper: {
     elevation: 0,
+    ...Platform.select({
+      android: {
+        zIndex: SHADOW_LAYER_Z_INDEX,
+      },
+    }),
   },
   shadow: {
     elevation: 6,


### PR DESCRIPTION
### Motivation

This PR fixes a stacking issue affecting `AnimatedFAB` on Android 9. The component renders shadow and content as sibling layers and on Android 9 an elevated view also affects z-order for overlapping siblings. In this case, the elevated shadow layer can render above the FAB content. This change explicitly sets the sibling z-index on Android so the content stays above the shadow.


### Related issue

https://github.com/callstack/react-native-paper/issues/4848

<!-- If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here. -->

### Test plan


<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<video src="https://github.com/user-attachments/assets/f5dcf709-d89e-40f2-8326-a885272be01a" />
    </td>
    <td>
<video src="https://github.com/user-attachments/assets/32c5c0d0-c8f5-4693-95fe-d1c04f32ae89" />
    </td>
</tr>
  <tr>
    <td>
<video src="https://github.com/user-attachments/assets/b7536ec8-78fd-49ec-8d26-a47c7b4af4ea" />
    </td>
    <td>
<video src="https://github.com/user-attachments/assets/34b2779c-b150-4660-935c-f0d3d8397442" />
    </td>
</tr>
</table>

<!-- Describe the **steps to test this change**, so that a reviewer can verify it. Provide screenshots or videos if the change affects UI. -->

<!-- Keep in mind that PR changes must pass lint, typescript and tests. -->
