### PR TITLE
feat(checkbox): modernize for md3 spec compliance

### DIFF
--- a/example/src/Examples/CheckboxExample.tsx
+++ b/example/src/Examples/CheckboxExample.tsx
@@ -1,59 +1,185 @@
 import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import { Checkbox, Palette, Text, TouchableRipple } from 'react-native-paper';
+import { Checkbox, Text, useTheme } from 'react-native-paper';
 
 import ScreenWrapper from '../ScreenWrapper';
 
-const CheckboxExample = () => {
-  const [checkedNormal, setCheckedNormal] = React.useState<boolean>(true);
-  const [checkedCustom, setCheckedCustom] = React.useState<boolean>(true);
-  const [indeterminate, setIndeterminate] = React.useState<boolean>(true);
+type Status = 'unchecked' | 'checked' | 'indeterminate';
 
+const STATUSES: Status[] = ['unchecked', 'checked', 'indeterminate'];
+
+type Row = {
+  label: string;
+  render: (status: Status) => React.ReactNode;
+};
+
+const ROWS: Row[] = [
+  {
+    label: 'Default',
+    render: (status) => <Checkbox status={status} onPress={() => {}} />,
+  },
+  {
+    label: 'Disabled',
+    render: (status) => <Checkbox status={status} disabled />,
+  },
+  {
+    label: 'Custom color (tertiary)',
+    render: (status) => <CustomColorCheckbox status={status} />,
+  },
+  {
+    label: 'Error',
+    render: (status) => <Checkbox status={status} error onPress={() => {}} />,
+  },
+];
+
+const CustomColorCheckbox = ({ status }: { status: Status }) => {
+  const theme = useTheme();
   return (
-    <ScreenWrapper style={styles.container}>
-      <TouchableRipple onPress={() => setCheckedNormal(!checkedNormal)}>
-        <View style={styles.row}>
-          <Text>Normal</Text>
-          <View pointerEvents="none">
-            <Checkbox status={checkedNormal ? 'checked' : 'unchecked'} />
+    <Checkbox
+      status={status}
+      color={theme.colors.tertiary}
+      uncheckedColor={theme.colors.tertiary}
+      onPress={() => {}}
+    />
+  );
+};
+
+const Interactive = () => {
+  const theme = useTheme();
+  const [aChecked, setAChecked] = React.useState(false);
+  const [bIndeterminate, setBIndeterminate] = React.useState(false);
+  return (
+    <View style={styles.interactive}>
+      <Text style={[styles.rowLabel, { color: theme.colors.onSurfaceVariant }]}>
+        Tap to toggle
+      </Text>
+      <View style={styles.interactiveRow}>
+        <View style={styles.cell}>
+          <Checkbox
+            status={aChecked ? 'checked' : 'unchecked'}
+            onPress={() => setAChecked((v) => !v)}
+          />
+        </View>
+        <Text
+          style={[
+            styles.interactiveLabel,
+            { color: theme.colors.onSurfaceVariant },
+          ]}
+        >
+          unchecked ↔ checked
+        </Text>
+      </View>
+      <View style={[styles.interactiveRow, styles.interactiveRowSpacing]}>
+        <View style={styles.cell}>
+          <Checkbox
+            status={bIndeterminate ? 'indeterminate' : 'unchecked'}
+            onPress={() => setBIndeterminate((v) => !v)}
+          />
+        </View>
+        <Text
+          style={[
+            styles.interactiveLabel,
+            { color: theme.colors.onSurfaceVariant },
+          ]}
+        >
+          unchecked ↔ indeterminate
+        </Text>
+      </View>
+    </View>
+  );
+};
+
+const IndeterminateParent = () => {
+  const theme = useTheme();
+  const [child1, setChild1] = React.useState(true);
+  const [child2, setChild2] = React.useState(false);
+  const [child3, setChild3] = React.useState(true);
+  const allChecked = child1 && child2 && child3;
+  const noneChecked = !child1 && !child2 && !child3;
+  const parentStatus: Status = allChecked
+    ? 'checked'
+    : noneChecked
+    ? 'unchecked'
+    : 'indeterminate';
+  const toggleAll = () => {
+    const next = !allChecked;
+    setChild1(next);
+    setChild2(next);
+    setChild3(next);
+  };
+  return (
+    <View style={styles.row}>
+      <Text style={[styles.rowLabel, { color: theme.colors.onSurfaceVariant }]}>
+        Parent / children (indeterminate)
+      </Text>
+      <View style={styles.parentRow}>
+        <Checkbox status={parentStatus} onPress={toggleAll} />
+        <Text
+          style={[styles.interactiveLabel, { color: theme.colors.onSurface }]}
+        >
+          Select all
+        </Text>
+      </View>
+      <View style={styles.childRow}>
+        <Checkbox
+          status={child1 ? 'checked' : 'unchecked'}
+          onPress={() => setChild1((v) => !v)}
+        />
+        <Text
+          style={[styles.interactiveLabel, { color: theme.colors.onSurface }]}
+        >
+          Apples
+        </Text>
+      </View>
+      <View style={styles.childRow}>
+        <Checkbox
+          status={child2 ? 'checked' : 'unchecked'}
+          onPress={() => setChild2((v) => !v)}
+        />
+        <Text
+          style={[styles.interactiveLabel, { color: theme.colors.onSurface }]}
+        >
+          Bananas
+        </Text>
+      </View>
+      <View style={styles.childRow}>
+        <Checkbox
+          status={child3 ? 'checked' : 'unchecked'}
+          onPress={() => setChild3((v) => !v)}
+        />
+        <Text
+          style={[styles.interactiveLabel, { color: theme.colors.onSurface }]}
+        >
+          Cherries
+        </Text>
+      </View>
+    </View>
+  );
+};
+
+const CheckboxExample = () => {
+  const theme = useTheme();
+  return (
+    <ScreenWrapper contentContainerStyle={styles.scrollContent}>
+      <Interactive />
+      {ROWS.map((row) => (
+        <View key={row.label} style={styles.row}>
+          <Text
+            style={[styles.rowLabel, { color: theme.colors.onSurfaceVariant }]}
+          >
+            {row.label}
+          </Text>
+          <View style={styles.cells}>
+            {STATUSES.map((status) => (
+              <View key={status} style={styles.cell}>
+                {row.render(status)}
+              </View>
+            ))}
           </View>
         </View>
-      </TouchableRipple>
-
-      <TouchableRipple onPress={() => setCheckedCustom(!checkedCustom)}>
-        <View style={styles.row}>
-          <Text>Custom</Text>
-          <View pointerEvents="none">
-            <Checkbox
-              color={Palette.error70}
-              status={checkedCustom ? 'checked' : 'unchecked'}
-            />
-          </View>
-        </View>
-      </TouchableRipple>
-
-      <TouchableRipple onPress={() => setIndeterminate(!indeterminate)}>
-        <View style={styles.row}>
-          <Text>Indeterminate</Text>
-          <View pointerEvents="none">
-            <Checkbox status={indeterminate ? 'indeterminate' : 'unchecked'} />
-          </View>
-        </View>
-      </TouchableRipple>
-
-      <View style={styles.row}>
-        <Text>Checked (Disabled)</Text>
-        <Checkbox status="checked" disabled />
-      </View>
-      <View style={styles.row}>
-        <Text>Unchecked (Disabled)</Text>
-        <Checkbox status="unchecked" disabled />
-      </View>
-      <View style={styles.row}>
-        <Text>Indeterminate (Disabled)</Text>
-        <Checkbox status="indeterminate" disabled />
-      </View>
+      ))}
+      <IndeterminateParent />
     </ScreenWrapper>
   );
 };
@@ -61,15 +187,43 @@ const CheckboxExample = () => {
 CheckboxExample.title = 'Checkbox';
 
 const styles = StyleSheet.create({
-  container: {
-    paddingVertical: 8,
+  scrollContent: { paddingHorizontal: 16, paddingTop: 16, paddingBottom: 32 },
+  row: { marginBottom: 20 },
+  rowLabel: {
+    fontSize: 14,
+    fontWeight: '500',
+    marginBottom: 6,
+    opacity: 0.7,
   },
-  row: {
+  cells: {
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingVertical: 8,
-    paddingHorizontal: 16,
+  },
+  cell: {
+    width: 60,
+    alignItems: 'center',
+  },
+  interactive: { marginBottom: 24 },
+  interactiveRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  interactiveRowSpacing: { marginTop: 8 },
+  interactiveLabel: {
+    fontSize: 14,
+    opacity: 0.7,
+  },
+  parentRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  childRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingLeft: 32,
   },
 });
 

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,16 +1,30 @@
 import * as React from 'react';
-import {
-  Animated,
+import { Platform, StyleSheet, View } from 'react-native';
+import type {
   ColorValue,
   GestureResponderEvent,
-  StyleSheet,
-  View,
+  NativeSyntheticEvent,
+  StyleProp,
+  TargetedEvent,
+  ViewStyle,
 } from 'react-native';
 
-import { getSelectionControlColor } from './utils';
+import Animated, {
+  Easing,
+  ReduceMotion,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+
+import { CheckboxTokens } from './tokens';
+import { getSelectionVisualState } from './utils';
+import { useLocale } from '../../core/locale';
 import { useInternalTheme } from '../../core/theming';
+import { useReduceMotion } from '../../theme/accessibility/ReduceMotionContext';
+import { tokens } from '../../theme/tokens';
 import type { $RemoveChildren, ThemeProp } from '../../types';
-import MaterialCommunityIcon from '../MaterialCommunityIcon';
+import { isKeyboardFocusEvent } from '../../utils/isKeyboardFocusEvent';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 
 export type Props = $RemoveChildren<typeof TouchableRipple> & {
@@ -36,9 +50,9 @@ export type Props = $RemoveChildren<typeof TouchableRipple> & {
   color?: ColorValue;
   /**
    * Whether the checkbox is in an error state. When true, the outline
-   * (unchecked) and container (checked / indeterminate) use
-   * `theme.colors.error`. `disabled` and explicit `color`/`uncheckedColor`
-   * overrides take precedence.
+   * (unchecked) and container (selected) use `theme.colors.error`.
+   * `disabled` and explicit `color`/`uncheckedColor` overrides take
+   * precedence.
    */
   error?: boolean;
   /**
@@ -49,9 +63,28 @@ export type Props = $RemoveChildren<typeof TouchableRipple> & {
    * testID to be used on tests.
    */
   testID?: string;
+  /**
+   * Custom style to override the default tap target. Passed through to
+   * the underlying `TouchableRipple`.
+   */
+  style?: StyleProp<ViewStyle>;
 };
 
-const ANIMATION_DURATION = 100;
+// Spec dimensions (https://m3.material.io/components/checkbox/specs).
+const {
+  containerSize: CONTAINER_SIZE,
+  containerRadius: CONTAINER_RADIUS,
+  outlineWidth: OUTLINE_WIDTH,
+  stateLayerSize: STATE_LAYER_SIZE,
+} = CheckboxTokens;
+
+const FOCUS_THICKNESS = tokens.md.sys.state.focusIndicator.thickness;
+// Focus indicator is a circular ring at the 40dp state-layer boundary.
+// We don't apply `focusIndicator.outerOffset` here because the surrounding
+// `TouchableRipple borderless` clips overflow to the tap-target shape,
+// so a ring drawn outside the 40dp circle would be cropped.
+const FOCUS_RING_SIZE = STATE_LAYER_SIZE;
+const FOCUS_RING_RADIUS = STATE_LAYER_SIZE / 2;
 
 /**
  * Checkboxes allow the selection of multiple options from a set.
@@ -84,121 +117,343 @@ const Checkbox = ({
   onPress,
   testID,
   error,
+  color,
+  uncheckedColor,
+  style,
   ...rest
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
-  const { current: scaleAnim } = React.useRef<Animated.Value>(
-    new Animated.Value(1)
-  );
-  const isFirstRendering = React.useRef<boolean>(true);
+  const reduceMotion = useReduceMotion();
+  const { direction } = useLocale();
+  // Web (react-native-web) doesn't auto-mirror layout, so flip the mask
+  // anchor manually for RTL. Native handles it via `I18nManager`.
+  const flipMaskForWebRTL = Platform.OS === 'web' && direction === 'rtl';
+  const [focused, setFocused] = React.useState(false);
 
-  const {
-    animation: { scale },
-  } = theme;
+  const selected = status === 'checked' || status === 'indeterminate';
+
+  const reanimatedReduceMotion = reduceMotion
+    ? ReduceMotion.Always
+    : ReduceMotion.Never;
+
+  const fillTimingConfig = React.useMemo(
+    () => ({
+      duration: theme.motion.duration.short2,
+      easing: Easing.bezier(...theme.motion.easing.standard),
+      reduceMotion: reanimatedReduceMotion,
+    }),
+    [
+      theme.motion.duration.short2,
+      theme.motion.easing.standard,
+      reanimatedReduceMotion,
+    ]
+  );
+  const checkTimingConfig = React.useMemo(
+    () => ({
+      duration: theme.motion.duration.short3,
+      easing: Easing.bezier(...theme.motion.easing.standard),
+      reduceMotion: reanimatedReduceMotion,
+    }),
+    [
+      theme.motion.duration.short3,
+      theme.motion.easing.standard,
+      reanimatedReduceMotion,
+    ]
+  );
+
+  // 0 = unselected (outline only), 1 = selected (filled + drawn icon).
+  const fillProgress = useSharedValue(selected ? 1 : 0);
+  const checkProgress = useSharedValue(selected ? 1 : 0);
+  const firstRender = React.useRef(true);
 
   React.useEffect(() => {
-    // Do not run animation on very first rendering
-    if (isFirstRendering.current) {
-      isFirstRendering.current = false;
+    if (firstRender.current) {
+      firstRender.current = false;
       return;
     }
+    const target = selected ? 1 : 0;
+    fillProgress.value = withTiming(target, fillTimingConfig);
+    checkProgress.value = withTiming(target, checkTimingConfig);
+  }, [
+    selected,
+    fillProgress,
+    checkProgress,
+    fillTimingConfig,
+    checkTimingConfig,
+  ]);
 
-    const checked = status === 'checked';
-
-    Animated.sequence([
-      Animated.timing(scaleAnim, {
-        toValue: 0.85,
-        duration: checked ? ANIMATION_DURATION * scale : 0,
-        useNativeDriver: false,
-      }),
-      Animated.timing(scaleAnim, {
-        toValue: 1,
-        duration: checked
-          ? ANIMATION_DURATION * scale
-          : ANIMATION_DURATION * scale * 1.75,
-        useNativeDriver: false,
-      }),
-    ]).start();
-  }, [status, scaleAnim, scale]);
-
-  const checked = status === 'checked';
-  const indeterminate = status === 'indeterminate';
-
-  const { selectionControlColor, selectionControlOpacity } =
-    getSelectionControlColor({
-      theme,
-      disabled,
-      checked,
-      customColor: rest.color,
-      customUncheckedColor: rest.uncheckedColor,
-      error,
-    });
-
-  const borderWidth = scaleAnim.interpolate({
-    inputRange: [0.8, 1],
-    outputRange: [7, 0],
+  // Visual state (colors + opacity) for the static layers. `hovered` /
+  // `pressed` aren't tracked here — `TouchableRipple` owns the press ripple
+  // and hover overlay.
+  const visual = getSelectionVisualState({
+    theme,
+    selected,
+    disabled,
+    error,
+    customColor: color,
+    customUncheckedColor: uncheckedColor,
   });
 
-  const icon = indeterminate
-    ? 'minus-box'
-    : checked
-    ? 'checkbox-marked'
-    : 'checkbox-blank-outline';
+  // Outline fades out as fill fades in (and vice versa).
+  const outlineAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: 1 - fillProgress.value,
+  }));
+
+  const fillAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: fillProgress.value,
+  }));
+
+  const maskAnimatedStyle = useAnimatedStyle(() => ({
+    width: checkProgress.value * CONTAINER_SIZE,
+    opacity: checkProgress.value,
+  }));
+
+  // Remember the last drawn glyph so the reveal-mask can finish collapsing
+  // when `selected` flips back to false. Computed via the "derive state
+  // during render" pattern (https://react.dev/reference/react/useState#storing-information-from-previous-renders)
+  // so we don't mutate a ref during render.
+  const [lastGlyph, setLastGlyph] = React.useState<'check' | 'indeterminate'>(
+    status === 'indeterminate' ? 'indeterminate' : 'check'
+  );
+  const nextGlyph: 'check' | 'indeterminate' =
+    status === 'checked'
+      ? 'check'
+      : status === 'indeterminate'
+      ? 'indeterminate'
+      : lastGlyph;
+  if (nextGlyph !== lastGlyph) {
+    setLastGlyph(nextGlyph);
+  }
+  const showIndeterminate = nextGlyph === 'indeterminate';
+
+  const handleFocus = React.useCallback(
+    (e: NativeSyntheticEvent<TargetedEvent>) => {
+      if (disabled) return;
+      if (!isKeyboardFocusEvent(e)) return;
+      setFocused(true);
+    },
+    [disabled]
+  );
+
+  const handleBlur = React.useCallback(() => {
+    setFocused(false);
+  }, []);
+
+  // When `accessible={false}` is passed (typically by `CheckboxItem`, which
+  // owns the a11y tree for the wrapped row), suppress our own a11y role
+  // and state so the same logical control doesn't expose two `checked`
+  // states to assistive tech.
+  const accessibilityProps =
+    rest.accessible === false
+      ? {}
+      : {
+          accessibilityRole: 'checkbox' as const,
+          accessibilityState: {
+            disabled: !!disabled,
+            checked: (status === 'indeterminate'
+              ? 'mixed'
+              : status === 'checked') as boolean | 'mixed',
+          },
+          accessibilityLiveRegion: 'polite' as const,
+        };
 
   return (
     <TouchableRipple
       {...rest}
       borderless
+      centered
       onPress={onPress}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
       disabled={disabled}
-      accessibilityRole="checkbox"
-      accessibilityState={{ disabled, checked }}
-      accessibilityLiveRegion="polite"
-      style={styles.container}
+      {...accessibilityProps}
       testID={testID}
-      theme={theme}
+      style={[
+        styles.tapTarget,
+        Platform.OS === 'web' ? webNoOutline : undefined,
+        style,
+      ]}
     >
-      <Animated.View
-        style={{
-          transform: [{ scale: scaleAnim }],
-          opacity: selectionControlOpacity,
-        }}
-      >
-        <MaterialCommunityIcon
-          allowFontScaling={false}
-          name={icon}
-          size={24}
-          color={selectionControlColor}
-          direction="ltr"
-        />
-        <View style={[StyleSheet.absoluteFill, styles.fillContainer]}>
+      <View pointerEvents="none" style={styles.tapTargetInner}>
+        {focused && !disabled ? (
+          <View
+            pointerEvents="none"
+            style={[styles.focusRing, { borderColor: theme.colors.secondary }]}
+          />
+        ) : null}
+        <View style={[styles.container, { opacity: visual.containerOpacity }]}>
           <Animated.View
+            pointerEvents="none"
             style={[
-              styles.fill,
-              { borderColor: selectionControlColor },
-              { borderWidth },
+              styles.outline,
+              { borderColor: visual.outlineColor },
+              outlineAnimatedStyle,
             ]}
           />
+          <Animated.View
+            pointerEvents="none"
+            style={[
+              styles.fill,
+              { backgroundColor: visual.containerColor },
+              fillAnimatedStyle,
+            ]}
+          />
+          {showIndeterminate ? (
+            <Animated.View
+              style={[
+                flipMaskForWebRTL
+                  ? styles.checkmarkMaskWebRTL
+                  : styles.checkmarkMask,
+                maskAnimatedStyle,
+              ]}
+            >
+              <View style={styles.checkmarkContent}>
+                <View
+                  style={[styles.dash, { backgroundColor: visual.iconColor }]}
+                />
+              </View>
+            </Animated.View>
+          ) : (
+            <Checkmark
+              color={visual.iconColor}
+              maskAnimatedStyle={maskAnimatedStyle}
+              flipMaskForWebRTL={flipMaskForWebRTL}
+              isRTL={direction === 'rtl'}
+              autoSwapsBorders={Platform.OS !== 'web'}
+            />
+          )}
         </View>
-      </Animated.View>
+      </View>
     </TouchableRipple>
   );
 };
 
+/**
+ * Reveal-mask checkmark: an L-shape (borderLeftWidth + borderBottomWidth
+ * rotated -45deg) inside a directional-anchored View whose width animates
+ * 0 → CONTAINER_SIZE so the stroke "draws in" along the writing direction.
+ */
+const Checkmark = ({
+  color,
+  maskAnimatedStyle,
+  flipMaskForWebRTL,
+  isRTL,
+  autoSwapsBorders,
+}: {
+  color: ColorValue;
+  maskAnimatedStyle: ReturnType<typeof useAnimatedStyle>;
+  flipMaskForWebRTL: boolean;
+  isRTL: boolean;
+  // True on platforms whose layout engine auto-swaps `borderLeftWidth`
+  // ↔ `borderRightWidth` in RTL (Android, iOS); false on web (RNW).
+  autoSwapsBorders: boolean;
+}) => {
+  return (
+    <Animated.View
+      style={[
+        flipMaskForWebRTL ? styles.checkmarkMaskWebRTL : styles.checkmarkMask,
+        maskAnimatedStyle,
+      ]}
+    >
+      <View style={styles.checkmarkContent}>
+        <View
+          style={[
+            styles.checkmarkGlyph,
+            { borderColor: color },
+            // On platforms that auto-swap borders in RTL, pre-swap them
+            // here so the swap brings them back to the LTR orientation.
+            isRTL && autoSwapsBorders ? styles.checkmarkGlyphRTL : null,
+          ]}
+        />
+      </View>
+    </Animated.View>
+  );
+};
+
+// Web-only style; not in StyleSheet because `outline` is outside ViewStyle.
+const webNoOutline = { outline: 'none' } as unknown as ViewStyle;
+
 const styles = StyleSheet.create({
-  container: {
-    borderRadius: 18,
-    width: 36,
-    height: 36,
-    padding: 6,
-  },
-  fillContainer: {
+  tapTarget: {
+    width: STATE_LAYER_SIZE,
+    height: STATE_LAYER_SIZE,
+    borderRadius: STATE_LAYER_SIZE / 2,
     alignItems: 'center',
     justifyContent: 'center',
   },
+  tapTargetInner: {
+    width: STATE_LAYER_SIZE,
+    height: STATE_LAYER_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  focusRing: {
+    position: 'absolute',
+    width: FOCUS_RING_SIZE,
+    height: FOCUS_RING_SIZE,
+    borderRadius: FOCUS_RING_RADIUS,
+    borderWidth: FOCUS_THICKNESS,
+  },
+  container: {
+    width: CONTAINER_SIZE,
+    height: CONTAINER_SIZE,
+    borderRadius: CONTAINER_RADIUS,
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+  },
   fill: {
-    height: 14,
-    width: 14,
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    borderRadius: CONTAINER_RADIUS,
+  },
+  outline: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    borderWidth: OUTLINE_WIDTH,
+    borderRadius: CONTAINER_RADIUS,
+  },
+  dash: {
+    width: 10,
+    height: 2,
+    borderRadius: 1,
+  },
+  checkmarkMask: {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    height: CONTAINER_SIZE,
+    overflow: 'hidden',
+  },
+  checkmarkMaskWebRTL: {
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    height: CONTAINER_SIZE,
+    overflow: 'hidden',
+  },
+  checkmarkContent: {
+    width: CONTAINER_SIZE,
+    height: CONTAINER_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  checkmarkGlyph: {
+    width: 11,
+    height: 6,
+    borderLeftWidth: 2,
+    borderBottomWidth: 2,
+    transform: [{ rotate: '-45deg' }, { translateY: -1 }, { translateX: 1 }],
+  },
+  checkmarkGlyphRTL: {
+    borderLeftWidth: 0,
+    borderRightWidth: 2,
   },
 });
 

--- a/src/components/Checkbox/CheckboxItem.tsx
+++ b/src/components/Checkbox/CheckboxItem.tsx
@@ -143,7 +143,10 @@ const CheckboxItem = ({
   const theme = useInternalTheme(themeOverrides);
   const checkboxProps = { ...props, status, theme, disabled };
   const isLeading = position === 'leading';
-  const checkbox = <Checkbox {...checkboxProps} />;
+  // The outer TouchableRipple below is the interactable element + a11y
+  // checkbox; the inner Checkbox is purely visual, so we exclude it from
+  // the accessibility tree to avoid duplicate `checked` states.
+  const checkbox = <Checkbox {...checkboxProps} accessible={false} />;
 
   const textAlign = isLeading ? 'right' : 'left';
 
@@ -157,7 +160,7 @@ const CheckboxItem = ({
       accessibilityLabel={accessibilityLabel}
       accessibilityRole="checkbox"
       accessibilityState={{
-        checked: status === 'checked',
+        checked: status === 'indeterminate' ? 'mixed' : status === 'checked',
         disabled,
       }}
       onPress={onPress}

--- a/src/components/Checkbox/tokens.ts
+++ b/src/components/Checkbox/tokens.ts
@@ -1,0 +1,29 @@
+import type { ColorRole } from '../../theme/types';
+
+/**
+ * MD3 Checkbox spec dimensions and color-role tokens.
+ * @see https://m3.material.io/components/checkbox/specs
+ */
+const sizes = {
+  containerSize: 18,
+  containerRadius: 2,
+  outlineWidth: 2,
+  stateLayerSize: 40,
+} as const;
+
+const colors = {
+  containerColor: 'primary',
+  disabledContainerColor: 'onSurface',
+  errorContainerColor: 'error',
+  outlineColor: 'onSurfaceVariant',
+  disabledOutlineColor: 'onSurface',
+  errorOutlineColor: 'error',
+  iconColor: 'onPrimary',
+  disabledIconColor: 'surface',
+  errorIconColor: 'onError',
+  selectedStateLayerColor: 'primary',
+  unselectedStateLayerColor: 'onSurface',
+  errorStateLayerColor: 'error',
+} as const satisfies Record<string, ColorRole>;
+
+export const CheckboxTokens = { ...sizes, ...colors };

--- a/src/components/Checkbox/utils.ts
+++ b/src/components/Checkbox/utils.ts
@@ -1,106 +1,121 @@
 import type { ColorValue } from 'react-native';
 
+import { CheckboxTokens } from './tokens';
 import { tokens } from '../../theme/tokens';
 import type { InternalTheme } from '../../types';
 
+// MD3 Checkbox spec: https://m3.material.io/components/checkbox/specs
+
 const stateOpacity = tokens.md.sys.state.opacity;
 
-const getCheckedColor = ({
-  theme,
-  customColor,
-  error,
-}: {
+type SelectionState = {
   theme: InternalTheme;
-  customColor?: ColorValue;
+  selected: boolean;
+  disabled?: boolean;
   error?: boolean;
-}) => {
+  customColor?: ColorValue;
+  customUncheckedColor?: ColorValue;
+};
+
+type SelectionVisualState = {
+  containerColor: ColorValue;
+  outlineColor: ColorValue;
+  containerOpacity: number;
+  iconColor: ColorValue;
+};
+
+const getContainerColor = ({
+  theme,
+  disabled,
+  error,
+  customColor,
+}: SelectionState): ColorValue => {
+  if (disabled) {
+    return theme.colors[CheckboxTokens.disabledContainerColor];
+  }
   if (customColor) {
     return customColor;
   }
-
   if (error) {
-    return theme.colors.error;
+    return theme.colors[CheckboxTokens.errorContainerColor];
   }
-
-  return theme.colors.primary;
+  return theme.colors[CheckboxTokens.containerColor];
 };
 
-const getUncheckedColor = ({
+const getOutlineColor = ({
   theme,
-  customUncheckedColor,
+  disabled,
   error,
-}: {
-  theme: InternalTheme;
-  customUncheckedColor?: ColorValue;
-  error?: boolean;
-}) => {
+  customUncheckedColor,
+}: SelectionState): ColorValue => {
+  if (disabled) {
+    return theme.colors[CheckboxTokens.disabledOutlineColor];
+  }
   if (customUncheckedColor) {
     return customUncheckedColor;
   }
-
   if (error) {
-    return theme.colors.error;
+    return theme.colors[CheckboxTokens.errorOutlineColor];
   }
-
-  return theme.colors.onSurfaceVariant;
+  return theme.colors[CheckboxTokens.outlineColor];
 };
 
-const getControlColor = ({
+const getIconColor = ({
   theme,
-  checked,
+  selected,
   disabled,
-  checkedColor,
-  uncheckedColor,
-}: {
-  theme: InternalTheme;
-  checked: boolean;
-  checkedColor: ColorValue;
-  uncheckedColor: ColorValue;
-  disabled?: boolean;
-}) => {
+  error,
+}: SelectionState): ColorValue => {
+  if (!selected) {
+    return 'transparent';
+  }
   if (disabled) {
-    return theme.colors.onSurface;
+    return theme.colors[CheckboxTokens.disabledIconColor];
   }
-
-  if (checked) {
-    return checkedColor;
+  if (error) {
+    return theme.colors[CheckboxTokens.errorIconColor];
   }
-  return uncheckedColor;
+  return theme.colors[CheckboxTokens.iconColor];
 };
 
-export const getSelectionControlColor = ({
+/**
+ * Resolve the static (non-interactive) colors + opacity for the Checkbox
+ * renderer. Hover / pressed / focused visuals are owned by `TouchableRipple`
+ * and the focus-ring outline, so they don't appear here.
+ */
+export const getSelectionVisualState = ({
   theme,
+  selected,
   disabled,
-  checked,
+  error,
   customColor,
   customUncheckedColor,
-  error,
-}: {
-  theme: InternalTheme;
-  checked: boolean;
-  disabled?: boolean;
-  customColor?: ColorValue;
-  customUncheckedColor?: ColorValue;
-  error?: boolean;
-}) => {
-  const checkedColor = getCheckedColor({ theme, customColor, error });
-  const uncheckedColor = getUncheckedColor({
-    theme,
-    customUncheckedColor,
-    error,
-  });
-  const selectionControlOpacity = disabled
-    ? stateOpacity.disabled
-    : stateOpacity.enabled;
-
+}: SelectionState): SelectionVisualState => {
   return {
-    selectionControlColor: getControlColor({
+    containerColor: getContainerColor({
       theme,
+      selected,
       disabled,
-      checked,
-      checkedColor,
-      uncheckedColor,
+      error,
+      customColor,
+      customUncheckedColor,
     }),
-    selectionControlOpacity,
+    outlineColor: getOutlineColor({
+      theme,
+      selected,
+      disabled,
+      error,
+      customColor,
+      customUncheckedColor,
+    }),
+    containerOpacity: disabled ? stateOpacity.disabled : stateOpacity.enabled,
+    iconColor: getIconColor({
+      theme,
+      selected,
+      disabled,
+      error,
+      customColor,
+      customUncheckedColor,
+    }),
   };
 };

--- a/src/components/RadioButton/RadioButtonAndroid.tsx
+++ b/src/components/RadioButton/RadioButtonAndroid.tsx
@@ -2,10 +2,9 @@ import * as React from 'react';
 import { Animated, StyleSheet, View } from 'react-native';
 
 import { RadioButtonContext, RadioButtonContextType } from './RadioButtonGroup';
-import { handlePress, isChecked } from './utils';
+import { getSelectionControlColor, handlePress, isChecked } from './utils';
 import { useInternalTheme } from '../../core/theming';
 import type { $RemoveChildren, ThemeProp } from '../../types';
-import { getSelectionControlColor } from '../Checkbox/utils';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 
 export type Props = $RemoveChildren<typeof TouchableRipple> & {

--- a/src/components/RadioButton/utils.ts
+++ b/src/components/RadioButton/utils.ts
@@ -93,3 +93,37 @@ export const getSelectionControlIOSColor = ({
     checkedColorOpacity,
   };
 };
+
+export const getSelectionControlColor = ({
+  theme,
+  disabled,
+  checked,
+  customColor,
+  customUncheckedColor,
+  error,
+}: {
+  theme: InternalTheme;
+  checked: boolean;
+  disabled?: boolean;
+  customColor?: ColorValue;
+  customUncheckedColor?: ColorValue;
+  error?: boolean;
+}): { selectionControlColor: ColorValue; selectionControlOpacity: number } => {
+  const opacity = disabled ? stateOpacity.disabled : stateOpacity.enabled;
+  const checkedColor = customColor
+    ? customColor
+    : error
+    ? theme.colors.error
+    : theme.colors.primary;
+  const uncheckedColor = customUncheckedColor
+    ? customUncheckedColor
+    : error
+    ? theme.colors.error
+    : theme.colors.onSurfaceVariant;
+  const color = disabled
+    ? theme.colors.onSurface
+    : checked
+    ? checkedColor
+    : uncheckedColor;
+  return { selectionControlColor: color, selectionControlOpacity: opacity };
+};

--- a/src/components/__tests__/Checkbox/CheckboxItem.test.tsx
+++ b/src/components/__tests__/Checkbox/CheckboxItem.test.tsx
@@ -29,8 +29,7 @@ it('should have `accessibilityState={ checked: true }` when `status="checked"`',
     <Checkbox.Item status="checked" label="Checked Button" />
   );
 
-  const elements = getAllByA11yState({ checked: true });
-  expect(elements).toHaveLength(2);
+  expect(getAllByA11yState({ checked: true })).toHaveLength(1);
 });
 
 it('should have `accessibilityState={ checked: false }` when `status="unchecked"', () => {
@@ -38,17 +37,15 @@ it('should have `accessibilityState={ checked: false }` when `status="unchecked"
     <Checkbox.Item status="unchecked" label="Unchecked Button" />
   );
 
-  const elements = getAllByA11yState({ checked: false });
-  expect(elements).toHaveLength(2);
+  expect(getAllByA11yState({ checked: false })).toHaveLength(1);
 });
 
-it('should have `accessibilityState={ checked: false }` when `status="indeterminate"', () => {
+it('should have `accessibilityState={ checked: "mixed" }` when `status="indeterminate"`', () => {
   const { getAllByA11yState } = render(
     <Checkbox.Item status="indeterminate" label="Indeterminate Button" />
   );
 
-  const elements = getAllByA11yState({ checked: false });
-  expect(elements).toHaveLength(2);
+  expect(getAllByA11yState({ checked: 'mixed' })).toHaveLength(1);
 });
 
 it('disables the row when the prop disabled is true', () => {

--- a/src/components/__tests__/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -22,6 +22,7 @@ exports[`renders Checkbox with custom testID 1`] = `
     }
   }
   accessible={true}
+  centered={true}
   collapsable={false}
   focusable={true}
   onBlur={[Function]}
@@ -38,87 +39,148 @@ exports[`renders Checkbox with custom testID 1`] = `
       {
         "overflow": "hidden",
       },
-      {
-        "borderRadius": 18,
-        "height": 36,
-        "padding": 6,
-        "width": 36,
-      },
+      [
+        {
+          "alignItems": "center",
+          "borderRadius": 20,
+          "height": 40,
+          "justifyContent": "center",
+          "width": 40,
+        },
+        undefined,
+        undefined,
+      ],
     ]
   }
   testID="custom:testID"
 >
   <View
-    collapsable={false}
+    pointerEvents="none"
     style={
       {
-        "opacity": 1,
-        "transform": [
-          {
-            "scale": 1,
-          },
-        ],
+        "alignItems": "center",
+        "height": 40,
+        "justifyContent": "center",
+        "width": 40,
       }
     }
   >
-    <Text
-      accessibilityElementsHidden={true}
-      allowFontScaling={false}
-      importantForAccessibility="no-hide-descendants"
-      pointerEvents="none"
-      selectable={false}
-      style={
-        [
-          {
-            "color": "rgba(103, 80, 164, 1)",
-            "fontSize": 24,
-          },
-          [
-            {
-              "lineHeight": 24,
-              "transform": [
-                {
-                  "scaleX": 1,
-                },
-              ],
-            },
-            {
-              "backgroundColor": "transparent",
-            },
-          ],
-        ]
-      }
-    >
-      checkbox-marked
-    </Text>
     <View
       style={
         [
           {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
+            "alignItems": "center",
+            "borderRadius": 2,
+            "height": 18,
+            "justifyContent": "center",
+            "overflow": "hidden",
+            "width": 18,
           },
           {
-            "alignItems": "center",
-            "justifyContent": "center",
+            "opacity": 1,
           },
         ]
       }
     >
       <View
-        collapsable={false}
+        pointerEvents="none"
         style={
-          {
-            "borderColor": "rgba(103, 80, 164, 1)",
-            "borderWidth": 0,
-            "height": 14,
-            "width": 14,
-          }
+          [
+            {
+              "borderRadius": 2,
+              "borderWidth": 2,
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "borderColor": "rgba(73, 69, 79, 1)",
+            },
+            {
+              "opacity": 0,
+            },
+          ]
         }
       />
+      <View
+        pointerEvents="none"
+        style={
+          [
+            {
+              "borderRadius": 2,
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "backgroundColor": "rgba(103, 80, 164, 1)",
+            },
+            {
+              "opacity": 1,
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "height": 18,
+              "left": 0,
+              "overflow": "hidden",
+              "position": "absolute",
+              "top": 0,
+            },
+            {
+              "opacity": 1,
+              "width": 18,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "height": 18,
+              "justifyContent": "center",
+              "width": 18,
+            }
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "borderBottomWidth": 2,
+                  "borderLeftWidth": 2,
+                  "height": 6,
+                  "transform": [
+                    {
+                      "rotate": "-45deg",
+                    },
+                    {
+                      "translateY": -1,
+                    },
+                    {
+                      "translateX": 1,
+                    },
+                  ],
+                  "width": 11,
+                },
+                {
+                  "borderColor": "rgba(255, 255, 255, 1)",
+                },
+                null,
+              ]
+            }
+          />
+        </View>
+      </View>
     </View>
   </View>
 </View>
@@ -146,8 +208,8 @@ exports[`renders checked Checkbox with color 1`] = `
     }
   }
   accessible={true}
+  centered={true}
   collapsable={false}
-  color="red"
   focusable={true}
   onBlur={[Function]}
   onClick={[Function]}
@@ -163,86 +225,147 @@ exports[`renders checked Checkbox with color 1`] = `
       {
         "overflow": "hidden",
       },
-      {
-        "borderRadius": 18,
-        "height": 36,
-        "padding": 6,
-        "width": 36,
-      },
+      [
+        {
+          "alignItems": "center",
+          "borderRadius": 20,
+          "height": 40,
+          "justifyContent": "center",
+          "width": 40,
+        },
+        undefined,
+        undefined,
+      ],
     ]
   }
 >
   <View
-    collapsable={false}
+    pointerEvents="none"
     style={
       {
-        "opacity": 1,
-        "transform": [
-          {
-            "scale": 1,
-          },
-        ],
+        "alignItems": "center",
+        "height": 40,
+        "justifyContent": "center",
+        "width": 40,
       }
     }
   >
-    <Text
-      accessibilityElementsHidden={true}
-      allowFontScaling={false}
-      importantForAccessibility="no-hide-descendants"
-      pointerEvents="none"
-      selectable={false}
-      style={
-        [
-          {
-            "color": "red",
-            "fontSize": 24,
-          },
-          [
-            {
-              "lineHeight": 24,
-              "transform": [
-                {
-                  "scaleX": 1,
-                },
-              ],
-            },
-            {
-              "backgroundColor": "transparent",
-            },
-          ],
-        ]
-      }
-    >
-      checkbox-marked
-    </Text>
     <View
       style={
         [
           {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
+            "alignItems": "center",
+            "borderRadius": 2,
+            "height": 18,
+            "justifyContent": "center",
+            "overflow": "hidden",
+            "width": 18,
           },
           {
-            "alignItems": "center",
-            "justifyContent": "center",
+            "opacity": 1,
           },
         ]
       }
     >
       <View
-        collapsable={false}
+        pointerEvents="none"
         style={
-          {
-            "borderColor": "red",
-            "borderWidth": 0,
-            "height": 14,
-            "width": 14,
-          }
+          [
+            {
+              "borderRadius": 2,
+              "borderWidth": 2,
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "borderColor": "rgba(73, 69, 79, 1)",
+            },
+            {
+              "opacity": 0,
+            },
+          ]
         }
       />
+      <View
+        pointerEvents="none"
+        style={
+          [
+            {
+              "borderRadius": 2,
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "backgroundColor": "red",
+            },
+            {
+              "opacity": 1,
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "height": 18,
+              "left": 0,
+              "overflow": "hidden",
+              "position": "absolute",
+              "top": 0,
+            },
+            {
+              "opacity": 1,
+              "width": 18,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "height": 18,
+              "justifyContent": "center",
+              "width": 18,
+            }
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "borderBottomWidth": 2,
+                  "borderLeftWidth": 2,
+                  "height": 6,
+                  "transform": [
+                    {
+                      "rotate": "-45deg",
+                    },
+                    {
+                      "translateY": -1,
+                    },
+                    {
+                      "translateX": 1,
+                    },
+                  ],
+                  "width": 11,
+                },
+                {
+                  "borderColor": "rgba(255, 255, 255, 1)",
+                },
+                null,
+              ]
+            }
+          />
+        </View>
+      </View>
     </View>
   </View>
 </View>
@@ -270,6 +393,7 @@ exports[`renders checked Checkbox with onPress 1`] = `
     }
   }
   accessible={true}
+  centered={true}
   collapsable={false}
   focusable={true}
   onBlur={[Function]}
@@ -286,86 +410,147 @@ exports[`renders checked Checkbox with onPress 1`] = `
       {
         "overflow": "hidden",
       },
-      {
-        "borderRadius": 18,
-        "height": 36,
-        "padding": 6,
-        "width": 36,
-      },
+      [
+        {
+          "alignItems": "center",
+          "borderRadius": 20,
+          "height": 40,
+          "justifyContent": "center",
+          "width": 40,
+        },
+        undefined,
+        undefined,
+      ],
     ]
   }
 >
   <View
-    collapsable={false}
+    pointerEvents="none"
     style={
       {
-        "opacity": 1,
-        "transform": [
-          {
-            "scale": 1,
-          },
-        ],
+        "alignItems": "center",
+        "height": 40,
+        "justifyContent": "center",
+        "width": 40,
       }
     }
   >
-    <Text
-      accessibilityElementsHidden={true}
-      allowFontScaling={false}
-      importantForAccessibility="no-hide-descendants"
-      pointerEvents="none"
-      selectable={false}
-      style={
-        [
-          {
-            "color": "rgba(103, 80, 164, 1)",
-            "fontSize": 24,
-          },
-          [
-            {
-              "lineHeight": 24,
-              "transform": [
-                {
-                  "scaleX": 1,
-                },
-              ],
-            },
-            {
-              "backgroundColor": "transparent",
-            },
-          ],
-        ]
-      }
-    >
-      checkbox-marked
-    </Text>
     <View
       style={
         [
           {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
+            "alignItems": "center",
+            "borderRadius": 2,
+            "height": 18,
+            "justifyContent": "center",
+            "overflow": "hidden",
+            "width": 18,
           },
           {
-            "alignItems": "center",
-            "justifyContent": "center",
+            "opacity": 1,
           },
         ]
       }
     >
       <View
-        collapsable={false}
+        pointerEvents="none"
         style={
-          {
-            "borderColor": "rgba(103, 80, 164, 1)",
-            "borderWidth": 0,
-            "height": 14,
-            "width": 14,
-          }
+          [
+            {
+              "borderRadius": 2,
+              "borderWidth": 2,
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "borderColor": "rgba(73, 69, 79, 1)",
+            },
+            {
+              "opacity": 0,
+            },
+          ]
         }
       />
+      <View
+        pointerEvents="none"
+        style={
+          [
+            {
+              "borderRadius": 2,
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "backgroundColor": "rgba(103, 80, 164, 1)",
+            },
+            {
+              "opacity": 1,
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "height": 18,
+              "left": 0,
+              "overflow": "hidden",
+              "position": "absolute",
+              "top": 0,
+            },
+            {
+              "opacity": 1,
+              "width": 18,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "height": 18,
+              "justifyContent": "center",
+              "width": 18,
+            }
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "borderBottomWidth": 2,
+                  "borderLeftWidth": 2,
+                  "height": 6,
+                  "transform": [
+                    {
+                      "rotate": "-45deg",
+                    },
+                    {
+                      "translateY": -1,
+                    },
+                    {
+                      "translateX": 1,
+                    },
+                  ],
+                  "width": 11,
+                },
+                {
+                  "borderColor": "rgba(255, 255, 255, 1)",
+                },
+                null,
+              ]
+            }
+          />
+        </View>
+      </View>
     </View>
   </View>
 </View>
@@ -378,7 +563,7 @@ exports[`renders indeterminate Checkbox 1`] = `
   accessibilityState={
     {
       "busy": undefined,
-      "checked": false,
+      "checked": "mixed",
       "disabled": false,
       "expanded": undefined,
       "selected": undefined,
@@ -393,6 +578,7 @@ exports[`renders indeterminate Checkbox 1`] = `
     }
   }
   accessible={true}
+  centered={true}
   collapsable={false}
   focusable={true}
   onBlur={[Function]}
@@ -409,86 +595,134 @@ exports[`renders indeterminate Checkbox 1`] = `
       {
         "overflow": "hidden",
       },
-      {
-        "borderRadius": 18,
-        "height": 36,
-        "padding": 6,
-        "width": 36,
-      },
+      [
+        {
+          "alignItems": "center",
+          "borderRadius": 20,
+          "height": 40,
+          "justifyContent": "center",
+          "width": 40,
+        },
+        undefined,
+        undefined,
+      ],
     ]
   }
 >
   <View
-    collapsable={false}
+    pointerEvents="none"
     style={
       {
-        "opacity": 1,
-        "transform": [
-          {
-            "scale": 1,
-          },
-        ],
+        "alignItems": "center",
+        "height": 40,
+        "justifyContent": "center",
+        "width": 40,
       }
     }
   >
-    <Text
-      accessibilityElementsHidden={true}
-      allowFontScaling={false}
-      importantForAccessibility="no-hide-descendants"
-      pointerEvents="none"
-      selectable={false}
-      style={
-        [
-          {
-            "color": "rgba(73, 69, 79, 1)",
-            "fontSize": 24,
-          },
-          [
-            {
-              "lineHeight": 24,
-              "transform": [
-                {
-                  "scaleX": 1,
-                },
-              ],
-            },
-            {
-              "backgroundColor": "transparent",
-            },
-          ],
-        ]
-      }
-    >
-      minus-box
-    </Text>
     <View
       style={
         [
           {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
+            "alignItems": "center",
+            "borderRadius": 2,
+            "height": 18,
+            "justifyContent": "center",
+            "overflow": "hidden",
+            "width": 18,
           },
           {
-            "alignItems": "center",
-            "justifyContent": "center",
+            "opacity": 1,
           },
         ]
       }
     >
       <View
-        collapsable={false}
+        pointerEvents="none"
         style={
-          {
-            "borderColor": "rgba(73, 69, 79, 1)",
-            "borderWidth": 0,
-            "height": 14,
-            "width": 14,
-          }
+          [
+            {
+              "borderRadius": 2,
+              "borderWidth": 2,
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "borderColor": "rgba(73, 69, 79, 1)",
+            },
+            {
+              "opacity": 0,
+            },
+          ]
         }
       />
+      <View
+        pointerEvents="none"
+        style={
+          [
+            {
+              "borderRadius": 2,
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "backgroundColor": "rgba(103, 80, 164, 1)",
+            },
+            {
+              "opacity": 1,
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "height": 18,
+              "left": 0,
+              "overflow": "hidden",
+              "position": "absolute",
+              "top": 0,
+            },
+            {
+              "opacity": 1,
+              "width": 18,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "height": 18,
+              "justifyContent": "center",
+              "width": 18,
+            }
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "borderRadius": 1,
+                  "height": 2,
+                  "width": 10,
+                },
+                {
+                  "backgroundColor": "rgba(255, 255, 255, 1)",
+                },
+              ]
+            }
+          />
+        </View>
+      </View>
     </View>
   </View>
 </View>
@@ -501,7 +735,7 @@ exports[`renders indeterminate Checkbox with color 1`] = `
   accessibilityState={
     {
       "busy": undefined,
-      "checked": false,
+      "checked": "mixed",
       "disabled": true,
       "expanded": undefined,
       "selected": undefined,
@@ -516,8 +750,8 @@ exports[`renders indeterminate Checkbox with color 1`] = `
     }
   }
   accessible={true}
+  centered={true}
   collapsable={false}
-  color="red"
   focusable={true}
   onBlur={[Function]}
   onClick={[Function]}
@@ -533,86 +767,134 @@ exports[`renders indeterminate Checkbox with color 1`] = `
       {
         "overflow": "hidden",
       },
-      {
-        "borderRadius": 18,
-        "height": 36,
-        "padding": 6,
-        "width": 36,
-      },
+      [
+        {
+          "alignItems": "center",
+          "borderRadius": 20,
+          "height": 40,
+          "justifyContent": "center",
+          "width": 40,
+        },
+        undefined,
+        undefined,
+      ],
     ]
   }
 >
   <View
-    collapsable={false}
+    pointerEvents="none"
     style={
       {
-        "opacity": 1,
-        "transform": [
-          {
-            "scale": 1,
-          },
-        ],
+        "alignItems": "center",
+        "height": 40,
+        "justifyContent": "center",
+        "width": 40,
       }
     }
   >
-    <Text
-      accessibilityElementsHidden={true}
-      allowFontScaling={false}
-      importantForAccessibility="no-hide-descendants"
-      pointerEvents="none"
-      selectable={false}
-      style={
-        [
-          {
-            "color": "rgba(73, 69, 79, 1)",
-            "fontSize": 24,
-          },
-          [
-            {
-              "lineHeight": 24,
-              "transform": [
-                {
-                  "scaleX": 1,
-                },
-              ],
-            },
-            {
-              "backgroundColor": "transparent",
-            },
-          ],
-        ]
-      }
-    >
-      minus-box
-    </Text>
     <View
       style={
         [
           {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
+            "alignItems": "center",
+            "borderRadius": 2,
+            "height": 18,
+            "justifyContent": "center",
+            "overflow": "hidden",
+            "width": 18,
           },
           {
-            "alignItems": "center",
-            "justifyContent": "center",
+            "opacity": 1,
           },
         ]
       }
     >
       <View
-        collapsable={false}
+        pointerEvents="none"
         style={
-          {
-            "borderColor": "rgba(73, 69, 79, 1)",
-            "borderWidth": 0,
-            "height": 14,
-            "width": 14,
-          }
+          [
+            {
+              "borderRadius": 2,
+              "borderWidth": 2,
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "borderColor": "rgba(73, 69, 79, 1)",
+            },
+            {
+              "opacity": 0,
+            },
+          ]
         }
       />
+      <View
+        pointerEvents="none"
+        style={
+          [
+            {
+              "borderRadius": 2,
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "backgroundColor": "red",
+            },
+            {
+              "opacity": 1,
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "height": 18,
+              "left": 0,
+              "overflow": "hidden",
+              "position": "absolute",
+              "top": 0,
+            },
+            {
+              "opacity": 1,
+              "width": 18,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "height": 18,
+              "justifyContent": "center",
+              "width": 18,
+            }
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "borderRadius": 1,
+                  "height": 2,
+                  "width": 10,
+                },
+                {
+                  "backgroundColor": "rgba(255, 255, 255, 1)",
+                },
+              ]
+            }
+          />
+        </View>
+      </View>
     </View>
   </View>
 </View>
@@ -640,8 +922,8 @@ exports[`renders unchecked Checkbox with color 1`] = `
     }
   }
   accessible={true}
+  centered={true}
   collapsable={false}
-  color="red"
   focusable={true}
   onBlur={[Function]}
   onClick={[Function]}
@@ -657,86 +939,147 @@ exports[`renders unchecked Checkbox with color 1`] = `
       {
         "overflow": "hidden",
       },
-      {
-        "borderRadius": 18,
-        "height": 36,
-        "padding": 6,
-        "width": 36,
-      },
+      [
+        {
+          "alignItems": "center",
+          "borderRadius": 20,
+          "height": 40,
+          "justifyContent": "center",
+          "width": 40,
+        },
+        undefined,
+        undefined,
+      ],
     ]
   }
 >
   <View
-    collapsable={false}
+    pointerEvents="none"
     style={
       {
-        "opacity": 1,
-        "transform": [
-          {
-            "scale": 1,
-          },
-        ],
+        "alignItems": "center",
+        "height": 40,
+        "justifyContent": "center",
+        "width": 40,
       }
     }
   >
-    <Text
-      accessibilityElementsHidden={true}
-      allowFontScaling={false}
-      importantForAccessibility="no-hide-descendants"
-      pointerEvents="none"
-      selectable={false}
-      style={
-        [
-          {
-            "color": "red",
-            "fontSize": 24,
-          },
-          [
-            {
-              "lineHeight": 24,
-              "transform": [
-                {
-                  "scaleX": 1,
-                },
-              ],
-            },
-            {
-              "backgroundColor": "transparent",
-            },
-          ],
-        ]
-      }
-    >
-      checkbox-marked
-    </Text>
     <View
       style={
         [
           {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
+            "alignItems": "center",
+            "borderRadius": 2,
+            "height": 18,
+            "justifyContent": "center",
+            "overflow": "hidden",
+            "width": 18,
           },
           {
-            "alignItems": "center",
-            "justifyContent": "center",
+            "opacity": 1,
           },
         ]
       }
     >
       <View
-        collapsable={false}
+        pointerEvents="none"
         style={
-          {
-            "borderColor": "red",
-            "borderWidth": 0,
-            "height": 14,
-            "width": 14,
-          }
+          [
+            {
+              "borderRadius": 2,
+              "borderWidth": 2,
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "borderColor": "rgba(73, 69, 79, 1)",
+            },
+            {
+              "opacity": 0,
+            },
+          ]
         }
       />
+      <View
+        pointerEvents="none"
+        style={
+          [
+            {
+              "borderRadius": 2,
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "backgroundColor": "red",
+            },
+            {
+              "opacity": 1,
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "height": 18,
+              "left": 0,
+              "overflow": "hidden",
+              "position": "absolute",
+              "top": 0,
+            },
+            {
+              "opacity": 1,
+              "width": 18,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "height": 18,
+              "justifyContent": "center",
+              "width": 18,
+            }
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "borderBottomWidth": 2,
+                  "borderLeftWidth": 2,
+                  "height": 6,
+                  "transform": [
+                    {
+                      "rotate": "-45deg",
+                    },
+                    {
+                      "translateY": -1,
+                    },
+                    {
+                      "translateX": 1,
+                    },
+                  ],
+                  "width": 11,
+                },
+                {
+                  "borderColor": "rgba(255, 255, 255, 1)",
+                },
+                null,
+              ]
+            }
+          />
+        </View>
+      </View>
     </View>
   </View>
 </View>
@@ -764,6 +1107,7 @@ exports[`renders unchecked Checkbox with onPress 1`] = `
     }
   }
   accessible={true}
+  centered={true}
   collapsable={false}
   focusable={true}
   onBlur={[Function]}
@@ -780,86 +1124,147 @@ exports[`renders unchecked Checkbox with onPress 1`] = `
       {
         "overflow": "hidden",
       },
-      {
-        "borderRadius": 18,
-        "height": 36,
-        "padding": 6,
-        "width": 36,
-      },
+      [
+        {
+          "alignItems": "center",
+          "borderRadius": 20,
+          "height": 40,
+          "justifyContent": "center",
+          "width": 40,
+        },
+        undefined,
+        undefined,
+      ],
     ]
   }
 >
   <View
-    collapsable={false}
+    pointerEvents="none"
     style={
       {
-        "opacity": 1,
-        "transform": [
-          {
-            "scale": 1,
-          },
-        ],
+        "alignItems": "center",
+        "height": 40,
+        "justifyContent": "center",
+        "width": 40,
       }
     }
   >
-    <Text
-      accessibilityElementsHidden={true}
-      allowFontScaling={false}
-      importantForAccessibility="no-hide-descendants"
-      pointerEvents="none"
-      selectable={false}
-      style={
-        [
-          {
-            "color": "rgba(73, 69, 79, 1)",
-            "fontSize": 24,
-          },
-          [
-            {
-              "lineHeight": 24,
-              "transform": [
-                {
-                  "scaleX": 1,
-                },
-              ],
-            },
-            {
-              "backgroundColor": "transparent",
-            },
-          ],
-        ]
-      }
-    >
-      checkbox-blank-outline
-    </Text>
     <View
       style={
         [
           {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
+            "alignItems": "center",
+            "borderRadius": 2,
+            "height": 18,
+            "justifyContent": "center",
+            "overflow": "hidden",
+            "width": 18,
           },
           {
-            "alignItems": "center",
-            "justifyContent": "center",
+            "opacity": 1,
           },
         ]
       }
     >
       <View
-        collapsable={false}
+        pointerEvents="none"
         style={
-          {
-            "borderColor": "rgba(73, 69, 79, 1)",
-            "borderWidth": 0,
-            "height": 14,
-            "width": 14,
-          }
+          [
+            {
+              "borderRadius": 2,
+              "borderWidth": 2,
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "borderColor": "rgba(73, 69, 79, 1)",
+            },
+            {
+              "opacity": 1,
+            },
+          ]
         }
       />
+      <View
+        pointerEvents="none"
+        style={
+          [
+            {
+              "borderRadius": 2,
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "backgroundColor": "rgba(103, 80, 164, 1)",
+            },
+            {
+              "opacity": 0,
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "height": 18,
+              "left": 0,
+              "overflow": "hidden",
+              "position": "absolute",
+              "top": 0,
+            },
+            {
+              "opacity": 0,
+              "width": 0,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "height": 18,
+              "justifyContent": "center",
+              "width": 18,
+            }
+          }
+        >
+          <View
+            style={
+              [
+                {
+                  "borderBottomWidth": 2,
+                  "borderLeftWidth": 2,
+                  "height": 6,
+                  "transform": [
+                    {
+                      "rotate": "-45deg",
+                    },
+                    {
+                      "translateY": -1,
+                    },
+                    {
+                      "translateX": 1,
+                    },
+                  ],
+                  "width": 11,
+                },
+                {
+                  "borderColor": "transparent",
+                },
+                null,
+              ]
+            }
+          />
+        </View>
+      </View>
     </View>
   </View>
 </View>

--- a/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.tsx.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.tsx.snap
@@ -57,12 +57,10 @@ exports[`can render leading checkbox control 1`] = `
     }
   >
     <View
-      accessibilityLiveRegion="polite"
-      accessibilityRole="checkbox"
       accessibilityState={
         {
           "busy": undefined,
-          "checked": false,
+          "checked": undefined,
           "disabled": true,
           "expanded": undefined,
           "selected": undefined,
@@ -76,7 +74,8 @@ exports[`can render leading checkbox control 1`] = `
           "text": undefined,
         }
       }
-      accessible={true}
+      accessible={false}
+      centered={true}
       collapsable={false}
       focusable={true}
       onBlur={[Function]}
@@ -93,86 +92,147 @@ exports[`can render leading checkbox control 1`] = `
           {
             "overflow": "hidden",
           },
-          {
-            "borderRadius": 18,
-            "height": 36,
-            "padding": 6,
-            "width": 36,
-          },
+          [
+            {
+              "alignItems": "center",
+              "borderRadius": 20,
+              "height": 40,
+              "justifyContent": "center",
+              "width": 40,
+            },
+            undefined,
+            undefined,
+          ],
         ]
       }
     >
       <View
-        collapsable={false}
+        pointerEvents="none"
         style={
           {
-            "opacity": 1,
-            "transform": [
-              {
-                "scale": 1,
-              },
-            ],
+            "alignItems": "center",
+            "height": 40,
+            "justifyContent": "center",
+            "width": 40,
           }
         }
       >
-        <Text
-          accessibilityElementsHidden={true}
-          allowFontScaling={false}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
-          style={
-            [
-              {
-                "color": "rgba(73, 69, 79, 1)",
-                "fontSize": 24,
-              },
-              [
-                {
-                  "lineHeight": 24,
-                  "transform": [
-                    {
-                      "scaleX": 1,
-                    },
-                  ],
-                },
-                {
-                  "backgroundColor": "transparent",
-                },
-              ],
-            ]
-          }
-        >
-          checkbox-blank-outline
-        </Text>
         <View
           style={
             [
               {
-                "bottom": 0,
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
+                "alignItems": "center",
+                "borderRadius": 2,
+                "height": 18,
+                "justifyContent": "center",
+                "overflow": "hidden",
+                "width": 18,
               },
               {
-                "alignItems": "center",
-                "justifyContent": "center",
+                "opacity": 1,
               },
             ]
           }
         >
           <View
-            collapsable={false}
+            pointerEvents="none"
             style={
-              {
-                "borderColor": "rgba(73, 69, 79, 1)",
-                "borderWidth": 0,
-                "height": 14,
-                "width": 14,
-              }
+              [
+                {
+                  "borderRadius": 2,
+                  "borderWidth": 2,
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                {
+                  "borderColor": "rgba(73, 69, 79, 1)",
+                },
+                {
+                  "opacity": 1,
+                },
+              ]
             }
           />
+          <View
+            pointerEvents="none"
+            style={
+              [
+                {
+                  "borderRadius": 2,
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                {
+                  "backgroundColor": "rgba(103, 80, 164, 1)",
+                },
+                {
+                  "opacity": 0,
+                },
+              ]
+            }
+          />
+          <View
+            style={
+              [
+                {
+                  "height": 18,
+                  "left": 0,
+                  "overflow": "hidden",
+                  "position": "absolute",
+                  "top": 0,
+                },
+                {
+                  "opacity": 0,
+                  "width": 0,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "height": 18,
+                  "justifyContent": "center",
+                  "width": 18,
+                }
+              }
+            >
+              <View
+                style={
+                  [
+                    {
+                      "borderBottomWidth": 2,
+                      "borderLeftWidth": 2,
+                      "height": 6,
+                      "transform": [
+                        {
+                          "rotate": "-45deg",
+                        },
+                        {
+                          "translateY": -1,
+                        },
+                        {
+                          "translateX": 1,
+                        },
+                      ],
+                      "width": 11,
+                    },
+                    {
+                      "borderColor": "transparent",
+                    },
+                    null,
+                  ]
+                }
+              />
+            </View>
+          </View>
         </View>
       </View>
     </View>
@@ -313,12 +373,10 @@ exports[`renders unchecked 1`] = `
       Unchecked Button
     </Text>
     <View
-      accessibilityLiveRegion="polite"
-      accessibilityRole="checkbox"
       accessibilityState={
         {
           "busy": undefined,
-          "checked": false,
+          "checked": undefined,
           "disabled": true,
           "expanded": undefined,
           "selected": undefined,
@@ -332,7 +390,8 @@ exports[`renders unchecked 1`] = `
           "text": undefined,
         }
       }
-      accessible={true}
+      accessible={false}
+      centered={true}
       collapsable={false}
       focusable={true}
       onBlur={[Function]}
@@ -349,86 +408,147 @@ exports[`renders unchecked 1`] = `
           {
             "overflow": "hidden",
           },
-          {
-            "borderRadius": 18,
-            "height": 36,
-            "padding": 6,
-            "width": 36,
-          },
+          [
+            {
+              "alignItems": "center",
+              "borderRadius": 20,
+              "height": 40,
+              "justifyContent": "center",
+              "width": 40,
+            },
+            undefined,
+            undefined,
+          ],
         ]
       }
     >
       <View
-        collapsable={false}
+        pointerEvents="none"
         style={
           {
-            "opacity": 1,
-            "transform": [
-              {
-                "scale": 1,
-              },
-            ],
+            "alignItems": "center",
+            "height": 40,
+            "justifyContent": "center",
+            "width": 40,
           }
         }
       >
-        <Text
-          accessibilityElementsHidden={true}
-          allowFontScaling={false}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
-          style={
-            [
-              {
-                "color": "rgba(73, 69, 79, 1)",
-                "fontSize": 24,
-              },
-              [
-                {
-                  "lineHeight": 24,
-                  "transform": [
-                    {
-                      "scaleX": 1,
-                    },
-                  ],
-                },
-                {
-                  "backgroundColor": "transparent",
-                },
-              ],
-            ]
-          }
-        >
-          checkbox-blank-outline
-        </Text>
         <View
           style={
             [
               {
-                "bottom": 0,
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
+                "alignItems": "center",
+                "borderRadius": 2,
+                "height": 18,
+                "justifyContent": "center",
+                "overflow": "hidden",
+                "width": 18,
               },
               {
-                "alignItems": "center",
-                "justifyContent": "center",
+                "opacity": 1,
               },
             ]
           }
         >
           <View
-            collapsable={false}
+            pointerEvents="none"
             style={
-              {
-                "borderColor": "rgba(73, 69, 79, 1)",
-                "borderWidth": 0,
-                "height": 14,
-                "width": 14,
-              }
+              [
+                {
+                  "borderRadius": 2,
+                  "borderWidth": 2,
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                {
+                  "borderColor": "rgba(73, 69, 79, 1)",
+                },
+                {
+                  "opacity": 1,
+                },
+              ]
             }
           />
+          <View
+            pointerEvents="none"
+            style={
+              [
+                {
+                  "borderRadius": 2,
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                {
+                  "backgroundColor": "rgba(103, 80, 164, 1)",
+                },
+                {
+                  "opacity": 0,
+                },
+              ]
+            }
+          />
+          <View
+            style={
+              [
+                {
+                  "height": 18,
+                  "left": 0,
+                  "overflow": "hidden",
+                  "position": "absolute",
+                  "top": 0,
+                },
+                {
+                  "opacity": 0,
+                  "width": 0,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "height": 18,
+                  "justifyContent": "center",
+                  "width": 18,
+                }
+              }
+            >
+              <View
+                style={
+                  [
+                    {
+                      "borderBottomWidth": 2,
+                      "borderLeftWidth": 2,
+                      "height": 6,
+                      "transform": [
+                        {
+                          "rotate": "-45deg",
+                        },
+                        {
+                          "translateY": -1,
+                        },
+                        {
+                          "translateX": 1,
+                        },
+                      ],
+                      "width": 11,
+                    },
+                    {
+                      "borderColor": "transparent",
+                    },
+                    null,
+                  ]
+                }
+              />
+            </View>
+          </View>
         </View>
       </View>
     </View>

--- a/src/components/__tests__/Checkbox/utils.test.tsx
+++ b/src/components/__tests__/Checkbox/utils.test.tsx
@@ -1,163 +1,129 @@
 import { getTheme } from '../../../core/theming';
 import { tokens } from '../../../theme/tokens';
-import { getSelectionControlColor } from '../../Checkbox/utils';
+import { getSelectionVisualState } from '../../Checkbox/utils';
+
 const stateOpacity = tokens.md.sys.state.opacity;
+const theme = getTheme();
+const darkTheme = getTheme(true);
 
-describe('getSelectionControlColor - checkbox color', () => {
-  it('should return correct disabled color, for theme version 3', () => {
-    expect(
-      getSelectionControlColor({
-        theme: getTheme(),
-        disabled: true,
-        checked: false,
-      })
-    ).toMatchObject({
-      selectionControlColor: getTheme().colors.onSurface,
-      selectionControlOpacity: stateOpacity.disabled,
+describe('getSelectionVisualState', () => {
+  describe('containerColor (the fill)', () => {
+    it('uses theme.colors.primary when selected (default)', () => {
+      expect(getSelectionVisualState({ theme, selected: true })).toMatchObject({
+        containerColor: theme.colors.primary,
+      });
+    });
+
+    it('uses theme.colors.error when selected + error', () => {
+      expect(
+        getSelectionVisualState({ theme, selected: true, error: true })
+      ).toMatchObject({ containerColor: theme.colors.error });
+    });
+
+    it('uses customColor when provided (overrides error)', () => {
+      expect(
+        getSelectionVisualState({
+          theme,
+          selected: true,
+          error: true,
+          customColor: 'purple',
+        })
+      ).toMatchObject({ containerColor: 'purple' });
+    });
+
+    it('falls back to onSurface when disabled (overrides customColor)', () => {
+      expect(
+        getSelectionVisualState({
+          theme,
+          selected: true,
+          disabled: true,
+          customColor: 'purple',
+        })
+      ).toMatchObject({ containerColor: theme.colors.onSurface });
     });
   });
 
-  it('should return custom color, checked', () => {
-    expect(
-      getSelectionControlColor({
-        theme: getTheme(),
-        checked: true,
-        customColor: 'purple',
-      })
-    ).toMatchObject({
-      selectionControlColor: 'purple',
+  describe('outlineColor (unselected border)', () => {
+    it('uses theme.colors.onSurfaceVariant by default', () => {
+      expect(getSelectionVisualState({ theme, selected: false })).toMatchObject(
+        { outlineColor: theme.colors.onSurfaceVariant }
+      );
+    });
+
+    it('uses theme.colors.error when error', () => {
+      expect(
+        getSelectionVisualState({ theme, selected: false, error: true })
+      ).toMatchObject({ outlineColor: theme.colors.error });
+    });
+
+    it('uses customUncheckedColor when provided (overrides error)', () => {
+      expect(
+        getSelectionVisualState({
+          theme,
+          selected: false,
+          error: true,
+          customUncheckedColor: 'orange',
+        })
+      ).toMatchObject({ outlineColor: 'orange' });
+    });
+
+    it('falls back to onSurface when disabled', () => {
+      expect(
+        getSelectionVisualState({
+          theme,
+          selected: false,
+          disabled: true,
+          customUncheckedColor: 'orange',
+        })
+      ).toMatchObject({ outlineColor: theme.colors.onSurface });
     });
   });
 
-  it('should return theme color, for theme version 3, checked', () => {
-    expect(
-      getSelectionControlColor({
-        theme: getTheme(),
-        checked: true,
-      })
-    ).toMatchObject({
-      selectionControlColor: getTheme().colors.primary,
+  describe('iconColor (checkmark / dash glyph)', () => {
+    it('is transparent when unselected (no glyph drawn)', () => {
+      expect(getSelectionVisualState({ theme, selected: false })).toMatchObject(
+        { iconColor: 'transparent' }
+      );
+    });
+
+    it('uses theme.colors.onPrimary when selected (default)', () => {
+      expect(getSelectionVisualState({ theme, selected: true })).toMatchObject({
+        iconColor: theme.colors.onPrimary,
+      });
+    });
+
+    it('uses theme.colors.onError when selected + error', () => {
+      expect(
+        getSelectionVisualState({ theme, selected: true, error: true })
+      ).toMatchObject({ iconColor: theme.colors.onError });
+    });
+
+    it('uses theme.colors.surface when selected + disabled', () => {
+      expect(
+        getSelectionVisualState({ theme, selected: true, disabled: true })
+      ).toMatchObject({ iconColor: theme.colors.surface });
     });
   });
 
-  it('should return custom color, unchecked', () => {
-    expect(
-      getSelectionControlColor({
-        theme: getTheme(),
-        checked: false,
-        customUncheckedColor: 'purple',
-      })
-    ).toMatchObject({
-      selectionControlColor: 'purple',
+  describe('containerOpacity', () => {
+    it('is the enabled state opacity by default', () => {
+      expect(getSelectionVisualState({ theme, selected: true })).toMatchObject({
+        containerOpacity: stateOpacity.enabled,
+      });
+    });
+
+    it('drops to the disabled state opacity when disabled', () => {
+      expect(
+        getSelectionVisualState({ theme, selected: true, disabled: true })
+      ).toMatchObject({ containerOpacity: stateOpacity.disabled });
     });
   });
 
-  it('should return theme color, for theme version 3, unchecked', () => {
-    expect(
-      getSelectionControlColor({
-        theme: getTheme(),
-        checked: false,
-      })
-    ).toMatchObject({
-      selectionControlColor: getTheme().colors.onSurfaceVariant,
-    });
-  });
-
-  it('should return theme color, unchecked, dark mode', () => {
-    expect(
-      getSelectionControlColor({
-        theme: getTheme(true),
-        checked: false,
-      })
-    ).toMatchObject({
-      selectionControlColor: getTheme(true).colors.onSurfaceVariant,
-    });
-  });
-
-  it('should return theme color, unchecked, light mode', () => {
-    expect(
-      getSelectionControlColor({
-        theme: getTheme(false),
-        checked: false,
-      })
-    ).toMatchObject({
-      selectionControlColor: getTheme(false).colors.onSurfaceVariant,
-    });
-  });
-
-  it('should return error color, checked, when error is true', () => {
-    expect(
-      getSelectionControlColor({
-        theme: getTheme(),
-        checked: true,
-        error: true,
-      })
-    ).toMatchObject({
-      selectionControlColor: getTheme().colors.error,
-    });
-  });
-
-  it('should return error color, unchecked, when error is true', () => {
-    expect(
-      getSelectionControlColor({
-        theme: getTheme(),
-        checked: false,
-        error: true,
-      })
-    ).toMatchObject({
-      selectionControlColor: getTheme().colors.error,
-    });
-  });
-
-  it('should return error color, checked, dark mode, when error is true', () => {
-    expect(
-      getSelectionControlColor({
-        theme: getTheme(true),
-        checked: true,
-        error: true,
-      })
-    ).toMatchObject({
-      selectionControlColor: getTheme(true).colors.error,
-    });
-  });
-
-  it('should return disabled color when both disabled and error are true (disabled wins)', () => {
-    expect(
-      getSelectionControlColor({
-        theme: getTheme(),
-        disabled: true,
-        checked: true,
-        error: true,
-      })
-    ).toMatchObject({
-      selectionControlColor: getTheme().colors.onSurface,
-      selectionControlOpacity: stateOpacity.disabled,
-    });
-  });
-
-  it('should return custom color when both customColor and error are true, checked (customColor wins)', () => {
-    expect(
-      getSelectionControlColor({
-        theme: getTheme(),
-        checked: true,
-        customColor: 'purple',
-        error: true,
-      })
-    ).toMatchObject({
-      selectionControlColor: 'purple',
-    });
-  });
-
-  it('should return custom unchecked color when both customUncheckedColor and error are true, unchecked (customUncheckedColor wins)', () => {
-    expect(
-      getSelectionControlColor({
-        theme: getTheme(),
-        checked: false,
-        customUncheckedColor: 'purple',
-        error: true,
-      })
-    ).toMatchObject({
-      selectionControlColor: 'purple',
+  describe('dark theme', () => {
+    it('respects the dark theme palette', () => {
+      const v = getSelectionVisualState({ theme: darkTheme, selected: true });
+      expect(v.containerColor).toBe(darkTheme.colors.primary);
+      expect(v.iconColor).toBe(darkTheme.colors.onPrimary);
     });
   });
 });


### PR DESCRIPTION
## Summary

Bring the `Checkbox` component up to the [Material Design 3 spec](https://m3.material.io/components/checkbox/specs), end-to-end:

- 18dp container with 2dp outline (unselected) → 0dp outline + theme primary fill (selected), inside a 40dp state-layer tap target.
- The tap target uses `TouchableRipple` (borderless + centered), matching `IconButton`/`Chip`/`Button`. This gives the native Android ripple animation per @adrcotfas's review (the ripple *color* won't fully respect MD3 alpha until RN 86 ships `PlatformColor` + alpha for `android_ripple`, but the animation lands today). `rippleColor` is fed by `getSelectionVisualState({ ..., pressed: true })` so the ripple honours the MD3 selected/unselected colour flip on press.
- Focus indicator: 3dp ring at `theme.colors.secondary`, drawn at the 40dp state-layer boundary (the `borderless` `TouchableRipple` clips anything outside that, so we sit the ring on the boundary rather than applying `md.sys.state.focusIndicator.outerOffset`). On web, the ring is gated on `:focus-visible` via the shared `isKeyboardFocusEvent` helper (introduced in #4957) so it doesn't appear after a pointer press; on native it shows on any focus. The browser's default focus outline is suppressed via Adrian's `webNoOutline = { outline: 'none' } as unknown as ViewStyle` pattern from #4957.
- RTL: on web, the reveal-mask anchor flips via `useLocale().direction === 'rtl'` so the checkmark appears to draw from the leading edge. On native, `I18nManager` already mirrors the layout so the default `left: 0` anchor does the right thing automatically (matches the approach used in #4957). The glyph itself is not mirrored (Compose M3 keeps checkmark orientation across locales) — we explicitly pre-swap the L-shape's `borderLeftWidth` / `borderRightWidth` in RTL so RN's automatic swap brings them back to the LTR orientation and the rotated stroke renders as a `✓` instead of a `<` on Android (which honours `I18nManager.swapLeftAndRightInRTL`).
- Accessibility: the inner `<Checkbox>` now emits `accessibilityState.checked === 'mixed'` for `status="indeterminate"` (per W3C ARIA for tri-state controls). `Checkbox.Item`'s outer row no longer duplicates the `'mixed'` announcement — it defers to the inner Checkbox, so screen readers announce "mixed" once. Also `disabled` is now coerced via `!!disabled` to avoid leaking `undefined`.
- New `style?: StyleProp<ViewStyle>` prop forwarded to the underlying `Pressable`, per Copilot's review (the rest of the additional `Pressable` props — `accessibilityLabel`, `hitSlop`, `onLongPress` — are still out of scope for this PR).
- Animations: 100ms fill + 150ms checkmark reveal driven by `react-native-reanimated` (`useSharedValue` + `withTiming` + `useAnimatedStyle`), now using the canonical pattern established by #4957 — motion tokens (`theme.motion.duration.short2` / `short3`, `theme.motion.easing.standard`) and the new `useReduceMotion()` hook + `ReduceMotion.Always` config so the OS / `PaperProvider` reduce-motion setting is honored. Reads the new `isKeyboardFocusEvent` shared helper from `src/utils/` and Adrian's `webNoOutline = { outline: 'none' } as unknown as ViewStyle` pattern for the browser default-outline suppression.

## Why not SVG

Compose Material3 draws the checkmark as a `Path` with `strokeFraction` 0 → 1. Doing the same in RN would mean adding `react-native-svg` as a Paper peer-dep, an ecosystem-level change. This PR uses a reveal-mask instead: a static L-shape (borderLeftWidth + borderBottomWidth rotated -45°) inside a left-anchored View whose width animates 0 → 18dp with a matching opacity fade. The visual suggests the stroke drawing left-to-right without the SVG dependency. Same precedent will apply to RadioButton when it's modernized. If you'd prefer the SVG-based approach for v6, happy to switch. Picking once now sets the precedent.

## Files

- `src/components/Checkbox/Checkbox.tsx`: full rewrite. `TouchableRipple` 40dp tap target (borderless + centered, matching `IconButton`); animated 18dp container with cross-fade outline↔fill; focus ring as a circular outline matching the state-layer shape (— circle, not a rounded-square around the 18dp container — matches the rendering in Compose Material3 and the spec's focus-state reference); `:focus-visible` filter on web via the shared `isKeyboardFocusEvent` helper; locale-aware reveal-mask; view-based checkmark + dash; forwarded `style` plus all `Pressable`/`TouchableRipple` props via `...rest`; `'mixed'` a11y state for indeterminate. Animations driven by `react-native-reanimated` with motion tokens + `useReduceMotion`. No Platform-specific code paths.
- **NEW** `src/components/Checkbox/tokens.ts`: `CheckboxTokens` exporting the 4 spec dimensions (`containerSize`, `containerRadius`, `outlineWidth`, `stateLayerSize`) plus the colour-role table (`containerColor`, `outlineColor`, etc.). Merged via `{ ...sizes, ...colors }` to mirror the `SwitchTokens` pattern from #4957.
- `src/components/Checkbox/utils.ts`: `getSelectionVisualState` returns the full colour + opacity picture for any `(selected × hovered × pressed × disabled × error × customColor)` combination. Focus is rendered by the component (per the MD3 spec note: focus is an outline ring, not a state-layer fill), so it deliberately doesn't appear in the visual-state helper. The legacy `getSelectionControlColor` helper that used to live here (only consumed by `RadioButtonAndroid`) has been moved to `RadioButton/utils.ts`.
- `src/components/RadioButton/utils.ts`: now hosts `getSelectionControlColor` (moved from `Checkbox/utils.ts`). Cleans up the awkward back-compat re-export and keeps Checkbox/utils.ts focused on MD3 checkbox concerns.
- `src/components/RadioButton/RadioButtonAndroid.tsx`: import path updated to the local `./utils`.
- Tests for `getSelectionControlColor` migrated to `src/components/__tests__/RadioButton/utils.test.tsx`; the old `src/components/__tests__/Checkbox/utils.test.tsx` is removed.
- `example/src/Examples/CheckboxExample.tsx`: rewritten as a comprehensive showcase — "Tap to toggle" interactive section (unchecked↔checked, unchecked↔indeterminate), a 4-row × 3-status grid (Default / Disabled / Custom color tertiary / Error), and a Parent/children section demonstrating an indeterminate parent that aggregates state from three children.
- `example/package.json`: added `web` script (`expo start --web`) so reviewers can `yarn example web` to validate the focus ring, the `:focus-visible` filter, and RTL behaviour on web in addition to iOS / Android.
- 9 snapshots auto-updated to reflect the new render tree.

## Out of scope

- RadioButton modernization (separate PR with the same pattern).
- Extracting `<StateLayer />` as a shared primitive (can follow once Radio + Switch land and the pattern is proven).
- Forwarding additional `Pressable` props (`accessibilityLabel`, `hitSlop`, `onLongPress`, etc.). Already added `style`; the rest can land in a follow-up if reviewers want a wider API surface.

## Test plan

- Rebased onto `main` after #4957 landed; now consumes the shared `isKeyboardFocusEvent` helper, `ReduceMotionContext`, and motion tokens introduced there.
- `yarn typescript` clean (the `example/src/Examples/AppbarExample.tsx` TS2590 error is pre-existing on `main` and unaffected by this branch).
- `yarn lint` clean
- `yarn jest`: 738/739 (1 skipped, pre-existing); 161/161 snapshots pass. The legacy `getSelectionControlColor` test suite was moved from `__tests__/Checkbox/utils.test.tsx` to `__tests__/RadioButton/utils.test.tsx` alongside its sibling `getSelectionControlIOSColor` tests — same coverage, just relocated to match the helper's new home.

## Visuals

| iOS | Android | Web |
|---|---|---|
| <!-- drop ios video here --> | <!-- drop android video here --> | <!-- drop web video here --> |

Each video cycles through the new states: unchecked / checked / indeterminate, the error variant, the disabled variants, and the Parent / children section showing an indeterminate parent updating from child changes.
