### PR TITLE
fix(appbar): prevent large/medium header title from being clipped on iOS

### DIFF
--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -364,6 +364,10 @@ const styles = StyleSheet.create({
   columnContainer: {
     flexDirection: 'column',
     flex: 1,
+    // Stretch to the Appbar's fixed `modeAppbarHeight` instead of being sized
+    // to content. Without this the column can exceed the header height and the
+    // title gets clipped on iOS, where `Surface` renders a fixed-size layer.
+    alignSelf: 'stretch',
     paddingTop: 8,
   },
   centerAlignedContainer: {


### PR DESCRIPTION
## Summary

`Appbar.Header` with `mode="large"` (and `mode="medium"`) renders its title **clipped** on **iOS** — the lower portion of the title text is cut off, and it sits too high in the header instead of being bottom-aligned. Android is unaffected.

## Root cause

In `medium`/`large` mode, `Appbar` renders a `columnContainer` (`flexDirection: 'column'`, `flex: 1`) holding a `controlsRow` stacked over `AppbarContent`. The Appbar's content row uses `alignItems: 'center'`, so `columnContainer` is **not stretched** to the Appbar's fixed `modeAppbarHeight` (`large` = 152, `medium` = 112) — it's sized to its content. The controls row plus `AppbarContent`'s mode padding (`v3LargeContainer`: `paddingTop: 36` + `paddingBottom: 28`; `v3MediumContainer`: `paddingBottom: 24`) plus the headline line-height can exceed the header height, so the title overflows the Appbar's bounds. On iOS, where `Surface` renders a fixed-size layer (`SurfaceIOS`), that overflow is clipped; on Android it's a single view, so it spills instead of clipping (less visible).

## Fix

Add `alignSelf: 'stretch'` to `styles.columnContainer` so the column fills the header's fixed height in `medium`/`large` mode. The controls row and `AppbarContent` (`justifyContent: 'flex-end'`) then partition a known height and the title stays within bounds.

```diff
 columnContainer: {
   flexDirection: 'column',
   flex: 1,
+  alignSelf: 'stretch',
   paddingTop: 8,
 },
```

## Testing

- `yarn jest src/components/__tests__/Appbar` — 37 passed, 2 snapshots passed (no snapshot churn)
- `yarn eslint src/components/Appbar/Appbar.tsx` — clean
- ⚠️ Marked **draft** pending manual verification on an iOS simulator (example app → Appbar screen → cycle `small`/`medium`/`large`/`center-aligned`; confirm the title is fully visible and bottom-aligned in medium/large, and there's no Android regression). If `alignSelf: 'stretch'` alone isn't sufficient, follow-ups would be giving `controlsRow` a fixed height instead of `flex: 1`, and/or rebalancing the `v3MediumContainer` / `v3LargeContainer` paddings in `AppbarContent.tsx`.