### PR TITLE
fix(modal): avoid keyboard in edge-to-edge Android

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { Animated, Easing, StyleSheet, Pressable, View } from 'react-native';
+import {
+  Animated,
+  Easing,
+  KeyboardAvoidingView,
+  StyleSheet,
+  Pressable,
+} from 'react-native';
 import type { StyleProp, ViewStyle } from 'react-native';
 
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -206,7 +212,16 @@ function Modal({
         ]}
         testID={`${testID}-backdrop`}
       />
-      <View
+      {/*
+       * Keep the modal content clear of the soft keyboard. In legacy Android
+       * (non edge-to-edge) the window is resized by `adjustResize`, so the
+       * centered content shifts up on its own. In edge-to-edge mode (Android
+       * 15+ default) the window is no longer resized, so we rely on
+       * `KeyboardAvoidingView` to reserve space for the keyboard instead. It
+       * measures its own frame, so it doesn't double up with `adjustResize`.
+       */}
+      <KeyboardAvoidingView
+        behavior="padding"
         style={[
           styles.wrapper,
           { marginTop: top, marginBottom: bottom },
@@ -223,7 +238,7 @@ function Modal({
         >
           {children}
         </Surface>
-      </View>
+      </KeyboardAvoidingView>
     </Animated.View>
   );
 }


### PR DESCRIPTION
### Motivation

On Android with **edge-to-edge** enabled (the default on Android 15+, or `edgeToEdgeEnabled=true` in `gradle.properties`), `Dialog`s do not move out of the way when the soft keyboard opens, so the keyboard covers dialog content such as a `TextInput`.

`Dialog` renders through `Modal`, which centers its content in a full-screen `absoluteFill` view with no keyboard avoidance. In legacy Android the OS resizes the window (`adjustResize`), so the `absoluteFill` shrinks and the centered content shifts up on its own. In edge-to-edge mode the window is no longer resized — the app draws behind the keyboard — so the content stays centered behind it. The same gap exists on iOS, which never had this avoidance.

The fix wraps the modal content in a `KeyboardAvoidingView` (`behavior="padding"`). It measures its own frame against the keyboard, so it reserves space in edge-to-edge mode without double-shifting when `adjustResize` is active, and fixes the behavior on iOS too.

### Related issue

Fixes #5021

### Test plan

- `yarn typecheck` — passes
- `yarn lint` — passes
- `yarn test` (Modal + Dialog suites) — 26/26 pass, no regressions

Manual (Android 15+ emulator or `edgeToEdgeEnabled=true`):
1. Open a `Dialog` containing a `TextInput`.
2. Focus the `TextInput` to bring up the soft keyboard.
3. The dialog shifts up and stays clear of the keyboard (previously it stayed centered behind it). Confirm behavior is unchanged in non-edge-to-edge mode and on iOS.
