### PR TITLE
fix: rewrite paper re-exports in babel plugin

### DIFF
--- a/src/babel/__fixtures__/rewrite-imports/code.js
+++ b/src/babel/__fixtures__/rewrite-imports/code.js
@@ -12,3 +12,5 @@ import {
   withTheme,
   LightTheme,
 } from 'react-native-paper';
+
+export { TextInput } from 'react-native-paper';

--- a/src/babel/__fixtures__/rewrite-imports/output.js
+++ b/src/babel/__fixtures__/rewrite-imports/output.js
@@ -8,3 +8,4 @@ import { Palette } from "react-native-paper/lib/module/theme/tokens";
 import { NonExistent, NonExistentSecond as Stuff, LightTheme } from "react-native-paper/lib/module/index.js";
 import { ThemeProvider } from "react-native-paper/lib/module/core/theming";
 import { withTheme } from "react-native-paper/lib/module/core/theming";
+export { default as TextInput } from "react-native-paper/lib/module/components/TextInput";

--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -58,6 +58,70 @@ module.exports = function rewire(babel, options) {
 
         path.requeue();
       },
+      ExportNamedDeclaration(path) {
+        if (
+          !path.node.source ||
+          path.node.source.value !== name ||
+          path.node[SKIP]
+        ) {
+          return;
+        }
+
+        path.node.source.value = `${name}/${index}`;
+        path.replaceWithMultiple(
+          path.node.specifiers.reduce((declarations, specifier) => {
+            const mapping = mappings[specifier.local.name];
+
+            if (mapping) {
+              const alias = `${name}/${mapping.path}`;
+              let s;
+
+              switch (mapping.name) {
+                case 'default':
+                  s = t.exportSpecifier(
+                    t.identifier('default'),
+                    t.identifier(specifier.exported.name)
+                  );
+                  break;
+                case '*':
+                  s = t.exportNamespaceSpecifier(
+                    t.identifier(specifier.exported.name)
+                  );
+                  break;
+                default:
+                  s = t.exportSpecifier(
+                    t.identifier(mapping.name),
+                    t.identifier(specifier.exported.name)
+                  );
+              }
+
+              declarations.push(
+                t.exportNamedDeclaration(null, [s], t.stringLiteral(alias))
+              );
+            } else {
+              const previous = declarations.find(
+                (d) => d.source.value === path.node.source.value
+              );
+
+              if (previous) {
+                previous.specifiers.push(specifier);
+              } else {
+                const node = t.exportNamedDeclaration(
+                  null,
+                  [specifier],
+                  path.node.source
+                );
+                node[SKIP] = true;
+                declarations.push(node);
+              }
+            }
+
+            return declarations;
+          }, [])
+        );
+
+        path.requeue();
+      },
     },
   };
 };


### PR DESCRIPTION
### Motivation

The Babel plugin rewrites imports from `react-native-paper` to component-specific paths, but it currently leaves re-exports unchanged. That means a barrel like:

```js
export { TextInput } from 'react-native-paper';
```

still points at the package root instead of the mapped component path.

This adds the same mapping behavior for named re-exports while preserving unmapped symbols on the generated index path.

### Related issue

Fixes #4874

### Test plan

- `yarn test src/babel/__tests__/index.js --runInBand`
- `yarn eslint src/babel/index.js src/babel/__tests__/index.js --max-warnings=0`
- `git diff --check`
- Pre-commit hook full Jest run: 55 suites passed, 738 tests passed, 1 skipped
