### PR TITLE
feat: add theme.shapes and cornersToStyle

### DIFF
--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -672,7 +672,7 @@ const TextInputExample = () => {
               <TextInput
                 mode="outlined"
                 theme={{
-                  roundness: 25,
+                  shapes: { corner: { extraSmall: 25 } },
                 }}
                 label="Outlined text input with custom roundness"
               />
@@ -681,7 +681,7 @@ const TextInputExample = () => {
               <TextInput
                 mode="outlined"
                 label="Outlined text input without roundness"
-                theme={{ roundness: 0 }}
+                theme={{ shapes: { corner: { extraSmall: 0 } } }}
               />
             </View>
             <View style={styles.inputContainerStyle}>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -210,7 +210,7 @@ const Button = (
     },
     [mode]
   );
-  const { roundness, animation } = theme;
+  const { animation } = theme;
   const uppercase = uppercaseProp ?? false;
   const isWeb = Platform.OS === 'web';
 
@@ -271,7 +271,7 @@ const Button = (
     (style) => style.startsWith('border') && style.endsWith('Radius')
   );
 
-  const borderRadius = 5 * roundness;
+  const borderRadius = theme.shapes.corner.largeIncreased;
   const iconSize = 18;
 
   const {

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -181,7 +181,7 @@ const Card = (
   const { current: elevationDarkAdaptive } = React.useRef<Animated.Value>(
     new Animated.Value(cardElevation)
   );
-  const { animation, dark, mode, roundness } = theme;
+  const { animation, dark, mode } = theme;
 
   const prevDarkRef = React.useRef<boolean>(dark);
   React.useEffect(() => {
@@ -267,7 +267,7 @@ const Card = (
   );
 
   const borderRadiusCombinedStyles = {
-    borderRadius: 3 * roundness,
+    borderRadius: theme.shapes.corner.medium,
     ...borderRadiusStyles,
   };
 

--- a/src/components/Card/utils.tsx
+++ b/src/components/Card/utils.tsx
@@ -26,17 +26,15 @@ export const getCardCoverStyle = ({
   index?: number;
   total?: number;
 }) => {
-  const { roundness } = theme;
-
   if (Object.keys(borderRadiusStyles).length > 0) {
     return {
-      borderRadius: 3 * roundness,
+      borderRadius: theme.shapes.corner.medium,
       ...borderRadiusStyles,
     };
   }
 
   return {
-    borderRadius: 3 * roundness,
+    borderRadius: theme.shapes.corner.medium,
   };
 };
 

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -205,7 +205,6 @@ const Chip = ({
   ...rest
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
-  const { roundness } = theme;
   const isWeb = Platform.OS === 'web';
 
   const { current: elevation } = React.useRef<Animated.Value>(
@@ -244,7 +243,7 @@ const Chip = ({
   });
 
   const opacity = 0.38;
-  const defaultBorderRadius = roundness * 2;
+  const defaultBorderRadius = theme.shapes.corner.small;
   const iconSize = 18;
 
   const {

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -105,8 +105,7 @@ const Dialog = ({
 }: Props) => {
   const { right, left } = useSafeAreaInsets();
   const theme = useInternalTheme(themeOverrides);
-  const { roundness } = theme as Theme;
-  const borderRadius = 7 * roundness;
+  const borderRadius = (theme as Theme).shapes.corner.extraLarge;
 
   const backgroundColor = theme.colors.surfaceContainerHigh;
 

--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -100,7 +100,6 @@ const DrawerItem = ({
   ...rest
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
-  const { roundness } = theme;
 
   const backgroundColor = active ? theme.colors.secondaryContainer : undefined;
   const contentColor = active
@@ -108,7 +107,7 @@ const DrawerItem = ({
     : theme.colors.onSurfaceVariant;
 
   const labelMargin = icon ? 12 : 0;
-  const borderRadius = 7 * roundness;
+  const borderRadius = theme.shapes.corner.extraLarge;
   const font = theme.fonts.labelLarge;
 
   return (

--- a/src/components/FAB/utils.ts
+++ b/src/components/FAB/utils.ts
@@ -284,10 +284,10 @@ const v3LargeSize = {
   width: 96,
 };
 
-const getCustomFabSize = (customSize: number, roundness: number) => ({
+const getCustomFabSize = (customSize: number) => ({
   height: customSize,
   width: customSize,
-  borderRadius: roundness === 0 ? 0 : customSize / roundness,
+  borderRadius: customSize / 4,
 });
 
 export const getFabStyle = ({
@@ -299,17 +299,15 @@ export const getFabStyle = ({
   size: 'small' | 'medium' | 'large';
   theme: InternalTheme;
 }) => {
-  const { roundness } = theme;
-
-  if (customSize) return getCustomFabSize(customSize, roundness);
+  if (customSize) return getCustomFabSize(customSize);
 
   switch (size) {
     case 'small':
-      return { ...v3SmallSize, borderRadius: 3 * roundness };
+      return { ...v3SmallSize, borderRadius: theme.shapes.corner.medium };
     case 'medium':
-      return { ...v3MediumSize, borderRadius: 4 * roundness };
+      return { ...v3MediumSize, borderRadius: theme.shapes.corner.large };
     case 'large':
-      return { ...v3LargeSize, borderRadius: 7 * roundness };
+      return { ...v3LargeSize, borderRadius: theme.shapes.corner.extraLarge };
   }
 };
 

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -622,7 +622,7 @@ const Menu = ({
         }),
       },
     ],
-    borderRadius: theme.roundness,
+    borderRadius: theme.shapes.corner.extraSmall,
     ...(scrollableMenuHeight ? { height: scrollableMenuHeight } : {}),
   };
 

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -20,6 +20,7 @@ import IconButton from './IconButton/IconButton';
 import MaterialCommunityIcon from './MaterialCommunityIcon';
 import Surface from './Surface';
 import { useInternalTheme } from '../core/theming';
+import { cornerNone } from '../theme/tokens/sys/shape';
 import type { Theme, ThemeProp } from '../types';
 import { forwardRef } from '../utils/forwardRef';
 
@@ -213,7 +214,7 @@ const Searchbar = forwardRef<TextInputHandles, Props>(
       onClearIconPress?.(e);
     };
 
-    const { roundness, dark } = theme;
+    const { dark } = theme;
 
     const placeholderTextColor = theme.colors.onSurface;
     const textColor = theme.colors.onSurfaceVariant;
@@ -237,10 +238,12 @@ const Searchbar = forwardRef<TextInputHandles, Props>(
     return (
       <Surface
         style={[
-          { borderRadius: roundness },
+          { borderRadius: theme.shapes.corner.extraSmall },
           {
             backgroundColor: theme.colors.surfaceContainerHigh,
-            borderRadius: roundness * (isBarMode ? 7 : 0),
+            borderRadius: isBarMode
+              ? theme.shapes.corner.extraLarge
+              : cornerNone,
           },
           styles.container,
           style,

--- a/src/components/SegmentedButtons/SegmentedButtonItem.tsx
+++ b/src/components/SegmentedButtons/SegmentedButtonItem.tsx
@@ -145,7 +145,6 @@ const SegmentedButtonItem = ({
     }
   }, [checked, checkScale, showSelectedCheck]);
 
-  const { roundness } = theme;
   const { borderColor, textColor, textOpacity, borderWidth, backgroundColor } =
     getSegmentedButtonColors({
       checked,
@@ -155,7 +154,7 @@ const SegmentedButtonItem = ({
       uncheckedColor,
     });
 
-  const borderRadius = 5 * roundness;
+  const borderRadius = theme.shapes.corner.largeIncreased;
   const segmentBorderRadius = getSegmentedButtonBorderRadius({
     theme,
     segment,

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -235,7 +235,7 @@ const Snackbar = ({
     }
   }, [visible, handleOnVisible, handleOnHidden]);
 
-  const { colors, roundness } = theme as Theme;
+  const { colors } = theme as Theme;
 
   if (hidden) {
     return null;
@@ -295,7 +295,7 @@ const Snackbar = ({
           styles.container,
           {
             backgroundColor,
-            borderRadius: roundness,
+            borderRadius: (theme as Theme).shapes.corner.extraSmall,
             opacity: opacity,
             transform: [
               {

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -78,7 +78,8 @@ const TextInputFlat = ({
   ...rest
 }: ChildTextInputProps) => {
   const isAndroid = Platform.OS === 'android';
-  const { colors, roundness } = theme;
+  const { colors } = theme;
+  const roundness = theme.shapes.corner.extraSmall;
   const font = theme.fonts.bodyLarge;
   const hasActiveOutline = parentState.focused || error;
 
@@ -156,8 +157,8 @@ const TextInputFlat = ({
 
   const containerStyle = {
     backgroundColor,
-    borderTopLeftRadius: theme.roundness,
-    borderTopRightRadius: theme.roundness,
+    borderTopLeftRadius: roundness,
+    borderTopRightRadius: roundness,
   };
 
   const labelScale = MINIMIZED_LABEL_FONT_SIZE / fontSize;

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -81,7 +81,8 @@ const TextInputOutlined = ({
 }: ChildTextInputProps) => {
   const adornmentConfig = getAdornmentConfig({ left, right });
 
-  const { colors, roundness } = theme;
+  const { colors } = theme;
+  const roundness = theme.shapes.corner.extraSmall;
   const font = theme.fonts.bodyLarge;
   const hasActiveOutline = parentState.focused || error;
 

--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -108,7 +108,7 @@ const ToggleButton = forwardRef<View, Props>(
     ref
   ) => {
     const theme = useInternalTheme(themeOverrides);
-    const borderRadius = theme.roundness;
+    const borderRadius = theme.shapes.corner.extraSmall;
 
     return (
       <ToggleButtonGroupContext.Consumer>

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -209,7 +209,7 @@ const Tooltip = ({
                   measurement as Measurement,
                   children as React.ReactElement<TooltipChildProps>
                 ),
-                borderRadius: theme.roundness,
+                borderRadius: theme.shapes.corner.extraSmall,
                 ...(measurement.measured ? styles.visible : styles.hidden),
               },
             ]}

--- a/src/components/__tests__/Card/Card.test.tsx
+++ b/src/components/__tests__/Card/Card.test.tsx
@@ -220,7 +220,7 @@ describe('getCardCoverStyle - border radius', () => {
         theme: getTheme(),
         borderRadiusStyles: {},
       })
-    ).toMatchObject({ borderRadius: 3 * getTheme().roundness });
+    ).toMatchObject({ borderRadius: getTheme().shapes.corner.medium });
   });
 });
 

--- a/src/components/__tests__/Chip.test.tsx
+++ b/src/components/__tests__/Chip.test.tsx
@@ -83,7 +83,7 @@ it('renders active chip if only onLongPress handler is passed', () => {
 
 it('renders chip with zero border radius', () => {
   const { getByTestId } = render(
-    <Chip testID="active-chip" theme={{ roundness: 0 }}>
+    <Chip testID="active-chip" theme={{ shapes: { corner: { small: 0 } } }}>
       Active chip
     </Chip>
   );

--- a/src/components/__tests__/FAB.test.tsx
+++ b/src/components/__tests__/FAB.test.tsx
@@ -131,7 +131,12 @@ it('renders FAB with custom border radius', () => {
 
 it('renders FAB with zero border radius', () => {
   const { getByTestId } = render(
-    <FAB theme={{ roundness: 0 }} onPress={() => {}} icon="plus" testID="fab" />
+    <FAB
+      theme={{ shapes: { corner: { large: 0 } } }}
+      onPress={() => {}}
+      icon="plus"
+      testID="fab"
+    />
   );
 
   expect(getByTestId('fab-container')).toHaveStyle({ borderRadius: 0 });

--- a/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
@@ -187,7 +187,18 @@ exports[`renders list section with custom title style 1`] = `
           "lineHeight": 20,
         },
       },
-      "roundness": 4,
+      "shapes": {
+        "corner": {
+          "extraExtraLarge": 48,
+          "extraLarge": 28,
+          "extraLargeIncreased": 32,
+          "extraSmall": 4,
+          "large": 16,
+          "largeIncreased": 20,
+          "medium": 12,
+          "small": 8,
+        },
+      },
     }
   }
 >
@@ -729,7 +740,18 @@ exports[`renders list section with subheader 1`] = `
           "lineHeight": 20,
         },
       },
-      "roundness": 4,
+      "shapes": {
+        "corner": {
+          "extraExtraLarge": 48,
+          "extraLarge": 28,
+          "extraLargeIncreased": 32,
+          "extraSmall": 4,
+          "large": 16,
+          "largeIncreased": 20,
+          "medium": 12,
+          "small": 8,
+        },
+      },
     }
   }
 >
@@ -1269,7 +1291,18 @@ exports[`renders list section without subheader 1`] = `
           "lineHeight": 20,
         },
       },
-      "roundness": 4,
+      "shapes": {
+        "corner": {
+          "extraExtraLarge": 48,
+          "extraLarge": 28,
+          "extraLargeIncreased": 32,
+          "extraSmall": 4,
+          "large": 16,
+          "largeIncreased": 20,
+          "medium": 12,
+          "small": 8,
+        },
+      },
     }
   }
 >

--- a/src/theme/schemes/DarkTheme.tsx
+++ b/src/theme/schemes/DarkTheme.tsx
@@ -1,6 +1,7 @@
 import { baseTheme } from './base';
 import { tokens } from '../tokens';
 import { buildScheme } from '../tokens/sys/color/roles';
+import { defaultShapes } from '../tokens/sys/shape';
 import type { Theme } from '../types';
 
 export const DarkTheme: Theme = {
@@ -8,4 +9,5 @@ export const DarkTheme: Theme = {
   dark: true,
   mode: 'adaptive',
   colors: buildScheme(tokens.md.ref.palette, tokens.md.ref, { mode: 'dark' }),
+  shapes: defaultShapes,
 };

--- a/src/theme/schemes/LightTheme.tsx
+++ b/src/theme/schemes/LightTheme.tsx
@@ -1,10 +1,12 @@
 import { baseTheme } from './base';
 import { tokens } from '../tokens';
 import { buildScheme } from '../tokens/sys/color/roles';
+import { defaultShapes } from '../tokens/sys/shape';
 import type { Theme } from '../types';
 
 export const LightTheme: Theme = {
   ...baseTheme,
   dark: false,
   colors: buildScheme(tokens.md.ref.palette, tokens.md.ref, { mode: 'light' }),
+  shapes: defaultShapes,
 };

--- a/src/theme/schemes/base.ts
+++ b/src/theme/schemes/base.ts
@@ -1,7 +1,6 @@
 import configureFonts from '../fonts';
 
 export const baseTheme = {
-  roundness: 4,
   fonts: configureFonts(),
   animation: {
     scale: 1.0,

--- a/src/theme/tokens/sys/shape.ts
+++ b/src/theme/tokens/sys/shape.ts
@@ -1,0 +1,17 @@
+import type { ThemeShapes } from '../../types';
+
+export const cornerNone = 0;
+export const cornerFull = 9999;
+
+export const defaultShapes: ThemeShapes = {
+  corner: {
+    extraSmall: 4,
+    small: 8,
+    medium: 12,
+    large: 16,
+    largeIncreased: 20,
+    extraLarge: 28,
+    extraLargeIncreased: 32,
+    extraExtraLarge: 48,
+  },
+};

--- a/src/theme/types/index.ts
+++ b/src/theme/types/index.ts
@@ -1,6 +1,7 @@
 export * from './color';
 export * from './elevation';
 export * from './navigation';
+export * from './shape';
 export * from './theme';
 export * from './typography';
 export * from './utils';

--- a/src/theme/types/shape.ts
+++ b/src/theme/types/shape.ts
@@ -1,0 +1,14 @@
+export type ThemeShapeCorners = {
+  extraSmall: number;
+  small: number;
+  medium: number;
+  large: number;
+  largeIncreased: number;
+  extraLarge: number;
+  extraLargeIncreased: number;
+  extraExtraLarge: number;
+};
+
+export type ThemeShapes = {
+  corner: ThemeShapeCorners;
+};

--- a/src/theme/types/theme.ts
+++ b/src/theme/types/theme.ts
@@ -1,6 +1,7 @@
 import type { $DeepPartial } from '@callstack/react-theme-provider';
 
 import type { ThemeColors } from './color';
+import type { ThemeShapes } from './shape';
 import type { Typescale } from './typography';
 
 type Mode = 'adaptive' | 'exact';
@@ -8,7 +9,6 @@ type Mode = 'adaptive' | 'exact';
 export type ThemeBase = {
   dark: boolean;
   mode?: Mode;
-  roundness: number;
   animation: {
     scale: number;
     defaultAnimationDuration?: number;
@@ -18,6 +18,7 @@ export type ThemeBase = {
 export type Theme = ThemeBase & {
   colors: ThemeColors;
   fonts: Typescale;
+  shapes: ThemeShapes;
 };
 
 export type InternalTheme = Theme;


### PR DESCRIPTION


<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Adds the 10 MD3 shape scale tokens to theme.shapes.*, ShapeCorners for directional variants, and cornersToStyle() for mapping to RN style props. Deprecates theme.roundness in favour of theme.shapes.

### Related issue

See https://www.notion.so/callstack/React-Native-Paper-Foundation-for-MD3-Expressive-34c5d027c0f880edba3df107cd35946f?source=copy_link

  #### Merge order:
- https://github.com/callstack/react-native-paper/pull/4910
- https://github.com/callstack/react-native-paper/pull/4915
- https://github.com/callstack/react-native-paper/pull/4916
- https://github.com/callstack/react-native-paper/pull/4917
- https://github.com/callstack/react-native-paper/pull/4919
- https://github.com/callstack/react-native-paper/pull/4920
- https://github.com/callstack/react-native-paper/pull/4922
- https://github.com/callstack/react-native-paper/pull/4923
- https://github.com/callstack/react-native-paper/pull/4924
- https://github.com/callstack/react-native-paper/pull/4925
- https://github.com/callstack/react-native-paper/pull/4926
- https://github.com/callstack/react-native-paper/pull/4927 

### Test plan

  - `yarn typescript` -- no new type errors
  - `yarn test` -- all tests pass
