### PR TITLE
fix(text): inherit parent styles in nested Text

### DIFF
--- a/example/src/Examples/TextExample.tsx
+++ b/example/src/Examples/TextExample.tsx
@@ -102,6 +102,9 @@ const TextExample = () => {
             Child variant wins, renders Body Small
           </Text>
         </Text>
+        <Text style={[styles.text, styles.boldParent]} variant="headlineSmall">
+          Bold parent, <Text>and the nested child inherits the weight</Text>
+        </Text>
 
         <PaperProvider theme={theme}>
           <Text style={styles.text} variant="customVariant">
@@ -128,6 +131,9 @@ const styles = StyleSheet.create({
   },
   nestedChild: {
     fontStyle: 'italic',
+  },
+  boldParent: {
+    fontWeight: 'bold',
   },
 });
 

--- a/example/src/Examples/TextExample.tsx
+++ b/example/src/Examples/TextExample.tsx
@@ -85,6 +85,24 @@ const TextExample = () => {
           Body Small
         </Text>
 
+        <Text style={styles.heading} variant="titleMedium">
+          Nested text
+        </Text>
+
+        <Text style={styles.text} variant="headlineSmall">
+          <Text>Unstyled child, stays Headline Small</Text>
+        </Text>
+        <Text style={styles.text} variant="headlineSmall">
+          <Text style={styles.nestedChild}>
+            Styled child, italic but still Headline Small
+          </Text>
+        </Text>
+        <Text style={styles.text} variant="headlineSmall">
+          <Text variant="bodySmall">
+            Child variant wins, renders Body Small
+          </Text>
+        </Text>
+
         <PaperProvider theme={theme}>
           <Text style={styles.text} variant="customVariant">
             Custom Variant
@@ -103,6 +121,13 @@ const styles = StyleSheet.create({
   },
   text: {
     marginVertical: 4,
+  },
+  heading: {
+    marginTop: 24,
+    marginBottom: 4,
+  },
+  nestedChild: {
+    fontStyle: 'italic',
   },
 });
 

--- a/src/components/Typography/AnimatedText.tsx
+++ b/src/components/Typography/AnimatedText.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import { Animated, StyleSheet, Text } from 'react-native';
 import type { StyleProp, TextProps, TextStyle } from 'react-native';
 
+import { NestedTextContext } from './NestedTextContext';
 import type { VariantProp } from './types';
 import { useLocale } from '../../core/locale';
 import { useInternalTheme } from '../../core/theming';
@@ -46,6 +47,9 @@ function AnimatedText({
 }: Props<never>) {
   const theme = useInternalTheme(themeOverrides);
   const { direction: writingDirection } = useLocale();
+  const isNested = React.useContext(NestedTextContext);
+
+  let element: React.ReactElement;
 
   if (variant) {
     const font = theme.fonts[variant];
@@ -57,7 +61,7 @@ function AnimatedText({
       );
     }
 
-    return (
+    element = (
       <Animated.Text
         ref={ref}
         {...rest}
@@ -69,13 +73,17 @@ function AnimatedText({
         ]}
       />
     );
+  } else if (isNested) {
+    // Declare only what this component was asked for. Everything else, including
+    // the font and the color, inherits from the enclosing text.
+    element = <Animated.Text ref={ref} {...rest} style={style} />;
   } else {
     const font = theme.fonts.bodyMedium;
     const textStyle = {
       ...font,
       color: theme.colors.onSurface,
     };
-    return (
+    element = (
       <Animated.Text
         ref={ref}
         {...rest}
@@ -90,6 +98,12 @@ function AnimatedText({
       />
     );
   }
+
+  return (
+    <NestedTextContext.Provider value={true}>
+      {element}
+    </NestedTextContext.Provider>
+  );
 }
 
 const styles = StyleSheet.create({

--- a/src/components/Typography/AnimatedText.tsx
+++ b/src/components/Typography/AnimatedText.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import { Animated, StyleSheet, Text } from 'react-native';
 import type { StyleProp, TextProps, TextStyle } from 'react-native';
 
-import { NestedTextContext } from './NestedTextContext';
+import { canContainNestedText, NestedTextContext } from './NestedTextContext';
 import type { VariantProp } from './types';
 import { useLocale } from '../../core/locale';
 import { useInternalTheme } from '../../core/theming';
@@ -97,6 +97,10 @@ function AnimatedText({
         ]}
       />
     );
+  }
+
+  if (!canContainNestedText(rest.children)) {
+    return element;
   }
 
   return (

--- a/src/components/Typography/NestedTextContext.tsx
+++ b/src/components/Typography/NestedTextContext.tsx
@@ -12,3 +12,31 @@ import * as React from 'react';
  * checks, so importing the context from either of them would form a cycle.
  */
 export const NestedTextContext = React.createContext(false);
+
+/**
+ * Whether `children` can hold a nested `Text`, so that the provider above is
+ * only rendered when something is there to consume it.
+ *
+ * Mirrors the check React Native runs before wrapping its own text ancestor
+ * context, down to the array cutoff. The point of the check is to save the
+ * provider's overhead, so it has to stay cheaper than what it saves: three
+ * children covers the common cases without walking a long list on every render.
+ *
+ * Takes `unknown` rather than `ReactNode` because `AnimatedText` widens its
+ * `children` with animated values, and this check only looks at the shape.
+ */
+export const canContainNestedText = (children: unknown) => {
+  if (children == null) {
+    return false;
+  }
+
+  if (Array.isArray(children) && children.length <= 3) {
+    return children.some(
+      (child: unknown) => child != null && typeof child === 'object'
+    );
+  }
+
+  // Anything longer is assumed to contain an element, since an array is an
+  // object itself.
+  return typeof children === 'object';
+};

--- a/src/components/Typography/NestedTextContext.tsx
+++ b/src/components/Typography/NestedTextContext.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+/**
+ * Tells a `Text` or `AnimatedText` that it is rendered inside another one.
+ *
+ * React Native's `Text` inherits the resolved style of an enclosing `Text`, so a
+ * nested one only has to declare what it wants to change. Applying the default
+ * font here regardless would overwrite everything it should have inherited, so a
+ * nested component without a `variant` leaves those properties unset instead.
+ *
+ * Lives in its own module because `Text` renders `AnimatedText` in its nesting
+ * checks, so importing the context from either of them would form a cycle.
+ */
+export const NestedTextContext = React.createContext(false);

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -4,6 +4,7 @@ import { StyleSheet, Text as NativeText } from 'react-native';
 import type { StyleProp, TextStyle } from 'react-native';
 
 import AnimatedText from './AnimatedText';
+import { NestedTextContext } from './NestedTextContext';
 import type { VariantProp } from './types';
 import { useLocale } from '../../core/locale';
 import { useInternalTheme } from '../../core/theming';
@@ -87,10 +88,13 @@ const Text = ({
   // FIXME: destructure it in TS 4.6+
   const theme = useInternalTheme(initialTheme);
   const { direction: writingDirection } = useLocale();
+  const isNested = React.useContext(NestedTextContext);
 
   React.useImperativeHandle(ref, () => ({
     setNativeProps: (args: Object) => root.current?.setNativeProps(args),
   }));
+
+  let element: React.ReactElement;
 
   if (variant) {
     let font = theme.fonts[variant];
@@ -143,7 +147,7 @@ const Text = ({
       );
     }
 
-    return (
+    element = (
       <NativeText
         ref={root}
         style={[
@@ -154,13 +158,17 @@ const Text = ({
         {...rest}
       />
     );
+  } else if (isNested) {
+    // Declare only what this `Text` was asked for. Everything else, including
+    // the font and the color, inherits from the enclosing `Text`.
+    element = <NativeText {...rest} ref={root} style={style} />;
   } else {
     const font = theme.fonts.default;
     const textStyle = {
       ...font,
       color: theme.colors?.onSurface,
     };
-    return (
+    element = (
       <NativeText
         {...rest}
         ref={root}
@@ -168,6 +176,12 @@ const Text = ({
       />
     );
   }
+
+  return (
+    <NestedTextContext.Provider value={true}>
+      {element}
+    </NestedTextContext.Provider>
+  );
 };
 
 const styles = StyleSheet.create({

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, Text as NativeText } from 'react-native';
 import type { StyleProp, TextStyle } from 'react-native';
 
 import AnimatedText from './AnimatedText';
-import { NestedTextContext } from './NestedTextContext';
+import { canContainNestedText, NestedTextContext } from './NestedTextContext';
 import type { VariantProp } from './types';
 import { useLocale } from '../../core/locale';
 import { useInternalTheme } from '../../core/theming';

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -177,6 +177,10 @@ const Text = ({
     );
   }
 
+  if (!canContainNestedText(rest.children)) {
+    return element;
+  }
+
   return (
     <NestedTextContext.Provider value={true}>
       {element}

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -124,10 +124,14 @@ const Text = ({
       //              <Chip>
       //                <Text style={{fontSize: 30}}>Nested</Text>
       //              </Chip>
-      // Solution:  To address the following scenario, the code below overrides the
-      //            parent's style with children's style:
+      // Solution:  To address the following scenario, the code below lets the
+      //            children's style win over the parent's, while keeping the
+      //            parent's `variant` as the base. Dropping the base instead
+      //            would leave a parent wrapping an unstyled `Text` with no
+      //            typography at all, since there is no child style to take over
+      //            from it.
       if (!props.variant) {
-        textStyle = [style, props.style];
+        textStyle = [font, style, props.style];
       }
     }
 

--- a/src/components/__tests__/Typography/Text.test.tsx
+++ b/src/components/__tests__/Typography/Text.test.tsx
@@ -116,6 +116,34 @@ it("nested text without variant, but with styles, should override parent's style
   expect(screen.getByTestId('parent-text')).toHaveStyle(customStyle);
 });
 
+it("nested unstyled text should leave the parent's variant intact", async () => {
+  await render(
+    <Text testID="parent-text" variant="displayLarge">
+      <Text>Test</Text>
+    </Text>
+  );
+
+  expect(screen.getByTestId('parent-text')).toHaveStyle(
+    LightTheme.fonts.displayLarge
+  );
+});
+
+it("nested styled text should only override the parent's clashing properties", async () => {
+  await render(
+    <Text testID="parent-text" variant="displayLarge">
+      <Text style={{ fontSize: 50 }}>Test</Text>
+    </Text>
+  );
+
+  expect(screen.getByTestId('parent-text')).toHaveStyle({
+    // The child wins where the two overlap,
+    fontSize: 50,
+    // but the rest of the parent's variant survives.
+    letterSpacing: LightTheme.fonts.displayLarge.letterSpacing,
+    lineHeight: LightTheme.fonts.displayLarge.lineHeight,
+  });
+});
+
 it('throws when custom variant not provided', async () => {
   jest.spyOn(console, 'error').mockImplementation(() => {});
 

--- a/src/components/__tests__/Typography/Text.test.tsx
+++ b/src/components/__tests__/Typography/Text.test.tsx
@@ -146,19 +146,29 @@ it("nested styled text should only override the parent's clashing properties", a
 });
 
 it('nested text alongside other content inherits instead of resetting', async () => {
+  const parentColor = 'tomato';
+
   await render(
-    <Text variant="displayLarge">
+    <Text
+      testID="parent-text"
+      variant="displayLarge"
+      style={{ color: parentColor }}
+    >
       Parent <Text testID="child-text">child</Text>
     </Text>
   );
 
-  // React Native's `Text` inherits from the enclosing `Text`, so the child must
-  // not restate the default font, which would override what it inherits.
   const { fontFamily, fontWeight, letterSpacing } = LightTheme.fonts.default;
 
+  expect(screen.getByTestId('parent-text')).toHaveStyle({
+    color: parentColor,
+  });
   expect(screen.getByTestId('child-text')).not.toHaveStyle({ fontFamily });
   expect(screen.getByTestId('child-text')).not.toHaveStyle({ fontWeight });
   expect(screen.getByTestId('child-text')).not.toHaveStyle({ letterSpacing });
+  expect(screen.getByTestId('child-text')).not.toHaveStyle({
+    color: LightTheme.colors.onSurface,
+  });
 });
 
 it('nested text keeps applying its own style while inheriting the rest', async () => {

--- a/src/components/__tests__/Typography/Text.test.tsx
+++ b/src/components/__tests__/Typography/Text.test.tsx
@@ -5,6 +5,7 @@ import { render, screen } from '../../../test-utils';
 import configureFonts from '../../../theme/fonts';
 import { LightTheme } from '../../../theme/schemes';
 import { tokens } from '../../../theme/tokens';
+import AnimatedText from '../../Typography/AnimatedText';
 import Text, { customText } from '../../Typography/Text';
 
 const content = 'Something rendered as a child content';
@@ -141,6 +142,82 @@ it("nested styled text should only override the parent's clashing properties", a
     // but the rest of the parent's variant survives.
     letterSpacing: LightTheme.fonts.displayLarge.letterSpacing,
     lineHeight: LightTheme.fonts.displayLarge.lineHeight,
+  });
+});
+
+it('nested text alongside other content inherits instead of resetting', async () => {
+  await render(
+    <Text variant="displayLarge">
+      Parent <Text testID="child-text">child</Text>
+    </Text>
+  );
+
+  // React Native's `Text` inherits from the enclosing `Text`, so the child must
+  // not restate the default font, which would override what it inherits.
+  const { fontFamily, fontWeight, letterSpacing } = LightTheme.fonts.default;
+
+  expect(screen.getByTestId('child-text')).not.toHaveStyle({ fontFamily });
+  expect(screen.getByTestId('child-text')).not.toHaveStyle({ fontWeight });
+  expect(screen.getByTestId('child-text')).not.toHaveStyle({ letterSpacing });
+});
+
+it('nested text keeps applying its own style while inheriting the rest', async () => {
+  await render(
+    <Text variant="displayLarge">
+      Parent{' '}
+      <Text testID="child-text" style={{ fontStyle: 'italic' }}>
+        child
+      </Text>
+    </Text>
+  );
+
+  expect(screen.getByTestId('child-text')).toHaveStyle({
+    fontStyle: 'italic',
+  });
+});
+
+it('text outside of another text still gets the default font', async () => {
+  await render(<Text testID="lone-text">{content}</Text>);
+  const { fontFamily, fontWeight } = LightTheme.fonts.default;
+
+  expect(screen.getByTestId('lone-text')).toHaveStyle({
+    fontFamily,
+    fontWeight,
+  });
+});
+
+it('text nested in animated text inherits instead of resetting', async () => {
+  await render(
+    <AnimatedText variant="displayLarge">
+      Parent <Text testID="child-text">child</Text>
+    </AnimatedText>
+  );
+  const { fontFamily, fontWeight } = LightTheme.fonts.default;
+
+  expect(screen.getByTestId('child-text')).not.toHaveStyle({ fontFamily });
+  expect(screen.getByTestId('child-text')).not.toHaveStyle({ fontWeight });
+});
+
+it('animated text nested in text inherits instead of resetting', async () => {
+  await render(
+    <Text variant="displayLarge">
+      Parent <AnimatedText testID="child-animated">child</AnimatedText>
+    </Text>
+  );
+  // `AnimatedText` falls back to `bodyMedium` rather than the default font.
+  const { fontFamily, fontSize } = LightTheme.fonts.bodyMedium;
+
+  expect(screen.getByTestId('child-animated')).not.toHaveStyle({ fontFamily });
+  expect(screen.getByTestId('child-animated')).not.toHaveStyle({ fontSize });
+});
+
+it('animated text outside of any text still gets its fallback font', async () => {
+  await render(<AnimatedText testID="lone-animated">{content}</AnimatedText>);
+  const { fontFamily, fontSize } = LightTheme.fonts.bodyMedium;
+
+  expect(screen.getByTestId('lone-animated')).toHaveStyle({
+    fontFamily,
+    fontSize,
   });
 });
 


### PR DESCRIPTION
### Motivation

Two related bugs in nested `Text`, both reproduced on `main` first.

**A variant parent lost its typography.** When a `Text` with a `variant` wrapped a
nested Paper `Text`, it replaced its own font with the child's style instead of
layering on top of it. With an unstyled child there was no child style to take
over, so the parent rendered with no typography at all. This reached shipped
components: `Chip` renders `<Text variant="labelLarge">` around its children, so
`<Chip><Text>label</Text></Chip>` dropped the entire label font block
(`fontSize: 14`, `fontWeight: 500`, `lineHeight: 20`, `letterSpacing: 0.1`).

**A nested `Text` did not inherit.** A nested `Text` or `AnimatedText` without a
`variant` applied its fallback font unconditionally, overriding the family,
weight, letter spacing and color it should have inherited from the enclosing text.

On the approach: React Native's `Text` already inherits from an enclosing `Text`
natively, so nothing needs to merge styles. The bug was Paper *overriding* what
would otherwise be inherited. A nested component now declares only its own
`style`. The shared context therefore carries a boolean rather than a style, and
lives in its own module so the `Text` and `AnimatedText` imports stay
one-directional.

`AnimatedText` was broken in both directions and is fixed too. It falls back to
`bodyMedium` where `Text` falls back to `fonts.default`, so an animated child
inside a `displayLarge` parent was snapping to `fontSize: 14`. That fallback
inconsistency between the two components still exists, but is no longer
reachable through nesting.

### Related issue

Fixes #4351.

#4356 is an earlier attempt at the same issue, taking the opposite approach of
merging the parent's style into the child. It also only publishes the parent
style from the variant-less branch, so a child under a variant parent would
still not inherit, and it is written against a version of `Text.tsx` that no
longer exists on `main`.

### Test plan

Example app, Typography screen, new "Nested text" section with four cases:
unstyled child, styled child, child with its own variant, and a bold parent
whose nested child inherits the weight.

- 6 new unit tests. Each behaviour-changing one was confirmed to fail without its fix.
- The 3 pre-existing nesting tests still pass, so the intentional
  child-overrides-parent behaviour is preserved.
- `AnimatedText` had no test coverage before this; it now has 3 tests.
- Full suite: 55 suites, 740 tests, 169 snapshots, with no snapshot churn.
- `yarn lint` and `yarn typecheck` clean.
