### PR TITLE
fix: memoize chip color resolution

### DIFF
--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -259,13 +259,17 @@ const Chip = ({
     contentOpacity,
     selectedBackgroundColor,
     backgroundColor,
-  } = getChipColors({
-    isOutlined,
-    theme,
-    selectedColor,
-    customBackgroundColor,
-    disabled,
-  });
+  } = React.useMemo(
+    () =>
+      getChipColors({
+        isOutlined,
+        theme,
+        selectedColor,
+        customBackgroundColor,
+        disabled,
+      }),
+    [customBackgroundColor, disabled, isOutlined, selectedColor, theme]
+  );
 
   const accessibilityState: AccessibilityState = {
     selected,


### PR DESCRIPTION
### Motivation

`Chip` resolves multiple theme-derived colors during render. The current main branch has already removed most of the color chains mentioned in issue #4946, but `Chip` still calls `getChipColors` every render even when its color inputs are unchanged.

This wraps the color resolution in `React.useMemo` so the derived color object is recomputed only when the relevant inputs change. There is no API or visual behavior change.

### Related issue

Related to #4946.

### Test plan

- `yarn test src/components/__tests__/Chip.test.tsx --runInBand`
- `yarn lint-no-fix src/components/Chip/Chip.tsx`
- `yarn typescript`
- Full test suite also ran during the pre-commit hook: 55 suites / 736 tests passed.