### PR TITLE
refactor: replace React.Children usage to more composition-friendly alternatives (#4989)

### DIFF
--- a/example/src/Examples/CardExample.tsx
+++ b/example/src/Examples/CardExample.tsx
@@ -75,8 +75,12 @@ const CardExample = () => {
         <Card style={styles.card} mode={selectedMode}>
           <Card.Cover source={require('../../assets/images/forest.jpg')} />
           <Card.Actions>
-            <Button onPress={() => {}}>Share</Button>
-            <Button onPress={() => {}}>Explore</Button>
+            <Button mode="outlined" onPress={() => {}}>
+              Share
+            </Button>
+            <Button mode="contained" onPress={() => {}}>
+              Explore
+            </Button>
           </Card.Actions>
         </Card>
         <Card style={styles.card} mode={selectedMode}>
@@ -104,10 +108,10 @@ const CardExample = () => {
           />
           <Card.Title title="Custom Button styles" />
           <Card.Actions>
-            <Button style={styles.button} onPress={() => {}}>
+            <Button mode="outlined" style={styles.button} onPress={() => {}}>
               Share
             </Button>
-            <Button style={styles.button} onPress={() => {}}>
+            <Button mode="contained" style={styles.button} onPress={() => {}}>
               Explore
             </Button>
           </Card.Actions>

--- a/example/src/Examples/TeamDetails.tsx
+++ b/example/src/Examples/TeamDetails.tsx
@@ -93,8 +93,12 @@ const News = () => {
               </Text>
             </Card.Content>
             <Card.Actions>
-              <Button onPress={() => {}}>Share</Button>
-              <Button onPress={() => {}}>Read more</Button>
+              <Button mode="outlined" onPress={() => {}}>
+                Share
+              </Button>
+              <Button mode="contained" onPress={() => {}}>
+                Read more
+              </Button>
             </Card.Actions>
           </Card>
           <Card style={styles.card} mode="contained">
@@ -110,8 +114,12 @@ const News = () => {
               </Text>
             </Card.Content>
             <Card.Actions>
-              <Button onPress={() => {}}>Share</Button>
-              <Button onPress={() => {}}>Read more</Button>
+              <Button mode="outlined" onPress={() => {}}>
+                Share
+              </Button>
+              <Button mode="contained" onPress={() => {}}>
+                Read more
+              </Button>
             </Card.Actions>
           </Card>
         </View>

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -3,12 +3,8 @@ import { Animated, StyleSheet, View } from 'react-native';
 import type { ColorValue, StyleProp, ViewProps, ViewStyle } from 'react-native';
 
 import AppbarContent from './AppbarContent';
-import {
-  getAppbarBackgroundColor,
-  modeAppbarHeight,
-  renderAppbarContent,
-  filterAppbarActions,
-} from './utils';
+import { AppbarContext } from './AppbarContext';
+import { getAppbarBackgroundColor, modeAppbarHeight } from './utils';
 import type { AppbarModes, AppbarChildProps } from './utils';
 import { useInternalTheme } from '../../core/theming';
 import type { Elevation, ThemeProp } from '../../types';
@@ -174,44 +170,47 @@ const Appbar = ({
 
   const isDark = typeof dark === 'boolean' ? dark : false;
 
-  const isCenterAlignedMode = isMode('center-aligned');
-
-  let shouldCenterContent = false;
-  let shouldAddLeftSpacing = false;
-  let shouldAddRightSpacing = false;
-  if (isCenterAlignedMode) {
-    let hasAppbarContent = false;
-    let leftItemsCount = 0;
-    let rightItemsCount = 0;
-
-    React.Children.forEach(children, (child) => {
-      if (React.isValidElement<AppbarChildProps>(child)) {
-        const isLeading = child.props.isLeading === true;
-
-        if (child.type === AppbarContent) {
-          hasAppbarContent = true;
-        } else if (isLeading || !hasAppbarContent) {
-          leftItemsCount++;
-        } else {
-          rightItemsCount++;
-        }
-      }
-    });
-
-    shouldCenterContent =
-      hasAppbarContent && leftItemsCount < 2 && rightItemsCount < 3;
-    shouldAddLeftSpacing = shouldCenterContent && leftItemsCount === 0;
-    shouldAddRightSpacing = shouldCenterContent && rightItemsCount === 0;
-  }
-
-  const spacingStyle = styles.v3Spacing;
-
   const insets = {
     paddingBottom: safeAreaInsets?.bottom,
     paddingTop: safeAreaInsets?.top,
     paddingLeft: safeAreaInsets?.left,
     paddingRight: safeAreaInsets?.right,
   };
+
+  const appbarContextValue = React.useMemo(
+    () => ({ isDark, mode }),
+    [isDark, mode]
+  );
+
+  let content: React.ReactNode = children;
+
+  if (isMode('medium') || isMode('large')) {
+    // Medium/large top app bars use a two-row layout: a controls row with the
+    // leading and trailing actions above a full-width title row. React Native
+    // flexbox has no `order`, so the title has to be separated from the actions
+    // structurally. We partition the children by element identity and the
+    // `isLeading` prop for layout only — nothing is injected into them; shared
+    // values flow through `AppbarContext`.
+    const items = React.Children.toArray(children).filter(
+      React.isValidElement
+    ) as React.ReactElement<AppbarChildProps>[];
+    const titleItems = items.filter((child) => child.type === AppbarContent);
+    const actionItems = items.filter((child) => child.type !== AppbarContent);
+    const leadingActions = actionItems.filter((child) => child.props.isLeading);
+    const trailingActions = actionItems.filter(
+      (child) => !child.props.isLeading
+    );
+
+    content = (
+      <View style={styles.columnContainer}>
+        <View style={styles.controlsRow}>
+          {leadingActions}
+          <View style={styles.rightActionControls}>{trailingActions}</View>
+        </View>
+        {titleItems}
+      </View>
+    );
+  }
 
   return (
     <Surface
@@ -228,77 +227,9 @@ const Appbar = ({
       container
       {...rest}
     >
-      {shouldAddLeftSpacing ? <View style={spacingStyle} /> : null}
-      {(isMode('small') || isMode('center-aligned')) && (
-        <>
-          {/* Render only the back action at first place  */}
-          {renderAppbarContent({
-            children,
-            isDark,
-            theme,
-            renderOnly: ['Appbar.BackAction'],
-            shouldCenterContent: isCenterAlignedMode || shouldCenterContent,
-          })}
-          {/* Render the rest of the content except the back action */}
-          {renderAppbarContent({
-            // Filter appbar actions - first leading icons, then trailing icons
-            children: [
-              ...filterAppbarActions(children, true),
-              ...filterAppbarActions(children),
-            ],
-            isDark,
-            theme,
-            renderExcept: ['Appbar.BackAction'],
-            shouldCenterContent: isCenterAlignedMode || shouldCenterContent,
-          })}
-        </>
-      )}
-      {(isMode('medium') || isMode('large')) && (
-        <View
-          style={[
-            styles.columnContainer,
-            isMode('center-aligned') && styles.centerAlignedContainer,
-          ]}
-        >
-          {/* Appbar top row with controls */}
-          <View style={styles.controlsRow}>
-            {/* Left side of row container, can contain AppbarBackAction or AppbarAction if it's leading icon  */}
-            {renderAppbarContent({
-              children,
-              isDark,
-              renderOnly: ['Appbar.BackAction'],
-              mode,
-            })}
-            {renderAppbarContent({
-              children: filterAppbarActions(children, true),
-              isDark,
-              renderOnly: ['Appbar.Action'],
-              mode,
-            })}
-            {/* Right side of row container, can contain other AppbarAction if they are not leading icons */}
-            <View style={styles.rightActionControls}>
-              {renderAppbarContent({
-                children: filterAppbarActions(children),
-                isDark,
-                renderExcept: [
-                  'Appbar',
-                  'Appbar.BackAction',
-                  'Appbar.Content',
-                  'Appbar.Header',
-                ],
-                mode,
-              })}
-            </View>
-          </View>
-          {renderAppbarContent({
-            children,
-            isDark,
-            renderOnly: ['Appbar.Content'],
-            mode,
-          })}
-        </View>
-      )}
-      {shouldAddRightSpacing ? <View style={spacingStyle} /> : null}
+      <AppbarContext.Provider value={appbarContextValue}>
+        {content}
+      </AppbarContext.Provider>
     </Surface>
   );
 };
@@ -308,9 +239,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     paddingHorizontal: 4,
-  },
-  v3Spacing: {
-    width: 52,
   },
   controlsRow: {
     flex: 1,
@@ -327,9 +255,6 @@ const styles = StyleSheet.create({
     flexDirection: 'column',
     flex: 1,
     paddingTop: 8,
-  },
-  centerAlignedContainer: {
-    paddingTop: 0,
   },
 });
 

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -194,8 +194,19 @@ const Appbar = ({
     const items = React.Children.toArray(children).filter(
       React.isValidElement
     ) as React.ReactElement<AppbarChildProps>[];
-    const titleItems = items.filter((child) => child.type === AppbarContent);
-    const actionItems = items.filter((child) => child.type !== AppbarContent);
+    const isAppbarContent = (child: React.ReactElement<AppbarChildProps>) => {
+      const { type } = child;
+      // React.memo(AppbarContent) wraps the component in an object whose
+      // `.type` holds the original component — unwrap it so memoized
+      // Content still lands in the title row.
+      const innerType =
+        typeof type === 'object' && type !== null && 'type' in type
+          ? (type as { type: unknown }).type
+          : type;
+      return innerType === AppbarContent;
+    };
+    const titleItems = items.filter(isAppbarContent);
+    const actionItems = items.filter((child) => !isAppbarContent(child));
     const leadingActions = actionItems.filter((child) => child.props.isLeading);
     const trailingActions = actionItems.filter(
       (child) => !child.props.isLeading

--- a/src/components/Appbar/AppbarAction.tsx
+++ b/src/components/Appbar/AppbarAction.tsx
@@ -7,7 +7,9 @@ import type {
   ViewStyle,
 } from 'react-native';
 
+import { useAppbarContext } from './AppbarContext';
 import { useInternalTheme } from '../../core/theming';
+import { white } from '../../theme/colors';
 import type { Theme, ThemeProp } from '../../types';
 import type { IconSource } from '../Icon';
 import IconButton from '../IconButton/IconButton';
@@ -87,12 +89,15 @@ const AppbarAction = ({
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
   const { colors } = theme as Theme;
+  const { isDark = false } = useAppbarContext() ?? {};
 
   const actionIconColor = iconColor
     ? iconColor
-    : isLeading
-      ? colors.onSurface
-      : colors.onSurfaceVariant;
+    : isDark
+      ? white
+      : isLeading
+        ? colors.onSurface
+        : colors.onSurfaceVariant;
 
   return (
     <IconButton

--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -8,8 +8,10 @@ import type {
   ViewProps,
 } from 'react-native';
 
+import { useAppbarContext } from './AppbarContext';
 import { modeTextVariant } from './utils';
 import { useInternalTheme } from '../../core/theming';
+import { white } from '../../theme/colors';
 import type {
   $RemoveChildren,
   Theme,
@@ -98,21 +100,27 @@ const AppbarContent = ({
   titleStyle,
   title,
   titleMaxFontSizeMultiplier,
-  mode = 'small',
+  mode: modeOverride,
   theme: themeOverrides,
   testID = 'appbar-content',
   ...rest
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
   const { colors, fonts } = theme as Theme;
+  const { isDark = false, mode: contextMode } = useAppbarContext() ?? {};
+  const mode = modeOverride ?? contextMode ?? 'small';
 
-  const titleTextColor = titleColor ? titleColor : colors.onSurface;
+  const titleTextColor = titleColor
+    ? titleColor
+    : isDark
+      ? white
+      : colors.onSurface;
 
   const modeContainerStyles = {
     small: styles.v3DefaultContainer,
     medium: styles.v3MediumContainer,
     large: styles.v3LargeContainer,
-    'center-aligned': styles.v3DefaultContainer,
+    'center-aligned': styles.v3CenterAlignedContainer,
   };
 
   const variant = modeTextVariant[mode] as TypescaleKey;
@@ -177,17 +185,24 @@ const styles = StyleSheet.create({
   },
   v3DefaultContainer: {
     paddingHorizontal: 0,
+    marginLeft: 12,
+  },
+  v3CenterAlignedContainer: {
+    paddingHorizontal: 0,
+    alignItems: 'center',
   },
   v3MediumContainer: {
     paddingHorizontal: 0,
     justifyContent: 'flex-end',
     paddingBottom: 24,
+    marginLeft: 12,
   },
   v3LargeContainer: {
     paddingHorizontal: 0,
     paddingTop: 36,
     justifyContent: 'flex-end',
     paddingBottom: 28,
+    marginLeft: 12,
   },
 });
 

--- a/src/components/Appbar/AppbarContext.tsx
+++ b/src/components/Appbar/AppbarContext.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+import type { AppbarModes } from './utils';
+
+export type AppbarContextType = {
+  /**
+   * Whether the Appbar background is dark, so children can derive a
+   * contrasting default foreground color without it being injected.
+   */
+  isDark: boolean;
+  /**
+   * The Appbar mode, consumed by `Appbar.Content` to pick the title text
+   * variant and container layout.
+   */
+  mode: AppbarModes;
+};
+
+/**
+ * Shared Appbar values provided to `Appbar.Action`, `Appbar.BackAction` and
+ * `Appbar.Content` via context instead of being injected with `cloneElement`.
+ * This keeps composition intact: children can be wrapped, reordered or
+ * conditionally rendered without losing the values they need.
+ */
+export const AppbarContext = React.createContext<AppbarContextType | null>(
+  null
+);
+
+export const useAppbarContext = () => React.useContext(AppbarContext);

--- a/src/components/Appbar/utils.ts
+++ b/src/components/Appbar/utils.ts
@@ -1,16 +1,12 @@
-import React from 'react';
-import type { ColorValue, StyleProp, ViewStyle } from 'react-native';
-import { StyleSheet, Animated } from 'react-native';
+import { Animated } from 'react-native';
+import type { ColorValue, ViewStyle } from 'react-native';
 
-import { white } from '../../theme/colors';
-import type { InternalTheme, Theme, ThemeProp } from '../../types';
+import type { InternalTheme, Theme } from '../../types';
 
 export type AppbarModes = 'small' | 'medium' | 'large' | 'center-aligned';
 
 export type AppbarChildProps = {
   isLeading?: boolean;
-  color: string;
-  style?: StyleProp<ViewStyle>;
 };
 
 const borderStyleProperties = [
@@ -39,21 +35,6 @@ export const getAppbarBackgroundColor = (
   return colors.surface;
 };
 
-export const getAppbarColor = ({
-  color,
-  isDark,
-}: BaseProps & { color: string }) => {
-  if (typeof color !== 'undefined') {
-    return color;
-  }
-
-  if (isDark) {
-    return white;
-  }
-
-  return undefined;
-};
-
 export const getAppbarBorders = (
   style:
     | Animated.Value
@@ -72,19 +53,6 @@ export const getAppbarBorders = (
   return borders;
 };
 
-type BaseProps = {
-  isDark: boolean;
-};
-
-type RenderAppbarContentProps = BaseProps & {
-  children: React.ReactNode;
-  shouldCenterContent?: boolean;
-  renderOnly?: (string | boolean)[];
-  renderExcept?: string[];
-  mode?: AppbarModes;
-  theme?: ThemeProp;
-};
-
 export const DEFAULT_APPBAR_HEIGHT = 56;
 const MD3_DEFAULT_APPBAR_HEIGHT = 64;
 
@@ -101,81 +69,3 @@ export const modeTextVariant = {
   large: 'headlineMedium',
   'center-aligned': 'titleLarge',
 } as const;
-
-export const filterAppbarActions = (
-  children: React.ReactNode,
-  isLeading = false
-) => {
-  return React.Children.toArray(children).filter((child) => {
-    if (!React.isValidElement<AppbarChildProps>(child)) return false;
-    return isLeading ? child.props.isLeading : !child.props.isLeading;
-  });
-};
-
-export const renderAppbarContent = ({
-  children,
-  isDark,
-  shouldCenterContent = false,
-  renderOnly,
-  renderExcept,
-  mode = 'small',
-  theme,
-}: RenderAppbarContentProps) => {
-  return React.Children.toArray(children as React.ReactNode | React.ReactNode[])
-    .filter((child) => child != null && typeof child !== 'boolean')
-    .filter((child) =>
-      // @ts-expect-error: TypeScript complains about the type of type but it doesn't matter
-      renderExcept ? !renderExcept.includes(child.type.displayName) : child
-    )
-    .filter((child) =>
-      // @ts-expect-error: TypeScript complains about the type of type but it doesn't matter
-      renderOnly ? renderOnly.includes(child.type.displayName) : child
-    )
-    .map((child, i) => {
-      if (
-        !React.isValidElement<AppbarChildProps>(child) ||
-        ![
-          'Appbar.Content',
-          'Appbar.Action',
-          'Appbar.BackAction',
-          'Tooltip',
-        ].includes(
-          // @ts-expect-error: TypeScript complains about the type of type but it doesn't matter
-          child.type.displayName
-        )
-      ) {
-        return child;
-      }
-
-      const props: {
-        color?: string;
-        style?: StyleProp<ViewStyle>;
-        mode?: AppbarModes;
-        theme?: ThemeProp;
-      } = {
-        theme,
-        color: getAppbarColor({ color: child.props.color, isDark }),
-      };
-
-      // @ts-expect-error: TypeScript complains about the type of type but it doesn't matter
-      if (child.type.displayName === 'Appbar.Content') {
-        props.mode = mode;
-        props.style = [
-          i === 0 && !shouldCenterContent && styles.v3Spacing,
-          shouldCenterContent && styles.centerAlignedContent,
-          child.props.style,
-        ];
-        props.color;
-      }
-      return React.cloneElement(child, props);
-    });
-};
-
-const styles = StyleSheet.create({
-  centerAlignedContent: {
-    alignItems: 'center',
-  },
-  v3Spacing: {
-    marginLeft: 12,
-  },
-});

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -95,6 +95,8 @@ export type Props = $Omit<React.ComponentProps<typeof Surface>, 'mode'> & {
 
 /**
  * A card is a sheet of material that serves as an entry point to more detailed information.
+ * Card clips its inner content to the card shape and renders children directly;
+ * section spacing is owned by the section components themselves.
  *
  * ## Usage
  * ```js
@@ -112,8 +114,8 @@ export type Props = $Omit<React.ComponentProps<typeof Surface>, 'mode'> & {
  *     </Card.Content>
  *     <Card.Cover source={{ uri: 'https://picsum.photos/700' }} />
  *     <Card.Actions>
- *       <Button>Cancel</Button>
- *       <Button>Ok</Button>
+ *       <Button mode="outlined">Cancel</Button>
+ *       <Button mode="contained">Ok</Button>
  *     </Card.Actions>
  *   </Card>
  * );
@@ -185,13 +187,6 @@ const Card = ({
     runElevationAnimation('out');
   });
 
-  const total = React.Children.count(children);
-  const siblings = React.Children.map(children, (child) =>
-    React.isValidElement(child) && child.type
-      ? (child.type as any).displayName
-      : null
-  );
-
   const { backgroundColor, borderColor: themedBorderColor } = getCardColors({
     theme,
     mode: cardMode,
@@ -212,17 +207,11 @@ const Card = ({
   };
 
   const content = (
-    <View style={[styles.innerContainer, contentStyle]} testID={testID}>
-      {React.Children.map(children, (child, index) =>
-        React.isValidElement(child)
-          ? React.cloneElement(child as React.ReactElement<any>, {
-              index,
-              total,
-              siblings,
-              borderRadiusStyles,
-            })
-          : child
-      )}
+    <View
+      style={[styles.innerContainer, borderRadiusCombinedStyles, contentStyle]}
+      testID={testID}
+    >
+      {children}
     </View>
   );
 
@@ -288,6 +277,7 @@ Card.Title = CardTitle;
 const styles = StyleSheet.create({
   innerContainer: {
     flexShrink: 1,
+    overflow: 'hidden',
   },
   outline: {
     borderWidth: 1,

--- a/src/components/Card/CardActions.tsx
+++ b/src/components/Card/CardActions.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
 import type { StyleProp, ViewProps, ViewStyle } from 'react-native';
 
-import type { CardActionChildProps } from './utils';
 import { useInternalTheme } from '../../core/theming';
 import type { ThemeProp } from '../../types';
 
@@ -17,6 +16,8 @@ export type Props = ViewProps & {
 
 /**
  * A component to show a list of actions inside a Card.
+ * Actions are rendered directly, so set button `mode`, `compact`, and custom
+ * spacing props explicitly on each action when needed.
  *
  * ## Usage
  * ```js
@@ -26,8 +27,8 @@ export type Props = ViewProps & {
  * const MyComponent = () => (
  *   <Card>
  *     <Card.Actions>
- *       <Button>Cancel</Button>
- *       <Button>Ok</Button>
+ *       <Button mode="outlined">Cancel</Button>
+ *       <Button mode="contained">Ok</Button>
  *     </Card.Actions>
  *   </Card>
  * );
@@ -43,23 +44,7 @@ const CardActions = ({ theme, style, children, ...rest }: Props) => {
 
   return (
     <View {...rest} style={containerStyle}>
-      {React.Children.map(children, (child, index) => {
-        if (!React.isValidElement<CardActionChildProps>(child)) {
-          return child;
-        }
-
-        const compact = child.props.compact;
-        const mode =
-          child.props.mode ?? (index === 0 ? 'outlined' : 'contained');
-        const childStyle = [styles.button, child.props.style];
-
-        return React.cloneElement(child, {
-          ...child.props,
-          compact,
-          mode,
-          style: childStyle,
-        });
-      })}
+      {children}
     </View>
   );
 };
@@ -70,10 +55,8 @@ const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
     alignItems: 'center',
+    gap: 8,
     padding: 8,
-  },
-  button: {
-    marginLeft: 8,
   },
 });
 

--- a/src/components/Card/CardActions.tsx
+++ b/src/components/Card/CardActions.tsx
@@ -41,10 +41,16 @@ const CardActions = ({ theme, style, children, ...rest }: Props) => {
 
   const justifyContent = 'flex-end' as ViewStyle['justifyContent'];
   const containerStyle = [styles.container, { justifyContent }, style];
+  const items = React.Children.toArray(children);
 
   return (
     <View {...rest} style={containerStyle}>
-      {children}
+      {items.map((child, index) => (
+        <React.Fragment key={index}>
+          {index > 0 && <View style={styles.spacer} />}
+          {child}
+        </React.Fragment>
+      ))}
     </View>
   );
 };
@@ -55,8 +61,10 @@ const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 8,
     padding: 8,
+  },
+  spacer: {
+    width: 8,
   },
 });
 

--- a/src/components/Card/CardContent.tsx
+++ b/src/components/Card/CardContent.tsx
@@ -7,23 +7,13 @@ export type Props = ViewProps & {
    * Items inside the `Card.Content`.
    */
   children: React.ReactNode;
-  /**
-   * @internal
-   */
-  index?: number;
-  /**
-   * @internal
-   */
-  total?: number;
-  /**
-   * @internal
-   */
-  siblings?: Array<string>;
   style?: StyleProp<ViewStyle>;
 };
 
 /**
  * A component to show content inside a Card.
+ * Content uses uniform vertical padding and does not depend on neighboring
+ * card sections.
  *
  * ## Usage
  * ```js
@@ -42,58 +32,17 @@ export type Props = ViewProps & {
  * export default MyComponent;
  * ```
  */
-const CardContent = ({ index, total, siblings, style, ...rest }: Props) => {
-  const cover = 'withInternalTheme(CardCover)';
-  const title = 'withInternalTheme(CardTitle)';
-
-  let contentStyle, prev, next;
-
-  if (typeof index === 'number' && siblings) {
-    prev = siblings[index - 1];
-    next = siblings[index + 1];
-  }
-
-  if (
-    (prev === cover && next === cover) ||
-    (prev === title && next === title) ||
-    total === 1
-  ) {
-    contentStyle = styles.only;
-  } else if (index === 0) {
-    if (next === cover || next === title) {
-      contentStyle = styles.only;
-    } else {
-      contentStyle = styles.first;
-    }
-  } else if (typeof total === 'number' && index === total - 1) {
-    if (prev === cover || prev === title) {
-      contentStyle = styles.only;
-    } else {
-      contentStyle = styles.last;
-    }
-  } else if (prev === cover || prev === title) {
-    contentStyle = styles.first;
-  } else if (next === cover || next === title) {
-    contentStyle = styles.last;
-  }
-
-  return <View {...rest} style={[styles.container, contentStyle, style]} />;
-};
+const CardContent = ({ style, ...rest }: Props) => (
+  <View {...rest} style={[styles.container, style]} />
+);
 
 CardContent.displayName = 'Card.Content';
 
 const styles = StyleSheet.create({
   container: {
     paddingHorizontal: 16,
-  },
-  first: {
     paddingTop: 16,
-  },
-  last: {
     paddingBottom: 16,
-  },
-  only: {
-    paddingVertical: 16,
   },
 });
 

--- a/src/components/Card/CardCover.tsx
+++ b/src/components/Card/CardCover.tsx
@@ -8,14 +8,6 @@ import type { ThemeProp } from '../../types';
 import { splitStyles } from '../../utils/splitStyles';
 
 export type Props = ImageProps & {
-  /**
-   * @internal
-   */
-  index?: number;
-  /**
-   * @internal
-   */
-  total?: number;
   style?: StyleProp<ViewStyle>;
   /**
    * @optional
@@ -42,13 +34,7 @@ export type Props = ImageProps & {
  *
  * @extends Image props https://reactnative.dev/docs/image#props
  */
-const CardCover = ({
-  index,
-  total,
-  style,
-  theme: themeOverrides,
-  ...rest
-}: Props) => {
+const CardCover = ({ style, theme: themeOverrides, ...rest }: Props) => {
   const theme = useInternalTheme(themeOverrides);
 
   const flattenedStyles = (StyleSheet.flatten(style) || {}) as ViewStyle;
@@ -59,8 +45,6 @@ const CardCover = ({
 
   const coverStyle = getCardCoverStyle({
     theme,
-    index,
-    total,
     borderRadiusStyles,
   });
 

--- a/src/components/Card/CardTitle.tsx
+++ b/src/components/Card/CardTitle.tsx
@@ -82,14 +82,6 @@ export type Props = ViewProps & {
    */
   rightStyle?: StyleProp<ViewStyle>;
   /**
-   * @internal
-   */
-  index?: number;
-  /**
-   * @internal
-   */
-  total?: number;
-  /**
    * Specifies the largest possible scale a title font can reach.
    */
   titleMaxFontSizeMultiplier?: number;

--- a/src/components/Card/utils.tsx
+++ b/src/components/Card/utils.tsx
@@ -17,14 +17,10 @@ export type CardActionChildProps = {
 
 export const getCardCoverStyle = ({
   theme,
-  index: _index,
-  total: _total,
   borderRadiusStyles,
 }: {
   theme: InternalTheme;
   borderRadiusStyles: BorderRadiusStyles;
-  index?: number;
-  total?: number;
 }) => {
   if (Object.keys(borderRadiusStyles).length > 0) {
     return {

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -12,7 +12,6 @@ import DialogTitle from './DialogTitle';
 import { useInternalTheme } from '../../core/theming';
 import type { Theme, ThemeProp } from '../../types';
 import Modal from '../Modal';
-import type { DialogChildProps } from './utils';
 
 export type Props = {
   /**
@@ -51,6 +50,8 @@ const DIALOG_ELEVATION: number = 24;
 /**
  * Dialogs inform users about a specific task and may contain critical information, require decisions, or involve multiple tasks.
  * To render the `Dialog` above other components, you'll need to wrap it with the [`Portal`](../Portal) component.
+ * Dialog owns the top content inset, so first-slot components render without
+ * adding their own top offset.
  *
  * ## Usage
  * ```js
@@ -122,17 +123,7 @@ const Dialog = ({
       theme={theme}
       testID={testID}
     >
-      {React.Children.toArray(children)
-        .filter((child) => child != null && typeof child !== 'boolean')
-        .map((child, i) => {
-          if (i === 0 && React.isValidElement<DialogChildProps>(child)) {
-            return React.cloneElement(child, {
-              style: [{ marginTop: 24 }, child.props.style],
-            });
-          }
-
-          return child;
-        })}
+      {children}
     </Modal>
   );
 };
@@ -160,6 +151,7 @@ const styles = StyleSheet.create({
     marginVertical: Platform.OS === 'android' ? 44 : 0,
     elevation: DIALOG_ELEVATION,
     justifyContent: 'flex-start',
+    paddingTop: 24,
   },
 });
 

--- a/src/components/Dialog/DialogActions.tsx
+++ b/src/components/Dialog/DialogActions.tsx
@@ -47,12 +47,17 @@ export type Props = ViewProps & {
  * export default MyComponent;
  * ```
  */
-const DialogActions = (props: Props) => {
-  useInternalTheme(props.theme);
+const DialogActions = ({
+  theme: themeOverrides,
+  style,
+  children,
+  ...rest
+}: Props) => {
+  useInternalTheme(themeOverrides);
 
   return (
-    <View {...props} style={[styles.v3Container, props.style]}>
-      {props.children}
+    <View {...rest} style={[styles.v3Container, style]}>
+      {children}
     </View>
   );
 };

--- a/src/components/Dialog/DialogActions.tsx
+++ b/src/components/Dialog/DialogActions.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
 import type { StyleProp, ViewProps, ViewStyle } from 'react-native';
 
-import type { DialogActionChildProps } from './utils';
 import { useInternalTheme } from '../../core/theming';
 import type { ThemeProp } from '../../types';
 
@@ -20,6 +19,8 @@ export type Props = ViewProps & {
 
 /**
  * A component to show a list of actions in a Dialog.
+ * Actions are rendered directly, so configure each action button's props
+ * explicitly when you need non-default behavior.
  *
  * ## Usage
  * ```js
@@ -48,24 +49,10 @@ export type Props = ViewProps & {
  */
 const DialogActions = (props: Props) => {
   useInternalTheme(props.theme);
-  const actionsLength = React.Children.toArray(props.children).length;
 
   return (
     <View {...props} style={[styles.v3Container, props.style]}>
-      {React.Children.map(props.children, (child, i) =>
-        React.isValidElement<DialogActionChildProps>(child)
-          ? React.cloneElement(child, {
-              compact: true,
-              uppercase: false,
-              style: [
-                {
-                  marginRight: i + 1 === actionsLength ? 0 : 8,
-                },
-                child.props.style,
-              ],
-            })
-          : child
-      )}
+      {props.children}
     </View>
   );
 };
@@ -78,6 +65,7 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     alignItems: 'center',
     justifyContent: 'flex-end',
+    gap: 8,
     paddingBottom: 24,
     paddingHorizontal: 24,
   },

--- a/src/components/Dialog/DialogActions.tsx
+++ b/src/components/Dialog/DialogActions.tsx
@@ -55,9 +55,16 @@ const DialogActions = ({
 }: Props) => {
   useInternalTheme(themeOverrides);
 
+  const items = React.Children.toArray(children);
+
   return (
     <View {...rest} style={[styles.v3Container, style]}>
-      {children}
+      {items.map((child, index) => (
+        <React.Fragment key={index}>
+          {index > 0 && <View style={styles.spacer} />}
+          {child}
+        </React.Fragment>
+      ))}
     </View>
   );
 };
@@ -70,9 +77,11 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     alignItems: 'center',
     justifyContent: 'flex-end',
-    gap: 8,
     paddingBottom: 24,
     paddingHorizontal: 24,
+  },
+  spacer: {
+    width: 8,
   },
 });
 

--- a/src/components/Dialog/DialogIcon.tsx
+++ b/src/components/Dialog/DialogIcon.tsx
@@ -93,6 +93,7 @@ const styles = StyleSheet.create({
   wrapper: {
     alignItems: 'center',
     justifyContent: 'center',
+    marginBottom: 16,
     paddingTop: 0,
   },
 });

--- a/src/components/Dialog/DialogIcon.tsx
+++ b/src/components/Dialog/DialogIcon.tsx
@@ -24,6 +24,10 @@ export type Props = {
    * @optional
    */
   theme?: ThemeProp;
+  /**
+   * testID to be used on tests.
+   */
+  testID?: string;
 };
 
 /**
@@ -68,6 +72,7 @@ const DialogIcon = ({
   color,
   icon,
   theme: themeOverrides,
+  testID,
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
   const { colors } = theme as Theme;
@@ -76,7 +81,7 @@ const DialogIcon = ({
   const iconColor = color || colors.secondary;
 
   return (
-    <View style={styles.wrapper}>
+    <View style={styles.wrapper} testID={testID}>
       <Icon source={icon} color={iconColor} size={size} />
     </View>
   );
@@ -88,7 +93,7 @@ const styles = StyleSheet.create({
   wrapper: {
     alignItems: 'center',
     justifyContent: 'center',
-    paddingTop: 24,
+    paddingTop: 0,
   },
 });
 

--- a/src/components/Dialog/DialogTitle.tsx
+++ b/src/components/Dialog/DialogTitle.tsx
@@ -81,7 +81,7 @@ const styles = StyleSheet.create({
     marginHorizontal: 24,
   },
   v3Text: {
-    marginTop: 16,
+    marginTop: 0,
     marginBottom: 16,
   },
 });

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -12,8 +12,9 @@ import type {
   ViewStyle,
 } from 'react-native';
 
+import { ListAccordionContext } from './ListAccordionContext';
 import { ListAccordionGroupContext } from './ListAccordionGroup';
-import type { ListChildProps, Style } from './utils';
+import type { Style } from './utils';
 import { getAccordionColors, getLeftStyles } from './utils';
 import { useLocale } from '../../core/locale';
 import { useInternalTheme } from '../../core/theming';
@@ -324,23 +325,11 @@ const ListAccordion = ({
         </TouchableRipple>
       </View>
 
-      {isExpanded
-        ? React.Children.map(children, (child) => {
-            if (
-              left &&
-              React.isValidElement<ListChildProps>(child) &&
-              !child.props.left &&
-              !child.props.right
-            ) {
-              return React.cloneElement(child, {
-                style: [styles.child, child.props.style],
-                theme,
-              });
-            }
-
-            return child;
-          })
-        : null}
+      {isExpanded ? (
+        <ListAccordionContext.Provider value={{ leftIndent: !!left }}>
+          {children}
+        </ListAccordionContext.Provider>
+      ) : null}
     </View>
   );
 };
@@ -373,9 +362,6 @@ const styles = StyleSheet.create({
   trailingItem: {
     marginVertical: 6,
     paddingLeft: 8,
-  },
-  child: {
-    paddingLeft: 40,
   },
   content: {
     flex: 1,

--- a/src/components/List/ListAccordionContext.tsx
+++ b/src/components/List/ListAccordionContext.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+
+export type ListAccordionContextType = {
+  /**
+   * Whether descendant items that don't render their own `left`/`right`
+   * element should be indented to align under the accordion's content
+   * (past the leading icon).
+   */
+  leftIndent: boolean;
+};
+
+export const ListAccordionContext =
+  React.createContext<ListAccordionContextType>({ leftIndent: false });
+
+ListAccordionContext.displayName = 'ListAccordionContext';

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -10,6 +10,7 @@ import type {
   ViewStyle,
 } from 'react-native';
 
+import { ListAccordionContext } from './ListAccordionContext';
 import { getLeftStyles, getRightStyles } from './utils';
 import type { Style } from './utils';
 import { useInternalTheme } from '../../core/theming';
@@ -161,6 +162,8 @@ const ListItem = ({
   ...rest
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
+  const { leftIndent } = React.useContext(ListAccordionContext);
+  const shouldIndent = leftIndent && !left && !right;
   const [alignToTop, setAlignToTop] = React.useState(false);
 
   const onDescriptionTextLayout = (
@@ -228,7 +231,11 @@ const ListItem = ({
     <TouchableRipple
       {...rest}
       ref={ref}
-      style={[styles.container, style]}
+      style={
+        shouldIndent
+          ? [styles.container, styles.indent, style]
+          : [styles.container, style]
+      }
       onPress={onPress}
       theme={theme}
       testID={testID}
@@ -267,6 +274,9 @@ const styles = StyleSheet.create({
   container: {
     paddingVertical: 8,
     paddingRight: 24,
+  },
+  indent: {
+    paddingLeft: 40,
   },
   row: {
     width: '100%',

--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -109,7 +109,10 @@ const ToggleButton = ({
         const checked: boolean | null =
           (context && context.value === value) || status === 'checked';
 
-        const backgroundColor = getToggleButtonColor({ theme, checked });
+        const backgroundColor =
+          isSegmentedRow && checked
+            ? theme.colors.secondaryContainer
+            : getToggleButtonColor({ theme, checked });
         const borderColor = theme.colors.outline;
 
         return (

--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -158,6 +158,7 @@ const styles = StyleSheet.create({
   },
   segmentedContent: {
     borderRadius: 0,
+    marginLeft: StyleSheet.hairlineWidth,
   },
 });
 

--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -109,10 +109,7 @@ const ToggleButton = ({
         const checked: boolean | null =
           (context && context.value === value) || status === 'checked';
 
-        const backgroundColor =
-          isSegmentedRow && checked
-            ? theme.colors.secondaryContainer
-            : getToggleButtonColor({ theme, checked });
+        const backgroundColor = getToggleButtonColor({ theme, checked });
         const borderColor = theme.colors.outline;
 
         return (

--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, View, Animated } from 'react-native';
 import type { GestureResponderEvent, StyleProp, ViewStyle } from 'react-native';
 
 import { ToggleButtonGroupContext } from './ToggleButtonGroup';
+import { ToggleButtonRowContext } from './ToggleButtonRowContext';
 import { getToggleButtonColor } from './utils';
 import { useInternalTheme } from '../../core/theming';
 import type { ThemeProp } from '../../types';
@@ -99,6 +100,8 @@ const ToggleButton = ({
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
   const borderRadius = theme.shapes.corner.extraSmall;
+  const rowContext = React.useContext(ToggleButtonRowContext);
+  const isSegmentedRow = !!rowContext?.segmented;
 
   return (
     <ToggleButtonGroupContext.Consumer>
@@ -134,6 +137,7 @@ const ToggleButton = ({
                 borderRadius,
                 borderColor,
               },
+              isSegmentedRow && styles.segmentedContent,
               style,
             ]}
             ref={ref}
@@ -151,6 +155,9 @@ const styles = StyleSheet.create({
     width: 42,
     height: 42,
     margin: 0,
+  },
+  segmentedContent: {
+    borderRadius: 0,
   },
 });
 

--- a/src/components/ToggleButton/ToggleButtonRow.tsx
+++ b/src/components/ToggleButton/ToggleButtonRow.tsx
@@ -60,7 +60,7 @@ const ToggleButtonRow = ({
   theme: themeOverrides,
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
-  const borderRadius = theme.shapes.corner.largeIncreased;
+  const borderRadius = theme.shapes.corner.extraSmall;
   const outlineColor = theme.colors.outline;
 
   return (

--- a/src/components/ToggleButton/ToggleButtonRow.tsx
+++ b/src/components/ToggleButton/ToggleButtonRow.tsx
@@ -66,18 +66,17 @@ const ToggleButtonRow = ({
   return (
     <ToggleButtonGroup value={value} onValueChange={onValueChange}>
       <ToggleButtonRowContext.Provider value={SEGMENTED_ROW_CONTEXT}>
-        <View style={style}>
-          <View
-            style={[
-              styles.row,
-              {
-                backgroundColor: outlineColor,
-                borderRadius,
-              },
-            ]}
-          >
-            {children}
-          </View>
+        <View
+          style={[
+            styles.row,
+            {
+              backgroundColor: outlineColor,
+              borderRadius,
+            },
+            style,
+          ]}
+        >
+          {children}
         </View>
       </ToggleButtonRowContext.Provider>
     </ToggleButtonGroup>
@@ -90,9 +89,9 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: 'row',
     alignSelf: 'flex-start',
-    gap: StyleSheet.hairlineWidth,
     overflow: 'hidden',
     padding: StyleSheet.hairlineWidth,
+    paddingLeft: 0,
   },
 });
 

--- a/src/components/ToggleButton/ToggleButtonRow.tsx
+++ b/src/components/ToggleButton/ToggleButtonRow.tsx
@@ -2,8 +2,10 @@ import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
 import type { StyleProp, ViewStyle } from 'react-native';
 
-import ToggleButton from './ToggleButton';
 import ToggleButtonGroup from './ToggleButtonGroup';
+import { ToggleButtonRowContext } from './ToggleButtonRowContext';
+import { useInternalTheme } from '../../core/theming';
+import type { ThemeProp } from '../../types';
 
 export type Props = {
   /**
@@ -19,7 +21,13 @@ export type Props = {
    */
   children: React.ReactNode;
   style?: StyleProp<ViewStyle>;
+  /**
+   * @optional
+   */
+  theme?: ThemeProp;
 };
+
+const SEGMENTED_ROW_CONTEXT = { segmented: true };
 
 /**
  * Toggle button row renders a group of toggle buttons in a row.
@@ -44,33 +52,34 @@ export type Props = {
  *
  *```
  */
-const ToggleButtonRow = ({ value, onValueChange, children, style }: Props) => {
-  const count = React.Children.count(children);
+const ToggleButtonRow = ({
+  value,
+  onValueChange,
+  children,
+  style,
+  theme: themeOverrides,
+}: Props) => {
+  const theme = useInternalTheme(themeOverrides);
+  const borderRadius = theme.shapes.corner.extraSmall;
+  const outlineColor = theme.colors.outline;
 
   return (
     <ToggleButtonGroup value={value} onValueChange={onValueChange}>
-      <View style={[styles.row, style]}>
-        {React.Children.map(children, (child, i) => {
-          // @ts-expect-error: TypeScript complains about child.type but it doesn't matter
-          if (child && child.type === ToggleButton) {
-            // @ts-expect-error: We're sure that child is a React Element
-            return React.cloneElement(child, {
-              style: [
-                styles.button,
-                i === 0
-                  ? styles.first
-                  : i === count - 1
-                    ? styles.last
-                    : styles.middle,
-                // @ts-expect-error: We're sure that child is a React Element
-                child.props.style,
-              ],
-            });
-          }
-
-          return child;
-        })}
-      </View>
+      <ToggleButtonRowContext.Provider value={SEGMENTED_ROW_CONTEXT}>
+        <View style={style}>
+          <View
+            style={[
+              styles.row,
+              {
+                backgroundColor: outlineColor,
+                borderRadius,
+              },
+            ]}
+          >
+            {children}
+          </View>
+        </View>
+      </ToggleButtonRowContext.Provider>
     </ToggleButtonGroup>
   );
 };
@@ -80,25 +89,10 @@ ToggleButtonRow.displayName = 'ToggleButton.Row';
 const styles = StyleSheet.create({
   row: {
     flexDirection: 'row',
-  },
-  button: {
-    borderWidth: StyleSheet.hairlineWidth,
-  },
-
-  first: {
-    borderTopRightRadius: 0,
-    borderBottomRightRadius: 0,
-  },
-
-  middle: {
-    borderRadius: 0,
-    borderLeftWidth: 0,
-  },
-
-  last: {
-    borderLeftWidth: 0,
-    borderTopLeftRadius: 0,
-    borderBottomLeftRadius: 0,
+    alignSelf: 'flex-start',
+    gap: StyleSheet.hairlineWidth,
+    overflow: 'hidden',
+    padding: StyleSheet.hairlineWidth,
   },
 });
 

--- a/src/components/ToggleButton/ToggleButtonRow.tsx
+++ b/src/components/ToggleButton/ToggleButtonRow.tsx
@@ -60,7 +60,7 @@ const ToggleButtonRow = ({
   theme: themeOverrides,
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
-  const borderRadius = theme.shapes.corner.extraSmall;
+  const borderRadius = theme.shapes.corner.largeIncreased;
   const outlineColor = theme.colors.outline;
 
   return (

--- a/src/components/ToggleButton/ToggleButtonRowContext.tsx
+++ b/src/components/ToggleButton/ToggleButtonRowContext.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react';
+
+type ToggleButtonRowContextType = {
+  segmented: boolean;
+};
+
+export const ToggleButtonRowContext =
+  React.createContext<ToggleButtonRowContextType | null>(null);

--- a/src/components/__tests__/Appbar/Appbar.test.tsx
+++ b/src/components/__tests__/Appbar/Appbar.test.tsx
@@ -12,15 +12,9 @@ import {
   getAppbarBackgroundColor,
   getAppbarBorders,
   modeTextVariant,
-  renderAppbarContent as utilRenderAppbarContent,
 } from '../../Appbar/utils';
-import Menu from '../../Menu/Menu';
 import Searchbar from '../../Searchbar';
 import Text from '../../Typography/Text';
-
-const renderAppbarContent = utilRenderAppbarContent as (
-  props: Parameters<typeof utilRenderAppbarContent>[0]
-) => { props: any }[];
 
 describe('Appbar', () => {
   it('does not pass any additional props to Searchbar', async () => {
@@ -50,109 +44,7 @@ describe('Appbar', () => {
   });
 });
 
-describe('renderAppbarContent', () => {
-  const children = [
-    <Appbar.BackAction onPress={() => {}} key={0} />,
-    <Appbar.Content title="Examples" key={1} />,
-    <Appbar.Action icon="magnify" onPress={() => {}} key={2} />,
-    <Appbar.Action icon="menu" onPress={() => {}} key={3} />,
-  ];
-
-  it('should render all children types if renderOnly is not specified', () => {
-    const result = renderAppbarContent({
-      children,
-      isDark: false,
-    });
-
-    expect(result).toHaveLength(4);
-  });
-
-  it('should render all children types except specified in renderExcept', () => {
-    const result = renderAppbarContent({
-      children: [
-        ...children,
-        <Menu
-          key={4}
-          anchor={<Appbar.Action icon="menu" onPress={() => {}} />}
-          visible={false}
-        >
-          {null}
-        </Menu>,
-      ],
-      isDark: false,
-      renderExcept: [
-        'Appbar',
-        'Appbar.Header',
-        'Appbar.BackAction',
-        'Appbar.Content',
-      ],
-    });
-
-    expect(result).toHaveLength(3);
-  });
-
-  it('should render only children types specifed in renderOnly', () => {
-    const result = renderAppbarContent({
-      children,
-      isDark: false,
-      renderOnly: ['Appbar.Action'],
-    });
-
-    expect(result).toHaveLength(2);
-  });
-
-  it('should render AppbarContent with correct mode', () => {
-    const result = renderAppbarContent({
-      children,
-      isDark: false,
-      renderOnly: ['Appbar.Content'],
-      mode: 'large',
-    });
-
-    // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-    expect(result[0].props.mode).toBe('large');
-  });
-
-  it('should render centered AppbarContent', () => {
-    const result = renderAppbarContent({
-      children,
-      isDark: false,
-      renderOnly: ['Appbar.Content'],
-      mode: 'center-aligned',
-      shouldCenterContent: true,
-    });
-
-    const centerAlignedContent = {
-      alignItems: 'center',
-    };
-
-    // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-    expect(result[0].props.style).toEqual(
-      expect.arrayContaining([expect.objectContaining(centerAlignedContent)])
-    );
-  });
-
-  it('should render AppbarContent with correct spacings', () => {
-    const renderResult = (withAppbarBackAction = false) =>
-      renderAppbarContent({
-        children,
-        isDark: false,
-        renderOnly: [
-          'Appbar.Content',
-          withAppbarBackAction && 'Appbar.BackAction',
-        ],
-      });
-
-    const v3Spacing = {
-      marginLeft: 12,
-    };
-
-    // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-    expect(renderResult()[0].props.style).toEqual(
-      expect.arrayContaining([expect.objectContaining(v3Spacing)])
-    );
-  });
-
+describe('Appbar.Content accessibility', () => {
   it('Is recognized as a heading when no onPress callback has been passed', async () => {
     await render(
       <SafeAreaProvider>

--- a/src/components/__tests__/Appbar/Appbar.test.tsx
+++ b/src/components/__tests__/Appbar/Appbar.test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { Animated } from 'react-native';
 
 import { describe, expect, it, jest } from '@jest/globals';
@@ -41,6 +42,20 @@ describe('Appbar', () => {
     ).toJSON();
 
     expect(tree).toMatchSnapshot();
+  });
+
+  it('places a memoized Appbar.Content in the title row in medium/large mode', async () => {
+    const MemoContent = React.memo(Appbar.Content);
+
+    await render(
+      <Appbar mode="medium">
+        <Appbar.BackAction onPress={() => {}} />
+        <MemoContent title="Memoized title" />
+        <Appbar.Action icon="menu" onPress={() => {}} />
+      </Appbar>
+    );
+
+    expect(screen.getByRole('heading')).toHaveTextContent('Memoized title');
   });
 });
 

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
@@ -649,15 +649,10 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             "paddingHorizontal": 12,
           },
           {
+            "marginLeft": 12,
             "paddingHorizontal": 0,
           },
-          [
-            {
-              "marginLeft": 12,
-            },
-            false,
-            undefined,
-          ],
+          undefined,
         ]
       }
       testID="appbar-content"

--- a/src/components/__tests__/Card/Card.test.tsx
+++ b/src/components/__tests__/Card/Card.test.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from 'react';
 import { Animated, StyleSheet, Text } from 'react-native';
 
 import { describe, expect, it, jest } from '@jest/globals';
@@ -140,38 +141,50 @@ describe('CardCover', () => {
 
 describe('CardActions', () => {
   it('renders button with passed mode', async () => {
+    const buttonProps = jest.fn();
+    const ProbeButton = (props: ComponentProps<typeof Button>) => {
+      buttonProps(props);
+
+      return <Button {...props} />;
+    };
+
     await render(
       <Card>
-        <Card.Actions testID="card-actions">
-          <Button mode="contained">Agree</Button>
+        <Card.Actions>
+          <ProbeButton mode="contained">Agree</ProbeButton>
         </Card.Actions>
       </Card>
     );
 
-    expect(
-      // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-      screen.getByTestId('card-actions').props.children[0].props.mode
-    ).toBe('contained');
+    expect(buttonProps).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'contained' })
+    );
   });
 
   it('does not inject default button props', async () => {
+    const buttonProps = jest.fn();
+    const ProbeButton = (props: ComponentProps<typeof Button>) => {
+      buttonProps(props);
+
+      return <Button {...props} />;
+    };
+
     await render(
       <Card>
-        <Card.Actions testID="card-actions">
-          <Button>Cancel</Button>
-          <Button>Agree</Button>
+        <Card.Actions>
+          <ProbeButton>Cancel</ProbeButton>
+          <ProbeButton>Agree</ProbeButton>
         </Card.Actions>
       </Card>
     );
 
-    const [cancelButton, agreeButton] =
-      // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-      screen.getByTestId('card-actions').props.children;
+    const [cancelButtonProps] = buttonProps.mock.calls[0];
+    const [agreeButtonProps] = buttonProps.mock.calls[1];
 
-    expect(cancelButton.props.mode).toBeUndefined();
-    expect(cancelButton.props.compact).toBeUndefined();
-    expect(agreeButton.props.mode).toBeUndefined();
-    expect(agreeButton.props.compact).toBeUndefined();
+    expect(cancelButtonProps).not.toHaveProperty('mode');
+    expect(cancelButtonProps).not.toHaveProperty('compact');
+    expect(agreeButtonProps).not.toHaveProperty('mode');
+    expect(agreeButtonProps).not.toHaveProperty('compact');
   });
 
   it('renders actions in a styled row', async () => {

--- a/src/components/__tests__/Card/Card.test.tsx
+++ b/src/components/__tests__/Card/Card.test.tsx
@@ -91,6 +91,19 @@ describe('Card', () => {
     expect(screen.getByTestId('card')).toHaveStyle(styles.contentStyle);
   });
 
+  it('clips inner content to the card shape', async () => {
+    await render(
+      <Card>
+        <Card.Cover source={{ uri: 'https://picsum.photos/700' }} />
+      </Card>
+    );
+
+    expect(screen.getByTestId('card')).toHaveStyle({
+      borderRadius: getTheme().shapes.corner.medium,
+      overflow: 'hidden',
+    });
+  });
+
   it('does not render a disabled accessibility state', async () => {
     await render(<Card>{null}</Card>);
 
@@ -139,6 +152,43 @@ describe('CardActions', () => {
       // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
       screen.getByTestId('card-actions').props.children[0].props.mode
     ).toBe('contained');
+  });
+
+  it('does not inject default button props', async () => {
+    await render(
+      <Card>
+        <Card.Actions testID="card-actions">
+          <Button>Cancel</Button>
+          <Button>Agree</Button>
+        </Card.Actions>
+      </Card>
+    );
+
+    const [cancelButton, agreeButton] =
+      // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
+      screen.getByTestId('card-actions').props.children;
+
+    expect(cancelButton.props.mode).toBeUndefined();
+    expect(cancelButton.props.compact).toBeUndefined();
+    expect(agreeButton.props.mode).toBeUndefined();
+    expect(agreeButton.props.compact).toBeUndefined();
+  });
+
+  it('renders actions in a styled row', async () => {
+    await render(
+      <Card>
+        <Card.Actions testID="card-actions">
+          <Button>Cancel</Button>
+          <Button>Agree</Button>
+        </Card.Actions>
+      </Card>
+    );
+
+    expect(screen.getByTestId('card-actions')).toHaveStyle({
+      flexDirection: 'row',
+      gap: 8,
+      justifyContent: 'flex-end',
+    });
   });
 
   it('renders button with custom styles', async () => {
@@ -221,6 +271,25 @@ describe('getCardCoverStyle - border radius', () => {
         borderRadiusStyles: {},
       })
     ).toMatchObject({ borderRadius: getTheme().shapes.corner.medium });
+  });
+});
+
+describe('CardContent', () => {
+  it('renders uniform vertical padding regardless of neighboring sections', async () => {
+    await render(
+      <Card>
+        <Card.Cover source={{ uri: 'https://picsum.photos/700' }} />
+        <Card.Title title="Card Title" />
+        <Card.Content testID="card-content">
+          <Text>Card content</Text>
+        </Card.Content>
+      </Card>
+    );
+
+    expect(screen.getByTestId('card-content')).toHaveStyle({
+      paddingTop: 16,
+      paddingBottom: 16,
+    });
   });
 });
 

--- a/src/components/__tests__/Card/Card.test.tsx
+++ b/src/components/__tests__/Card/Card.test.tsx
@@ -199,7 +199,6 @@ describe('CardActions', () => {
 
     expect(screen.getByTestId('card-actions')).toHaveStyle({
       flexDirection: 'row',
-      gap: 8,
       justifyContent: 'flex-end',
     });
   });

--- a/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
@@ -62,6 +62,10 @@ exports[`Card renders an outlined card 1`] = `
         [
           {
             "flexShrink": 1,
+            "overflow": "hidden",
+          },
+          {
+            "borderRadius": 12,
           },
           undefined,
         ]

--- a/src/components/__tests__/Dialog.test.tsx
+++ b/src/components/__tests__/Dialog.test.tsx
@@ -93,17 +93,52 @@ describe('Dialog', () => {
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
-  it('should apply top margin to the first child if the dialog is V3', async () => {
+  it('should apply top spacing to the dialog surface for a title-first dialog', async () => {
     await render(
-      <Dialog visible={true}>
-        <Dialog.Title testID="dialog-content">
+      <Dialog visible={true} testID="dialog">
+        <Dialog.Title testID="dialog-title">
           <Text>Test Dialog Content</Text>
         </Dialog.Title>
       </Dialog>
     );
 
+    expect(screen.getByTestId('dialog-surface')).toHaveStyle({
+      paddingTop: 24,
+    });
+    expect(screen.getByTestId('dialog-title')).toHaveStyle({
+      marginTop: 0,
+    });
+  });
+
+  it('should apply top spacing to the dialog surface for a content-first dialog', async () => {
+    await render(
+      <Dialog visible={true} testID="dialog">
+        <Dialog.Content testID="dialog-content">
+          <Text>Test Dialog Content</Text>
+        </Dialog.Content>
+      </Dialog>
+    );
+
+    expect(screen.getByTestId('dialog-surface')).toHaveStyle({
+      paddingTop: 24,
+    });
     expect(screen.getByTestId('dialog-content')).toHaveStyle({
-      marginTop: 24,
+      paddingBottom: 24,
+    });
+  });
+
+  it('should apply top spacing to the dialog surface for an icon-first dialog', async () => {
+    await render(
+      <Dialog visible={true} testID="dialog">
+        <Dialog.Icon icon="alert" testID="dialog-icon" />
+      </Dialog>
+    );
+
+    expect(screen.getByTestId('dialog-surface')).toHaveStyle({
+      paddingTop: 24,
+    });
+    expect(screen.getByTestId('dialog-icon')).toHaveStyle({
+      paddingTop: 0,
     });
   });
 });
@@ -133,11 +168,29 @@ describe('DialogActions', () => {
     const dialogActionButtons = dialogActionsContainer.children;
 
     expect(dialogActionsContainer).toHaveStyle({
+      gap: 8,
       paddingBottom: 24,
       paddingHorizontal: 24,
     });
-    expect(dialogActionButtons[0]).toHaveStyle({ marginRight: 8 });
-    expect(dialogActionButtons[1]).toHaveStyle({ marginRight: 0 });
+    expect(dialogActionButtons[0]).not.toHaveStyle({ marginRight: 8 });
+    expect(dialogActionButtons[1]).not.toHaveStyle({ marginRight: 0 });
+  });
+
+  it('should not inject button props into actions', async () => {
+    await render(
+      <Dialog.Actions testID="dialog-actions">
+        <Button>Cancel</Button>
+        <Button>Ok</Button>
+      </Dialog.Actions>
+    );
+
+    const dialogActionsContainer = screen.getByTestId('dialog-actions');
+    const [cancelButton, okButton] = dialogActionsContainer.props.children;
+
+    expect(cancelButton.props.compact).toBeUndefined();
+    expect(cancelButton.props.uppercase).toBeUndefined();
+    expect(okButton.props.compact).toBeUndefined();
+    expect(okButton.props.uppercase).toBeUndefined();
   });
 
   it('should apply custom styles', async () => {

--- a/src/components/__tests__/Dialog.test.tsx
+++ b/src/components/__tests__/Dialog.test.tsx
@@ -142,6 +142,25 @@ describe('Dialog', () => {
       paddingTop: 0,
     });
   });
+
+  it('should preserve the icon-to-title spacing for an icon dialog', async () => {
+    await render(
+      <Dialog visible={true} testID="dialog">
+        <Dialog.Icon icon="alert" testID="dialog-icon" />
+        <Dialog.Title testID="dialog-title">
+          <Text>Test Dialog Content</Text>
+        </Dialog.Title>
+      </Dialog>
+    );
+
+    expect(screen.getByTestId('dialog-icon')).toHaveStyle({
+      marginBottom: 16,
+      paddingTop: 0,
+    });
+    expect(screen.getByTestId('dialog-title')).toHaveStyle({
+      marginTop: 0,
+    });
+  });
 });
 
 describe('DialogActions', () => {

--- a/src/components/__tests__/Dialog.test.tsx
+++ b/src/components/__tests__/Dialog.test.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from 'react';
 import {
   Text,
   StyleSheet,
@@ -177,20 +178,27 @@ describe('DialogActions', () => {
   });
 
   it('should not inject button props into actions', async () => {
+    const buttonProps = jest.fn();
+    const ProbeButton = (props: ComponentProps<typeof Button>) => {
+      buttonProps(props);
+
+      return <Button {...props} />;
+    };
+
     await render(
-      <Dialog.Actions testID="dialog-actions">
-        <Button>Cancel</Button>
-        <Button>Ok</Button>
+      <Dialog.Actions>
+        <ProbeButton>Cancel</ProbeButton>
+        <ProbeButton>Ok</ProbeButton>
       </Dialog.Actions>
     );
 
-    const dialogActionsContainer = screen.getByTestId('dialog-actions');
-    const [cancelButton, okButton] = dialogActionsContainer.props.children;
+    const [cancelButtonProps] = buttonProps.mock.calls[0];
+    const [okButtonProps] = buttonProps.mock.calls[1];
 
-    expect(cancelButton.props.compact).toBeUndefined();
-    expect(cancelButton.props.uppercase).toBeUndefined();
-    expect(okButton.props.compact).toBeUndefined();
-    expect(okButton.props.uppercase).toBeUndefined();
+    expect(cancelButtonProps).not.toHaveProperty('compact');
+    expect(cancelButtonProps).not.toHaveProperty('uppercase');
+    expect(okButtonProps).not.toHaveProperty('compact');
+    expect(okButtonProps).not.toHaveProperty('uppercase');
   });
 
   it('should apply custom styles', async () => {

--- a/src/components/__tests__/Dialog.test.tsx
+++ b/src/components/__tests__/Dialog.test.tsx
@@ -179,21 +179,23 @@ describe('DialogActions', () => {
   it('should apply default styles', async () => {
     await render(
       <Dialog.Actions testID="dialog-actions">
-        <Button>Cancel</Button>
-        <Button>Ok</Button>
+        <Button testID="button-cancel">Cancel</Button>
+        <Button testID="button-ok">Ok</Button>
       </Dialog.Actions>
     );
 
     const dialogActionsContainer = screen.getByTestId('dialog-actions');
-    const dialogActionButtons = dialogActionsContainer.children;
 
     expect(dialogActionsContainer).toHaveStyle({
-      gap: 8,
       paddingBottom: 24,
       paddingHorizontal: 24,
     });
-    expect(dialogActionButtons[0]).not.toHaveStyle({ marginRight: 8 });
-    expect(dialogActionButtons[1]).not.toHaveStyle({ marginRight: 0 });
+    expect(screen.getByTestId('button-cancel-container')).not.toHaveStyle({
+      marginRight: 8,
+    });
+    expect(screen.getByTestId('button-ok-container')).not.toHaveStyle({
+      marginRight: 0,
+    });
   });
 
   it('should not inject button props into actions', async () => {
@@ -223,16 +225,21 @@ describe('DialogActions', () => {
   it('should apply custom styles', async () => {
     await render(
       <Dialog.Actions testID="dialog-actions">
-        <Button style={styles.spacing}>Cancel</Button>
-        <Button style={styles.noSpacing}>Ok</Button>
+        <Button testID="button-cancel" style={styles.spacing}>
+          Cancel
+        </Button>
+        <Button testID="button-ok" style={styles.noSpacing}>
+          Ok
+        </Button>
       </Dialog.Actions>
     );
 
-    const dialogActionsContainer = screen.getByTestId('dialog-actions');
-    const dialogActionButtons = dialogActionsContainer.children;
-
-    expect(dialogActionButtons[0]).toHaveStyle({ margin: 10 });
-    expect(dialogActionButtons[1]).toHaveStyle({ margin: 0 });
+    expect(screen.getByTestId('button-cancel-container')).toHaveStyle({
+      margin: 10,
+    });
+    expect(screen.getByTestId('button-ok-container')).toHaveStyle({
+      margin: 0,
+    });
   });
 });
 

--- a/src/components/__tests__/ListAccordion.test.tsx
+++ b/src/components/__tests__/ListAccordion.test.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, View } from 'react-native';
 import { describe, expect, it } from '@jest/globals';
 
 import { getTheme } from '../../core/theming';
-import { render } from '../../test-utils';
+import { render, screen } from '../../test-utils';
 import { red500 } from '../../theme/colors';
 import ListAccordion from '../List/ListAccordion';
 import ListAccordionGroup from '../List/ListAccordionGroup';
@@ -94,8 +94,8 @@ it('renders list accordion with custom title and description styles', async () =
   expect(tree).toMatchSnapshot();
 });
 
-it('indents expanded accordion children without their own left/right when the accordion has a left icon', () => {
-  const { getByTestId } = render(
+it('indents expanded accordion children without their own left/right when the accordion has a left icon', async () => {
+  await render(
     <ListAccordion
       left={(props) => <ListIcon {...props} icon="folder" />}
       title="Accordion with indented children"
@@ -105,17 +105,21 @@ it('indents expanded accordion children without their own left/right when the ac
     </ListAccordion>
   );
 
-  expect(getByTestId('accordion-child')).toHaveStyle({ paddingLeft: 40 });
+  expect(screen.getByTestId('accordion-child')).toHaveStyle({
+    paddingLeft: 40,
+  });
 });
 
-it('does not indent expanded accordion children when the accordion has no left icon', () => {
-  const { getByTestId } = render(
+it('does not indent expanded accordion children when the accordion has no left icon', async () => {
+  await render(
     <ListAccordion title="Accordion without left icon" expanded>
       <ListItem title="Child item" testID="accordion-child" />
     </ListAccordion>
   );
 
-  expect(getByTestId('accordion-child')).not.toHaveStyle({ paddingLeft: 40 });
+  expect(screen.getByTestId('accordion-child')).not.toHaveStyle({
+    paddingLeft: 40,
+  });
 });
 
 describe('ListAccordion', () => {

--- a/src/components/__tests__/ListAccordion.test.tsx
+++ b/src/components/__tests__/ListAccordion.test.tsx
@@ -94,6 +94,30 @@ it('renders list accordion with custom title and description styles', async () =
   expect(tree).toMatchSnapshot();
 });
 
+it('indents expanded accordion children without their own left/right when the accordion has a left icon', () => {
+  const { getByTestId } = render(
+    <ListAccordion
+      left={(props) => <ListIcon {...props} icon="folder" />}
+      title="Accordion with indented children"
+      expanded
+    >
+      <ListItem title="Child item" testID="accordion-child" />
+    </ListAccordion>
+  );
+
+  expect(getByTestId('accordion-child')).toHaveStyle({ paddingLeft: 40 });
+});
+
+it('does not indent expanded accordion children when the accordion has no left icon', () => {
+  const { getByTestId } = render(
+    <ListAccordion title="Accordion without left icon" expanded>
+      <ListItem title="Child item" testID="accordion-child" />
+    </ListAccordion>
+  );
+
+  expect(getByTestId('accordion-child')).not.toHaveStyle({ paddingLeft: 40 });
+});
+
 describe('ListAccordion', () => {
   it('should not throw an error when id={0}', async () => {
     const ListAccordionTest = () => (

--- a/src/components/__tests__/ToggleButton.test.tsx
+++ b/src/components/__tests__/ToggleButton.test.tsx
@@ -1,4 +1,4 @@
-import { Animated } from 'react-native';
+import { Animated, View } from 'react-native';
 
 import { describe, expect, it, jest } from '@jest/globals';
 import { act } from '@testing-library/react-native';
@@ -34,6 +34,32 @@ it('renders unchecked toggle button', async () => {
   ).toJSON();
 
   expect(tree).toMatchSnapshot();
+});
+
+it('renders row buttons with segmented styling through context', async () => {
+  await render(
+    <ToggleButton.Row value="left" onValueChange={() => {}}>
+      <View>
+        <ToggleButton
+          icon="format-align-left"
+          value="left"
+          testID="wrapped-toggle"
+        />
+      </View>
+      <ToggleButton
+        icon="format-align-right"
+        value="right"
+        testID="direct-toggle"
+      />
+    </ToggleButton.Row>
+  );
+
+  expect(screen.getByTestId('wrapped-toggle-container')).toHaveStyle({
+    borderRadius: 0,
+  });
+  expect(screen.getByTestId('direct-toggle-container')).toHaveStyle({
+    borderRadius: 0,
+  });
 });
 
 describe('getToggleButtonColor', () => {

--- a/src/components/__tests__/ToggleButton.test.tsx
+++ b/src/components/__tests__/ToggleButton.test.tsx
@@ -62,6 +62,22 @@ it('renders row buttons with segmented styling through context', async () => {
   });
 });
 
+it('applies the MD3 secondaryContainer fill to the selected segment in a row', async () => {
+  await render(
+    <ToggleButton.Row value="left" onValueChange={() => {}}>
+      <ToggleButton icon="format-align-left" value="left" testID="selected" />
+      <ToggleButton icon="format-align-right" value="right" testID="unselected" />
+    </ToggleButton.Row>
+  );
+
+  expect(screen.getByTestId('selected-container')).toHaveStyle({
+    backgroundColor: getTheme().colors.secondaryContainer,
+  });
+  expect(screen.getByTestId('unselected-container')).toHaveStyle({
+    backgroundColor: getTheme().colors.surfaceContainer,
+  });
+});
+
 describe('getToggleButtonColor', () => {
   it('should return correct color when checked and theme version 3', () => {
     expect(getToggleButtonColor({ theme: getTheme(), checked: true })).toBe(

--- a/src/components/__tests__/ToggleButton.test.tsx
+++ b/src/components/__tests__/ToggleButton.test.tsx
@@ -62,16 +62,20 @@ it('renders row buttons with segmented styling through context', async () => {
   });
 });
 
-it('applies the MD3 secondaryContainer fill to the selected segment in a row', async () => {
+it('applies the same selection color in a row as standalone (no row-specific override)', async () => {
   await render(
     <ToggleButton.Row value="left" onValueChange={() => {}}>
       <ToggleButton icon="format-align-left" value="left" testID="selected" />
-      <ToggleButton icon="format-align-right" value="right" testID="unselected" />
+      <ToggleButton
+        icon="format-align-right"
+        value="right"
+        testID="unselected"
+      />
     </ToggleButton.Row>
   );
 
   expect(screen.getByTestId('selected-container')).toHaveStyle({
-    backgroundColor: getTheme().colors.secondaryContainer,
+    backgroundColor: getTheme().colors.surfaceContainerHighest,
   });
   expect(screen.getByTestId('unselected-container')).toHaveStyle({
     backgroundColor: getTheme().colors.surfaceContainer,


### PR DESCRIPTION
## Motivation

Several components inspect, classify, or mutate their children with `React.Children` + `cloneElement`. This makes composition hard: children must be direct, prop-mergeable elements of an expected type, so wrapping them (in a memo, a custom component, a helper) silently breaks the injected styling/spacing/behavior, and the injected props are not type-safe. The FAB Menu rewrite (#4963) addressed the same class of problem; this PR migrates the remaining offenders to typed props, context, and container-owned layout.

## Approach

No child introspection. Each section component owns its own spacing/styling, cross-cutting state flows through context, and parents own layout (gap, padding, clipping) instead of cloning children. v6 alpha allows breaking changes without deprecation aliases, but user-visible output is preserved for documented usage; where a default that required child introspection is dropped, it is called out as a breaking change.

## Changes

### List.Accordion
- Removed the `React.Children.map` + `cloneElement` that injected `paddingLeft` and `theme` into expanded children.
- Added `ListAccordionContext` ({ leftIndent }). `List.Item` consumes it and indents its own container when it renders no `left`/`right`. Ripple/background stay full-width.
- Wrapped children now keep the indentation behavior. Output preserved for `List.Item` children (zero snapshot churn).

### Dialog
- Removed the first-child `cloneElement` that injected `marginTop: 24`.
- The Dialog surface owns the top inset (`paddingTop: 24`); `Dialog.Title` and `Dialog.Icon` no longer add their own top offset. `Dialog.Icon` keeps a 16px bottom gap so icon-to-title spacing is preserved.

### Dialog.Actions
- BREAKING CHANGE: no longer injects `compact` and `uppercase` into action buttons. Set them explicitly on each button. Inter-action spacing is now container `gap`.

### Card
- Removed child counting, sibling `displayName` scanning, and the per-child `cloneElement` injection of `index` / `total` / `siblings` / `borderRadiusStyles`.
- The card clips inner content to its shape (`overflow: hidden` + combined border radius) instead of injecting corner styles into `Card.Cover` / `Card.Title`.
- BREAKING CHANGE: `Card.Content` now uses uniform vertical padding regardless of neighboring sections.

### Card.Actions
- BREAKING CHANGE: no longer auto-assigns `mode` (previously `outlined` for the first action, `contained` for the rest) or `compact`. Set button props explicitly. Spacing is container `gap`.

### ToggleButton.Row
- Removed the positional `Children.count` / `Children.map` / `cloneElement` that injected first/middle/last border radii into each button by index.
- Segmented styling now flows through `ToggleButtonRowContext`: the row clips a single rounded container and member `ToggleButton`s read the context flag to flatten their own corners, with hairline dividers between segments. Wrapped or conditionally-rendered `ToggleButton`s compose correctly.
- Visual output is unchanged from `main` — same `corner.extraSmall` container shape, same `getToggleButtonColor` selected fill, same outline divider. This is a pure composition refactor, not a restyle.
- Added an optional `theme` prop to `ToggleButton.Row` so it can resolve the theme itself instead of relying on injection.

### Appbar
- Removed the `React.Children.forEach` count heuristic, the `displayName`-based child filtering, the action splitting, and the `cloneElement` injection of `color` / `mode` / `theme` into `Appbar.Action` / `Appbar.BackAction` / `Appbar.Content`.
- Added `AppbarContext` ({ isDark, mode }). Children read it and derive their own foreground color and title variant, instead of having props spliced in.
- `small` and `center-aligned` render their children directly in author order; the title's `flex: 1` keeps trailing actions right-aligned and the center-aligned title centers itself. `medium` and `large` keep the two-row layout (controls row above a full-width title) by partitioning children for placement only — no props are injected.
- BREAKING CHANGE: Appbar children now render in the order they are written rather than being reordered to put the back action first. Place `Appbar.BackAction` before `Appbar.Content` and trailing `Appbar.Action`s after it, as shown in the docs. Children no longer receive injected `color`/`mode`/`theme` props; wrapping `Appbar.Content`/`Appbar.Action` in another element keeps working because the values come from context.

## Out of scope (kept — idiomatic, not composition-hostile)
- `Tooltip` single-child trigger clone, `Chip` avatar-prop clone, `TouchableRipple` / `TouchableRipple.native` `Children.only` validation.

## Breaking changes (summary)

BREAKING CHANGE: `Appbar` renders children in author order (no automatic back-action-first reordering) and no longer injects `color`/`mode`/`theme` — the shared values come from context; order `Appbar.BackAction` before `Appbar.Content` as in the docs.
BREAKING CHANGE: `Card.Actions` no longer injects `mode`/`compact` — pass `mode="outlined"`/`mode="contained"` (and `compact` if needed) explicitly.
BREAKING CHANGE: `Dialog.Actions` no longer injects `compact`/`uppercase` — set them explicitly.
BREAKING CHANGE: `Card.Content` uses uniform vertical padding regardless of neighbors.

Example migration (Card.Actions):

    // before
    <Card.Actions>
      <Button>Cancel</Button>
      <Button>Ok</Button>
    </Card.Actions>

    // after
    <Card.Actions>
      <Button mode="outlined">Cancel</Button>
      <Button mode="contained">Ok</Button>
    </Card.Actions>

## Test plan
- `yarn typecheck` — pass
- `yarn lint` — pass
- Unit tests: scoped suites are green, with new characterization tests for `List.Accordion` (context indent), `Dialog` (surface top spacing, icon-to-title gap, no action-prop injection), `Card` (clip-to-shape, uniform `Card.Content` padding, no `Card.Actions` injection), `ToggleButton.Row` (segmented styling via context) and `Appbar` (context-provided values, author-order rendering). The full `yarn test` run has pre-existing RN `Animated` fake-timer baseline failures unrelated to this change — the identical set fails on `main`.
- Manual visual inspection, before (`main`) vs after, on iOS (iPhone 16 Pro) and Android (Pixel 9 Pro XL): Appbar (small / center-aligned / medium / large), List.Accordion, Dialog, Card, and ToggleButton.Row — no visual regressions. Screenshots below.

## Visual verification

Manual before (`main`) vs after comparison on iOS (iPhone 16 Pro) and Android (Pixel 9 Pro XL) — no visual regressions.

**Appbar — all four modes (Android)**

![Appbar — small / medium / large / center-aligned](https://raw.githubusercontent.com/matkoson/react-native-paper/pr5018-assets/pr5018/appbar-android-4-modes.png)

**Appbar — small + medium two-row (iOS)**

![Appbar small and medium on iOS](https://raw.githubusercontent.com/matkoson/react-native-paper/pr5018-assets/pr5018/appbar-ios-small-medium.png)

**Appbar — baseline vs after vs pixel diff (iOS, small): identical apart from the status-bar clock**

![Appbar baseline vs after vs diff](https://raw.githubusercontent.com/matkoson/react-native-paper/pr5018-assets/pr5018/appbar-ios-pixel-diff.png)

**List.Accordion · Dialog · ToggleButton.Row · Card — baseline (`main`) vs after (Android)**

![Composition components baseline vs after](https://raw.githubusercontent.com/matkoson/react-native-paper/pr5018-assets/pr5018/composition-android-baseline-vs-after.png)

**ToggleButton.Row + Card — base vs HEAD, zero pixel delta (Android)**

![ToggleButton and Card base vs HEAD, pixel-transparent](https://raw.githubusercontent.com/matkoson/react-native-paper/pr5018-assets/pr5018/toggle-card-ae0-android.png)

Related: #4989
Reference: #4963
