### PR TITLE
fix: focus stealing on render of Menu Trigger button

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -364,7 +364,7 @@ const Menu = ({
     });
   }, [anchor, attachListeners, measureAnchorLayout, theme]);
 
-  const hide = React.useCallback(() => {
+  const hide = React.useCallback((focus = true) => {
     removeListeners();
 
     const { animation } = theme;
@@ -378,7 +378,7 @@ const Menu = ({
       setMenuLayout({ width: 0, height: 0 });
       setRendered(false);
       prevRendered.current = false;
-      focusFirstDOMNode(anchorRef.current);
+      if (focus) { focusFirstDOMNode(anchorRef.current) };
     });
   }, [removeListeners, theme]);
 
@@ -393,7 +393,7 @@ const Menu = ({
         }
 
         if (!display) {
-          hide();
+          hide(prevRendered.current);
         }
 
         return;


### PR DESCRIPTION
When the menu is rendered, the portal is updated async. This steals the focus as `hide()` focuses the button. Instead only focus when requested, for example when the menu was visible and hiding should focus the trigger.

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Stealing the focus is bad for me as a keyboard user and bad for assistive technology

### Test plan

Before: open any page with a menu rendered in the appbar. The focus should move automatically to the trigger button, even without opening.
After: open any page with a menu rendered in the appbar. The focus should not move automatically to the trigger button, unless the menu is opened and then closed.

### Workaround before this is merged

`react-native-paper-npm-5.15.3-9a600de527.patch`
```patch
diff --git a/lib/commonjs/components/Menu/Menu.js b/lib/commonjs/components/Menu/Menu.js
index dea22ecd5960f77463b27196ec1d2fb892f44d50..c45bf480d260ae73c3c4114f06bd6f4a22f61963 100644
--- a/lib/commonjs/components/Menu/Menu.js
+++ b/lib/commonjs/components/Menu/Menu.js
@@ -250,7 +250,7 @@ const Menu = ({
       });
     });
   }, [anchor, attachListeners, measureAnchorLayout, theme]);
-  const hide = React.useCallback(() => {
+  const hide = React.useCallback((focus = true) => {
     removeListeners();
     const {
       animation
@@ -267,7 +267,7 @@ const Menu = ({
       });
       setRendered(false);
       prevRendered.current = false;
-      focusFirstDOMNode(anchorRef.current);
+      if (focus) { focusFirstDOMNode(anchorRef.current) };
     });
   }, [removeListeners, theme]);
   const updateVisibility = React.useCallback(async display => {
@@ -279,7 +279,7 @@ const Menu = ({
         return;
       }
       if (!display) {
-        hide();
+        hide(prevRendered.current);
       }
       return;
     });
diff --git a/lib/module/components/Menu/Menu.js b/lib/module/components/Menu/Menu.js
index f0c9330d3809654b404bf2f65950905667935ac4..913bd74f863b8e9723a8ac92b79c8a282ab887ee 100644
--- a/lib/module/components/Menu/Menu.js
+++ b/lib/module/components/Menu/Menu.js
@@ -242,7 +242,7 @@ const Menu = ({
       });
     });
   }, [anchor, attachListeners, measureAnchorLayout, theme]);
-  const hide = React.useCallback(() => {
+  const hide = React.useCallback((focus = true) => {
     removeListeners();
     const {
       animation
@@ -259,7 +259,7 @@ const Menu = ({
       });
       setRendered(false);
       prevRendered.current = false;
-      focusFirstDOMNode(anchorRef.current);
+      if (focus) { focusFirstDOMNode(anchorRef.current); }
     });
   }, [removeListeners, theme]);
   const updateVisibility = React.useCallback(async display => {
@@ -271,7 +271,7 @@ const Menu = ({
         return;
       }
       if (!display) {
-        hide();
+        hide(prevRendered.current);
       }
       return;
     });
diff --git a/src/components/Menu/Menu.tsx b/src/components/Menu/Menu.tsx
index 669656ca652799f9a377acf68eb2d281c45fb9c4..b07e76d3f38b3e554009af7a66392dd57b753224 100644
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -367,7 +367,7 @@ const Menu = ({
     });
   }, [anchor, attachListeners, measureAnchorLayout, theme]);
 
-  const hide = React.useCallback(() => {
+  const hide = React.useCallback((focus = true) => {
     removeListeners();
 
     const { animation } = theme;
@@ -381,7 +381,7 @@ const Menu = ({
       setMenuLayout({ width: 0, height: 0 });
       setRendered(false);
       prevRendered.current = false;
-      focusFirstDOMNode(anchorRef.current);
+      if (focus) { focusFirstDOMNode(anchorRef.current) };
     });
   }, [removeListeners, theme]);
 
@@ -396,7 +396,7 @@ const Menu = ({
         }
 
         if (!display) {
-          hide();
+          hide(prevRendered.current);
         }
 
         return;
```