### PR TITLE
fix: prevent prototype hijack in theme safeMerge (CWE-1321)

### DIFF
--- a/src/theme/provider.tsx
+++ b/src/theme/provider.tsx
@@ -29,6 +29,11 @@ export const isPlatformColorSentinel = (v: unknown): boolean =>
   typeof v === 'object' &&
   ('resource_paths' in v || 'semantic' in v || 'dynamic' in v);
 
+// Keys that would otherwise let a crafted `overrides` object (e.g. parsed via
+// `JSON.parse` from an external theme config) hijack the prototype of the
+// merged output through bracket-notation assignment below.
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 export const safeMerge = <T,>(base: T, overrides: unknown): T => {
   if (
     !base ||
@@ -45,6 +50,9 @@ export const safeMerge = <T,>(base: T, overrides: unknown): T => {
   }
   const out: Record<string, unknown> = { ...(base as Record<string, unknown>) };
   for (const key of Object.keys(overrides as Record<string, unknown>)) {
+    if (UNSAFE_KEYS.has(key)) {
+      continue;
+    }
     out[key] = safeMerge(
       (base as Record<string, unknown>)[key],
       (overrides as Record<string, unknown>)[key]


### PR DESCRIPTION
## Summary

`safeMerge` in `src/theme/provider.tsx` (used by every component's `theme` prop override via `useInternalTheme`) recursively merges the override object into a fresh copy of the base theme using bracket-notation assignment:

```ts
const out: Record<string, unknown> = { ...(base as Record<string, unknown>) };
for (const key of Object.keys(overrides as Record<string, unknown>)) {
  out[key] = safeMerge(base[key], overrides[key]);
}
```

Unlike object-literal spread (`{...obj}`), which copies a property literally named `"__proto__"` as an ordinary own data property, **bracket-notation assignment invokes the `Object.prototype.__proto__` accessor**. If `overrides` (e.g. parsed via `JSON.parse` from an external/remote theme config) has an own key named `"__proto__"`, then `out["__proto__"] = value` calls `Object.setPrototypeOf(out, value)` — hijacking the prototype of the object `safeMerge` is building instead of storing it as a normal property.

### Proof

```js
const overrides = JSON.parse('{"colors": {"__proto__": {"polluted": "yes"}}}');
const merged = safeMerge({ colors: { primary: 'blue' } }, overrides);

merged.colors.polluted; // => "yes"  (before this fix)
```

This is scoped to the specific object `safeMerge` returns (it does **not** reach the shared global `Object.prototype`), so the blast radius is limited — but it's still a real CWE-1321 gap in a function whose name and surrounding comment ("Upstream `deepmerge` corrupts PlatformColor objects, so we recurse manually") signal it's meant to be a *safe*, hardened replacement.

### Realistic impact

Applications that build per-component `theme` overrides from external/remote JSON (e.g. white-label/dynamic-branding apps) and pass that data straight into a component's `theme` prop without validating its shape are exposed. Because the merge starts from `{...base}`, keys already present in the real theme schema are shadowed by own properties, so the practical effect is limited to forging fallback values for *undefined* theme property lookups — not overriding existing, actively-used theme values.

## Fix

Add a denylist for `__proto__`/`constructor`/`prototype` so `safeMerge` never assigns those keys, closing the hijack regardless of what shape `overrides` takes:

```ts
const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
...
for (const key of Object.keys(overrides as Record<string, unknown>)) {
  if (UNSAFE_KEYS.has(key)) {
    continue;
  }
  out[key] = safeMerge(...);
}
```

## Test plan

- [x] Verified in an isolated Node harness that the exploit (`__proto__` key in overrides hijacking the merged object's prototype) is blocked after the fix.
- [x] Verified legitimate deep-merge behavior (overriding existing keys like `colors.primary`, adding new keys, leaving untouched keys intact) is unchanged.
- [x] Verified `PlatformColor`/`DynamicColorIOS` sentinel objects are still treated as leaves (not walked into) as before.
- [x] Full existing test suite passes (`yarn jest`): 732 passed, 1 skipped, 0 failed.
- [x] `tsc --noEmit` and `eslint` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)