### PR TITLE
Fix react native 0.85 absolutefillobject

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -236,7 +236,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   wrapper: {
-    ...(StyleSheet.absoluteFill),
+    ...StyleSheet.absoluteFill,
     justifyContent: 'center',
   },
   // eslint-disable-next-line react-native/no-color-literals

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -236,13 +236,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   wrapper: {
-    ...(StyleSheet.absoluteFillObject || {
-      position: 'absolute',
-      left: 0,
-      right: 0,
-      top: 0,
-      bottom: 0,
-    }),
+    ...(StyleSheet.absoluteFill),
     justifyContent: 'center',
   },
   // eslint-disable-next-line react-native/no-color-literals

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -236,7 +236,13 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   wrapper: {
-    ...StyleSheet.absoluteFillObject,
+    ...(StyleSheet.absoluteFillObject || {
+      position: 'absolute',
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 0,
+    }),
     justifyContent: 'center',
   },
   // eslint-disable-next-line react-native/no-color-literals

--- a/src/components/TouchableRipple/TouchableRipple.native.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.native.tsx
@@ -135,13 +135,7 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
   underlay: {
-    ...(StyleSheet.absoluteFillObject || {
-      position: 'absolute',
-      left: 0,
-      right: 0,
-      top: 0,
-      bottom: 0,
-    }),
+    ...StyleSheet.absoluteFill,
     zIndex: 2,
   },
 });

--- a/src/components/TouchableRipple/TouchableRipple.native.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.native.tsx
@@ -135,7 +135,13 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
   underlay: {
-    ...StyleSheet.absoluteFillObject,
+    ...(StyleSheet.absoluteFillObject || {
+      position: 'absolute',
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 0,
+    }),
     zIndex: 2,
   },
 });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

This PR fixes a layout regression where Dialogs, Modals, and Portals appear at the bottom of the screen instead of being centered or properly positioned.

The issue was introduced with React Native 0.85, which removed StyleSheet.absoluteFillObject. Since React Native Paper uses the spread operator (...StyleSheet.absoluteFillObject) in several components, these styles were returning undefined, causing absolute positioning to fail.

This change introduces a robust fallback to ensure the library remains compatible with both React Native 0.85+ and older versions.

### Related issue
Fixes an issue where UI components using Portal or Modal lose their fullscreen overlay and centering on RN 0.85.

### Test plan
Environment: React Native 0.85.0, Android/iOS.

Steps:

Open a Dialog or Modal component.

Verify the component is centered on the screen and the underlay covers the entire background.

Backward Compatibility:

Verified that the manual object fallback { position: 'absolute', ... } behaves identically to the previous absoluteFillObject on older versions of React Native.

Before:

Dialogs stuck at the bottom of the screen.

Underlay/Overlay has 0 height/width.

After:

Dialogs correctly centered.

Underlay correctly covers the full screen.
