### PR TITLE
fix(tooltip): forward press event to wrapped child onPress

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -6,7 +6,11 @@ import {
   Platform,
   Pressable,
 } from 'react-native';
-import type { LayoutChangeEvent, ViewStyle } from 'react-native';
+import type {
+  GestureResponderEvent,
+  LayoutChangeEvent,
+  ViewStyle,
+} from 'react-native';
 
 import { getTooltipPosition } from './utils';
 import type { Measurement, TooltipChildProps } from './utils';
@@ -146,15 +150,18 @@ const Tooltip = ({
     hideTooltipTimer.current.push(id);
   }, [leaveTouchDelay]);
 
-  const handlePress = React.useCallback(() => {
-    if (touched.current) {
-      return null;
-    }
-    if (!isValidChild) return null;
-    const props = children.props as TooltipChildProps;
-    if (props.disabled) return null;
-    return props.onPress?.();
-  }, [children.props, isValidChild]);
+  const handlePress = React.useCallback(
+    (e: GestureResponderEvent) => {
+      if (touched.current) {
+        return null;
+      }
+      if (!isValidChild) return null;
+      const props = children.props as TooltipChildProps;
+      if (props.disabled) return null;
+      return props.onPress?.(e);
+    },
+    [children.props, isValidChild]
+  );
 
   const handleHoverIn = React.useCallback(() => {
     handleTouchStart();

--- a/src/components/Tooltip/utils.ts
+++ b/src/components/Tooltip/utils.ts
@@ -1,5 +1,10 @@
 import { Dimensions, StyleSheet } from 'react-native';
-import type { LayoutRectangle, StyleProp, ViewStyle } from 'react-native';
+import type {
+  GestureResponderEvent,
+  LayoutRectangle,
+  StyleProp,
+  ViewStyle,
+} from 'react-native';
 
 type ChildrenMeasurement = {
   width: number;
@@ -19,7 +24,7 @@ export type Measurement = {
 export type TooltipChildProps = {
   style: StyleProp<ViewStyle>;
   disabled?: boolean;
-  onPress?: () => void;
+  onPress?: (e: GestureResponderEvent) => void;
   onHoverIn?: () => void;
   onHoverOut?: () => void;
 };

--- a/src/components/__tests__/Tooltip.test.tsx
+++ b/src/components/__tests__/Tooltip.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Dimensions, Text, View, Platform } from 'react-native';
-import type { ViewProps } from 'react-native';
+import type { GestureResponderEvent, ViewProps } from 'react-native';
 
 import {
   afterAll,
@@ -28,9 +28,12 @@ jest.mock('../../utils/addEventListener', () => ({
 
 const DummyComponent = ({
   ref,
+  // `onPress` is consumed by Tooltip via `children.props`, not by the inner View
+  onPress: _onPress,
   ...props
 }: ViewProps & {
   ref?: React.RefObject<View | null>;
+  onPress?: (e: GestureResponderEvent) => void;
 }) => (
   <View {...props} ref={ref}>
     <Text>dummy component</Text>
@@ -147,6 +150,29 @@ describe('Tooltip', () => {
         fireEvent(trigger, 'longPress');
 
         expect(global.clearTimeout).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('onPress', () => {
+      afterEach(() => {
+        jest.clearAllMocks();
+      });
+
+      it('forwards the press event object to the child onPress', () => {
+        const onPress = jest.fn();
+        const {
+          wrapper: { getByText },
+        } = setup({
+          children: <DummyComponent onPress={onPress} />,
+        });
+
+        const nativeEvent = { nativeEvent: { locationX: 1, locationY: 2 } };
+        fireEvent(getTrigger(getByText), 'press', nativeEvent);
+
+        expect(onPress).toHaveBeenCalledTimes(1);
+        expect(onPress).toHaveBeenCalledWith(
+          expect.objectContaining(nativeEvent)
+        );
       });
     });
 


### PR DESCRIPTION
### Motivation

On native, the press event object is not propagated to the component wrapped by `Tooltip`. A child such as `Button` or `IconButton` with `onPress={(e) => ...}` receives `undefined` instead of the `GestureResponderEvent`.

The cause is in `Tooltip`. The component injects its own `handlePress` as the child's `onPress` through `cloneElement`. `handlePress` took no argument and called `props.onPress?.()` with nothing, so the event coming from `Pressable` was dropped before it reached the child's handler.

This change makes `handlePress` accept the `GestureResponderEvent` from `Pressable` and forward it to the child's `onPress`. The `onPress` type in `TooltipChildProps` (in `Tooltip/utils.ts`) was too narrow (`() => void`) and is widened to `(e: GestureResponderEvent) => void` to match the `onPress` signatures of `Button` and `IconButton`.

Note: PR #4994 also rewrites `Tooltip/Tooltip.tsx` (for the Material Design 3 update) and overlaps with this file. That PR targets a different issue (#4980) and does not address the event-forwarding problem, so there may be a small conflict to resolve depending on merge order.

### Related issue

Closes #5003

A reproduction is provided in the issue (Expo Snack).

### Test plan

- `yarn jest Tooltip`

A test was added to the existing mobile suite in `src/components/__tests__/Tooltip.test.tsx`. It renders a tooltip-wrapped component with an `onPress` spy, fires a `press` with a `nativeEvent`, and asserts the spy is called with that event. The test fails on the previous code (the spy is called with no arguments) and passes with this change.

Locally verified: `yarn typescript` and `yarn jest Tooltip` both pass.