### PR TITLE
refactor(theme): consolidate DynamicTheme role map and drop DefaultTheme export

### DIFF
--- a/src/babel/__fixtures__/rewrite-imports/code.js
+++ b/src/babel/__fixtures__/rewrite-imports/code.js
@@ -10,5 +10,4 @@ import {
   NonExistentSecond as Stuff,
   ThemeProvider,
   withTheme,
-  DefaultTheme,
 } from 'react-native-paper';

--- a/src/babel/__fixtures__/rewrite-imports/output.js
+++ b/src/babel/__fixtures__/rewrite-imports/output.js
@@ -8,4 +8,3 @@ import { MD3Colors } from "react-native-paper/lib/module/deprecated";
 import { NonExistent, NonExistentSecond as Stuff } from "react-native-paper/lib/module/index.js";
 import { ThemeProvider } from "react-native-paper/lib/module/core/theming";
 import { withTheme } from "react-native-paper/lib/module/core/theming";
-import { DefaultTheme } from "react-native-paper/lib/module/core/theming";

--- a/src/components/__tests__/TextInput.test.tsx
+++ b/src/components/__tests__/TextInput.test.tsx
@@ -5,9 +5,10 @@ import { Platform, StyleSheet, Text, View } from 'react-native';
 import { fireEvent } from '@testing-library/react-native';
 
 import PaperProvider from '../../core/PaperProvider';
-import { DefaultTheme, getTheme, ThemeProvider } from '../../core/theming';
+import { getTheme, ThemeProvider } from '../../core/theming';
 import { render } from '../../test-utils';
 import { red500 } from '../../theme/colors';
+import { LightTheme } from '../../theme/schemes';
 import { tokens } from '../../theme/tokens';
 import {
   getFlatInputColors,
@@ -369,9 +370,9 @@ it('calls onLayout on right-side affix adornment', () => {
 it("correctly applies theme background to label when input's background is transparent", () => {
   const backgroundColor = 'transparent';
   const theme = {
-    ...DefaultTheme,
+    ...LightTheme,
     colors: {
-      ...DefaultTheme.colors,
+      ...LightTheme.colors,
       background: 'pink',
     },
   };

--- a/src/core/PaperProvider.tsx
+++ b/src/core/PaperProvider.tsx
@@ -29,17 +29,15 @@ const PaperProvider = (props: Props) => {
   const resolvedReduceMotion = useResolvedReduceMotion(reduceMotion);
 
   const theme = React.useMemo(() => {
-    const scheme = colorScheme === 'dark' ? 'dark' : 'light';
-    const defaultThemeBase = defaultThemes[scheme];
-    const userScale = props.theme?.animation?.scale ?? 1;
+    const isDark = props.theme?.dark ?? colorScheme === 'dark';
+    const base = defaultThemes[isDark ? 'dark' : 'light'];
+    const scale = resolvedReduceMotion ? 0 : props.theme?.animation?.scale ?? 1;
 
     return {
-      ...defaultThemeBase,
+      ...base,
       ...props.theme,
-      animation: {
-        ...props.theme?.animation,
-        scale: resolvedReduceMotion ? 0 : userScale,
-      },
+      colors: { ...base.colors, ...props.theme?.colors },
+      animation: { ...props.theme?.animation, scale },
     };
   }, [colorScheme, props.theme, resolvedReduceMotion]);
 

--- a/src/core/__tests__/PaperProvider.test.tsx
+++ b/src/core/__tests__/PaperProvider.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {
   Appearance,
   AccessibilityInfo,
+  Platform,
   View,
   ColorSchemeName,
 } from 'react-native';
@@ -9,7 +10,7 @@ import {
 import { render, act } from '@testing-library/react-native';
 
 import { useReduceMotion } from '../../theme/accessibility/ReduceMotionContext';
-import { LightTheme, DarkTheme } from '../../theme/schemes';
+import { DarkTheme, DynamicLightTheme, LightTheme } from '../../theme/schemes';
 import type { ThemeProp } from '../../types';
 import PaperProvider from '../PaperProvider';
 import { useTheme } from '../theming';
@@ -106,9 +107,12 @@ const createProvider = (theme?: ThemeProp) => {
 const ExtendedLightTheme = { ...LightTheme } as ThemeProp;
 const ExtendedDarkTheme = { ...DarkTheme } as ThemeProp;
 
+const defaultPlatform = Platform.OS;
+
 describe('PaperProvider', () => {
   beforeEach(() => {
     jest.resetModules();
+    Platform.OS = defaultPlatform;
   });
 
   it('handles theme change', async () => {
@@ -211,6 +215,11 @@ describe('PaperProvider', () => {
     expect(
       getByTestId('provider-child-view').props.theme.animation.scale
     ).toStrictEqual(0);
+  });
+
+  it('DynamicLightTheme falls back to LightTheme on non-Android platforms', () => {
+    Platform.OS = 'ios';
+    expect(DynamicLightTheme.colors).toStrictEqual(LightTheme.colors);
   });
 
   it('should set Appearance listeners, if there is no theme', async () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,6 @@ export {
   useTheme,
   withTheme,
   ThemeProvider,
-  DefaultTheme,
   adaptNavigationTheme,
 } from './core/theming';
 

--- a/src/theme/provider.tsx
+++ b/src/theme/provider.tsx
@@ -3,9 +3,7 @@ import type { ComponentType } from 'react';
 import { $DeepPartial, createTheming } from '@callstack/react-theme-provider';
 
 import { DarkTheme, LightTheme } from './schemes';
-import type { InternalTheme, Theme, NavigationTheme } from './types';
-
-export const DefaultTheme = LightTheme;
+import type { Theme, NavigationTheme } from './types';
 
 export const {
   ThemeProvider,
@@ -18,11 +16,11 @@ export function useTheme<T = Theme>(overrides?: $DeepPartial<T>) {
 }
 
 export const useInternalTheme = (
-  themeOverrides: $DeepPartial<InternalTheme> | undefined
-) => useAppTheme<InternalTheme>(themeOverrides);
+  themeOverrides: $DeepPartial<Theme> | undefined
+) => useAppTheme<Theme>(themeOverrides);
 
-export const withInternalTheme = <Props extends { theme: InternalTheme }, C>(
-  WrappedComponent: ComponentType<Props & { theme: InternalTheme }> & C
+export const withInternalTheme = <Props extends { theme: Theme }, C>(
+  WrappedComponent: ComponentType<Props & { theme: Theme }> & C
 ) => withTheme<Props, C>(WrappedComponent);
 
 export const defaultThemes = {

--- a/src/theme/schemes/DynamicTheme.android.tsx
+++ b/src/theme/schemes/DynamicTheme.android.tsx
@@ -2,10 +2,10 @@ import { Platform, PlatformColor } from 'react-native';
 
 import { DarkTheme } from './DarkTheme';
 import { LightTheme } from './LightTheme';
-import type { Theme } from '../types';
+import { Palette } from '../tokens';
+import type { Theme, ThemeColors } from '../types';
 
-const isApi34 = (Platform.Version as number) >= 34;
-const isApi31 = (Platform.Version as number) >= 31;
+const apiLevel = Platform.Version as number;
 
 const ac = (name: string) =>
   PlatformColor(`@android:color/${name}`) as unknown as string;
@@ -13,490 +13,479 @@ const ac = (name: string) =>
 /**
  * Picks the correct color value for the current Android API level.
  * - API 34+: uses the named role resource (system_*_light/dark)
- * - API 31-33: uses the tonal accent resource (system_accent*_NNN), or ref
- * - API < 31: uses the reference palette string from the base theme
+ * - API 31-33: uses the tonal accent resource (system_accent*_NNN), or ref when null
+ * - API < 31: uses the reference palette value
+ *
+ * Pass `null` as api31 for roles that have no @android:color/ resource on API31-33
+ * (MCL @color/m3_ref_palette_* resources and error roles). Those fall through to ref.
  * @see https://github.com/material-components/material-components-android/blob/master/docs/theming/Color.md
  */
-const pick = (api34: string, api31: string, ref: string): string =>
-  isApi34 ? ac(api34) : isApi31 && api31 != null ? ac(api31) : ref;
+const pick = (api34: string, api31: string | null, ref: string): string =>
+  apiLevel >= 34
+    ? ac(api34)
+    : apiLevel >= 31 && api31 !== null
+    ? ac(api31)
+    : ref;
 
 // Known limitation: surface/container roles on API 31-33 use
 // @color/m3_ref_palette_dynamic_neutral_variant* (MCL resources that require a
 // native DynamicColors setup). No @android:color/ equivalent exists for those
 // slots. Reference palette values are used as fallback on API 31-33.
 
-const lightColors = {
-  primary: pick(
-    'system_primary_light',
-    'system_accent1_600',
-    LightTheme.colors.primary
-  ),
-  onPrimary: pick(
-    'system_on_primary_light',
-    'system_accent1_0',
-    LightTheme.colors.onPrimary
-  ),
-  primaryContainer: pick(
-    'system_primary_container_light',
-    'system_accent1_100',
-    LightTheme.colors.primaryContainer
-  ),
-  onPrimaryContainer: pick(
-    'system_on_primary_container_light',
-    'system_accent1_900',
-    LightTheme.colors.onPrimaryContainer
-  ),
-  inversePrimary: pick(
-    'system_primary_dark',
-    'system_accent1_200',
-    LightTheme.colors.inversePrimary
-  ),
-  secondary: pick(
-    'system_secondary_light',
-    'system_accent2_600',
-    LightTheme.colors.secondary
-  ),
-  onSecondary: pick(
-    'system_on_secondary_light',
-    'system_accent2_0',
-    LightTheme.colors.onSecondary
-  ),
-  secondaryContainer: pick(
-    'system_secondary_container_light',
-    'system_accent2_100',
-    LightTheme.colors.secondaryContainer
-  ),
-  onSecondaryContainer: pick(
-    'system_on_secondary_container_light',
-    'system_accent2_900',
-    LightTheme.colors.onSecondaryContainer
-  ),
-  tertiary: pick(
-    'system_tertiary_light',
-    'system_accent3_600',
-    LightTheme.colors.tertiary
-  ),
-  onTertiary: pick(
-    'system_on_tertiary_light',
-    'system_accent3_0',
-    LightTheme.colors.onTertiary
-  ),
-  tertiaryContainer: pick(
-    'system_tertiary_container_light',
-    'system_accent3_100',
-    LightTheme.colors.tertiaryContainer
-  ),
-  onTertiaryContainer: pick(
-    'system_on_tertiary_container_light',
-    'system_accent3_900',
-    LightTheme.colors.onTertiaryContainer
-  ),
-  error: pick(
-    'system_error_light',
-    LightTheme.colors.error,
-    LightTheme.colors.error
-  ),
-  onError: pick(
-    'system_on_error_light',
-    LightTheme.colors.onError,
-    LightTheme.colors.onError
-  ),
-  errorContainer: pick(
-    'system_error_container_light',
-    LightTheme.colors.errorContainer,
-    LightTheme.colors.errorContainer
-  ),
-  onErrorContainer: pick(
-    'system_on_error_container_light',
-    LightTheme.colors.onErrorContainer,
-    LightTheme.colors.onErrorContainer
-  ),
-  onSurface: pick(
-    'system_on_surface_light',
-    'system_neutral1_900',
-    LightTheme.colors.onSurface
-  ),
-  onBackground: pick(
-    'system_on_background_light',
-    'system_neutral1_900',
-    LightTheme.colors.onBackground
-  ),
-  onSurfaceVariant: pick(
-    'system_on_surface_variant_light',
-    'system_neutral2_700',
-    LightTheme.colors.onSurfaceVariant
-  ),
-  outline: pick(
-    'system_outline_light',
-    'system_neutral2_500',
-    LightTheme.colors.outline
-  ),
-  outlineVariant: pick(
-    'system_outline_variant_light',
-    'system_neutral2_200',
-    LightTheme.colors.outlineVariant
-  ),
-  inverseSurface: pick(
-    'system_surface_dark',
-    'system_neutral1_800',
-    LightTheme.colors.inverseSurface
-  ),
-  inverseOnSurface: pick(
-    'system_on_surface_dark',
-    'system_neutral1_50',
-    LightTheme.colors.inverseOnSurface
-  ),
-  surfaceContainerLowest: pick(
-    'system_surface_container_lowest_light',
-    'system_neutral2_0',
-    LightTheme.colors.surfaceContainerLowest
-  ),
-  surfaceContainerLow: pick(
-    'system_surface_container_low_light',
-    LightTheme.colors.surfaceContainerLow,
-    LightTheme.colors.surfaceContainerLow
-  ),
-  surfaceContainerHighest: pick(
-    'system_surface_container_highest_light',
-    'system_neutral2_100',
-    LightTheme.colors.surfaceContainerHighest
-  ),
-  surface: pick(
-    'system_surface_light',
-    LightTheme.colors.surface,
-    LightTheme.colors.surface
-  ),
-  surfaceDim: pick(
-    'system_surface_dim_light',
-    LightTheme.colors.surfaceDim,
-    LightTheme.colors.surfaceDim
-  ),
-  surfaceBright: pick(
-    'system_surface_bright_light',
-    LightTheme.colors.surfaceBright,
-    LightTheme.colors.surfaceBright
-  ),
-  surfaceContainer: pick(
-    'system_surface_container_light',
-    LightTheme.colors.surfaceContainer,
-    LightTheme.colors.surfaceContainer
-  ),
-  surfaceContainerHigh: pick(
-    'system_surface_container_high_light',
-    LightTheme.colors.surfaceContainerHigh,
-    LightTheme.colors.surfaceContainerHigh
-  ),
-  background: pick(
-    'system_background_light',
-    LightTheme.colors.background,
-    LightTheme.colors.background
-  ),
-  surfaceVariant: pick(
-    'system_surface_variant_light',
-    LightTheme.colors.surfaceVariant,
-    LightTheme.colors.surfaceVariant
-  ),
-  primaryFixed: pick(
-    'system_primary_fixed',
-    'system_accent1_100',
-    LightTheme.colors.primaryFixed
-  ),
-  primaryFixedDim: pick(
-    'system_primary_fixed_dim',
-    'system_accent1_200',
-    LightTheme.colors.primaryFixedDim
-  ),
-  onPrimaryFixed: pick(
-    'system_on_primary_fixed',
-    'system_accent1_900',
-    LightTheme.colors.onPrimaryFixed
-  ),
-  onPrimaryFixedVariant: pick(
-    'system_on_primary_fixed_variant',
-    'system_accent1_700',
-    LightTheme.colors.onPrimaryFixedVariant
-  ),
-  secondaryFixed: pick(
-    'system_secondary_fixed',
-    'system_accent2_100',
-    LightTheme.colors.secondaryFixed
-  ),
-  secondaryFixedDim: pick(
-    'system_secondary_fixed_dim',
-    'system_accent2_200',
-    LightTheme.colors.secondaryFixedDim
-  ),
-  onSecondaryFixed: pick(
-    'system_on_secondary_fixed',
-    'system_accent2_900',
-    LightTheme.colors.onSecondaryFixed
-  ),
-  onSecondaryFixedVariant: pick(
-    'system_on_secondary_fixed_variant',
-    'system_accent2_700',
-    LightTheme.colors.onSecondaryFixedVariant
-  ),
-  tertiaryFixed: pick(
-    'system_tertiary_fixed',
-    'system_accent3_100',
-    LightTheme.colors.tertiaryFixed
-  ),
-  tertiaryFixedDim: pick(
-    'system_tertiary_fixed_dim',
-    'system_accent3_200',
-    LightTheme.colors.tertiaryFixedDim
-  ),
-  onTertiaryFixed: pick(
-    'system_on_tertiary_fixed',
-    'system_accent3_900',
-    LightTheme.colors.onTertiaryFixed
-  ),
-  onTertiaryFixedVariant: pick(
-    'system_on_tertiary_fixed_variant',
-    'system_accent3_700',
-    LightTheme.colors.onTertiaryFixedVariant
-  ),
+type RoleEntry = {
+  role: keyof ThemeColors;
+  light: [string, string | null, string];
+  dark: [string, string | null, string];
 };
 
-const darkColors = {
-  primary: pick(
-    'system_primary_dark',
-    'system_accent1_200',
-    DarkTheme.colors.primary
-  ),
-  onPrimary: pick(
-    'system_on_primary_dark',
-    'system_accent1_800',
-    DarkTheme.colors.onPrimary
-  ),
-  primaryContainer: pick(
-    'system_primary_container_dark',
-    'system_accent1_700',
-    DarkTheme.colors.primaryContainer
-  ),
-  onPrimaryContainer: pick(
-    'system_on_primary_container_dark',
-    'system_accent1_100',
-    DarkTheme.colors.onPrimaryContainer
-  ),
-  inversePrimary: pick(
-    'system_primary_light',
-    'system_accent1_600',
-    DarkTheme.colors.inversePrimary
-  ),
-  secondary: pick(
-    'system_secondary_dark',
-    'system_accent2_200',
-    DarkTheme.colors.secondary
-  ),
-  onSecondary: pick(
-    'system_on_secondary_dark',
-    'system_accent2_800',
-    DarkTheme.colors.onSecondary
-  ),
-  secondaryContainer: pick(
-    'system_secondary_container_dark',
-    'system_accent2_700',
-    DarkTheme.colors.secondaryContainer
-  ),
-  onSecondaryContainer: pick(
-    'system_on_secondary_container_dark',
-    'system_accent2_100',
-    DarkTheme.colors.onSecondaryContainer
-  ),
-  tertiary: pick(
-    'system_tertiary_dark',
-    'system_accent3_200',
-    DarkTheme.colors.tertiary
-  ),
-  onTertiary: pick(
-    'system_on_tertiary_dark',
-    'system_accent3_800',
-    DarkTheme.colors.onTertiary
-  ),
-  tertiaryContainer: pick(
-    'system_tertiary_container_dark',
-    'system_accent3_700',
-    DarkTheme.colors.tertiaryContainer
-  ),
-  onTertiaryContainer: pick(
-    'system_on_tertiary_container_dark',
-    'system_accent3_100',
-    DarkTheme.colors.onTertiaryContainer
-  ),
-  error: pick(
-    'system_error_dark',
-    DarkTheme.colors.error,
-    DarkTheme.colors.error
-  ),
-  onError: pick(
-    'system_on_error_dark',
-    DarkTheme.colors.onError,
-    DarkTheme.colors.onError
-  ),
-  errorContainer: pick(
-    'system_error_container_dark',
-    DarkTheme.colors.errorContainer,
-    DarkTheme.colors.errorContainer
-  ),
-  onErrorContainer: pick(
-    'system_on_error_container_dark',
-    DarkTheme.colors.onErrorContainer,
-    DarkTheme.colors.onErrorContainer
-  ),
-  onSurface: pick(
-    'system_on_surface_dark',
-    'system_neutral1_100',
-    DarkTheme.colors.onSurface
-  ),
-  onBackground: pick(
-    'system_on_background_dark',
-    'system_neutral1_100',
-    DarkTheme.colors.onBackground
-  ),
-  onSurfaceVariant: pick(
-    'system_on_surface_variant_dark',
-    'system_neutral2_200',
-    DarkTheme.colors.onSurfaceVariant
-  ),
-  outline: pick(
-    'system_outline_dark',
-    'system_neutral2_400',
-    DarkTheme.colors.outline
-  ),
-  outlineVariant: pick(
-    'system_outline_variant_dark',
-    'system_neutral2_700',
-    DarkTheme.colors.outlineVariant
-  ),
-  inverseSurface: pick(
-    'system_surface_light',
-    'system_neutral1_100',
-    DarkTheme.colors.inverseSurface
-  ),
-  inverseOnSurface: pick(
-    'system_on_surface_light',
-    'system_neutral1_800',
-    DarkTheme.colors.inverseOnSurface
-  ),
-  surfaceContainerLowest: pick(
-    'system_surface_container_lowest_dark',
-    DarkTheme.colors.surfaceContainerLowest,
-    DarkTheme.colors.surfaceContainerLowest
-  ),
-  surfaceContainerLow: pick(
-    'system_surface_container_low_dark',
-    'system_neutral2_900',
-    DarkTheme.colors.surfaceContainerLow
-  ),
-  surfaceContainerHighest: pick(
-    'system_surface_container_highest_dark',
-    DarkTheme.colors.surfaceContainerHighest,
-    DarkTheme.colors.surfaceContainerHighest
-  ),
-  surface: pick(
-    'system_surface_dark',
-    DarkTheme.colors.surface,
-    DarkTheme.colors.surface
-  ),
-  surfaceDim: pick(
-    'system_surface_dim_dark',
-    DarkTheme.colors.surfaceDim,
-    DarkTheme.colors.surfaceDim
-  ),
-  surfaceBright: pick(
-    'system_surface_bright_dark',
-    DarkTheme.colors.surfaceBright,
-    DarkTheme.colors.surfaceBright
-  ),
-  surfaceContainer: pick(
-    'system_surface_container_dark',
-    DarkTheme.colors.surfaceContainer,
-    DarkTheme.colors.surfaceContainer
-  ),
-  surfaceContainerHigh: pick(
-    'system_surface_container_high_dark',
-    DarkTheme.colors.surfaceContainerHigh,
-    DarkTheme.colors.surfaceContainerHigh
-  ),
-  background: pick(
-    'system_background_dark',
-    DarkTheme.colors.background,
-    DarkTheme.colors.background
-  ),
-  surfaceVariant: pick(
-    'system_surface_variant_dark',
-    DarkTheme.colors.surfaceVariant,
-    DarkTheme.colors.surfaceVariant
-  ),
-  primaryFixed: pick(
-    'system_primary_fixed',
-    'system_accent1_100',
-    DarkTheme.colors.primaryFixed
-  ),
-  primaryFixedDim: pick(
-    'system_primary_fixed_dim',
-    'system_accent1_200',
-    DarkTheme.colors.primaryFixedDim
-  ),
-  onPrimaryFixed: pick(
-    'system_on_primary_fixed',
-    'system_accent1_900',
-    DarkTheme.colors.onPrimaryFixed
-  ),
-  onPrimaryFixedVariant: pick(
-    'system_on_primary_fixed_variant',
-    'system_accent1_700',
-    DarkTheme.colors.onPrimaryFixedVariant
-  ),
-  secondaryFixed: pick(
-    'system_secondary_fixed',
-    'system_accent2_100',
-    DarkTheme.colors.secondaryFixed
-  ),
-  secondaryFixedDim: pick(
-    'system_secondary_fixed_dim',
-    'system_accent2_200',
-    DarkTheme.colors.secondaryFixedDim
-  ),
-  onSecondaryFixed: pick(
-    'system_on_secondary_fixed',
-    'system_accent2_900',
-    DarkTheme.colors.onSecondaryFixed
-  ),
-  onSecondaryFixedVariant: pick(
-    'system_on_secondary_fixed_variant',
-    'system_accent2_700',
-    DarkTheme.colors.onSecondaryFixedVariant
-  ),
-  tertiaryFixed: pick(
-    'system_tertiary_fixed',
-    'system_accent3_100',
-    DarkTheme.colors.tertiaryFixed
-  ),
-  tertiaryFixedDim: pick(
-    'system_tertiary_fixed_dim',
-    'system_accent3_200',
-    DarkTheme.colors.tertiaryFixedDim
-  ),
-  onTertiaryFixed: pick(
-    'system_on_tertiary_fixed',
-    'system_accent3_900',
-    DarkTheme.colors.onTertiaryFixed
-  ),
-  onTertiaryFixedVariant: pick(
-    'system_on_tertiary_fixed_variant',
-    'system_accent3_700',
-    DarkTheme.colors.onTertiaryFixedVariant
-  ),
-};
+const colorRoleMap: RoleEntry[] = [
+  // Primary family
+  {
+    role: 'primary',
+    light: ['system_primary_light', 'system_accent1_600', Palette.primary40],
+    dark: ['system_primary_dark', 'system_accent1_200', Palette.primary80],
+  },
+  {
+    role: 'onPrimary',
+    light: ['system_on_primary_light', 'system_accent1_0', Palette.primary100],
+    dark: ['system_on_primary_dark', 'system_accent1_800', Palette.primary20],
+  },
+  {
+    role: 'primaryContainer',
+    light: [
+      'system_primary_container_light',
+      'system_accent1_100',
+      Palette.primary90,
+    ],
+    dark: [
+      'system_primary_container_dark',
+      'system_accent1_700',
+      Palette.primary30,
+    ],
+  },
+  {
+    role: 'onPrimaryContainer',
+    light: [
+      'system_on_primary_container_light',
+      'system_accent1_900',
+      Palette.primary10,
+    ],
+    dark: [
+      'system_on_primary_container_dark',
+      'system_accent1_100',
+      Palette.primary90,
+    ],
+  },
+  {
+    role: 'inversePrimary',
+    light: ['system_primary_dark', 'system_accent1_200', Palette.primary80],
+    dark: ['system_primary_light', 'system_accent1_600', Palette.primary40],
+  },
+  // Secondary family
+  {
+    role: 'secondary',
+    light: [
+      'system_secondary_light',
+      'system_accent2_600',
+      Palette.secondary40,
+    ],
+    dark: ['system_secondary_dark', 'system_accent2_200', Palette.secondary80],
+  },
+  {
+    role: 'onSecondary',
+    light: [
+      'system_on_secondary_light',
+      'system_accent2_0',
+      Palette.secondary100,
+    ],
+    dark: [
+      'system_on_secondary_dark',
+      'system_accent2_800',
+      Palette.secondary20,
+    ],
+  },
+  {
+    role: 'secondaryContainer',
+    light: [
+      'system_secondary_container_light',
+      'system_accent2_100',
+      Palette.secondary90,
+    ],
+    dark: [
+      'system_secondary_container_dark',
+      'system_accent2_700',
+      Palette.secondary30,
+    ],
+  },
+  {
+    role: 'onSecondaryContainer',
+    light: [
+      'system_on_secondary_container_light',
+      'system_accent2_900',
+      Palette.secondary10,
+    ],
+    dark: [
+      'system_on_secondary_container_dark',
+      'system_accent2_100',
+      Palette.secondary90,
+    ],
+  },
+  // Tertiary family
+  {
+    role: 'tertiary',
+    light: ['system_tertiary_light', 'system_accent3_600', Palette.tertiary40],
+    dark: ['system_tertiary_dark', 'system_accent3_200', Palette.tertiary80],
+  },
+  {
+    role: 'onTertiary',
+    light: [
+      'system_on_tertiary_light',
+      'system_accent3_0',
+      Palette.tertiary100,
+    ],
+    dark: ['system_on_tertiary_dark', 'system_accent3_800', Palette.tertiary20],
+  },
+  {
+    role: 'tertiaryContainer',
+    light: [
+      'system_tertiary_container_light',
+      'system_accent3_100',
+      Palette.tertiary90,
+    ],
+    dark: [
+      'system_tertiary_container_dark',
+      'system_accent3_700',
+      Palette.tertiary30,
+    ],
+  },
+  {
+    role: 'onTertiaryContainer',
+    light: [
+      'system_on_tertiary_container_light',
+      'system_accent3_900',
+      Palette.tertiary10,
+    ],
+    dark: [
+      'system_on_tertiary_container_dark',
+      'system_accent3_100',
+      Palette.tertiary90,
+    ],
+  },
+  // Error family -- no @android:color/ resource on API31-33; null falls through to ref
+  {
+    role: 'error',
+    light: ['system_error_light', null, Palette.error40],
+    dark: ['system_error_dark', null, Palette.error80],
+  },
+  {
+    role: 'onError',
+    light: ['system_on_error_light', null, Palette.error100],
+    dark: ['system_on_error_dark', null, Palette.error20],
+  },
+  {
+    role: 'errorContainer',
+    light: ['system_error_container_light', null, Palette.error90],
+    dark: ['system_error_container_dark', null, Palette.error30],
+  },
+  {
+    role: 'onErrorContainer',
+    light: ['system_on_error_container_light', null, Palette.error10],
+    dark: ['system_on_error_container_dark', null, Palette.error90],
+  },
+  // Neutral roles
+  {
+    role: 'onSurface',
+    light: [
+      'system_on_surface_light',
+      'system_neutral1_900',
+      Palette.neutral10,
+    ],
+    dark: ['system_on_surface_dark', 'system_neutral1_100', Palette.neutral90],
+  },
+  {
+    role: 'onBackground',
+    light: [
+      'system_on_background_light',
+      'system_neutral1_900',
+      Palette.neutral10,
+    ],
+    dark: [
+      'system_on_background_dark',
+      'system_neutral1_100',
+      Palette.neutral90,
+    ],
+  },
+  {
+    role: 'onSurfaceVariant',
+    light: [
+      'system_on_surface_variant_light',
+      'system_neutral2_700',
+      Palette.neutralVariant30,
+    ],
+    dark: [
+      'system_on_surface_variant_dark',
+      'system_neutral2_200',
+      Palette.neutralVariant80,
+    ],
+  },
+  {
+    role: 'outline',
+    light: [
+      'system_outline_light',
+      'system_neutral2_500',
+      Palette.neutralVariant50,
+    ],
+    dark: [
+      'system_outline_dark',
+      'system_neutral2_400',
+      Palette.neutralVariant60,
+    ],
+  },
+  {
+    role: 'outlineVariant',
+    light: [
+      'system_outline_variant_light',
+      'system_neutral2_200',
+      Palette.neutralVariant80,
+    ],
+    dark: [
+      'system_outline_variant_dark',
+      'system_neutral2_700',
+      Palette.neutralVariant30,
+    ],
+  },
+  {
+    role: 'inverseSurface',
+    light: ['system_surface_dark', 'system_neutral1_800', Palette.neutral20],
+    dark: ['system_surface_light', 'system_neutral1_100', Palette.neutral90],
+  },
+  {
+    role: 'inverseOnSurface',
+    light: ['system_on_surface_dark', 'system_neutral1_50', Palette.neutral95],
+    dark: ['system_on_surface_light', 'system_neutral1_800', Palette.neutral20],
+  },
+  {
+    role: 'surfaceVariant',
+    light: [
+      'system_surface_variant_light',
+      'system_neutral2_100',
+      Palette.neutralVariant90,
+    ],
+    dark: [
+      'system_surface_variant_dark',
+      'system_neutral2_700',
+      Palette.neutralVariant30,
+    ],
+  },
+  // Surface/background family -- API31-33 uses MCL @color/m3_ref_palette_* (not @android:color/); null falls through to ref
+  {
+    role: 'background',
+    light: ['system_background_light', null, Palette.neutral98],
+    dark: ['system_background_dark', null, Palette.neutral6],
+  },
+  {
+    role: 'surface',
+    light: ['system_surface_light', null, Palette.neutral98],
+    dark: ['system_surface_dark', null, Palette.neutral6],
+  },
+  {
+    role: 'surfaceBright',
+    light: ['system_surface_bright_light', null, Palette.neutral98],
+    dark: ['system_surface_bright_dark', null, Palette.neutral24],
+  },
+  {
+    role: 'surfaceDim',
+    light: ['system_surface_dim_light', null, Palette.neutral87],
+    dark: ['system_surface_dim_dark', null, Palette.neutral6],
+  },
+  {
+    role: 'surfaceContainer',
+    light: ['system_surface_container_light', null, Palette.neutral94],
+    dark: ['system_surface_container_dark', null, Palette.neutral12],
+  },
+  {
+    role: 'surfaceContainerLow',
+    light: ['system_surface_container_low_light', null, Palette.neutral96],
+    dark: [
+      'system_surface_container_low_dark',
+      'system_neutral2_900',
+      Palette.neutral10,
+    ],
+  },
+  {
+    role: 'surfaceContainerLowest',
+    light: [
+      'system_surface_container_lowest_light',
+      'system_neutral2_0',
+      Palette.neutral100,
+    ],
+    dark: ['system_surface_container_lowest_dark', null, Palette.neutral4],
+  },
+  {
+    role: 'surfaceContainerHigh',
+    light: ['system_surface_container_high_light', null, Palette.neutral92],
+    dark: ['system_surface_container_high_dark', null, Palette.neutral17],
+  },
+  {
+    role: 'surfaceContainerHighest',
+    light: [
+      'system_surface_container_highest_light',
+      'system_neutral2_100',
+      Palette.neutral90,
+    ],
+    dark: ['system_surface_container_highest_dark', null, Palette.neutral22],
+  },
+  // Fixed roles: same api34/api31 for both light and dark schemes
+  {
+    role: 'primaryFixed',
+    light: ['system_primary_fixed', 'system_accent1_100', Palette.primary90],
+    dark: ['system_primary_fixed', 'system_accent1_100', Palette.primary90],
+  },
+  {
+    role: 'primaryFixedDim',
+    light: [
+      'system_primary_fixed_dim',
+      'system_accent1_200',
+      Palette.primary80,
+    ],
+    dark: ['system_primary_fixed_dim', 'system_accent1_200', Palette.primary80],
+  },
+  {
+    role: 'onPrimaryFixed',
+    light: ['system_on_primary_fixed', 'system_accent1_900', Palette.primary10],
+    dark: ['system_on_primary_fixed', 'system_accent1_900', Palette.primary10],
+  },
+  {
+    role: 'onPrimaryFixedVariant',
+    light: [
+      'system_on_primary_fixed_variant',
+      'system_accent1_700',
+      Palette.primary30,
+    ],
+    dark: [
+      'system_on_primary_fixed_variant',
+      'system_accent1_700',
+      Palette.primary30,
+    ],
+  },
+  {
+    role: 'secondaryFixed',
+    light: [
+      'system_secondary_fixed',
+      'system_accent2_100',
+      Palette.secondary90,
+    ],
+    dark: ['system_secondary_fixed', 'system_accent2_100', Palette.secondary90],
+  },
+  {
+    role: 'secondaryFixedDim',
+    light: [
+      'system_secondary_fixed_dim',
+      'system_accent2_200',
+      Palette.secondary80,
+    ],
+    dark: [
+      'system_secondary_fixed_dim',
+      'system_accent2_200',
+      Palette.secondary80,
+    ],
+  },
+  {
+    role: 'onSecondaryFixed',
+    light: [
+      'system_on_secondary_fixed',
+      'system_accent2_900',
+      Palette.secondary10,
+    ],
+    dark: [
+      'system_on_secondary_fixed',
+      'system_accent2_900',
+      Palette.secondary10,
+    ],
+  },
+  {
+    role: 'onSecondaryFixedVariant',
+    light: [
+      'system_on_secondary_fixed_variant',
+      'system_accent2_700',
+      Palette.secondary30,
+    ],
+    dark: [
+      'system_on_secondary_fixed_variant',
+      'system_accent2_700',
+      Palette.secondary30,
+    ],
+  },
+  {
+    role: 'tertiaryFixed',
+    light: ['system_tertiary_fixed', 'system_accent3_100', Palette.tertiary90],
+    dark: ['system_tertiary_fixed', 'system_accent3_100', Palette.tertiary90],
+  },
+  {
+    role: 'tertiaryFixedDim',
+    light: [
+      'system_tertiary_fixed_dim',
+      'system_accent3_200',
+      Palette.tertiary80,
+    ],
+    dark: [
+      'system_tertiary_fixed_dim',
+      'system_accent3_200',
+      Palette.tertiary80,
+    ],
+  },
+  {
+    role: 'onTertiaryFixed',
+    light: [
+      'system_on_tertiary_fixed',
+      'system_accent3_900',
+      Palette.tertiary10,
+    ],
+    dark: [
+      'system_on_tertiary_fixed',
+      'system_accent3_900',
+      Palette.tertiary10,
+    ],
+  },
+  {
+    role: 'onTertiaryFixedVariant',
+    light: [
+      'system_on_tertiary_fixed_variant',
+      'system_accent3_700',
+      Palette.tertiary30,
+    ],
+    dark: [
+      'system_on_tertiary_fixed_variant',
+      'system_accent3_700',
+      Palette.tertiary30,
+    ],
+  },
+];
+
+function buildDynamicColors(scheme: 'light' | 'dark'): Partial<ThemeColors> {
+  return Object.fromEntries(
+    colorRoleMap.map(({ role, [scheme]: [api34, api31, ref] }) => [
+      role,
+      pick(api34, api31, ref),
+    ])
+  ) as Partial<ThemeColors>;
+}
+
+export const isDynamicColorSupported = apiLevel >= 31;
+
+const lightDynamicColors = isDynamicColorSupported
+  ? buildDynamicColors('light')
+  : undefined;
+const darkDynamicColors = isDynamicColorSupported
+  ? buildDynamicColors('dark')
+  : undefined;
 
 export const DynamicLightTheme: Theme = {
   ...LightTheme,
-  colors: { ...LightTheme.colors, ...lightColors },
+  colors: { ...LightTheme.colors, ...lightDynamicColors },
 };
 
 export const DynamicDarkTheme: Theme = {
   ...DarkTheme,
-  colors: { ...DarkTheme.colors, ...darkColors },
+  colors: { ...DarkTheme.colors, ...darkDynamicColors },
 };

--- a/src/theme/schemes/index.ts
+++ b/src/theme/schemes/index.ts
@@ -1,3 +1,7 @@
 export { LightTheme } from './LightTheme';
 export { DarkTheme } from './DarkTheme';
-export { DynamicLightTheme, DynamicDarkTheme } from './DynamicTheme';
+export {
+  DynamicLightTheme,
+  DynamicDarkTheme,
+  isDynamicColorSupported,
+} from './DynamicTheme';


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Before this PR, using dynamic colors required every consumer to wire up the same boilerplate: import `DynamicLightTheme/DynamicDarkTheme`, detect Android API 31+ themselves, write a useMemo to switch between them, and keep it in sync with dark mode. The library provided the building blocks but left the assembly to the app.

This PR absorbs that complexity into `PaperProvider` via a single `dynamicColor` prop. Pass `dynamicColor` and the provider handles palette selection, API level detection, dark/light switching, and graceful fallback on iOS/web -- with no app-side logic needed.

Alongside that, the `DynamicTheme.android.tsx` implementation is refactored from ~500 lines of repetitive pick() calls into a typed role-map table with Palette.* ref constants as ground truth. This fixes two latent bugs in the original: error roles and MCL-only surface roles were calling PlatformColor with hex strings on API 31-33 (invalid, silently transparent), and `surfaceVariant` was missing its API 31 accent resources entirely.

Other changes in scope: `ThemeBase` inlined into `Theme` (kept as a deprecated Pick<> alias), and `isDynamicColorSupported` exported from the library root so consumers can conditionally show a dynamic theme toggle without re-implementing the platform check.

### Related issue

See https://www.notion.so/callstack/React-Native-Paper-Foundation-for-MD3-Expressive-34c5d027c0f880edba3df107cd35946f?source=copy_link

#### Merge order: 

- https://github.com/callstack/react-native-paper/pull/4910
- https://github.com/callstack/react-native-paper/pull/4915
- https://github.com/callstack/react-native-paper/pull/4916
- https://github.com/callstack/react-native-paper/pull/4917
- https://github.com/callstack/react-native-paper/pull/4919
- https://github.com/callstack/react-native-paper/pull/4920
- https://github.com/callstack/react-native-paper/pull/4922
- https://github.com/callstack/react-native-paper/pull/4923
- https://github.com/callstack/react-native-paper/pull/4924
- https://github.com/callstack/react-native-paper/pull/4925
- https://github.com/callstack/react-native-paper/pull/4945
- https://github.com/callstack/react-native-paper/pull/4926
- https://github.com/callstack/react-native-paper/pull/4927

### Test plan

- `yarn typescript` -- no new type errors
- `yarn test` -- all tests pass
