### PR TITLE
feat: add SplitButton component

### DIFF
--- a/docs/src/data/themeColors.ts
+++ b/docs/src/data/themeColors.ts
@@ -307,6 +307,32 @@ export const themeColors = {
       iconColor: 'theme.colors.inverseOnSurface',
     },
   },
+  SplitButton: {
+    active: {
+      filled: {
+        backgroundColor: 'theme.colors.primary',
+        textColor: 'theme.colors.onPrimary',
+      },
+      tonal: {
+        backgroundColor: 'theme.colors.secondaryContainer',
+        textColor: 'theme.colors.onSecondaryContainer',
+      },
+      elevated: {
+        backgroundColor: 'theme.colors.surfaceContainerLow',
+        textColor: 'theme.colors.primary',
+      },
+      outlined: {
+        textColor: 'theme.colors.onSurfaceVariant',
+        borderColor: 'theme.colors.outline',
+      },
+    },
+    disabled: {
+      '-': {
+        backgroundColor: 'theme.colors.onSurface',
+        textColor: 'theme.colors.onSurface',
+      },
+    },
+  },
   Surface: {
     flat: {
       backgroundColor: 'theme.colors.elevation[elevation]',

--- a/example/src/ExampleList.tsx
+++ b/example/src/ExampleList.tsx
@@ -36,6 +36,7 @@ import SegmentedButtonMultiselectRealCase from './Examples/SegmentedButtons/Segm
 import SegmentedButtonRealCase from './Examples/SegmentedButtons/SegmentedButtonRealCase';
 import SegmentedButtonExample from './Examples/SegmentedButtonsExample';
 import SnackbarExample from './Examples/SnackbarExample';
+import SplitButtonExample from './Examples/SplitButtonExample';
 import SurfaceExample from './Examples/SurfaceExample';
 import SwitchExample from './Examples/SwitchExample';
 import TeamDetails from './Examples/TeamDetails';
@@ -79,6 +80,7 @@ export const mainExamples = {
   Searchbar: SearchbarExample,
   SegmentedButton: SegmentedButtonExample,
   Snackbar: SnackbarExample,
+  SplitButton: SplitButtonExample,
   Surface: SurfaceExample,
   Switch: SwitchExample,
   Text: TextExample,

--- a/example/src/Examples/SplitButtonExample.tsx
+++ b/example/src/Examples/SplitButtonExample.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { List, Menu, SplitButton, Switch, useTheme } from 'react-native-paper';
+
+import ScreenWrapper from '../ScreenWrapper';
+
+const modes = ['filled', 'tonal', 'elevated', 'outlined'] as const;
+const SplitButtonExample = () => {
+  const [menuVisible, setMenuVisible] = React.useState(false);
+  const [disabled, setDisabled] = React.useState(false);
+  const [loading, setLoading] = React.useState(false);
+  const theme = useTheme();
+
+  return (
+    <ScreenWrapper>
+      <List.Section title="Playground">
+        <View style={styles.playground}>
+          <Menu
+            visible={menuVisible}
+            onDismiss={() => setMenuVisible(false)}
+            anchorPosition="bottom"
+            anchor={
+              <SplitButton
+                label="Send"
+                icon="send"
+                mode="filled"
+                disabled={disabled}
+                loading={loading}
+                onPress={() => {}}
+                onTrailingPress={() => setMenuVisible(true)}
+                trailingAccessibilityLabel="Show send options"
+                trailingAccessibilityState={{ expanded: menuVisible }}
+              />
+            }
+          >
+            <Menu.Item
+              leadingIcon="schedule"
+              title="Schedule send"
+              onPress={() => setMenuVisible(false)}
+            />
+            <Menu.Item
+              leadingIcon="content-save"
+              title="Save draft"
+              onPress={() => setMenuVisible(false)}
+            />
+          </Menu>
+        </View>
+        <List.Item
+          title="Disabled"
+          right={() => <Switch value={disabled} onValueChange={setDisabled} />}
+        />
+        <List.Item
+          title="Loading"
+          right={() => <Switch value={loading} onValueChange={setLoading} />}
+        />
+      </List.Section>
+
+      <List.Section title="Modes">
+        <View style={styles.row}>
+          {modes.map((mode) => (
+            <SplitButton
+              key={mode}
+              mode={mode}
+              icon="plus"
+              label={mode}
+              onPress={() => {}}
+              onTrailingPress={() => {}}
+              trailingAccessibilityLabel={`${mode} options`}
+            />
+          ))}
+        </View>
+      </List.Section>
+
+      <List.Section title="Custom">
+        <View style={styles.column}>
+          <SplitButton
+            mode="outlined"
+            icon="palette"
+            label="Custom color"
+            buttonColor={theme.colors.tertiaryContainer}
+            textColor={theme.colors.onTertiaryContainer}
+            onPress={() => {}}
+            onTrailingPress={() => {}}
+            trailingAccessibilityLabel="Custom color options"
+          />
+          <SplitButton
+            mode="filled"
+            label="Custom label style"
+            icon="format-bold"
+            labelStyle={styles.boldLabel}
+            onPress={() => {}}
+            onTrailingPress={() => {}}
+            trailingAccessibilityLabel="Custom label options"
+          />
+        </View>
+      </List.Section>
+    </ScreenWrapper>
+  );
+};
+
+SplitButtonExample.title = 'SplitButton';
+
+const styles = StyleSheet.create({
+  playground: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    alignItems: 'flex-start',
+  },
+  row: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    gap: 12,
+  },
+  column: {
+    alignItems: 'flex-start',
+    paddingHorizontal: 16,
+    gap: 16,
+  },
+  boldLabel: {
+    fontWeight: '800',
+  },
+});
+
+export default SplitButtonExample;

--- a/src/components/SplitButton/SplitButton.tsx
+++ b/src/components/SplitButton/SplitButton.tsx
@@ -1,17 +1,23 @@
 import * as React from 'react';
 import {
   AccessibilityState,
-  Animated,
   ColorValue,
-  Easing,
   GestureResponderEvent,
   PressableAndroidRippleConfig,
   StyleProp,
   StyleSheet,
   TextStyle,
   View,
+  ViewProps,
   ViewStyle,
 } from 'react-native';
+
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 
 import { splitButtonElevation, type SplitButtonSize } from './tokens';
 import {
@@ -25,8 +31,7 @@ import {
   type SplitButtonMode,
 } from './utils';
 import { useInternalTheme } from '../../core/theming';
-import type { $Omit, Theme, ThemeProp } from '../../types';
-import { forwardRef } from '../../utils/forwardRef';
+import type { $Omit, ThemeProp } from '../../types';
 import hasTouchHandler from '../../utils/hasTouchHandler';
 import ActivityIndicator from '../ActivityIndicator';
 import { getButtonTouchableRippleStyle } from '../Button/utils';
@@ -37,9 +42,11 @@ import TouchableRipple, {
 } from '../TouchableRipple/TouchableRipple';
 import Text from '../Typography/Text';
 
+const AnimatedSurface = Animated.createAnimatedComponent(Surface);
+
 export type Props = $Omit<
-  React.ComponentProps<typeof Surface>,
-  'children' | 'mode'
+  ViewProps,
+  'children' | 'style' | 'onPress' | 'onPressIn' | 'onPressOut'
 > & {
   /**
    * Mode of the split button.
@@ -149,7 +156,7 @@ export type Props = $Omit<
   /**
    * Style for the outer split-button group.
    */
-  style?: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
+  style?: StyleProp<ViewStyle>;
   /**
    * Style for both button containers.
    */
@@ -190,7 +197,6 @@ export type Props = $Omit<
    * TestID used for testing purposes.
    */
   testID?: string;
-  ref?: React.RefObject<View>;
 };
 
 /**
@@ -216,397 +222,412 @@ export type Props = $Omit<
  * export default MyComponent;
  * ```
  */
-const SplitButton = forwardRef<View, Props>(
-  (
-    {
-      mode = 'filled',
-      size = 'small',
-      label,
-      icon,
-      trailingIcon = 'menu-down',
-      loading,
-      disabled,
-      buttonColor: customButtonColor,
-      textColor: customTextColor,
-      rippleColor: customRippleColor,
-      onPress,
-      onTrailingPress,
-      onPressIn,
-      onPressOut,
-      onTrailingPressIn,
-      onTrailingPressOut,
-      onLongPress,
-      onTrailingLongPress,
-      delayLongPress,
-      trailingDelayLongPress,
-      accessibilityLabel = label,
-      trailingAccessibilityLabel = 'Show options',
-      accessibilityState,
-      trailingAccessibilityState,
-      background,
-      style,
-      buttonStyle,
-      leadingButtonStyle,
-      trailingButtonStyle,
-      contentStyle,
-      labelStyle,
-      maxFontSizeMultiplier,
-      hitSlop,
-      trailingHitSlop,
-      theme: themeOverrides,
-      testID = 'split-button',
-      ...rest
+const SplitButton = ({
+  mode = 'filled',
+  size = 'small',
+  label,
+  icon,
+  trailingIcon = 'menu-down',
+  loading,
+  disabled,
+  buttonColor: customButtonColor,
+  textColor: customTextColor,
+  rippleColor: customRippleColor,
+  onPress,
+  onTrailingPress,
+  onPressIn,
+  onPressOut,
+  onTrailingPressIn,
+  onTrailingPressOut,
+  onLongPress,
+  onTrailingLongPress,
+  delayLongPress,
+  trailingDelayLongPress,
+  accessibilityLabel = label,
+  trailingAccessibilityLabel = 'Show options',
+  accessibilityState,
+  trailingAccessibilityState,
+  background,
+  style,
+  buttonStyle,
+  leadingButtonStyle,
+  trailingButtonStyle,
+  contentStyle,
+  labelStyle,
+  maxFontSizeMultiplier,
+  hitSlop,
+  trailingHitSlop,
+  theme: themeOverrides,
+  testID,
+  ...rest
+}: Props) => {
+  const theme = useInternalTheme(themeOverrides);
+  const normalizedMode = normalizeSplitButtonMode(mode);
+  const sizeStyle = React.useMemo(
+    () => getSplitButtonSizeStyle({ size, theme }),
+    [size, theme]
+  );
+  const leadingInnerRadius = useSharedValue(sizeStyle.innerRadius);
+  const trailingInnerRadius = useSharedValue(sizeStyle.innerRadius);
+  const colors = React.useMemo(
+    () =>
+      getSplitButtonColors({
+        theme,
+        mode,
+        disabled,
+        customButtonColor,
+        customTextColor,
+      }),
+    [theme, mode, disabled, customButtonColor, customTextColor]
+  );
+  const rippleColor = React.useMemo(
+    () =>
+      getSplitButtonRippleColor({
+        contentColor: colors.contentColor,
+        customRippleColor,
+      }),
+    [colors.contentColor, customRippleColor]
+  );
+  const leadingShape = React.useMemo(
+    () =>
+      getSplitButtonLeadingShape({
+        containerRadius: sizeStyle.containerRadius,
+        innerRadius: sizeStyle.innerRadius,
+      }),
+    [sizeStyle.containerRadius, sizeStyle.innerRadius]
+  );
+  const trailingShape = React.useMemo(
+    () =>
+      getSplitButtonTrailingShape({
+        containerRadius: sizeStyle.containerRadius,
+        innerRadius: sizeStyle.innerRadius,
+      }),
+    [sizeStyle.containerRadius, sizeStyle.innerRadius]
+  );
+  const pressTimingConfig = React.useMemo(
+    () => ({
+      duration: theme.motion.duration.short4,
+      easing: Easing.bezier(...theme.motion.easing.standard),
+    }),
+    [theme.motion.duration.short4, theme.motion.easing.standard]
+  );
+  const releaseTimingConfig = React.useMemo(
+    () => ({
+      duration: theme.motion.duration.short3,
+      easing: Easing.bezier(...theme.motion.easing.standard),
+    }),
+    [theme.motion.duration.short3, theme.motion.easing.standard]
+  );
+  const leadingAnimatedShapeStyle = useAnimatedStyle(
+    () => ({
+      ...getSplitButtonLeadingShape({
+        containerRadius: sizeStyle.containerRadius,
+        innerRadius: leadingInnerRadius.value,
+      }),
+    }),
+    [sizeStyle.containerRadius]
+  );
+  const trailingAnimatedShapeStyle = useAnimatedStyle(
+    () => ({
+      ...getSplitButtonTrailingShape({
+        containerRadius: sizeStyle.containerRadius,
+        innerRadius: trailingInnerRadius.value,
+      }),
+    }),
+    [sizeStyle.containerRadius]
+  );
+  const leadingHitSlop = React.useMemo(
+    () => getSplitButtonHitSlop({ size, hitSlop }),
+    [size, hitSlop]
+  );
+  const resolvedTrailingHitSlop = React.useMemo(
+    () => getSplitButtonHitSlop({ size, hitSlop: trailingHitSlop }),
+    [size, trailingHitSlop]
+  );
+
+  const { color: customLabelColor, fontSize: customLabelSize } =
+    StyleSheet.flatten(labelStyle) || {};
+  const contentColor =
+    typeof customLabelColor === 'string'
+      ? customLabelColor
+      : colors.contentColor;
+  const labelTextStyle: TextStyle = {
+    color: colors.contentColor,
+    ...theme.fonts[sizeStyle.labelVariant],
+  };
+  const disabledState = { disabled: true };
+  const leadingAccessibilityState = disabled
+    ? { ...accessibilityState, ...disabledState }
+    : accessibilityState;
+  const trailingAccessibilityStateWithDisabled = disabled
+    ? { ...trailingAccessibilityState, ...disabledState }
+    : trailingAccessibilityState;
+  const isElevationEntitled = !disabled && normalizedMode === 'elevated';
+  const leadingHasTouchHandler = hasTouchHandler({
+    onPress,
+    onPressIn,
+    onPressOut,
+    onLongPress,
+  });
+  const trailingHasTouchHandler = hasTouchHandler({
+    onPress: onTrailingPress,
+    onPressIn: onTrailingPressIn,
+    onPressOut: onTrailingPressOut,
+    onLongPress: onTrailingLongPress,
+  });
+  const handleLeadingPressIn = React.useCallback(
+    (e: GestureResponderEvent) => {
+      onPressIn?.(e);
+      leadingInnerRadius.value = withTiming(
+        sizeStyle.innerPressedRadius,
+        pressTimingConfig
+      );
+      trailingInnerRadius.value = withTiming(
+        sizeStyle.innerRadius,
+        releaseTimingConfig
+      );
     },
-    ref
-  ) => {
-    const theme = useInternalTheme(themeOverrides);
-    const normalizedMode = normalizeSplitButtonMode(mode);
-    const [pressedButton, setPressedButton] = React.useState<
-      'leading' | 'trailing' | null
-    >(null);
-    const sizeStyle = React.useMemo(
-      () => getSplitButtonSizeStyle({ size, theme }),
-      [size, theme]
-    );
-    const colors = React.useMemo(
-      () =>
-        getSplitButtonColors({
-          theme,
-          mode,
-          disabled,
-          customButtonColor,
-          customTextColor,
-        }),
-      [theme, mode, disabled, customButtonColor, customTextColor]
-    );
-    const rippleColor = React.useMemo(
-      () =>
-        getSplitButtonRippleColor({
-          contentColor: colors.contentColor,
-          customRippleColor,
-        }),
-      [colors.contentColor, customRippleColor]
-    );
-    const leadingShape = React.useMemo(
-      () =>
-        getSplitButtonLeadingShape({
-          containerRadius: sizeStyle.containerRadius,
-          innerRadius:
-            pressedButton === 'leading'
-              ? sizeStyle.innerPressedRadius
-              : sizeStyle.innerRadius,
-        }),
-      [
-        pressedButton,
-        sizeStyle.containerRadius,
-        sizeStyle.innerPressedRadius,
-        sizeStyle.innerRadius,
-      ]
-    );
-    const trailingShape = React.useMemo(
-      () =>
-        getSplitButtonTrailingShape({
-          containerRadius: sizeStyle.containerRadius,
-          innerRadius:
-            pressedButton === 'trailing'
-              ? sizeStyle.innerPressedRadius
-              : sizeStyle.innerRadius,
-        }),
-      [
-        pressedButton,
-        sizeStyle.containerRadius,
-        sizeStyle.innerPressedRadius,
-        sizeStyle.innerRadius,
-      ]
-    );
-    const leadingHitSlop = React.useMemo(
-      () => getSplitButtonHitSlop({ size, hitSlop }),
-      [size, hitSlop]
-    );
-    const resolvedTrailingHitSlop = React.useMemo(
-      () => getSplitButtonHitSlop({ size, hitSlop: trailingHitSlop }),
-      [size, trailingHitSlop]
-    );
-
-    const { color: customLabelColor, fontSize: customLabelSize } =
-      StyleSheet.flatten(labelStyle) || {};
-    const contentColor =
-      typeof customLabelColor === 'string'
-        ? customLabelColor
-        : colors.contentColor;
-    const labelTextStyle: TextStyle = {
-      color: colors.contentColor,
-      ...(theme as Theme).fonts[sizeStyle.labelVariant],
-    };
-    const disabledState = { disabled: true };
-    const leadingAccessibilityState = disabled
-      ? { ...accessibilityState, ...disabledState }
-      : accessibilityState;
-    const trailingAccessibilityStateWithDisabled = disabled
-      ? { ...trailingAccessibilityState, ...disabledState }
-      : trailingAccessibilityState;
-    const isElevationEntitled = !disabled && normalizedMode === 'elevated';
-    const { current: elevation } = React.useRef<Animated.Value>(
-      new Animated.Value(isElevationEntitled ? splitButtonElevation.enabled : 0)
-    );
-    const animateElevation = React.useCallback(
-      (toValue: number) => {
-        if (!isElevationEntitled) {
-          return;
-        }
-
-        Animated.timing(elevation, {
-          toValue,
-          duration:
-            toValue === splitButtonElevation.pressed
-              ? theme.motion.duration.short4
-              : theme.motion.duration.short3,
-          easing: Easing.bezier(...theme.motion.easing.standard),
-          useNativeDriver: false,
-        }).start();
-      },
-      [
-        elevation,
-        isElevationEntitled,
-        theme.motion.duration.short3,
-        theme.motion.duration.short4,
-        theme.motion.easing.standard,
-      ]
-    );
-    const leadingHasTouchHandler = hasTouchHandler({
-      onPress,
+    [
+      leadingInnerRadius,
       onPressIn,
-      onPressOut,
-      onLongPress,
-    });
-    const trailingHasTouchHandler = hasTouchHandler({
-      onPress: onTrailingPress,
-      onPressIn: onTrailingPressIn,
-      onPressOut: onTrailingPressOut,
-      onLongPress: onTrailingLongPress,
-    });
-    const handleLeadingPressIn = React.useCallback(
-      (e: GestureResponderEvent) => {
-        onPressIn?.(e);
-        setPressedButton('leading');
-        animateElevation(splitButtonElevation.pressed);
-      },
-      [animateElevation, onPressIn]
-    );
-    const handleLeadingPressOut = React.useCallback(
-      (e: GestureResponderEvent) => {
-        onPressOut?.(e);
-        setPressedButton(null);
-        animateElevation(splitButtonElevation.enabled);
-      },
-      [animateElevation, onPressOut]
-    );
-    const handleTrailingPressIn = React.useCallback(
-      (e: GestureResponderEvent) => {
-        onTrailingPressIn?.(e);
-        setPressedButton('trailing');
-        animateElevation(splitButtonElevation.pressed);
-      },
-      [animateElevation, onTrailingPressIn]
-    );
-    const handleTrailingPressOut = React.useCallback(
-      (e: GestureResponderEvent) => {
-        onTrailingPressOut?.(e);
-        setPressedButton(null);
-        animateElevation(splitButtonElevation.enabled);
-      },
-      [animateElevation, onTrailingPressOut]
-    );
-    React.useEffect(() => {
-      if (!isElevationEntitled) {
-        setPressedButton(null);
-      }
+      pressTimingConfig,
+      releaseTimingConfig,
+      sizeStyle.innerPressedRadius,
+      sizeStyle.innerRadius,
+      trailingInnerRadius,
+    ]
+  );
+  const handleLeadingPressOut = React.useCallback(
+    (e: GestureResponderEvent) => {
+      onPressOut?.(e);
+      leadingInnerRadius.value = withTiming(
+        sizeStyle.innerRadius,
+        releaseTimingConfig
+      );
+    },
+    [leadingInnerRadius, onPressOut, releaseTimingConfig, sizeStyle.innerRadius]
+  );
+  const handleTrailingPressIn = React.useCallback(
+    (e: GestureResponderEvent) => {
+      onTrailingPressIn?.(e);
+      trailingInnerRadius.value = withTiming(
+        sizeStyle.innerPressedRadius,
+        pressTimingConfig
+      );
+      leadingInnerRadius.value = withTiming(
+        sizeStyle.innerRadius,
+        releaseTimingConfig
+      );
+    },
+    [
+      leadingInnerRadius,
+      onTrailingPressIn,
+      pressTimingConfig,
+      releaseTimingConfig,
+      sizeStyle.innerPressedRadius,
+      sizeStyle.innerRadius,
+      trailingInnerRadius,
+    ]
+  );
+  const handleTrailingPressOut = React.useCallback(
+    (e: GestureResponderEvent) => {
+      onTrailingPressOut?.(e);
+      trailingInnerRadius.value = withTiming(
+        sizeStyle.innerRadius,
+        releaseTimingConfig
+      );
+    },
+    [
+      onTrailingPressOut,
+      releaseTimingConfig,
+      sizeStyle.innerRadius,
+      trailingInnerRadius,
+    ]
+  );
+  React.useEffect(() => {
+    leadingInnerRadius.value = sizeStyle.innerRadius;
+    trailingInnerRadius.value = sizeStyle.innerRadius;
+  }, [leadingInnerRadius, sizeStyle.innerRadius, trailingInnerRadius]);
 
-      Animated.timing(elevation, {
-        toValue: isElevationEntitled ? splitButtonElevation.enabled : 0,
-        duration: 0,
-        useNativeDriver: false,
-      }).start();
-    }, [elevation, isElevationEntitled]);
+  const commonButtonStyle: ViewStyle = {
+    height: sizeStyle.containerHeight,
+    backgroundColor:
+      colors.containerOpacity < 1 ? 'transparent' : colors.containerColor,
+    borderColor: colors.borderColor,
+    borderWidth: colors.borderWidth,
+  };
+  const elevation = isElevationEntitled
+    ? splitButtonElevation.enabled
+    : splitButtonElevation.disabled;
+  const getTestID = (suffix: string) =>
+    testID ? `${testID}-${suffix}` : undefined;
 
-    const commonButtonStyle: ViewStyle = {
-      height: sizeStyle.containerHeight,
-      backgroundColor:
-        colors.containerOpacity < 1 ? 'transparent' : colors.containerColor,
-      borderColor: colors.borderColor,
-      borderWidth: colors.borderWidth,
-    };
-
-    return (
-      <Animated.View
-        {...rest}
-        ref={ref}
-        testID={`${testID}-container`}
-        style={
-          [
-            styles.group,
-            {
-              columnGap: sizeStyle.betweenSpace,
-              height: sizeStyle.containerHeight,
-            },
-            style,
-          ] as Animated.WithAnimatedValue<StyleProp<ViewStyle>>
-        }
+  return (
+    <Animated.View
+      {...rest}
+      testID={getTestID('container')}
+      style={[
+        styles.group,
+        {
+          columnGap: sizeStyle.betweenSpace,
+          height: sizeStyle.containerHeight,
+        },
+        style,
+      ]}
+    >
+      <AnimatedSurface
+        testID={getTestID('leading-container')}
+        elevation={elevation}
+        style={[
+          styles.leading,
+          commonButtonStyle,
+          leadingShape,
+          leadingAnimatedShapeStyle,
+          buttonStyle,
+          leadingButtonStyle,
+        ]}
+        container
       >
-        <Surface
-          testID={`${testID}-leading-container`}
-          elevation={elevation}
+        <ButtonBackground
+          backgroundColor={colors.containerColor}
+          opacity={colors.containerOpacity}
+          borderRadiusStyle={leadingShape}
+        />
+        <TouchableRipple
+          borderless
+          disabled={disabled}
+          onPress={onPress}
+          onLongPress={onLongPress}
+          onPressIn={leadingHasTouchHandler ? handleLeadingPressIn : undefined}
+          onPressOut={
+            leadingHasTouchHandler ? handleLeadingPressOut : undefined
+          }
+          delayLongPress={delayLongPress}
+          accessibilityLabel={accessibilityLabel}
+          accessibilityRole="button"
+          accessibilityState={leadingAccessibilityState}
+          background={background}
+          hitSlop={leadingHitSlop}
+          rippleColor={rippleColor}
           style={[
-            styles.leading,
-            commonButtonStyle,
-            leadingShape,
-            buttonStyle,
-            leadingButtonStyle,
+            styles.ripple,
+            getButtonTouchableRippleStyle(leadingShape, colors.borderWidth),
           ]}
-          container
+          testID={getTestID('leading')}
+          theme={theme}
         >
-          <ButtonBackground
-            backgroundColor={colors.containerColor}
-            opacity={colors.containerOpacity}
-            borderRadiusStyle={leadingShape}
-          />
-          <TouchableRipple
-            borderless
-            disabled={disabled}
-            onPress={onPress}
-            onLongPress={onLongPress}
-            onPressIn={
-              leadingHasTouchHandler ? handleLeadingPressIn : undefined
-            }
-            onPressOut={
-              leadingHasTouchHandler ? handleLeadingPressOut : undefined
-            }
-            delayLongPress={delayLongPress}
-            accessibilityLabel={accessibilityLabel}
-            accessibilityRole="button"
-            accessibilityState={leadingAccessibilityState}
-            background={background}
-            hitSlop={leadingHitSlop}
-            rippleColor={rippleColor}
+          <View
             style={[
-              styles.ripple,
-              getButtonTouchableRippleStyle(leadingShape, colors.borderWidth),
+              styles.leadingContent,
+              {
+                height: sizeStyle.containerHeight,
+                paddingStart: sizeStyle.leadingButtonLeadingSpace,
+                paddingEnd: sizeStyle.leadingButtonTrailingSpace,
+                opacity: colors.contentOpacity,
+              },
+              contentStyle,
             ]}
-            testID={`${testID}-leading`}
-            theme={theme}
           >
-            <View
-              style={[
-                styles.leadingContent,
-                {
-                  height: sizeStyle.containerHeight,
-                  paddingStart: sizeStyle.leadingButtonLeadingSpace,
-                  paddingEnd: sizeStyle.leadingButtonTrailingSpace,
-                  opacity: colors.contentOpacity,
-                },
-                contentStyle,
-              ]}
-            >
-              {icon && !loading ? (
-                <Icon
-                  source={icon}
-                  size={customLabelSize ?? sizeStyle.leadingIconSize}
-                  color={contentColor}
-                />
-              ) : null}
-              {loading ? (
-                <ActivityIndicator
-                  size={customLabelSize ?? sizeStyle.leadingIconSize}
-                  color={contentColor}
-                />
-              ) : null}
-              <Text
-                variant={sizeStyle.labelVariant}
-                selectable={false}
-                numberOfLines={1}
-                ellipsizeMode="tail"
-                maxFontSizeMultiplier={maxFontSizeMultiplier}
-                style={[
-                  styles.label,
-                  icon || loading
-                    ? { marginStart: sizeStyle.leadingIconSize / 3 }
-                    : null,
-                  labelTextStyle,
-                  labelStyle,
-                ]}
-                testID={`${testID}-label`}
-              >
-                {label}
-              </Text>
-            </View>
-          </TouchableRipple>
-        </Surface>
-
-        <Surface
-          testID={`${testID}-trailing-container`}
-          elevation={elevation}
-          style={[
-            styles.trailing,
-            commonButtonStyle,
-            trailingShape,
-            buttonStyle,
-            trailingButtonStyle,
-          ]}
-          container
-        >
-          <ButtonBackground
-            backgroundColor={colors.containerColor}
-            opacity={colors.containerOpacity}
-            borderRadiusStyle={trailingShape}
-          />
-          <TouchableRipple
-            borderless
-            disabled={disabled}
-            onPress={onTrailingPress}
-            onLongPress={onTrailingLongPress}
-            onPressIn={
-              trailingHasTouchHandler ? handleTrailingPressIn : undefined
-            }
-            onPressOut={
-              trailingHasTouchHandler ? handleTrailingPressOut : undefined
-            }
-            delayLongPress={trailingDelayLongPress}
-            accessibilityLabel={trailingAccessibilityLabel}
-            accessibilityRole="button"
-            accessibilityState={trailingAccessibilityStateWithDisabled}
-            background={background}
-            hitSlop={resolvedTrailingHitSlop}
-            rippleColor={rippleColor}
-            style={[
-              styles.ripple,
-              getButtonTouchableRippleStyle(trailingShape, colors.borderWidth),
-            ]}
-            testID={`${testID}-trailing`}
-            theme={theme}
-          >
-            <View
-              style={[
-                styles.trailingContent,
-                {
-                  height: sizeStyle.containerHeight,
-                  paddingStart: sizeStyle.trailingButtonLeadingSpace,
-                  paddingEnd: sizeStyle.trailingButtonTrailingSpace,
-                  opacity: colors.contentOpacity,
-                },
-              ]}
-            >
+            {icon && !loading ? (
               <Icon
-                source={trailingIcon}
-                size={sizeStyle.trailingIconSize}
+                source={icon}
+                size={customLabelSize ?? sizeStyle.leadingIconSize}
                 color={contentColor}
               />
-            </View>
-          </TouchableRipple>
-        </Surface>
-      </Animated.View>
-    );
-  }
-);
+            ) : null}
+            {loading ? (
+              <ActivityIndicator
+                size={customLabelSize ?? sizeStyle.leadingIconSize}
+                color={contentColor}
+              />
+            ) : null}
+            <Text
+              variant={sizeStyle.labelVariant}
+              selectable={false}
+              numberOfLines={1}
+              ellipsizeMode="tail"
+              maxFontSizeMultiplier={maxFontSizeMultiplier}
+              style={[
+                styles.label,
+                icon || loading
+                  ? { marginStart: sizeStyle.leadingIconSize / 3 }
+                  : null,
+                labelTextStyle,
+                labelStyle,
+              ]}
+              testID={getTestID('label')}
+            >
+              {label}
+            </Text>
+          </View>
+        </TouchableRipple>
+      </AnimatedSurface>
+
+      <AnimatedSurface
+        testID={getTestID('trailing-container')}
+        elevation={elevation}
+        style={[
+          styles.trailing,
+          commonButtonStyle,
+          trailingShape,
+          trailingAnimatedShapeStyle,
+          buttonStyle,
+          trailingButtonStyle,
+        ]}
+        container
+      >
+        <ButtonBackground
+          backgroundColor={colors.containerColor}
+          opacity={colors.containerOpacity}
+          borderRadiusStyle={trailingShape}
+        />
+        <TouchableRipple
+          borderless
+          disabled={disabled}
+          onPress={onTrailingPress}
+          onLongPress={onTrailingLongPress}
+          onPressIn={
+            trailingHasTouchHandler ? handleTrailingPressIn : undefined
+          }
+          onPressOut={
+            trailingHasTouchHandler ? handleTrailingPressOut : undefined
+          }
+          delayLongPress={trailingDelayLongPress}
+          accessibilityLabel={trailingAccessibilityLabel}
+          accessibilityRole="button"
+          accessibilityState={trailingAccessibilityStateWithDisabled}
+          background={background}
+          hitSlop={resolvedTrailingHitSlop}
+          rippleColor={rippleColor}
+          style={[
+            styles.ripple,
+            getButtonTouchableRippleStyle(trailingShape, colors.borderWidth),
+          ]}
+          testID={getTestID('trailing')}
+          theme={theme}
+        >
+          <View
+            style={[
+              styles.trailingContent,
+              {
+                height: sizeStyle.containerHeight,
+                paddingStart: sizeStyle.trailingButtonLeadingSpace,
+                paddingEnd: sizeStyle.trailingButtonTrailingSpace,
+                opacity: colors.contentOpacity,
+              },
+            ]}
+          >
+            <Icon
+              source={trailingIcon}
+              size={sizeStyle.trailingIconSize}
+              color={contentColor}
+            />
+          </View>
+        </TouchableRipple>
+      </AnimatedSurface>
+    </Animated.View>
+  );
+};
 
 const ButtonBackground = ({
   backgroundColor,

--- a/src/components/SplitButton/SplitButton.tsx
+++ b/src/components/SplitButton/SplitButton.tsx
@@ -1,0 +1,671 @@
+import * as React from 'react';
+import {
+  AccessibilityState,
+  Animated,
+  ColorValue,
+  Easing,
+  GestureResponderEvent,
+  PressableAndroidRippleConfig,
+  StyleProp,
+  StyleSheet,
+  TextStyle,
+  View,
+  ViewStyle,
+} from 'react-native';
+
+import { splitButtonElevation, type SplitButtonSize } from './tokens';
+import {
+  getSplitButtonColors,
+  getSplitButtonHitSlop,
+  getSplitButtonLeadingShape,
+  getSplitButtonRippleColor,
+  getSplitButtonSizeStyle,
+  getSplitButtonTrailingShape,
+  normalizeSplitButtonMode,
+  type SplitButtonMode,
+} from './utils';
+import { useInternalTheme } from '../../core/theming';
+import type { $Omit, Theme, ThemeProp } from '../../types';
+import { forwardRef } from '../../utils/forwardRef';
+import hasTouchHandler from '../../utils/hasTouchHandler';
+import ActivityIndicator from '../ActivityIndicator';
+import { getButtonTouchableRippleStyle } from '../Button/utils';
+import Icon, { IconSource } from '../Icon';
+import Surface from '../Surface';
+import TouchableRipple, {
+  Props as TouchableRippleProps,
+} from '../TouchableRipple/TouchableRipple';
+import Text from '../Typography/Text';
+
+export type Props = $Omit<
+  React.ComponentProps<typeof Surface>,
+  'children' | 'mode'
+> & {
+  /**
+   * Mode of the split button.
+   * - `filled` - high-emphasis split button for important or final actions.
+   * - `tonal` - medium-emphasis split button using secondary container colors.
+   * - `elevated` - tonal split button with elevation for separation from busy surfaces.
+   * - `outlined` - medium-emphasis split button with transparent containers and outline.
+   */
+  mode?: SplitButtonMode;
+  /**
+   * Size of the split button.
+   */
+  size?: SplitButtonSize;
+  /**
+   * Label text for the leading button.
+   */
+  label: string;
+  /**
+   * Icon to display before the label in the leading button.
+   */
+  icon?: IconSource;
+  /**
+   * Icon to display in the trailing button.
+   */
+  trailingIcon?: IconSource;
+  /**
+   * Whether to show a loading indicator in the leading button.
+   */
+  loading?: boolean;
+  /**
+   * Whether both buttons are disabled.
+   */
+  disabled?: boolean;
+  /**
+   * Custom container color for both buttons.
+   */
+  buttonColor?: ColorValue;
+  /**
+   * Custom content color for icons and label.
+   */
+  textColor?: ColorValue;
+  /**
+   * Custom ripple color for both buttons.
+   */
+  rippleColor?: ColorValue;
+  /**
+   * Function to execute when the leading button is pressed.
+   */
+  onPress?: (e: GestureResponderEvent) => void;
+  /**
+   * Function to execute when the trailing button is pressed.
+   */
+  onTrailingPress?: (e: GestureResponderEvent) => void;
+  /**
+   * Function to execute as soon as the leading button is pressed.
+   */
+  onPressIn?: (e: GestureResponderEvent) => void;
+  /**
+   * Function to execute when the leading button press is released.
+   */
+  onPressOut?: (e: GestureResponderEvent) => void;
+  /**
+   * Function to execute as soon as the trailing button is pressed.
+   */
+  onTrailingPressIn?: (e: GestureResponderEvent) => void;
+  /**
+   * Function to execute when the trailing button press is released.
+   */
+  onTrailingPressOut?: (e: GestureResponderEvent) => void;
+  /**
+   * Function to execute when the leading button is long pressed.
+   */
+  onLongPress?: (e: GestureResponderEvent) => void;
+  /**
+   * Function to execute when the trailing button is long pressed.
+   */
+  onTrailingLongPress?: (e: GestureResponderEvent) => void;
+  /**
+   * The number of milliseconds a user must touch the leading button before executing `onLongPress`.
+   */
+  delayLongPress?: number;
+  /**
+   * The number of milliseconds a user must touch the trailing button before executing `onTrailingLongPress`.
+   */
+  trailingDelayLongPress?: number;
+  /**
+   * Accessibility label for the leading button. Falls back to `label`.
+   */
+  accessibilityLabel?: string;
+  /**
+   * Accessibility label for the trailing button.
+   */
+  trailingAccessibilityLabel?: string;
+  /**
+   * Accessibility state for the leading button.
+   */
+  accessibilityState?: AccessibilityState;
+  /**
+   * Accessibility state for the trailing button.
+   */
+  trailingAccessibilityState?: AccessibilityState;
+  /**
+   * Type of background drawable to display the feedback (Android).
+   * https://reactnative.dev/docs/pressable#rippleconfig
+   */
+  background?: PressableAndroidRippleConfig;
+  /**
+   * Style for the outer split-button group.
+   */
+  style?: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
+  /**
+   * Style for both button containers.
+   */
+  buttonStyle?: StyleProp<ViewStyle>;
+  /**
+   * Style for the leading button container.
+   */
+  leadingButtonStyle?: StyleProp<ViewStyle>;
+  /**
+   * Style for the trailing button container.
+   */
+  trailingButtonStyle?: StyleProp<ViewStyle>;
+  /**
+   * Style for the leading button content row.
+   */
+  contentStyle?: StyleProp<ViewStyle>;
+  /**
+   * Style for the label.
+   */
+  labelStyle?: StyleProp<TextStyle>;
+  /**
+   * Specifies the largest possible scale a label font can reach.
+   */
+  maxFontSizeMultiplier?: number;
+  /**
+   * Sets additional distance outside of the leading button in which a press can be detected.
+   */
+  hitSlop?: TouchableRippleProps['hitSlop'];
+  /**
+   * Sets additional distance outside of the trailing button in which a press can be detected.
+   */
+  trailingHitSlop?: TouchableRippleProps['hitSlop'];
+  /**
+   * @optional
+   */
+  theme?: ThemeProp;
+  /**
+   * TestID used for testing purposes.
+   */
+  testID?: string;
+  ref?: React.RefObject<View>;
+};
+
+/**
+ * Split buttons let people trigger a primary action from the leading button
+ * and open or trigger a contextual action from the trailing button.
+ *
+ * ## Usage
+ * ```js
+ * import * as React from 'react';
+ * import { SplitButton } from 'react-native-paper';
+ *
+ * const MyComponent = () => (
+ *   <SplitButton
+ *     mode="filled"
+ *     icon="send"
+ *     label="Send"
+ *     trailingAccessibilityLabel="Show send options"
+ *     onPress={() => console.log('Send')}
+ *     onTrailingPress={() => console.log('Show options')}
+ *   />
+ * );
+ *
+ * export default MyComponent;
+ * ```
+ */
+const SplitButton = forwardRef<View, Props>(
+  (
+    {
+      mode = 'filled',
+      size = 'small',
+      label,
+      icon,
+      trailingIcon = 'menu-down',
+      loading,
+      disabled,
+      buttonColor: customButtonColor,
+      textColor: customTextColor,
+      rippleColor: customRippleColor,
+      onPress,
+      onTrailingPress,
+      onPressIn,
+      onPressOut,
+      onTrailingPressIn,
+      onTrailingPressOut,
+      onLongPress,
+      onTrailingLongPress,
+      delayLongPress,
+      trailingDelayLongPress,
+      accessibilityLabel = label,
+      trailingAccessibilityLabel = 'Show options',
+      accessibilityState,
+      trailingAccessibilityState,
+      background,
+      style,
+      buttonStyle,
+      leadingButtonStyle,
+      trailingButtonStyle,
+      contentStyle,
+      labelStyle,
+      maxFontSizeMultiplier,
+      hitSlop,
+      trailingHitSlop,
+      theme: themeOverrides,
+      testID = 'split-button',
+      ...rest
+    },
+    ref
+  ) => {
+    const theme = useInternalTheme(themeOverrides);
+    const normalizedMode = normalizeSplitButtonMode(mode);
+    const [pressedButton, setPressedButton] = React.useState<
+      'leading' | 'trailing' | null
+    >(null);
+    const sizeStyle = React.useMemo(
+      () => getSplitButtonSizeStyle({ size, theme }),
+      [size, theme]
+    );
+    const colors = React.useMemo(
+      () =>
+        getSplitButtonColors({
+          theme,
+          mode,
+          disabled,
+          customButtonColor,
+          customTextColor,
+        }),
+      [theme, mode, disabled, customButtonColor, customTextColor]
+    );
+    const rippleColor = React.useMemo(
+      () =>
+        getSplitButtonRippleColor({
+          contentColor: colors.contentColor,
+          customRippleColor,
+        }),
+      [colors.contentColor, customRippleColor]
+    );
+    const leadingShape = React.useMemo(
+      () =>
+        getSplitButtonLeadingShape({
+          containerRadius: sizeStyle.containerRadius,
+          innerRadius:
+            pressedButton === 'leading'
+              ? sizeStyle.innerPressedRadius
+              : sizeStyle.innerRadius,
+        }),
+      [
+        pressedButton,
+        sizeStyle.containerRadius,
+        sizeStyle.innerPressedRadius,
+        sizeStyle.innerRadius,
+      ]
+    );
+    const trailingShape = React.useMemo(
+      () =>
+        getSplitButtonTrailingShape({
+          containerRadius: sizeStyle.containerRadius,
+          innerRadius:
+            pressedButton === 'trailing'
+              ? sizeStyle.innerPressedRadius
+              : sizeStyle.innerRadius,
+        }),
+      [
+        pressedButton,
+        sizeStyle.containerRadius,
+        sizeStyle.innerPressedRadius,
+        sizeStyle.innerRadius,
+      ]
+    );
+    const leadingHitSlop = React.useMemo(
+      () => getSplitButtonHitSlop({ size, hitSlop }),
+      [size, hitSlop]
+    );
+    const resolvedTrailingHitSlop = React.useMemo(
+      () => getSplitButtonHitSlop({ size, hitSlop: trailingHitSlop }),
+      [size, trailingHitSlop]
+    );
+
+    const { color: customLabelColor, fontSize: customLabelSize } =
+      StyleSheet.flatten(labelStyle) || {};
+    const contentColor =
+      typeof customLabelColor === 'string'
+        ? customLabelColor
+        : colors.contentColor;
+    const labelTextStyle: TextStyle = {
+      color: colors.contentColor,
+      ...(theme as Theme).fonts[sizeStyle.labelVariant],
+    };
+    const disabledState = { disabled: true };
+    const leadingAccessibilityState = disabled
+      ? { ...accessibilityState, ...disabledState }
+      : accessibilityState;
+    const trailingAccessibilityStateWithDisabled = disabled
+      ? { ...trailingAccessibilityState, ...disabledState }
+      : trailingAccessibilityState;
+    const isElevationEntitled = !disabled && normalizedMode === 'elevated';
+    const { current: elevation } = React.useRef<Animated.Value>(
+      new Animated.Value(isElevationEntitled ? splitButtonElevation.enabled : 0)
+    );
+    const animateElevation = React.useCallback(
+      (toValue: number) => {
+        if (!isElevationEntitled) {
+          return;
+        }
+
+        Animated.timing(elevation, {
+          toValue,
+          duration:
+            toValue === splitButtonElevation.pressed
+              ? theme.motion.duration.short4
+              : theme.motion.duration.short3,
+          easing: Easing.bezier(...theme.motion.easing.standard),
+          useNativeDriver: false,
+        }).start();
+      },
+      [
+        elevation,
+        isElevationEntitled,
+        theme.motion.duration.short3,
+        theme.motion.duration.short4,
+        theme.motion.easing.standard,
+      ]
+    );
+    const leadingHasTouchHandler = hasTouchHandler({
+      onPress,
+      onPressIn,
+      onPressOut,
+      onLongPress,
+    });
+    const trailingHasTouchHandler = hasTouchHandler({
+      onPress: onTrailingPress,
+      onPressIn: onTrailingPressIn,
+      onPressOut: onTrailingPressOut,
+      onLongPress: onTrailingLongPress,
+    });
+    const handleLeadingPressIn = React.useCallback(
+      (e: GestureResponderEvent) => {
+        onPressIn?.(e);
+        setPressedButton('leading');
+        animateElevation(splitButtonElevation.pressed);
+      },
+      [animateElevation, onPressIn]
+    );
+    const handleLeadingPressOut = React.useCallback(
+      (e: GestureResponderEvent) => {
+        onPressOut?.(e);
+        setPressedButton(null);
+        animateElevation(splitButtonElevation.enabled);
+      },
+      [animateElevation, onPressOut]
+    );
+    const handleTrailingPressIn = React.useCallback(
+      (e: GestureResponderEvent) => {
+        onTrailingPressIn?.(e);
+        setPressedButton('trailing');
+        animateElevation(splitButtonElevation.pressed);
+      },
+      [animateElevation, onTrailingPressIn]
+    );
+    const handleTrailingPressOut = React.useCallback(
+      (e: GestureResponderEvent) => {
+        onTrailingPressOut?.(e);
+        setPressedButton(null);
+        animateElevation(splitButtonElevation.enabled);
+      },
+      [animateElevation, onTrailingPressOut]
+    );
+    React.useEffect(() => {
+      if (!isElevationEntitled) {
+        setPressedButton(null);
+      }
+
+      Animated.timing(elevation, {
+        toValue: isElevationEntitled ? splitButtonElevation.enabled : 0,
+        duration: 0,
+        useNativeDriver: false,
+      }).start();
+    }, [elevation, isElevationEntitled]);
+
+    const commonButtonStyle: ViewStyle = {
+      height: sizeStyle.containerHeight,
+      backgroundColor:
+        colors.containerOpacity < 1 ? 'transparent' : colors.containerColor,
+      borderColor: colors.borderColor,
+      borderWidth: colors.borderWidth,
+    };
+
+    return (
+      <Animated.View
+        {...rest}
+        ref={ref}
+        testID={`${testID}-container`}
+        style={
+          [
+            styles.group,
+            {
+              columnGap: sizeStyle.betweenSpace,
+              height: sizeStyle.containerHeight,
+            },
+            style,
+          ] as Animated.WithAnimatedValue<StyleProp<ViewStyle>>
+        }
+      >
+        <Surface
+          testID={`${testID}-leading-container`}
+          elevation={elevation}
+          style={[
+            styles.leading,
+            commonButtonStyle,
+            leadingShape,
+            buttonStyle,
+            leadingButtonStyle,
+          ]}
+          container
+        >
+          <ButtonBackground
+            backgroundColor={colors.containerColor}
+            opacity={colors.containerOpacity}
+            borderRadiusStyle={leadingShape}
+          />
+          <TouchableRipple
+            borderless
+            disabled={disabled}
+            onPress={onPress}
+            onLongPress={onLongPress}
+            onPressIn={
+              leadingHasTouchHandler ? handleLeadingPressIn : undefined
+            }
+            onPressOut={
+              leadingHasTouchHandler ? handleLeadingPressOut : undefined
+            }
+            delayLongPress={delayLongPress}
+            accessibilityLabel={accessibilityLabel}
+            accessibilityRole="button"
+            accessibilityState={leadingAccessibilityState}
+            background={background}
+            hitSlop={leadingHitSlop}
+            rippleColor={rippleColor}
+            style={[
+              styles.ripple,
+              getButtonTouchableRippleStyle(leadingShape, colors.borderWidth),
+            ]}
+            testID={`${testID}-leading`}
+            theme={theme}
+          >
+            <View
+              style={[
+                styles.leadingContent,
+                {
+                  height: sizeStyle.containerHeight,
+                  paddingStart: sizeStyle.leadingButtonLeadingSpace,
+                  paddingEnd: sizeStyle.leadingButtonTrailingSpace,
+                  opacity: colors.contentOpacity,
+                },
+                contentStyle,
+              ]}
+            >
+              {icon && !loading ? (
+                <Icon
+                  source={icon}
+                  size={customLabelSize ?? sizeStyle.leadingIconSize}
+                  color={contentColor}
+                />
+              ) : null}
+              {loading ? (
+                <ActivityIndicator
+                  size={customLabelSize ?? sizeStyle.leadingIconSize}
+                  color={contentColor}
+                />
+              ) : null}
+              <Text
+                variant={sizeStyle.labelVariant}
+                selectable={false}
+                numberOfLines={1}
+                ellipsizeMode="tail"
+                maxFontSizeMultiplier={maxFontSizeMultiplier}
+                style={[
+                  styles.label,
+                  icon || loading
+                    ? { marginStart: sizeStyle.leadingIconSize / 3 }
+                    : null,
+                  labelTextStyle,
+                  labelStyle,
+                ]}
+                testID={`${testID}-label`}
+              >
+                {label}
+              </Text>
+            </View>
+          </TouchableRipple>
+        </Surface>
+
+        <Surface
+          testID={`${testID}-trailing-container`}
+          elevation={elevation}
+          style={[
+            styles.trailing,
+            commonButtonStyle,
+            trailingShape,
+            buttonStyle,
+            trailingButtonStyle,
+          ]}
+          container
+        >
+          <ButtonBackground
+            backgroundColor={colors.containerColor}
+            opacity={colors.containerOpacity}
+            borderRadiusStyle={trailingShape}
+          />
+          <TouchableRipple
+            borderless
+            disabled={disabled}
+            onPress={onTrailingPress}
+            onLongPress={onTrailingLongPress}
+            onPressIn={
+              trailingHasTouchHandler ? handleTrailingPressIn : undefined
+            }
+            onPressOut={
+              trailingHasTouchHandler ? handleTrailingPressOut : undefined
+            }
+            delayLongPress={trailingDelayLongPress}
+            accessibilityLabel={trailingAccessibilityLabel}
+            accessibilityRole="button"
+            accessibilityState={trailingAccessibilityStateWithDisabled}
+            background={background}
+            hitSlop={resolvedTrailingHitSlop}
+            rippleColor={rippleColor}
+            style={[
+              styles.ripple,
+              getButtonTouchableRippleStyle(trailingShape, colors.borderWidth),
+            ]}
+            testID={`${testID}-trailing`}
+            theme={theme}
+          >
+            <View
+              style={[
+                styles.trailingContent,
+                {
+                  height: sizeStyle.containerHeight,
+                  paddingStart: sizeStyle.trailingButtonLeadingSpace,
+                  paddingEnd: sizeStyle.trailingButtonTrailingSpace,
+                  opacity: colors.contentOpacity,
+                },
+              ]}
+            >
+              <Icon
+                source={trailingIcon}
+                size={sizeStyle.trailingIconSize}
+                color={contentColor}
+              />
+            </View>
+          </TouchableRipple>
+        </Surface>
+      </Animated.View>
+    );
+  }
+);
+
+const ButtonBackground = ({
+  backgroundColor,
+  opacity,
+  borderRadiusStyle,
+}: {
+  backgroundColor: ColorValue;
+  opacity: number;
+  borderRadiusStyle: ViewStyle;
+}) => {
+  if (opacity >= 1) {
+    return null;
+  }
+
+  return (
+    <View
+      pointerEvents="none"
+      style={[
+        StyleSheet.absoluteFill,
+        borderRadiusStyle,
+        { backgroundColor, opacity },
+      ]}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  group: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    maxWidth: '100%',
+  },
+  leading: {
+    minWidth: 48,
+    flexShrink: 1,
+    borderStyle: 'solid',
+  },
+  trailing: {
+    minWidth: 48,
+    borderStyle: 'solid',
+  },
+  ripple: {
+    height: '100%',
+  },
+  leadingContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  label: {
+    flexShrink: 1,
+  },
+  trailingContent: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+export default SplitButton;
+
+// @component-docs ignore-next-line
+export { SplitButton };

--- a/src/components/SplitButton/SplitButton.tsx
+++ b/src/components/SplitButton/SplitButton.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
-import {
+import { StyleSheet, View } from 'react-native';
+import type {
   AccessibilityState,
   ColorValue,
   GestureResponderEvent,
   PressableAndroidRippleConfig,
   StyleProp,
-  StyleSheet,
   TextStyle,
-  View,
   ViewProps,
   ViewStyle,
 } from 'react-native';
@@ -35,10 +34,10 @@ import type { $Omit, ThemeProp } from '../../types';
 import hasTouchHandler from '../../utils/hasTouchHandler';
 import ActivityIndicator from '../ActivityIndicator';
 import { getButtonTouchableRippleStyle } from '../Button/utils';
-import Icon, { IconSource } from '../Icon';
+import Icon, { type IconSource } from '../Icon';
 import Surface from '../Surface';
 import TouchableRipple, {
-  Props as TouchableRippleProps,
+  type Props as TouchableRippleProps,
 } from '../TouchableRipple/TouchableRipple';
 import Text from '../Typography/Text';
 
@@ -320,19 +319,19 @@ const SplitButton = ({
   );
   const leadingAnimatedShapeStyle = useAnimatedStyle(
     () => ({
-      ...getSplitButtonLeadingShape({
-        containerRadius: sizeStyle.containerRadius,
-        innerRadius: leadingInnerRadius.value,
-      }),
+      borderTopStartRadius: sizeStyle.containerRadius,
+      borderBottomStartRadius: sizeStyle.containerRadius,
+      borderTopEndRadius: leadingInnerRadius.value,
+      borderBottomEndRadius: leadingInnerRadius.value,
     }),
     [sizeStyle.containerRadius]
   );
   const trailingAnimatedShapeStyle = useAnimatedStyle(
     () => ({
-      ...getSplitButtonTrailingShape({
-        containerRadius: sizeStyle.containerRadius,
-        innerRadius: trailingInnerRadius.value,
-      }),
+      borderTopStartRadius: trailingInnerRadius.value,
+      borderBottomStartRadius: trailingInnerRadius.value,
+      borderTopEndRadius: sizeStyle.containerRadius,
+      borderBottomEndRadius: sizeStyle.containerRadius,
     }),
     [sizeStyle.containerRadius]
   );

--- a/src/components/SplitButton/index.ts
+++ b/src/components/SplitButton/index.ts
@@ -1,0 +1,2 @@
+export { default } from './SplitButton';
+export type { Props } from './SplitButton';

--- a/src/components/SplitButton/tokens.ts
+++ b/src/components/SplitButton/tokens.ts
@@ -103,6 +103,7 @@ export const splitButtonSizeTokens: Record<
 export const splitButtonMinInteractiveSize = 48;
 
 export const splitButtonElevation = {
+  disabled: 0,
   enabled: 1,
   pressed: 2,
 } as const;

--- a/src/components/SplitButton/tokens.ts
+++ b/src/components/SplitButton/tokens.ts
@@ -1,0 +1,108 @@
+import type { ThemeShapeCorners, TypescaleKey } from '../../theme/types';
+
+export type SplitButtonSize =
+  | 'extra-small'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'extra-large';
+
+export type SplitButtonShapeKey = keyof ThemeShapeCorners | 'full';
+
+export type SplitButtonSizeTokens = {
+  betweenSpace: number;
+  containerHeight: number;
+  containerShape: SplitButtonShapeKey;
+  innerCornerShape: SplitButtonShapeKey;
+  innerPressedCornerShape: SplitButtonShapeKey;
+  leadingButtonLeadingSpace: number;
+  leadingButtonTrailingSpace: number;
+  leadingIconSize: number;
+  trailingButtonLeadingSpace: number;
+  trailingButtonTrailingSpace: number;
+  trailingIconSize: number;
+  labelVariant: TypescaleKey;
+};
+
+export const splitButtonSizeTokens: Record<
+  SplitButtonSize,
+  SplitButtonSizeTokens
+> = {
+  'extra-small': {
+    betweenSpace: 2,
+    containerHeight: 32,
+    containerShape: 'full',
+    innerCornerShape: 'extraSmall',
+    innerPressedCornerShape: 'small',
+    leadingButtonLeadingSpace: 12,
+    leadingButtonTrailingSpace: 10,
+    leadingIconSize: 20,
+    trailingButtonLeadingSpace: 13,
+    trailingButtonTrailingSpace: 13,
+    trailingIconSize: 22,
+    labelVariant: 'labelLarge',
+  },
+  small: {
+    betweenSpace: 2,
+    containerHeight: 40,
+    containerShape: 'full',
+    innerCornerShape: 'extraSmall',
+    innerPressedCornerShape: 'medium',
+    leadingButtonLeadingSpace: 16,
+    leadingButtonTrailingSpace: 12,
+    leadingIconSize: 20,
+    trailingButtonLeadingSpace: 13,
+    trailingButtonTrailingSpace: 13,
+    trailingIconSize: 22,
+    labelVariant: 'labelLarge',
+  },
+  medium: {
+    betweenSpace: 2,
+    containerHeight: 56,
+    containerShape: 'full',
+    innerCornerShape: 'extraSmall',
+    innerPressedCornerShape: 'medium',
+    leadingButtonLeadingSpace: 24,
+    leadingButtonTrailingSpace: 24,
+    leadingIconSize: 24,
+    trailingButtonLeadingSpace: 15,
+    trailingButtonTrailingSpace: 15,
+    trailingIconSize: 26,
+    labelVariant: 'titleMedium',
+  },
+  large: {
+    betweenSpace: 2,
+    containerHeight: 96,
+    containerShape: 'full',
+    innerCornerShape: 'small',
+    innerPressedCornerShape: 'largeIncreased',
+    leadingButtonLeadingSpace: 48,
+    leadingButtonTrailingSpace: 48,
+    leadingIconSize: 32,
+    trailingButtonLeadingSpace: 29,
+    trailingButtonTrailingSpace: 29,
+    trailingIconSize: 38,
+    labelVariant: 'headlineSmall',
+  },
+  'extra-large': {
+    betweenSpace: 2,
+    containerHeight: 136,
+    containerShape: 'full',
+    innerCornerShape: 'medium',
+    innerPressedCornerShape: 'largeIncreased',
+    leadingButtonLeadingSpace: 64,
+    leadingButtonTrailingSpace: 64,
+    leadingIconSize: 40,
+    trailingButtonLeadingSpace: 43,
+    trailingButtonTrailingSpace: 43,
+    trailingIconSize: 50,
+    labelVariant: 'headlineLarge',
+  },
+};
+
+export const splitButtonMinInteractiveSize = 48;
+
+export const splitButtonElevation = {
+  enabled: 1,
+  pressed: 2,
+} as const;

--- a/src/components/SplitButton/utils.ts
+++ b/src/components/SplitButton/utils.ts
@@ -1,0 +1,242 @@
+import type { ColorValue, Insets, ViewStyle } from 'react-native';
+
+import color from 'color';
+
+import {
+  splitButtonMinInteractiveSize,
+  splitButtonSizeTokens,
+  type SplitButtonShapeKey,
+  type SplitButtonSize,
+} from './tokens';
+import { tokens } from '../../theme/tokens';
+import { cornerFull } from '../../theme/tokens/sys/shape';
+import type { InternalTheme, Theme } from '../../types';
+import type { Props as TouchableRippleProps } from '../TouchableRipple/TouchableRipple';
+
+const stateOpacity = tokens.md.sys.state.opacity;
+
+export type SplitButtonMode = 'filled' | 'tonal' | 'elevated' | 'outlined';
+
+export type SplitButtonNormalizedMode =
+  | 'filled'
+  | 'tonal'
+  | 'elevated'
+  | 'outlined';
+
+export const normalizeSplitButtonMode = (
+  mode: SplitButtonMode
+): SplitButtonNormalizedMode => {
+  return mode;
+};
+
+export const resolveSplitButtonCorner = (
+  theme: InternalTheme,
+  key: SplitButtonShapeKey
+) => (key === 'full' ? cornerFull : (theme as Theme).shapes.corner[key]);
+
+export const getSplitButtonSizeStyle = ({
+  size,
+  theme,
+}: {
+  size: SplitButtonSize;
+  theme: InternalTheme;
+}) => {
+  const sizeTokens = splitButtonSizeTokens[size];
+
+  return {
+    ...sizeTokens,
+    containerRadius: resolveSplitButtonCorner(theme, sizeTokens.containerShape),
+    innerRadius: resolveSplitButtonCorner(theme, sizeTokens.innerCornerShape),
+    innerPressedRadius: resolveSplitButtonCorner(
+      theme,
+      sizeTokens.innerPressedCornerShape
+    ),
+  };
+};
+
+const getSplitButtonContainerColor = ({
+  mode,
+  theme,
+  disabled,
+  customButtonColor,
+}: {
+  mode: SplitButtonNormalizedMode;
+  theme: InternalTheme;
+  disabled?: boolean;
+  customButtonColor?: ColorValue;
+}) => {
+  const { colors } = theme as Theme;
+
+  if (customButtonColor && !disabled) {
+    return customButtonColor;
+  }
+
+  if (disabled) {
+    return mode === 'outlined' ? 'transparent' : colors.onSurface;
+  }
+
+  if (mode === 'filled') {
+    return colors.primary;
+  }
+
+  if (mode === 'tonal') {
+    return colors.secondaryContainer;
+  }
+
+  if (mode === 'elevated') {
+    return colors.surfaceContainerLow;
+  }
+
+  return 'transparent';
+};
+
+const getSplitButtonContentColor = ({
+  mode,
+  theme,
+  disabled,
+  customTextColor,
+}: {
+  mode: SplitButtonNormalizedMode;
+  theme: InternalTheme;
+  disabled?: boolean;
+  customTextColor?: ColorValue;
+}) => {
+  const { colors } = theme as Theme;
+
+  if (customTextColor && !disabled) {
+    return customTextColor;
+  }
+
+  if (disabled) {
+    return colors.onSurface;
+  }
+
+  if (mode === 'filled') {
+    return colors.onPrimary;
+  }
+
+  if (mode === 'tonal') {
+    return colors.onSecondaryContainer;
+  }
+
+  if (mode === 'outlined') {
+    return colors.onSurfaceVariant;
+  }
+
+  return colors.primary;
+};
+
+export const getSplitButtonColors = ({
+  theme,
+  mode,
+  disabled,
+  customButtonColor,
+  customTextColor,
+}: {
+  theme: InternalTheme;
+  mode: SplitButtonMode;
+  disabled?: boolean;
+  customButtonColor?: ColorValue;
+  customTextColor?: ColorValue;
+}) => {
+  const normalizedMode = normalizeSplitButtonMode(mode);
+  const containerColor = getSplitButtonContainerColor({
+    mode: normalizedMode,
+    theme,
+    disabled,
+    customButtonColor,
+  });
+  const contentColor = getSplitButtonContentColor({
+    mode: normalizedMode,
+    theme,
+    disabled,
+    customTextColor,
+  });
+  const isOutlined = normalizedMode === 'outlined';
+
+  return {
+    containerColor,
+    contentColor,
+    borderColor: isOutlined ? (theme as Theme).colors.outline : 'transparent',
+    borderWidth: isOutlined ? 1 : 0,
+    containerOpacity:
+      disabled && normalizedMode !== 'outlined'
+        ? stateOpacity.pressed
+        : stateOpacity.enabled,
+    contentOpacity: disabled ? stateOpacity.disabled : stateOpacity.enabled,
+  };
+};
+
+export const getSplitButtonRippleColor = ({
+  contentColor,
+  customRippleColor,
+}: {
+  contentColor: ColorValue;
+  customRippleColor?: ColorValue;
+}): ColorValue | undefined => {
+  if (customRippleColor) {
+    return customRippleColor;
+  }
+
+  if (typeof contentColor !== 'string') {
+    return undefined;
+  }
+
+  return color(contentColor).alpha(stateOpacity.pressed).rgb().string();
+};
+
+export const getSplitButtonHitSlop = ({
+  size,
+  hitSlop,
+}: {
+  size: SplitButtonSize;
+  hitSlop?: TouchableRippleProps['hitSlop'];
+}): TouchableRippleProps['hitSlop'] => {
+  if (typeof hitSlop === 'number') {
+    return hitSlop;
+  }
+
+  const height = splitButtonSizeTokens[size].containerHeight;
+  const verticalSlop = Math.max(
+    0,
+    (splitButtonMinInteractiveSize - height) / 2
+  );
+
+  if (verticalSlop === 0) {
+    return hitSlop;
+  }
+
+  const insetHitSlop = (hitSlop || {}) as Insets;
+
+  return {
+    ...insetHitSlop,
+    top: insetHitSlop.top ?? verticalSlop,
+    bottom: insetHitSlop.bottom ?? verticalSlop,
+  };
+};
+
+export const getSplitButtonLeadingShape = ({
+  containerRadius,
+  innerRadius,
+}: {
+  containerRadius: number;
+  innerRadius: number;
+}): ViewStyle => ({
+  borderTopStartRadius: containerRadius,
+  borderBottomStartRadius: containerRadius,
+  borderTopEndRadius: innerRadius,
+  borderBottomEndRadius: innerRadius,
+});
+
+export const getSplitButtonTrailingShape = ({
+  containerRadius,
+  innerRadius,
+}: {
+  containerRadius: number;
+  innerRadius: number;
+}): ViewStyle => ({
+  borderTopStartRadius: innerRadius,
+  borderBottomStartRadius: innerRadius,
+  borderTopEndRadius: containerRadius,
+  borderBottomEndRadius: containerRadius,
+});

--- a/src/components/SplitButton/utils.ts
+++ b/src/components/SplitButton/utils.ts
@@ -10,7 +10,7 @@ import {
 } from './tokens';
 import { tokens } from '../../theme/tokens';
 import { cornerFull } from '../../theme/tokens/sys/shape';
-import type { InternalTheme, Theme } from '../../types';
+import type { InternalTheme } from '../../types';
 import type { Props as TouchableRippleProps } from '../TouchableRipple/TouchableRipple';
 
 const stateOpacity = tokens.md.sys.state.opacity;
@@ -32,7 +32,7 @@ export const normalizeSplitButtonMode = (
 export const resolveSplitButtonCorner = (
   theme: InternalTheme,
   key: SplitButtonShapeKey
-) => (key === 'full' ? cornerFull : (theme as Theme).shapes.corner[key]);
+) => (key === 'full' ? cornerFull : theme.shapes.corner[key]);
 
 export const getSplitButtonSizeStyle = ({
   size,
@@ -65,7 +65,7 @@ const getSplitButtonContainerColor = ({
   disabled?: boolean;
   customButtonColor?: ColorValue;
 }) => {
-  const { colors } = theme as Theme;
+  const { colors } = theme;
 
   if (customButtonColor && !disabled) {
     return customButtonColor;
@@ -101,7 +101,7 @@ const getSplitButtonContentColor = ({
   disabled?: boolean;
   customTextColor?: ColorValue;
 }) => {
-  const { colors } = theme as Theme;
+  const { colors } = theme;
 
   if (customTextColor && !disabled) {
     return customTextColor;
@@ -157,7 +157,7 @@ export const getSplitButtonColors = ({
   return {
     containerColor,
     contentColor,
-    borderColor: isOutlined ? (theme as Theme).colors.outline : 'transparent',
+    borderColor: isOutlined ? theme.colors.outlineVariant : 'transparent',
     borderWidth: isOutlined ? 1 : 0,
     containerOpacity:
       disabled && normalizedMode !== 'outlined'

--- a/src/components/__tests__/SplitButton.test.tsx
+++ b/src/components/__tests__/SplitButton.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { PlatformColor, StyleSheet } from 'react-native';
 
-import { fireEvent } from '@testing-library/react-native';
+import { describe, expect, it, jest } from '@jest/globals';
 
 import { getTheme } from '../../core/theming';
-import { render } from '../../test-utils';
+import { fireEvent, render, screen, userEvent } from '../../test-utils';
 import SplitButton from '../SplitButton/SplitButton';
 import {
   getSplitButtonColors,
@@ -41,49 +41,46 @@ const renderSplitButton = (
     />
   );
 
-it('renders a filled split button by default', () => {
-  const { getByTestId } = renderSplitButton();
+it('renders a filled split button by default', async () => {
+  await renderSplitButton();
 
-  expect(getByTestId('split-button-label')).toHaveTextContent('Send');
-  expect(getByTestId('split-button-container')).toHaveStyle({
+  expect(screen.getByTestId('split-button-label')).toHaveTextContent('Send');
+  expect(screen.getByTestId('split-button-container')).toHaveStyle({
     height: 40,
   });
-  expect(getByTestId('split-button-leading-container')).toBeTruthy();
-  expect(getByTestId('split-button-trailing-container')).toBeTruthy();
+  expect(screen.getByTestId('split-button-leading-container')).toBeTruthy();
+  expect(screen.getByTestId('split-button-trailing-container')).toBeTruthy();
 });
 
-it('calls leading and trailing press handlers separately', () => {
+it('calls leading and trailing press handlers separately', async () => {
+  const user = userEvent.setup();
   const onPress = jest.fn();
   const onTrailingPress = jest.fn();
-  const { getByTestId } = renderSplitButton({ onPress, onTrailingPress });
+  await renderSplitButton({ onPress, onTrailingPress });
 
-  fireEvent.press(getByTestId('split-button-leading'));
-  fireEvent.press(getByTestId('split-button-trailing'));
+  await user.press(screen.getByTestId('split-button-leading'));
+  await user.press(screen.getByTestId('split-button-trailing'));
 
   expect(onPress).toHaveBeenCalledTimes(1);
   expect(onTrailingPress).toHaveBeenCalledTimes(1);
 });
 
-it('calls leading and trailing press-in and press-out handlers separately', () => {
-  const onPress = jest.fn();
+it('calls leading and trailing press-in and press-out handlers separately', async () => {
   const onPressIn = jest.fn();
   const onPressOut = jest.fn();
-  const onTrailingPress = jest.fn();
   const onTrailingPressIn = jest.fn();
   const onTrailingPressOut = jest.fn();
-  const { getByTestId } = renderSplitButton({
-    onPress,
+  await renderSplitButton({
     onPressIn,
     onPressOut,
-    onTrailingPress,
     onTrailingPressIn,
     onTrailingPressOut,
   });
 
-  fireEvent(getByTestId('split-button-leading'), 'onPressIn');
-  fireEvent(getByTestId('split-button-leading'), 'onPressOut');
-  fireEvent(getByTestId('split-button-trailing'), 'onPressIn');
-  fireEvent(getByTestId('split-button-trailing'), 'onPressOut');
+  await fireEvent(screen.getByTestId('split-button-leading'), 'onPressIn');
+  await fireEvent(screen.getByTestId('split-button-leading'), 'onPressOut');
+  await fireEvent(screen.getByTestId('split-button-trailing'), 'onPressIn');
+  await fireEvent(screen.getByTestId('split-button-trailing'), 'onPressOut');
 
   expect(onPressIn).toHaveBeenCalledTimes(1);
   expect(onPressOut).toHaveBeenCalledTimes(1);
@@ -91,69 +88,62 @@ it('calls leading and trailing press-in and press-out handlers separately', () =
   expect(onTrailingPressOut).toHaveBeenCalledTimes(1);
 });
 
-it('uses resting inner-corner tokens for both sides', () => {
+it('uses resting inner-corner tokens for both sides', async () => {
   const theme = getTheme();
-  const { getByTestId } = renderSplitButton();
+  await renderSplitButton();
 
-  expect(getByTestId('split-button-leading-container')).toHaveStyle({
+  expect(screen.getByTestId('split-button-leading-container')).toHaveStyle({
     borderTopEndRadius: theme.shapes.corner.extraSmall,
     borderBottomEndRadius: theme.shapes.corner.extraSmall,
   });
-  expect(getByTestId('split-button-trailing-container')).toHaveStyle({
+  expect(screen.getByTestId('split-button-trailing-container')).toHaveStyle({
     borderTopStartRadius: theme.shapes.corner.extraSmall,
     borderBottomStartRadius: theme.shapes.corner.extraSmall,
   });
 });
 
-it('marks both press targets disabled when disabled', () => {
-  const { getByTestId } = renderSplitButton({ disabled: true });
+it('marks both press targets disabled when disabled', async () => {
+  await renderSplitButton({ disabled: true });
 
-  expect(getByTestId('split-button-leading').props.accessibilityState).toEqual({
-    disabled: true,
-  });
-  expect(getByTestId('split-button-trailing').props.accessibilityState).toEqual(
-    {
-      disabled: true,
-    }
-  );
+  expect(screen.getByTestId('split-button-leading')).toBeDisabled();
+  expect(screen.getByTestId('split-button-trailing')).toBeDisabled();
 });
 
-it('passes custom styles to the correct target', () => {
-  const { getByTestId } = renderSplitButton({
+it('passes custom styles to the correct target', async () => {
+  await renderSplitButton({
     leadingButtonStyle: styles.leading,
     trailingButtonStyle: styles.trailing,
     labelStyle: styles.label,
   });
 
-  expect(getByTestId('split-button-leading-container')).toHaveStyle(
+  expect(screen.getByTestId('split-button-leading-container')).toHaveStyle(
     styles.leading
   );
-  expect(getByTestId('split-button-trailing-container')).toHaveStyle(
+  expect(screen.getByTestId('split-button-trailing-container')).toHaveStyle(
     styles.trailing
   );
-  expect(getByTestId('split-button-label')).toHaveStyle(styles.label);
+  expect(screen.getByTestId('split-button-label')).toHaveStyle(styles.label);
 });
 
-it('merges trailing accessibility state with expanded state', () => {
-  const { getByTestId } = renderSplitButton({
+it('merges trailing accessibility state with expanded state', async () => {
+  await renderSplitButton({
     trailingAccessibilityState: { expanded: true },
   });
 
-  expect(
-    getByTestId('split-button-trailing').props.accessibilityState
-  ).toMatchObject({
-    expanded: true,
-  });
+  expect(screen.getByTestId('split-button-trailing')).toHaveProp(
+    'accessibilityState',
+    expect.objectContaining({ expanded: true })
+  );
 });
 
-it('does not add SplitButton test IDs unless testID is provided', () => {
-  const { queryByTestId } = render(
+it('does not add SplitButton test IDs unless testID is provided', async () => {
+  await render(
     <SplitButton label="Send" onPress={() => {}} onTrailingPress={() => {}} />
   );
 
-  expect(queryByTestId('split-button-container')).toBeNull();
-  expect(queryByTestId('split-button-leading')).toBeNull();
-  expect(queryByTestId('split-button-trailing')).toBeNull();
+  expect(screen.queryByTestId('split-button-container')).toBeNull();
+  expect(screen.queryByTestId('split-button-leading')).toBeNull();
+  expect(screen.queryByTestId('split-button-trailing')).toBeNull();
 });
 
 describe('SplitButton utils', () => {

--- a/src/components/__tests__/SplitButton.test.tsx
+++ b/src/components/__tests__/SplitButton.test.tsx
@@ -1,0 +1,241 @@
+import * as React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { fireEvent } from '@testing-library/react-native';
+
+import { getTheme } from '../../core/theming';
+import { render } from '../../test-utils';
+import SplitButton from '../SplitButton/SplitButton';
+import {
+  getSplitButtonColors,
+  getSplitButtonHitSlop,
+  getSplitButtonLeadingShape,
+  getSplitButtonSizeStyle,
+  getSplitButtonTrailingShape,
+  normalizeSplitButtonMode,
+} from '../SplitButton/utils';
+
+const styles = StyleSheet.create({
+  leading: {
+    minWidth: 120,
+  },
+  trailing: {
+    minWidth: 64,
+  },
+  label: {
+    fontSize: 18,
+  },
+});
+
+it('renders a filled split button by default', () => {
+  const { getByTestId } = render(
+    <SplitButton label="Send" onPress={() => {}} onTrailingPress={() => {}} />
+  );
+
+  expect(getByTestId('split-button-label')).toHaveTextContent('Send');
+  expect(getByTestId('split-button-container')).toHaveStyle({
+    height: 40,
+  });
+  expect(getByTestId('split-button-leading-container')).toBeTruthy();
+  expect(getByTestId('split-button-trailing-container')).toBeTruthy();
+});
+
+it('calls leading and trailing press handlers separately', () => {
+  const onPress = jest.fn();
+  const onTrailingPress = jest.fn();
+  const { getByTestId } = render(
+    <SplitButton
+      label="Send"
+      onPress={onPress}
+      onTrailingPress={onTrailingPress}
+    />
+  );
+
+  fireEvent.press(getByTestId('split-button-leading'));
+  fireEvent.press(getByTestId('split-button-trailing'));
+
+  expect(onPress).toHaveBeenCalledTimes(1);
+  expect(onTrailingPress).toHaveBeenCalledTimes(1);
+});
+
+it('calls leading and trailing press-in and press-out handlers separately', () => {
+  const onPress = jest.fn();
+  const onPressIn = jest.fn();
+  const onPressOut = jest.fn();
+  const onTrailingPress = jest.fn();
+  const onTrailingPressIn = jest.fn();
+  const onTrailingPressOut = jest.fn();
+  const { getByTestId } = render(
+    <SplitButton
+      label="Send"
+      onPress={onPress}
+      onPressIn={onPressIn}
+      onPressOut={onPressOut}
+      onTrailingPress={onTrailingPress}
+      onTrailingPressIn={onTrailingPressIn}
+      onTrailingPressOut={onTrailingPressOut}
+    />
+  );
+
+  fireEvent(getByTestId('split-button-leading'), 'onPressIn');
+  fireEvent(getByTestId('split-button-leading'), 'onPressOut');
+  fireEvent(getByTestId('split-button-trailing'), 'onPressIn');
+  fireEvent(getByTestId('split-button-trailing'), 'onPressOut');
+
+  expect(onPressIn).toHaveBeenCalledTimes(1);
+  expect(onPressOut).toHaveBeenCalledTimes(1);
+  expect(onTrailingPressIn).toHaveBeenCalledTimes(1);
+  expect(onTrailingPressOut).toHaveBeenCalledTimes(1);
+});
+
+it('uses pressed inner-corner tokens for the active side', () => {
+  const theme = getTheme();
+  const { getByTestId } = render(
+    <SplitButton label="Send" onPress={() => {}} onTrailingPress={() => {}} />
+  );
+
+  fireEvent(getByTestId('split-button-leading'), 'onPressIn');
+
+  expect(getByTestId('split-button-leading-container')).toHaveStyle({
+    borderTopEndRadius: theme.shapes.corner.medium,
+    borderBottomEndRadius: theme.shapes.corner.medium,
+  });
+  expect(getByTestId('split-button-trailing-container')).toHaveStyle({
+    borderTopStartRadius: theme.shapes.corner.extraSmall,
+    borderBottomStartRadius: theme.shapes.corner.extraSmall,
+  });
+
+  fireEvent(getByTestId('split-button-leading'), 'onPressOut');
+  fireEvent(getByTestId('split-button-trailing'), 'onPressIn');
+
+  expect(getByTestId('split-button-trailing-container')).toHaveStyle({
+    borderTopStartRadius: theme.shapes.corner.medium,
+    borderBottomStartRadius: theme.shapes.corner.medium,
+  });
+});
+
+it('marks both press targets disabled when disabled', () => {
+  const { getByTestId } = render(
+    <SplitButton
+      label="Send"
+      disabled
+      onPress={() => {}}
+      onTrailingPress={() => {}}
+    />
+  );
+
+  expect(getByTestId('split-button-leading').props.accessibilityState).toEqual({
+    disabled: true,
+  });
+  expect(getByTestId('split-button-trailing').props.accessibilityState).toEqual(
+    {
+      disabled: true,
+    }
+  );
+});
+
+it('passes custom styles to the correct target', () => {
+  const { getByTestId } = render(
+    <SplitButton
+      label="Send"
+      onPress={() => {}}
+      onTrailingPress={() => {}}
+      leadingButtonStyle={styles.leading}
+      trailingButtonStyle={styles.trailing}
+      labelStyle={styles.label}
+    />
+  );
+
+  expect(getByTestId('split-button-leading-container')).toHaveStyle(
+    styles.leading
+  );
+  expect(getByTestId('split-button-trailing-container')).toHaveStyle(
+    styles.trailing
+  );
+  expect(getByTestId('split-button-label')).toHaveStyle(styles.label);
+});
+
+it('merges trailing accessibility state with expanded state', () => {
+  const { getByTestId } = render(
+    <SplitButton
+      label="Send"
+      onPress={() => {}}
+      onTrailingPress={() => {}}
+      trailingAccessibilityState={{ expanded: true }}
+    />
+  );
+
+  expect(
+    getByTestId('split-button-trailing').props.accessibilityState
+  ).toMatchObject({
+    expanded: true,
+  });
+});
+
+describe('SplitButton utils', () => {
+  it('normalizes supported MD3 modes', () => {
+    expect(normalizeSplitButtonMode('filled')).toBe('filled');
+    expect(normalizeSplitButtonMode('tonal')).toBe('tonal');
+    expect(normalizeSplitButtonMode('outlined')).toBe('outlined');
+  });
+
+  it('resolves MD3 color roles for modes', () => {
+    const theme = getTheme();
+
+    expect(getSplitButtonColors({ theme, mode: 'filled' }).containerColor).toBe(
+      theme.colors.primary
+    );
+    expect(getSplitButtonColors({ theme, mode: 'tonal' }).contentColor).toBe(
+      theme.colors.onSecondaryContainer
+    );
+    expect(getSplitButtonColors({ theme, mode: 'elevated' }).contentColor).toBe(
+      theme.colors.primary
+    );
+    expect(getSplitButtonColors({ theme, mode: 'outlined' }).borderColor).toBe(
+      theme.colors.outline
+    );
+  });
+
+  it('resolves per-size tokens against theme shape values', () => {
+    const theme = getTheme();
+    const sizeStyle = getSplitButtonSizeStyle({ theme, size: 'large' });
+
+    expect(sizeStyle.containerHeight).toBe(96);
+    expect(sizeStyle.trailingIconSize).toBe(38);
+    expect(sizeStyle.innerRadius).toBe(theme.shapes.corner.small);
+    expect(sizeStyle.innerPressedRadius).toBe(
+      theme.shapes.corner.largeIncreased
+    );
+  });
+
+  it('uses logical leading and trailing shapes', () => {
+    expect(
+      getSplitButtonLeadingShape({ containerRadius: 20, innerRadius: 4 })
+    ).toEqual({
+      borderTopStartRadius: 20,
+      borderBottomStartRadius: 20,
+      borderTopEndRadius: 4,
+      borderBottomEndRadius: 4,
+    });
+    expect(
+      getSplitButtonTrailingShape({ containerRadius: 20, innerRadius: 4 })
+    ).toEqual({
+      borderTopStartRadius: 4,
+      borderBottomStartRadius: 4,
+      borderTopEndRadius: 20,
+      borderBottomEndRadius: 20,
+    });
+  });
+
+  it('expands small visual sizes to a 48dp touch target', () => {
+    expect(getSplitButtonHitSlop({ size: 'extra-small' })).toEqual({
+      top: 8,
+      bottom: 8,
+    });
+    expect(getSplitButtonHitSlop({ size: 'small' })).toEqual({
+      top: 4,
+      bottom: 4,
+    });
+    expect(getSplitButtonHitSlop({ size: 'medium' })).toBeUndefined();
+  });
+});

--- a/src/components/__tests__/SplitButton.test.tsx
+++ b/src/components/__tests__/SplitButton.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleSheet } from 'react-native';
+import { PlatformColor, StyleSheet } from 'react-native';
 
 import { fireEvent } from '@testing-library/react-native';
 
@@ -10,6 +10,7 @@ import {
   getSplitButtonColors,
   getSplitButtonHitSlop,
   getSplitButtonLeadingShape,
+  getSplitButtonRippleColor,
   getSplitButtonSizeStyle,
   getSplitButtonTrailingShape,
   normalizeSplitButtonMode,
@@ -27,10 +28,21 @@ const styles = StyleSheet.create({
   },
 });
 
-it('renders a filled split button by default', () => {
-  const { getByTestId } = render(
-    <SplitButton label="Send" onPress={() => {}} onTrailingPress={() => {}} />
+const renderSplitButton = (
+  props: Partial<React.ComponentProps<typeof SplitButton>> = {}
+) =>
+  render(
+    <SplitButton
+      testID="split-button"
+      label="Send"
+      onPress={() => {}}
+      onTrailingPress={() => {}}
+      {...props}
+    />
   );
+
+it('renders a filled split button by default', () => {
+  const { getByTestId } = renderSplitButton();
 
   expect(getByTestId('split-button-label')).toHaveTextContent('Send');
   expect(getByTestId('split-button-container')).toHaveStyle({
@@ -43,13 +55,7 @@ it('renders a filled split button by default', () => {
 it('calls leading and trailing press handlers separately', () => {
   const onPress = jest.fn();
   const onTrailingPress = jest.fn();
-  const { getByTestId } = render(
-    <SplitButton
-      label="Send"
-      onPress={onPress}
-      onTrailingPress={onTrailingPress}
-    />
-  );
+  const { getByTestId } = renderSplitButton({ onPress, onTrailingPress });
 
   fireEvent.press(getByTestId('split-button-leading'));
   fireEvent.press(getByTestId('split-button-trailing'));
@@ -65,17 +71,14 @@ it('calls leading and trailing press-in and press-out handlers separately', () =
   const onTrailingPress = jest.fn();
   const onTrailingPressIn = jest.fn();
   const onTrailingPressOut = jest.fn();
-  const { getByTestId } = render(
-    <SplitButton
-      label="Send"
-      onPress={onPress}
-      onPressIn={onPressIn}
-      onPressOut={onPressOut}
-      onTrailingPress={onTrailingPress}
-      onTrailingPressIn={onTrailingPressIn}
-      onTrailingPressOut={onTrailingPressOut}
-    />
-  );
+  const { getByTestId } = renderSplitButton({
+    onPress,
+    onPressIn,
+    onPressOut,
+    onTrailingPress,
+    onTrailingPressIn,
+    onTrailingPressOut,
+  });
 
   fireEvent(getByTestId('split-button-leading'), 'onPressIn');
   fireEvent(getByTestId('split-button-leading'), 'onPressOut');
@@ -88,41 +91,22 @@ it('calls leading and trailing press-in and press-out handlers separately', () =
   expect(onTrailingPressOut).toHaveBeenCalledTimes(1);
 });
 
-it('uses pressed inner-corner tokens for the active side', () => {
+it('uses resting inner-corner tokens for both sides', () => {
   const theme = getTheme();
-  const { getByTestId } = render(
-    <SplitButton label="Send" onPress={() => {}} onTrailingPress={() => {}} />
-  );
-
-  fireEvent(getByTestId('split-button-leading'), 'onPressIn');
+  const { getByTestId } = renderSplitButton();
 
   expect(getByTestId('split-button-leading-container')).toHaveStyle({
-    borderTopEndRadius: theme.shapes.corner.medium,
-    borderBottomEndRadius: theme.shapes.corner.medium,
+    borderTopEndRadius: theme.shapes.corner.extraSmall,
+    borderBottomEndRadius: theme.shapes.corner.extraSmall,
   });
   expect(getByTestId('split-button-trailing-container')).toHaveStyle({
     borderTopStartRadius: theme.shapes.corner.extraSmall,
     borderBottomStartRadius: theme.shapes.corner.extraSmall,
   });
-
-  fireEvent(getByTestId('split-button-leading'), 'onPressOut');
-  fireEvent(getByTestId('split-button-trailing'), 'onPressIn');
-
-  expect(getByTestId('split-button-trailing-container')).toHaveStyle({
-    borderTopStartRadius: theme.shapes.corner.medium,
-    borderBottomStartRadius: theme.shapes.corner.medium,
-  });
 });
 
 it('marks both press targets disabled when disabled', () => {
-  const { getByTestId } = render(
-    <SplitButton
-      label="Send"
-      disabled
-      onPress={() => {}}
-      onTrailingPress={() => {}}
-    />
-  );
+  const { getByTestId } = renderSplitButton({ disabled: true });
 
   expect(getByTestId('split-button-leading').props.accessibilityState).toEqual({
     disabled: true,
@@ -135,16 +119,11 @@ it('marks both press targets disabled when disabled', () => {
 });
 
 it('passes custom styles to the correct target', () => {
-  const { getByTestId } = render(
-    <SplitButton
-      label="Send"
-      onPress={() => {}}
-      onTrailingPress={() => {}}
-      leadingButtonStyle={styles.leading}
-      trailingButtonStyle={styles.trailing}
-      labelStyle={styles.label}
-    />
-  );
+  const { getByTestId } = renderSplitButton({
+    leadingButtonStyle: styles.leading,
+    trailingButtonStyle: styles.trailing,
+    labelStyle: styles.label,
+  });
 
   expect(getByTestId('split-button-leading-container')).toHaveStyle(
     styles.leading
@@ -156,20 +135,25 @@ it('passes custom styles to the correct target', () => {
 });
 
 it('merges trailing accessibility state with expanded state', () => {
-  const { getByTestId } = render(
-    <SplitButton
-      label="Send"
-      onPress={() => {}}
-      onTrailingPress={() => {}}
-      trailingAccessibilityState={{ expanded: true }}
-    />
-  );
+  const { getByTestId } = renderSplitButton({
+    trailingAccessibilityState: { expanded: true },
+  });
 
   expect(
     getByTestId('split-button-trailing').props.accessibilityState
   ).toMatchObject({
     expanded: true,
   });
+});
+
+it('does not add SplitButton test IDs unless testID is provided', () => {
+  const { queryByTestId } = render(
+    <SplitButton label="Send" onPress={() => {}} onTrailingPress={() => {}} />
+  );
+
+  expect(queryByTestId('split-button-container')).toBeNull();
+  expect(queryByTestId('split-button-leading')).toBeNull();
+  expect(queryByTestId('split-button-trailing')).toBeNull();
 });
 
 describe('SplitButton utils', () => {
@@ -192,8 +176,26 @@ describe('SplitButton utils', () => {
       theme.colors.primary
     );
     expect(getSplitButtonColors({ theme, mode: 'outlined' }).borderColor).toBe(
-      theme.colors.outline
+      theme.colors.outlineVariant
     );
+  });
+
+  it('resolves ripple colors from overrides, string content colors, and opaque colors', () => {
+    const theme = getTheme();
+    const customRippleColor = 'rgba(1, 2, 3, 0.4)';
+
+    expect(
+      getSplitButtonRippleColor({
+        contentColor: theme.colors.primary,
+        customRippleColor,
+      })
+    ).toBe(customRippleColor);
+    expect(
+      getSplitButtonRippleColor({ contentColor: theme.colors.primary })
+    ).toBe('rgba(103, 80, 164, 0.1)');
+    expect(
+      getSplitButtonRippleColor({ contentColor: PlatformColor('label') })
+    ).toBeUndefined();
   });
 
   it('resolves per-size tokens against theme shape values', () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,6 +42,7 @@ export { default as ProgressBar } from './components/ProgressBar';
 export { default as RadioButton } from './components/RadioButton';
 export { default as Searchbar } from './components/Searchbar';
 export { default as Snackbar } from './components/Snackbar';
+export { default as SplitButton } from './components/SplitButton';
 export { default as Surface } from './components/Surface';
 export { default as Switch } from './components/Switch/Switch';
 export { default as Appbar } from './components/Appbar';
@@ -126,6 +127,7 @@ export type { Props as RadioButtonIOSProps } from './components/RadioButton/Radi
 export type { Props as RadioButtonItemProps } from './components/RadioButton/RadioButtonItem';
 export type { Props as SearchbarProps } from './components/Searchbar';
 export type { Props as SnackbarProps } from './components/Snackbar';
+export type { Props as SplitButtonProps } from './components/SplitButton';
 export type { Props as SurfaceProps } from './components/Surface';
 export type { Props as SwitchProps } from './components/Switch/Switch';
 export type {


### PR DESCRIPTION
 ### Motivation

  Implements the new Material Design 3 SplitButton component as part of the v6 component modernization work.

  The component provides a primary leading action and a separate trailing action for contextual options. It reuses the modernized Button API direction
  from #4928/#4943: explicit `label`/`icon` props, MD3 mode names (`filled`, `tonal`, `elevated`, `outlined`), derived ripple/state-layer colors,
  extracted component tokens, size metrics, shape tokens, disabled/loading states, and separate accessibility/press handlers for each button segment.

  This also adds the component to the public exports, documentation generation config, theme color docs data, and the example app. The example includes a
  Menu-based playground, mode showcase, loading/disabled controls, and custom color/label styling.

  ### Related issue

  Closes #4986

  Related to #4928 and #4943

  ### Test plan

  - `yarn lint-no-fix`
    - Passes with one existing unrelated warning in `src/components/__tests__/TextInput.test.tsx`.
  - `yarn typescript`
  - `yarn test --watchman=false`
  - `yarn docs build`

  Manual verification in the example app:

  - Open the `SplitButton` example screen.
  - In the playground, tap the leading `Send` action and trailing menu action separately.
  - Verify the trailing menu opens below the SplitButton anchor and does not cover the button.
  - Toggle `Disabled` and verify both press targets are disabled and styled correctly.
  - Toggle `Loading` and verify the leading icon is replaced with a spinner.
  - Review all modes: `filled`, `tonal`, `elevated`, and `outlined`.
  - Review custom color and custom label style examples.
  
  
<img width="600" height="1400" alt="Screenshot_1781525547" src="https://github.com/user-attachments/assets/caffbfce-d624-4383-98a6-466f27cdce59" />
<img width="600" height="1400" alt="Simulator Screenshot - iPhone 17 - 2026-06-15 at 14 15 22" src="https://github.com/user-attachments/assets/e0bcdb80-18dd-4448-83de-c14eac6c8bee" />

