### PR TITLE
fix: handle fragments in dialog actions

### DIFF
--- a/src/components/Dialog/DialogActions.tsx
+++ b/src/components/Dialog/DialogActions.tsx
@@ -48,18 +48,24 @@ export type Props = ViewProps & {
  */
 const DialogActions = (props: Props) => {
   useInternalTheme(props.theme);
-  const actionsLength = React.Children.toArray(props.children).length;
+
+  const actions = React.Children.toArray(props.children).flatMap((child) =>
+    React.isValidElement<{ children?: React.ReactNode }>(child) &&
+    child.type === React.Fragment
+      ? React.Children.toArray(child.props.children)
+      : child
+  );
 
   return (
     <View {...props} style={[styles.v3Container, props.style]}>
-      {React.Children.map(props.children, (child, i) =>
+      {actions.map((child, i) =>
         React.isValidElement<DialogActionChildProps>(child)
           ? React.cloneElement(child, {
               compact: true,
               uppercase: false,
               style: [
                 {
-                  marginRight: i + 1 === actionsLength ? 0 : 8,
+                  marginRight: i + 1 === actions.length ? 0 : 8,
                 },
                 child.props.style,
               ],

--- a/src/components/__tests__/Dialog.test.tsx
+++ b/src/components/__tests__/Dialog.test.tsx
@@ -152,6 +152,25 @@ describe('DialogActions', () => {
     expect(dialogActionButtons[0]).toHaveStyle({ margin: 10 });
     expect(dialogActionButtons[1]).toHaveStyle({ margin: 0 });
   });
+
+  it('should apply action props to children wrapped in a fragment', () => {
+    const { getByTestId } = render(
+      <Dialog.Actions testID="dialog-actions">
+        <>
+          <Button testID="button-cancel">Cancel</Button>
+          <Button testID="button-ok">Ok</Button>
+        </>
+      </Dialog.Actions>
+    );
+
+    const dialogActionsContainer = getByTestId('dialog-actions');
+    const dialogActionButtons = dialogActionsContainer.children;
+
+    expect(getByTestId('button-cancel')).toBeDefined();
+    expect(getByTestId('button-ok')).toBeDefined();
+    expect(dialogActionButtons[0]).toHaveStyle({ marginRight: 8 });
+    expect(dialogActionButtons[1]).toHaveStyle({ marginRight: 0 });
+  });
 });
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
### Motivation

`Dialog.Actions` clones each action child to inject `compact`, `uppercase`, and spacing props. When callers wrap actions in a fragment, React 19 warns because those props are applied to `React.Fragment`, which only accepts `key` and `children`.

This treats top-level fragments as transparent wrappers so their children still receive the dialog action props, while the fragment itself is not cloned.

### Related issue

Fixes #4794

### Test plan

- `yarn test src/components/__tests__/Dialog.test.tsx --runInBand`
- `yarn typescript`
- `yarn lint-no-fix src/components/Dialog/DialogActions.tsx src/components/__tests__/Dialog.test.tsx` (passes with an existing unrelated warning in `src/components/__tests__/TextInput.test.tsx`)

I also let the pre-commit hook run once. It ran lint, TypeScript, and the full Jest suite; the full suite failed in this sparse/source checkout because `src/babel/__tests__/index.js` expects `lib/mappings.json`, which is not present without generating/building `lib`. The touched Dialog test passed in that run.