### PR TITLE
fix(tooltip): propagate press event object to onPress (#5003)

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -6,7 +6,11 @@ import {
   Platform,
   Pressable,
 } from 'react-native';
-import type { LayoutChangeEvent, ViewStyle } from 'react-native';
+import type {
+  GestureResponderEvent,
+  LayoutChangeEvent,
+  ViewStyle,
+} from 'react-native';
 
 import { getTooltipPosition } from './utils';
 import type { Measurement, TooltipChildProps } from './utils';
@@ -146,15 +150,18 @@ const Tooltip = ({
     hideTooltipTimer.current.push(id);
   }, [leaveTouchDelay]);
 
-  const handlePress = React.useCallback(() => {
-    if (touched.current) {
-      return null;
-    }
-    if (!isValidChild) return null;
-    const props = children.props as TooltipChildProps;
-    if (props.disabled) return null;
-    return props.onPress?.();
-  }, [children.props, isValidChild]);
+  const handlePress = React.useCallback(
+    (e: GestureResponderEvent) => {
+      if (touched.current) {
+        return null;
+      }
+      if (!isValidChild) return null;
+      const props = children.props as TooltipChildProps;
+      if (props.disabled) return null;
+      return props.onPress?.(e);
+    },
+    [children.props, isValidChild]
+  );
 
   const handleHoverIn = React.useCallback(() => {
     handleTouchStart();

--- a/src/components/Tooltip/utils.ts
+++ b/src/components/Tooltip/utils.ts
@@ -1,5 +1,10 @@
 import { Dimensions, StyleSheet } from 'react-native';
-import type { LayoutRectangle, StyleProp, ViewStyle } from 'react-native';
+import type {
+  GestureResponderEvent,
+  LayoutRectangle,
+  StyleProp,
+  ViewStyle,
+} from 'react-native';
 
 type ChildrenMeasurement = {
   width: number;
@@ -19,7 +24,7 @@ export type Measurement = {
 export type TooltipChildProps = {
   style: StyleProp<ViewStyle>;
   disabled?: boolean;
-  onPress?: () => void;
+  onPress?: (e: GestureResponderEvent) => void;
   onHoverIn?: () => void;
   onHoverOut?: () => void;
 };

--- a/src/components/__tests__/Tooltip.test.tsx
+++ b/src/components/__tests__/Tooltip.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Dimensions, Text, View, Platform } from 'react-native';
-import type { ViewProps } from 'react-native';
+import type { GestureResponderEvent, ViewProps } from 'react-native';
 
 import {
   afterAll,
@@ -31,6 +31,7 @@ const DummyComponent = ({
   ...props
 }: ViewProps & {
   ref?: React.RefObject<View | null>;
+  onPress?: (e: GestureResponderEvent) => void;
 }) => (
   <View {...props} ref={ref}>
     <Text>dummy component</Text>
@@ -123,6 +124,31 @@ describe('Tooltip', () => {
         unmount();
 
         expect(mockedRemoveEventListener).toHaveBeenCalled();
+      });
+    });
+
+    describe('press', () => {
+      afterEach(() => {
+        jest.clearAllMocks();
+      });
+
+      it('propagates the press event object to the child onPress', () => {
+        const onPress = jest.fn();
+
+        const {
+          wrapper: { getByText },
+        } = setup({
+          children: <DummyComponent onPress={onPress} />,
+        });
+
+        const event = { nativeEvent: { locationX: 1, locationY: 2 } };
+
+        fireEvent(getTrigger(getByText), 'press', event);
+
+        expect(onPress).toHaveBeenCalledTimes(1);
+        expect(onPress).toHaveBeenCalledWith(
+          expect.objectContaining({ nativeEvent: event.nativeEvent })
+        );
       });
     });
 


### PR DESCRIPTION
## Summary

Fixes #5003

On native, `Tooltip`'s internal `handlePress` was defined as `() => { ...; props.onPress?.() }`, which dropped the `GestureResponderEvent` before forwarding to the wrapped child's `onPress`. As a result, any child rendered inside a `Tooltip` received `undefined` instead of the press event object, breaking handlers that rely on `event.nativeEvent` (e.g. reading touch coordinates).

## What changed

- `Tooltip.tsx`: `handlePress` now accepts the `GestureResponderEvent` and threads it through to `props.onPress?.(e)`.
- `utils.ts`: widened `TooltipChildProps.onPress` from `() => void` to `(e: GestureResponderEvent) => void` so the event type is correct end-to-end.

No behavior change for the tooltip show/hide flow; this only restores the event argument that was previously swallowed. `onLongPress`/hover handlers are unaffected.

## Why

Consumers expect a tooltip-wrapped element to behave like the element itself. Swallowing the press event silently breaks that contract on native.

## Verification

- Added a unit test asserting the press event object reaches the child `onPress` (verified it fails on `main` with "called with 0 arguments" and passes with this change).
- `yarn jest src/components/__tests__/Tooltip.test.tsx` → 18/18 pass.
- `yarn typescript` → passes.
- `yarn lint` on changed files → passes.
