### PR TITLE
feat(chip): distinguish flat-mode selected by background color

### DIFF
--- a/src/components/Chip/helpers.tsx
+++ b/src/components/Chip/helpers.tsx
@@ -82,7 +82,7 @@ const getDefaultBackgroundColor = ({
     return colors.surface;
   }
 
-  return colors.secondaryContainer;
+  return 'transparent';
 };
 
 const getBackgroundColor = ({
@@ -93,11 +93,11 @@ const getBackgroundColor = ({
 }: BaseProps & {
   customBackgroundColor?: ColorValue;
 }) => {
-  const { colors } = md3(theme);
-  if (typeof customBackgroundColor === 'string') {
+  if (customBackgroundColor !== undefined) {
     return customBackgroundColor;
   }
 
+  const { colors } = md3(theme);
   if (disabled) {
     if (isOutlined) {
       return 'transparent';
@@ -116,12 +116,23 @@ const getSelectedBackgroundColor = ({
 }: BaseProps & {
   customBackgroundColor?: ColorValue;
 }) => {
-  return getBackgroundColor({
-    theme,
-    disabled,
-    isOutlined,
-    customBackgroundColor,
-  });
+  if (customBackgroundColor !== undefined) {
+    return customBackgroundColor;
+  }
+
+  const { colors } = md3(theme);
+  if (disabled) {
+    if (isOutlined) {
+      return 'transparent';
+    }
+    return colors.surfaceContainerLow;
+  }
+
+  if (isOutlined) {
+    return colors.surface;
+  }
+
+  return colors.secondaryContainer;
 };
 
 const getIconColor = ({

--- a/src/components/__tests__/Chip.test.tsx
+++ b/src/components/__tests__/Chip.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Animated } from 'react-native';
+import { Animated, PlatformColor } from 'react-native';
 
 import { act } from '@testing-library/react-native';
 import color from 'color';
@@ -217,6 +217,20 @@ describe('getChipColor - selected background color', () => {
     });
   });
 
+  it('should return non-string custom color (e.g. PlatformColor / OpaqueColorValue), flat mode', () => {
+    const opaque = PlatformColor('systemBlue');
+    expect(
+      getChipColors({
+        theme: getTheme(),
+        customBackgroundColor: opaque,
+        isOutlined: false,
+      })
+    ).toMatchObject({
+      backgroundColor: opaque,
+      selectedBackgroundColor: opaque,
+    });
+  });
+
   it('should return theme color, for theme version 3, flat mode', () => {
     expect(
       getChipColors({
@@ -225,6 +239,41 @@ describe('getChipColor - selected background color', () => {
       })
     ).toMatchObject({
       selectedBackgroundColor: getTheme().colors.secondaryContainer,
+    });
+  });
+
+  it('should return surface color, for theme version 3, outlined mode', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+        isOutlined: true,
+      })
+    ).toMatchObject({
+      selectedBackgroundColor: getTheme().colors.surface,
+    });
+  });
+
+  it('should return disabled fill, for theme version 3, flat mode + disabled', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+        isOutlined: false,
+        disabled: true,
+      })
+    ).toMatchObject({
+      selectedBackgroundColor: getTheme().colors.surfaceContainerLow,
+    });
+  });
+
+  it('should return transparent for theme version 3, outlined mode + disabled', () => {
+    expect(
+      getChipColors({
+        theme: getTheme(),
+        isOutlined: true,
+        disabled: true,
+      })
+    ).toMatchObject({
+      selectedBackgroundColor: 'transparent',
     });
   });
 });
@@ -260,8 +309,16 @@ describe('getChipColor - background color', () => {
         isOutlined: false,
       })
     ).toMatchObject({
-      backgroundColor: getTheme().colors.secondaryContainer,
+      backgroundColor: 'transparent',
     });
+  });
+
+  it('should differ from selectedBackgroundColor for theme version 3, flat mode', () => {
+    const { backgroundColor, selectedBackgroundColor } = getChipColors({
+      theme: getTheme(),
+      isOutlined: false,
+    });
+    expect(backgroundColor).not.toBe(selectedBackgroundColor);
   });
 });
 

--- a/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`renders chip with close button 1`] = `
   collapsable={false}
   style={
     {
-      "backgroundColor": "rgba(232, 222, 248, 1)",
+      "backgroundColor": "transparent",
       "borderRadius": 8,
       "shadowColor": "rgba(0, 0, 0, 1)",
       "shadowOffset": {
@@ -22,7 +22,7 @@ exports[`renders chip with close button 1`] = `
     collapsable={false}
     style={
       {
-        "backgroundColor": "rgba(232, 222, 248, 1)",
+        "backgroundColor": "transparent",
         "borderColor": "transparent",
         "borderRadius": 8,
         "borderStyle": "solid",
@@ -303,7 +303,7 @@ exports[`renders chip with custom close button 1`] = `
   collapsable={false}
   style={
     {
-      "backgroundColor": "rgba(232, 222, 248, 1)",
+      "backgroundColor": "transparent",
       "borderRadius": 8,
       "shadowColor": "rgba(0, 0, 0, 1)",
       "shadowOffset": {
@@ -320,7 +320,7 @@ exports[`renders chip with custom close button 1`] = `
     collapsable={false}
     style={
       {
-        "backgroundColor": "rgba(232, 222, 248, 1)",
+        "backgroundColor": "transparent",
         "borderColor": "transparent",
         "borderRadius": 8,
         "borderStyle": "solid",
@@ -601,7 +601,7 @@ exports[`renders chip with icon 1`] = `
   collapsable={false}
   style={
     {
-      "backgroundColor": "rgba(232, 222, 248, 1)",
+      "backgroundColor": "transparent",
       "borderRadius": 8,
       "shadowColor": "rgba(0, 0, 0, 1)",
       "shadowOffset": {
@@ -618,7 +618,7 @@ exports[`renders chip with icon 1`] = `
     collapsable={false}
     style={
       {
-        "backgroundColor": "rgba(232, 222, 248, 1)",
+        "backgroundColor": "transparent",
         "borderColor": "transparent",
         "borderRadius": 8,
         "borderStyle": "solid",
@@ -806,7 +806,7 @@ exports[`renders chip with onPress 1`] = `
   collapsable={false}
   style={
     {
-      "backgroundColor": "rgba(232, 222, 248, 1)",
+      "backgroundColor": "transparent",
       "borderRadius": 8,
       "shadowColor": "rgba(0, 0, 0, 1)",
       "shadowOffset": {
@@ -823,7 +823,7 @@ exports[`renders chip with onPress 1`] = `
     collapsable={false}
     style={
       {
-        "backgroundColor": "rgba(232, 222, 248, 1)",
+        "backgroundColor": "transparent",
         "borderColor": "transparent",
         "borderRadius": 8,
         "borderStyle": "solid",

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`renders list item with custom description 1`] = `
             collapsable={false}
             style={
               {
-                "backgroundColor": "rgba(232, 222, 248, 1)",
+                "backgroundColor": "transparent",
                 "borderRadius": 8,
                 "shadowColor": "rgba(0, 0, 0, 1)",
                 "shadowOffset": {
@@ -138,7 +138,7 @@ exports[`renders list item with custom description 1`] = `
               collapsable={false}
               style={
                 {
-                  "backgroundColor": "rgba(232, 222, 248, 1)",
+                  "backgroundColor": "transparent",
                   "borderColor": "transparent",
                   "borderRadius": 8,
                   "borderStyle": "solid",


### PR DESCRIPTION
## Summary

Adds visual distinction between selected and unselected `flat` mode chips. Today `Chip mode="flat"` renders with `theme.colors.secondaryContainer` for BOTH the unselected and selected states. Selection is only visible via the check glyph (when `showSelectedCheck` is set). MD3 spec calls for flat chips to use a transparent fill when unselected and the `secondaryContainer` token only when selected.

This addresses one bullet from #4931 / discussion #4949 (Chip section):

> `flat` mode background is always `secondaryContainer` regardless of `selected` state. Unselected assist/suggestion chips should have no fill (transparent); only selected filter chips use `secondaryContainer`.

MD3 spec reference: <https://m3.material.io/components/chips/specs>

## Behavior

After the patch, with default props:

| Mode | Unselected | Selected |
|---|---|---|
| `flat` | `'transparent'` fill | `theme.colors.secondaryContainer` fill |
| `outlined` | `theme.colors.surface` fill (unchanged) | `theme.colors.surface` fill (unchanged; outlined chips show selection via the check glyph, not via background change) |

### Composition with existing props (precedence rules)

1. **`customBackgroundColor` wins** (passed via `style={{ backgroundColor: ... }}`): an explicit override takes precedence over both the unselected and selected token paths.
2. **`disabled` wins**: disabled tokens take precedence over the selected fill. Flat-disabled-selected returns `surfaceContainerLow`; outlined-disabled-selected returns `'transparent'`. Matches MD3.
3. **No fix-induced behavior change for outlined chips**. Outlined-unselected stays `surface` and outlined-selected stays `surface`. Outlined chips show selection via the check glyph only, as before.

## Implementation

`src/components/Chip/helpers.tsx`:

- `getDefaultBackgroundColor`: flat branch returns `'transparent'` (was `colors.secondaryContainer`).
- `getSelectedBackgroundColor`: no longer delegates to `getBackgroundColor`. New body that branches on `disabled`, `isOutlined` and `customBackgroundColor` to return the correct selected color for each composition.

Net: +18 / -7 lines in `helpers.tsx`. Outlined mode unchanged. No new public props.

## Testing

Visually verified on **iOS Simulator** (iPhone 17 Pro, iOS 18) and **Android Emulator** (Pixel 9, API 35) across **light and dark themes** using a standalone Expo app with the patch applied via `patch-package`.

**Unit tests** for the new behavior added in `src/components/__tests__/Chip.test.tsx` (4 new cases on top of the existing 33):

- `should differ from selectedBackgroundColor for theme version 3, flat mode` (the key behavioral contract this PR establishes)
- `should return surface color, for theme version 3, outlined mode` (selected, locks down outlined behavior is unchanged)
- `should return disabled fill, for theme version 3, flat mode + disabled` (selected, disabled composition)
- `should return transparent for theme version 3, outlined mode + disabled` (selected, disabled + outlined composition)

The existing `should return theme color, for theme version 3, flat mode` (background-color block) was updated to assert `'transparent'` instead of `secondaryContainer` (the test that previously codified the bug).

4 chip snapshots updated (`onPress`, `icon`, `close button`, `custom close button`) plus 1 ListItem snapshot (it renders a Chip and captured the old background). All 742 unit tests pass.

Screenshots:

**iOS**

| Theme | Before | After |
|---|---|---|
| Light | <img width="1206" height="2622" alt="ios-before-light" src="https://github.com/user-attachments/assets/2c789fa5-d136-4092-b9fe-329d78aaef8a" /> | <img width="1206" height="2622" alt="ios-after-light" src="https://github.com/user-attachments/assets/2cf4145b-30be-47a1-b110-082dd6bb32e3" /> |
| Dark | <img width="1206" height="2622" alt="ios-before-dark" src="https://github.com/user-attachments/assets/936b46b7-1137-41e1-97e7-395575993c87" /> | <img width="1206" height="2622" alt="ios-after-dark" src="https://github.com/user-attachments/assets/fc72d027-ff36-4526-a91a-9b4bc89748a3" /> |

**Android**

| Theme | Before | After |
|---|---|---|
| Light | <img width="1080" height="2424" alt="android-before-light" src="https://github.com/user-attachments/assets/3a71f150-0a0b-494c-9cdb-c459f8122a0f" /> | <img width="1080" height="2424" alt="android-after-light" src="https://github.com/user-attachments/assets/85191fc3-ef86-42ff-8122-de175d76eb8f" /> |
| Dark | <img width="1080" height="2424" alt="android-before-dark" src="https://github.com/user-attachments/assets/bde7136e-1e8a-4139-bc70-86f3b3c1bcd2" /> | <img width="1080" height="2424" alt="android-after-dark" src="https://github.com/user-attachments/assets/334be3fe-624a-4dc3-8577-c90c55982c6d" /> |

Observations:

- The dark-mode "after" screenshots show the same `secondaryContainer` token but resolved through the dark theme palette. Patch is token-based so any custom theme passed via `PaperProvider` Just Works.
- The "flat, no check icon" sandbox row makes the bug most visible: without the check glyph, the BEFORE selected and unselected chips are visually identical.
- Composition cases (`flat + disabled`, `flat + custom backgroundColor`) were each verified visually.

## What's NOT in this PR

These were considered and intentionally deferred (each could be its own PR):

- Separating the four MD3 chip types (`assist` / `filter` / `input` / `suggestion`) into distinct color logic (separate #4949 bullet about adding a `type` prop)
- `elevated=true` not changing background color (separate #4949 bullet)
- Per-type/per-state icon color (currently hardcoded `primary`, separate #4949 bullet)
- Wiring up or removing the unused `showSelectedOverlay` prop (separate #4949 bullet)
- Switching the close button from bare `Pressable` to `TouchableRipple` for the MD3 state layer (separate #4949 bullet)

## Conventional commit

`feat(chip): distinguish flat-mode selected by background color`

## Related

- Issue: #4931
- Discussion: #4949 (Chip section)
- MD3 spec: <https://m3.material.io/components/chips/specs>
- Previous PR in this series: #4955 (Checkbox error state, merged)

cc @adrcotfas
