### PR TITLE
fix(progress-bar): preserve fill border radius while animating progress

### DIFF
--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -194,6 +194,42 @@ const ProgressBar = ({
   const trackTintColor = theme.isV3
     ? theme.colors.surfaceVariant
     : setColor(tintColor).alpha(0.38).rgb().string();
+  const progressBarStyle = indeterminate
+    ? {
+        width,
+        backgroundColor: tintColor,
+        transform: [
+          {
+            translateX: timer.interpolate({
+              inputRange: [0, 0.5, 1],
+              outputRange: [
+                (isRTL ? 1 : -1) * 0.5 * width,
+                (isRTL ? 1 : -1) * 0.5 * INDETERMINATE_MAX_WIDTH * width,
+                (isRTL ? -1 : 1) * 0.7 * width,
+              ],
+            }),
+          },
+          {
+            // Workaround for workaround for https://github.com/facebook/react-native/issues/6278
+            scaleX: timer.interpolate({
+              inputRange: [0, 0.5, 1],
+              outputRange: [0.0001, INDETERMINATE_MAX_WIDTH, 0.0001],
+            }),
+          },
+        ],
+      }
+    : {
+        width,
+        backgroundColor: tintColor,
+        transform: [
+          {
+            translateX: timer.interpolate({
+              inputRange: [0, 1],
+              outputRange: [(isRTL ? 1 : -1) * width, 0],
+            }),
+          },
+        ],
+      };
 
   return (
     <View
@@ -220,54 +256,7 @@ const ProgressBar = ({
         {width ? (
           <Animated.View
             testID={`${testID}-fill`}
-            style={[
-              styles.progressBar,
-              {
-                width,
-                backgroundColor: tintColor,
-                transform: [
-                  {
-                    translateX: timer.interpolate(
-                      indeterminate
-                        ? {
-                            inputRange: [0, 0.5, 1],
-                            outputRange: [
-                              (isRTL ? 1 : -1) * 0.5 * width,
-                              (isRTL ? 1 : -1) *
-                                0.5 *
-                                INDETERMINATE_MAX_WIDTH *
-                                width,
-                              (isRTL ? -1 : 1) * 0.7 * width,
-                            ],
-                          }
-                        : {
-                            inputRange: [0, 1],
-                            outputRange: [(isRTL ? 1 : -1) * 0.5 * width, 0],
-                          }
-                    ),
-                  },
-                  {
-                    // Workaround for workaround for https://github.com/facebook/react-native/issues/6278
-                    scaleX: timer.interpolate(
-                      indeterminate
-                        ? {
-                            inputRange: [0, 0.5, 1],
-                            outputRange: [
-                              0.0001,
-                              INDETERMINATE_MAX_WIDTH,
-                              0.0001,
-                            ],
-                          }
-                        : {
-                            inputRange: [0, 1],
-                            outputRange: [0.0001, 1],
-                          }
-                    ),
-                  },
-                ],
-              },
-              fillStyle,
-            ]}
+            style={[styles.progressBar, progressBarStyle, fillStyle]}
           />
         ) : null}
       </Animated.View>

--- a/src/components/__tests__/ProgressBar.test.tsx
+++ b/src/components/__tests__/ProgressBar.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Animated, Platform, StyleSheet } from 'react-native';
+import type { ViewStyle } from 'react-native';
 
 import { act, render } from '@testing-library/react-native';
 
@@ -96,4 +97,18 @@ it('renders progress bar with custom style of filled part', async () => {
   expect(tree.getByTestId('progress-bar-fill')).toHaveStyle({
     borderRadius: 4,
   });
+});
+
+it('does not scale the determinate fill width', async () => {
+  const tree = render(<ProgressBar progress={0.2} testID="progress-bar" />);
+  await triggerLayout(tree);
+
+  const fillStyle = StyleSheet.flatten(
+    tree.getByTestId('progress-bar-fill').props.style
+  ) as ViewStyle;
+  const transform = fillStyle.transform;
+
+  expect(
+    Array.isArray(transform) && transform.some((value) => 'scaleX' in value)
+  ).toBe(false);
 });

--- a/src/components/__tests__/__snapshots__/ProgressBar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ProgressBar.test.tsx.snap
@@ -39,10 +39,7 @@ exports[`renders colored progress bar 1`] = `
           "flex": 1,
           "transform": [
             {
-              "translateX": -50,
-            },
-            {
-              "scaleX": 0.0001,
+              "translateX": -100,
             },
           ],
           "width": 100,
@@ -93,10 +90,7 @@ exports[`renders hidden progress bar 1`] = `
           "flex": 1,
           "transform": [
             {
-              "translateX": -50,
-            },
-            {
-              "scaleX": 0.0001,
+              "translateX": -100,
             },
           ],
           "width": 100,
@@ -195,10 +189,7 @@ exports[`renders progress bar with specific progress 1`] = `
           "flex": 1,
           "transform": [
             {
-              "translateX": -50,
-            },
-            {
-              "scaleX": 0.0001,
+              "translateX": -100,
             },
           ],
           "width": 100,


### PR DESCRIPTION
### Motivation

The determinate `ProgressBar` fill was rendered at full width and animated with `scaleX`. Since transforms also scale the rendered border radius, custom `fillStyle.borderRadius` looked nearly square at low progress values and only appeared correctly rounded near full progress.

This updates determinate progress to reveal the full-width fill by translating it under the clipped track instead of scaling it. That preserves rounded fill styles while keeping the animation transform-based and compatible with the native driver.

Indeterminate progress keeps the existing scale/translate animation.

### Related issue

Fixes a visual issue where determinate `ProgressBar` fill radius is scaled down at low progress values.

### Test plan

- `yarn test src/components/__tests__/ProgressBar.test.tsx`
- `yarn typescript`

Added a regression test to verify determinate fill no longer uses `scaleX`, while preserving custom `fillStyle` coverage and updated snapshots.

### Before

https://github.com/user-attachments/assets/d3f9a25f-5b91-4b02-8a60-7889edc0a40b


### After

https://github.com/user-attachments/assets/c6c6d12e-edca-481f-8c22-8fde14509924





