### PR TITLE
feat: add typed leading and trailing slots to List.Item

### DIFF
--- a/example/src/Examples/ListItemExample.tsx
+++ b/example/src/Examples/ListItemExample.tsx
@@ -16,7 +16,7 @@ const SelectableSection = () => {
           description="Supporting text"
           selected={index === selected}
           onPress={() => setSelected(index)}
-          left={(props) => <List.Icon {...props} icon="account-outline" />}
+          leading={<List.Icon icon="account-outline" />}
         />
       ))}
       <Divider />

--- a/example/src/Examples/ListItemExample.tsx
+++ b/example/src/Examples/ListItemExample.tsx
@@ -1,14 +1,6 @@
-import { View, StyleSheet } from 'react-native';
-
 import { List, Divider, Checkbox, Avatar, Switch } from 'react-native-paper';
 
 import ScreenWrapper from '../ScreenWrapper';
-
-const CenteredCheckbox = () => (
-  <View style={styles.centered}>
-    <Checkbox status="checked" />
-  </View>
-);
 
 const ListItemExample = () => {
   return (
@@ -21,16 +13,19 @@ const ListItemExample = () => {
           description="Supporting text that is long enough to fill up multiple lines in the item"
         />
         <Divider />
-        <List.Item title="Headline" right={() => <CenteredCheckbox />} />
+        <List.Item
+          title="Headline"
+          right={(props) => <Checkbox status="checked" style={props.style} />}
+        />
         <List.Item
           title="Headline"
           description="Supporting text"
-          right={() => <CenteredCheckbox />}
+          right={(props) => <Checkbox status="checked" style={props.style} />}
         />
         <List.Item
           title="Headline"
           description="Supporting text that is long enough to fill up multiple lines in the item"
-          right={() => <Checkbox status="checked" />}
+          right={(props) => <Checkbox status="checked" style={props.style} />}
         />
         <Divider />
       </List.Section>
@@ -54,19 +49,19 @@ const ListItemExample = () => {
         <List.Item
           title="Headline"
           left={(props) => <List.Icon {...props} icon="account-outline" />}
-          right={() => <CenteredCheckbox />}
+          right={(props) => <Checkbox status="checked" style={props.style} />}
         />
         <List.Item
           title="Headline"
           description="Supporting text"
           left={(props) => <List.Icon {...props} icon="account-outline" />}
-          right={() => <CenteredCheckbox />}
+          right={(props) => <Checkbox status="checked" style={props.style} />}
         />
         <List.Item
           title="Headline"
           description="Supporting text that is long enough to fill up multiple lines in the item"
           left={(props) => <List.Icon {...props} icon="account-outline" />}
-          right={() => <Checkbox status="checked" />}
+          right={(props) => <Checkbox status="checked" style={props.style} />}
         />
         <Divider />
       </List.Section>
@@ -98,7 +93,7 @@ const ListItemExample = () => {
           left={(props) => (
             <Avatar.Text style={props.style} label="A" size={40} />
           )}
-          right={() => <CenteredCheckbox />}
+          right={(props) => <Checkbox status="checked" style={props.style} />}
         />
         <List.Item
           title="Headline"
@@ -106,7 +101,7 @@ const ListItemExample = () => {
           left={(props) => (
             <Avatar.Text style={props.style} label="A" size={40} />
           )}
-          right={() => <CenteredCheckbox />}
+          right={(props) => <Checkbox status="checked" style={props.style} />}
         />
         <List.Item
           title="Headline"
@@ -114,7 +109,7 @@ const ListItemExample = () => {
           left={(props) => (
             <Avatar.Text style={props.style} label="A" size={40} />
           )}
-          right={() => <Checkbox status="checked" />}
+          right={(props) => <Checkbox status="checked" style={props.style} />}
         />
         <Divider />
       </List.Section>
@@ -158,7 +153,7 @@ const ListItemExample = () => {
               source={require('../../../example/assets/images/strawberries.jpg')}
             />
           )}
-          right={() => <CenteredCheckbox />}
+          right={(props) => <Checkbox status="checked" style={props.style} />}
         />
         <List.Item
           title="Headline"
@@ -169,7 +164,7 @@ const ListItemExample = () => {
               source={require('../../../example/assets/images/strawberries.jpg')}
             />
           )}
-          right={() => <CenteredCheckbox />}
+          right={(props) => <Checkbox status="checked" style={props.style} />}
         />
         <List.Item
           title="Headline"
@@ -180,7 +175,7 @@ const ListItemExample = () => {
               source={require('../../../example/assets/images/strawberries.jpg')}
             />
           )}
-          right={() => <Checkbox status="checked" />}
+          right={(props) => <Checkbox status="checked" style={props.style} />}
         />
         <Divider />
       </List.Section>
@@ -228,7 +223,7 @@ const ListItemExample = () => {
               source={require('../../../example/assets/images/strawberries.jpg')}
             />
           )}
-          right={() => <CenteredCheckbox />}
+          right={(props) => <Checkbox status="checked" style={props.style} />}
         />
         <List.Item
           title="Headline"
@@ -240,7 +235,7 @@ const ListItemExample = () => {
               source={require('../../../example/assets/images/strawberries.jpg')}
             />
           )}
-          right={() => <CenteredCheckbox />}
+          right={(props) => <Checkbox status="checked" style={props.style} />}
         />
         <List.Item
           title="Headline"
@@ -252,7 +247,7 @@ const ListItemExample = () => {
               source={require('../../../example/assets/images/strawberries.jpg')}
             />
           )}
-          right={() => <Checkbox status="checked" />}
+          right={(props) => <Checkbox status="checked" style={props.style} />}
         />
         <Divider />
       </List.Section>
@@ -260,47 +255,41 @@ const ListItemExample = () => {
       <List.Section title="With switch">
         <List.Item
           title="Headline"
-          right={() => <Switch disabled style={styles.centered} />}
+          right={(props) => <Switch disabled style={props.style} />}
         />
         <List.Item
           title="Headline"
           description="Supporting text"
-          right={() => <Switch disabled style={styles.centered} />}
+          right={(props) => <Switch disabled style={props.style} />}
         />
         <List.Item
           title="Headline"
           description="Supporting text that is long enough to fill up multiple lines in the item"
-          right={() => <Switch disabled />}
+          right={(props) => <Switch disabled style={props.style} />}
         />
         <Divider />
         <List.Item
           title="Headline"
           left={(props) => <List.Icon {...props} icon="account-outline" />}
-          right={() => <Switch disabled style={styles.centered} />}
+          right={(props) => <Switch disabled style={props.style} />}
         />
         <List.Item
           title="Headline"
           description="Supporting text"
           left={(props) => <List.Icon {...props} icon="account-outline" />}
-          right={() => <Switch disabled style={styles.centered} />}
+          right={(props) => <Switch disabled style={props.style} />}
         />
         <List.Item
           title="Headline"
           description="Supporting text that is long enough to fill up multiple lines in the item"
           left={(props) => <List.Icon {...props} icon="account-outline" />}
-          right={() => <Switch disabled />}
+          right={(props) => <Switch disabled style={props.style} />}
         />
         <Divider />
       </List.Section>
     </ScreenWrapper>
   );
 };
-
-const styles = StyleSheet.create({
-  centered: {
-    alignSelf: 'center',
-  },
-});
 
 ListItemExample.title = 'List.Item';
 

--- a/example/src/Examples/ListItemExample.tsx
+++ b/example/src/Examples/ListItemExample.tsx
@@ -1,10 +1,34 @@
+import { useState } from 'react';
+
 import { List, Divider, Checkbox, Avatar, Switch } from 'react-native-paper';
 
 import ScreenWrapper from '../ScreenWrapper';
 
+const SelectableSection = () => {
+  const [selected, setSelected] = useState(0);
+
+  return (
+    <List.Section title="Selected">
+      {[0, 1, 2].map((index) => (
+        <List.Item
+          key={index}
+          title="Headline"
+          description="Supporting text"
+          selected={index === selected}
+          onPress={() => setSelected(index)}
+          left={(props) => <List.Icon {...props} icon="account-outline" />}
+        />
+      ))}
+      <Divider />
+    </List.Section>
+  );
+};
+
 const ListItemExample = () => {
   return (
     <ScreenWrapper>
+      <SelectableSection />
+
       <List.Section title="Text-only">
         <List.Item title="Headline" />
         <List.Item title="Headline" description="Supporting text" />

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -212,16 +212,6 @@ const ListAccordion = ({
     setIsDescriptionMultiline(nativeEvent.lines.length >= 2);
   };
 
-  const getVerticalPaddingStyle = () => {
-    if (!description) {
-      return styles.containerOneLine;
-    }
-
-    return isDescriptionMultiline
-      ? styles.containerThreeLine
-      : styles.containerTwoLine;
-  };
-
   const handlePressAction = (e: GestureResponderEvent) => {
     onPress?.(e);
 
@@ -257,7 +247,11 @@ const ListAccordion = ({
         style={{ backgroundColor: theme.colors[ListTokens.containerColor] }}
       >
         <TouchableRipple
-          style={[styles.container, getVerticalPaddingStyle(), style]}
+          style={[
+            styles.container,
+            description ? styles.containerTwoLine : styles.containerOneLine,
+            style,
+          ]}
           onPress={handlePress}
           onLongPress={onLongPress}
           delayLongPress={delayLongPress}
@@ -323,7 +317,7 @@ const ListAccordion = ({
               ) : (
                 <MaterialCommunityIcon
                   name={isExpanded ? 'chevron-up' : 'chevron-down'}
-                  color={theme.colors[ListTokens.trailingIconColor]}
+                  color={theme.colors[ListTokens.expandTrailingIconColor]}
                   size={24}
                   direction={direction}
                 />
@@ -358,16 +352,15 @@ ListAccordion.displayName = 'List.Accordion';
 
 const styles = StyleSheet.create({
   container: {
+    paddingVertical: ListTokens.verticalPadding,
     paddingRight: ListTokens.trailingSpace,
+    justifyContent: 'center',
   },
   containerOneLine: {
-    paddingVertical: ListTokens.oneLineVerticalPadding,
+    minHeight: ListTokens.oneLineContainerHeight,
   },
   containerTwoLine: {
-    paddingVertical: ListTokens.twoLineVerticalPadding,
-  },
-  containerThreeLine: {
-    paddingVertical: ListTokens.threeLineVerticalPadding,
+    minHeight: ListTokens.twoLineContainerHeight,
   },
   row: {
     flexDirection: 'row',

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -48,6 +48,10 @@ export type Props = {
    */
   expanded?: boolean;
   /**
+   * Whether to highlight the accordion as selected.
+   */
+  selected?: boolean;
+  /**
    * Function to execute on press.
    */
   onPress?: (e: GestureResponderEvent) => void;
@@ -191,6 +195,7 @@ const ListAccordion = ({
   onLongPress,
   delayLongPress,
   expanded: expandedProp,
+  selected,
   'aria-label': ariaLabel,
   pointerEvents = 'none',
   titleMaxFontSizeMultiplier,
@@ -234,7 +239,12 @@ const ListAccordion = ({
     ? groupContext.expandedId === id
     : expandedInternal;
 
-  const { descriptionColor, titleTextColor } = getAccordionColors({ theme });
+  const {
+    descriptionColor,
+    titleTextColor,
+    leadingIconColor,
+    trailingIconColor,
+  } = getAccordionColors({ theme, selected });
 
   const handlePress =
     groupContext && id !== undefined
@@ -253,7 +263,11 @@ const ListAccordion = ({
   return (
     <View>
       <View
-        style={{ backgroundColor: theme.colors[ListTokens.containerColor] }}
+        style={{
+          backgroundColor: selected
+            ? theme.colors[ListTokens.selectedContainerColor]
+            : theme.colors[ListTokens.containerColor],
+        }}
       >
         <ListRowContext.Provider value={rowContext}>
           <TouchableRipple
@@ -268,6 +282,7 @@ const ListAccordion = ({
             delayLongPress={delayLongPress}
             role="button"
             aria-expanded={isExpanded}
+            aria-selected={selected}
             aria-label={ariaLabel}
             testID={testID}
             theme={theme}
@@ -281,7 +296,7 @@ const ListAccordion = ({
             >
               {left
                 ? left({
-                    color: theme.colors[ListTokens.leadingIconColor],
+                    color: leadingIconColor,
                     style: getLeftStyles(isDescriptionMultiline, description),
                   })
                 : null}
@@ -328,7 +343,7 @@ const ListAccordion = ({
                 ) : (
                   <MaterialCommunityIcon
                     name={isExpanded ? 'chevron-up' : 'chevron-down'}
-                    color={theme.colors[ListTokens.expandTrailingIconColor]}
+                    color={trailingIconColor}
                     size={24}
                     direction={direction}
                   />

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -202,13 +202,24 @@ const ListAccordion = ({
   const [expanded, setExpanded] = React.useState<boolean>(
     expandedProp || false
   );
-  const [alignToTop, setAlignToTop] = React.useState(false);
+  const [isDescriptionMultiline, setIsDescriptionMultiline] =
+    React.useState(false);
 
   const onDescriptionTextLayout = (
     event: NativeSyntheticEvent<TextLayoutEventData>
   ) => {
     const { nativeEvent } = event;
-    setAlignToTop(nativeEvent.lines.length >= 2);
+    setIsDescriptionMultiline(nativeEvent.lines.length >= 2);
+  };
+
+  const getVerticalPaddingStyle = () => {
+    if (!description) {
+      return styles.containerOneLine;
+    }
+
+    return isDescriptionMultiline
+      ? styles.containerThreeLine
+      : styles.containerTwoLine;
   };
 
   const handlePressAction = (e: GestureResponderEvent) => {
@@ -246,11 +257,7 @@ const ListAccordion = ({
         style={{ backgroundColor: theme.colors[ListTokens.containerColor] }}
       >
         <TouchableRipple
-          style={[
-            styles.container,
-            description ? styles.containerTwoLine : styles.containerOneLine,
-            style,
-          ]}
+          style={[styles.container, getVerticalPaddingStyle(), style]}
           onPress={handlePress}
           onLongPress={onLongPress}
           delayLongPress={delayLongPress}
@@ -270,12 +277,13 @@ const ListAccordion = ({
             {left
               ? left({
                   color: theme.colors[ListTokens.leadingIconColor],
-                  style: getLeftStyles(alignToTop, description),
+                  style: getLeftStyles(isDescriptionMultiline, description),
                 })
               : null}
             <View style={[styles.contentItem, styles.content, contentStyle]}>
               <Text
                 variant="bodyLarge"
+                theme={theme}
                 selectable={false}
                 numberOfLines={titleNumberOfLines}
                 style={[
@@ -291,6 +299,7 @@ const ListAccordion = ({
               {description ? (
                 <Text
                   variant="bodyMedium"
+                  theme={theme}
                   selectable={false}
                   numberOfLines={descriptionNumberOfLines}
                   style={[
@@ -356,6 +365,9 @@ const styles = StyleSheet.create({
   },
   containerTwoLine: {
     paddingVertical: ListTokens.twoLineVerticalPadding,
+  },
+  containerThreeLine: {
+    paddingVertical: ListTokens.threeLineVerticalPadding,
   },
   row: {
     flexDirection: 'row',

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -12,12 +12,25 @@ import type {
   ViewStyle,
 } from 'react-native';
 
+import Animated, {
+  Easing,
+  ReduceMotion,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import type {
+  EntryAnimationsValues,
+  ExitAnimationsValues,
+} from 'react-native-reanimated';
+
 import { ListAccordionGroupContext } from './ListAccordionGroup';
 import { ListTokens } from './tokens';
 import type { ListChildProps, Style } from './utils';
 import { ListRowContext, getAccordionColors, getLeftStyles } from './utils';
 import { useLocale } from '../../core/locale';
 import { useInternalTheme } from '../../core/theming';
+import { useReduceMotion } from '../../theme/accessibility/ReduceMotionContext';
 import type { ThemeProp } from '../../theme/types';
 import MaterialCommunityIcon from '../MaterialCommunityIcon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
@@ -239,6 +252,62 @@ const ListAccordion = ({
     ? groupContext.expandedId === id
     : expandedInternal;
 
+  const reduceMotion = useReduceMotion();
+  const reanimatedReduceMotion = reduceMotion
+    ? ReduceMotion.Always
+    : ReduceMotion.Never;
+
+  const timingConfig = React.useMemo(
+    () => ({
+      duration: theme.motion.duration.medium2,
+      easing: Easing.bezier(...theme.motion.easing.emphasized),
+      reduceMotion: reanimatedReduceMotion,
+    }),
+    [
+      theme.motion.duration.medium2,
+      theme.motion.easing.emphasized,
+      reanimatedReduceMotion,
+    ]
+  );
+
+  const chevronProgress = useSharedValue(isExpanded ? 1 : 0);
+
+  React.useEffect(() => {
+    chevronProgress.value = withTiming(isExpanded ? 1 : 0, timingConfig);
+  }, [isExpanded, chevronProgress, timingConfig]);
+
+  const chevronStyle = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${chevronProgress.value * 180}deg` }],
+  }));
+
+  const expandAnimation = React.useCallback(
+    (values: EntryAnimationsValues) => {
+      'worklet';
+      return {
+        initialValues: { height: 0, opacity: 0 },
+        animations: {
+          height: withTiming(values.targetHeight, timingConfig),
+          opacity: withTiming(1, timingConfig),
+        },
+      };
+    },
+    [timingConfig]
+  );
+
+  const collapseAnimation = React.useCallback(
+    (values: ExitAnimationsValues) => {
+      'worklet';
+      return {
+        initialValues: { height: values.currentHeight, opacity: 1 },
+        animations: {
+          height: withTiming(0, timingConfig),
+          opacity: withTiming(0, timingConfig),
+        },
+      };
+    },
+    [timingConfig]
+  );
+
   const {
     descriptionColor,
     titleTextColor,
@@ -341,12 +410,14 @@ const ListAccordion = ({
                     isExpanded: isExpanded,
                   })
                 ) : (
-                  <MaterialCommunityIcon
-                    name={isExpanded ? 'chevron-up' : 'chevron-down'}
-                    color={trailingIconColor}
-                    size={24}
-                    direction={direction}
-                  />
+                  <Animated.View style={chevronStyle}>
+                    <MaterialCommunityIcon
+                      name="chevron-down"
+                      color={trailingIconColor}
+                      size={24}
+                      direction={direction}
+                    />
+                  </Animated.View>
                 )}
               </View>
             </View>
@@ -354,8 +425,13 @@ const ListAccordion = ({
         </ListRowContext.Provider>
       </View>
 
-      {isExpanded
-        ? React.Children.map(children, (child) => {
+      {isExpanded ? (
+        <Animated.View
+          entering={expandAnimation}
+          exiting={collapseAnimation}
+          style={styles.expandedContent}
+        >
+          {React.Children.map(children, (child) => {
             if (
               left &&
               React.isValidElement<ListChildProps>(child) &&
@@ -369,8 +445,9 @@ const ListAccordion = ({
             }
 
             return child;
-          })
-        : null}
+          })}
+        </Animated.View>
+      ) : null}
     </View>
   );
 };
@@ -404,6 +481,9 @@ const styles = StyleSheet.create({
   },
   child: {
     paddingLeft: 40,
+  },
+  expandedContent: {
+    overflow: 'hidden',
   },
   content: {
     flex: 1,

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -13,8 +13,9 @@ import type {
 } from 'react-native';
 
 import { ListAccordionGroupContext } from './ListAccordionGroup';
+import { ListTokens } from './tokens';
 import type { ListChildProps, Style } from './utils';
-import { getAccordionColors, getLeftStyles } from './utils';
+import { getLeftStyles } from './utils';
 import { useLocale } from '../../core/locale';
 import { useInternalTheme } from '../../core/theming';
 import type { ThemeProp } from '../../theme/types';
@@ -232,10 +233,8 @@ const ListAccordion = ({
     ? groupContext.expandedId === id
     : expandedInternal;
 
-  const { descriptionColor, titleTextColor } = getAccordionColors({
-    theme,
-    isExpanded,
-  });
+  const titleTextColor = theme.colors[ListTokens.headlineColor];
+  const descriptionColor = theme.colors[ListTokens.supportingTextColor];
 
   const handlePress =
     groupContext && id !== undefined
@@ -243,9 +242,15 @@ const ListAccordion = ({
       : handlePressAction;
   return (
     <View>
-      <View style={{ backgroundColor: theme?.colors?.background }}>
+      <View
+        style={{ backgroundColor: theme.colors[ListTokens.containerColor] }}
+      >
         <TouchableRipple
-          style={[styles.container, style]}
+          style={[
+            styles.container,
+            description ? styles.containerTwoLine : styles.containerOneLine,
+            style,
+          ]}
           onPress={handlePress}
           onLongPress={onLongPress}
           delayLongPress={delayLongPress}
@@ -264,16 +269,16 @@ const ListAccordion = ({
           >
             {left
               ? left({
-                  color: isExpanded ? theme.colors?.primary : descriptionColor,
+                  color: theme.colors[ListTokens.leadingIconColor],
                   style: getLeftStyles(alignToTop, description),
                 })
               : null}
             <View style={[styles.contentItem, styles.content, contentStyle]}>
               <Text
+                variant="bodyLarge"
                 selectable={false}
                 numberOfLines={titleNumberOfLines}
                 style={[
-                  styles.title,
                   {
                     color: titleTextColor,
                   },
@@ -285,10 +290,10 @@ const ListAccordion = ({
               </Text>
               {description ? (
                 <Text
+                  variant="bodyMedium"
                   selectable={false}
                   numberOfLines={descriptionNumberOfLines}
                   style={[
-                    styles.description,
                     {
                       color: descriptionColor,
                     },
@@ -301,12 +306,7 @@ const ListAccordion = ({
                 </Text>
               ) : null}
             </View>
-            <View
-              style={[
-                styles.trailingItem,
-                description ? styles.multiline : undefined,
-              ]}
-            >
+            <View style={styles.trailingItem}>
               {right ? (
                 right({
                   isExpanded: isExpanded,
@@ -314,7 +314,7 @@ const ListAccordion = ({
               ) : (
                 <MaterialCommunityIcon
                   name={isExpanded ? 'chevron-up' : 'chevron-down'}
-                  color={descriptionColor}
+                  color={theme.colors[ListTokens.trailingIconColor]}
                   size={24}
                   direction={direction}
                 />
@@ -349,29 +349,22 @@ ListAccordion.displayName = 'List.Accordion';
 
 const styles = StyleSheet.create({
   container: {
-    paddingVertical: 8,
-    paddingRight: 24,
+    paddingRight: ListTokens.trailingSpace,
+  },
+  containerOneLine: {
+    paddingVertical: ListTokens.oneLineVerticalPadding,
+  },
+  containerTwoLine: {
+    paddingVertical: ListTokens.twoLineVerticalPadding,
   },
   row: {
     flexDirection: 'row',
-    marginVertical: 6,
-  },
-  multiline: {
-    height: 40,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  title: {
-    fontSize: 16,
-  },
-  description: {
-    fontSize: 14,
   },
   contentItem: {
-    paddingLeft: 16,
+    paddingLeft: ListTokens.leadingSpace,
   },
   trailingItem: {
-    marginVertical: 6,
+    alignSelf: 'center',
     paddingLeft: 8,
   },
   child: {

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -15,7 +15,7 @@ import type {
 import { ListAccordionGroupContext } from './ListAccordionGroup';
 import { ListTokens } from './tokens';
 import type { ListChildProps, Style } from './utils';
-import { getAccordionColors, getLeftStyles } from './utils';
+import { ListRowContext, getAccordionColors, getLeftStyles } from './utils';
 import { useLocale } from '../../core/locale';
 import { useInternalTheme } from '../../core/theming';
 import type { ThemeProp } from '../../theme/types';
@@ -240,90 +240,103 @@ const ListAccordion = ({
     groupContext && id !== undefined
       ? () => groupContext.onAccordionPress(id)
       : handlePressAction;
+
+  const rowContext = React.useMemo(
+    () => ({
+      verticalPadding: isDescriptionMultiline
+        ? ListTokens.threeLineVerticalPadding
+        : ListTokens.verticalPadding,
+    }),
+    [isDescriptionMultiline]
+  );
+
   return (
     <View>
       <View
         style={{ backgroundColor: theme.colors[ListTokens.containerColor] }}
       >
-        <TouchableRipple
-          style={[
-            styles.container,
-            description ? styles.containerTwoLine : styles.containerOneLine,
-            style,
-          ]}
-          onPress={handlePress}
-          onLongPress={onLongPress}
-          delayLongPress={delayLongPress}
-          role="button"
-          aria-expanded={isExpanded}
-          aria-label={ariaLabel}
-          testID={testID}
-          theme={theme}
-          background={background}
-          borderless
-          hitSlop={hitSlop}
-        >
-          <View
-            style={[styles.row, containerStyle]}
-            pointerEvents={pointerEvents}
+        <ListRowContext.Provider value={rowContext}>
+          <TouchableRipple
+            style={[
+              styles.container,
+              description ? styles.containerTwoLine : styles.containerOneLine,
+              isDescriptionMultiline && styles.containerThreeLine,
+              style,
+            ]}
+            onPress={handlePress}
+            onLongPress={onLongPress}
+            delayLongPress={delayLongPress}
+            role="button"
+            aria-expanded={isExpanded}
+            aria-label={ariaLabel}
+            testID={testID}
+            theme={theme}
+            background={background}
+            borderless
+            hitSlop={hitSlop}
           >
-            {left
-              ? left({
-                  color: theme.colors[ListTokens.leadingIconColor],
-                  style: getLeftStyles(isDescriptionMultiline, description),
-                })
-              : null}
-            <View style={[styles.contentItem, styles.content, contentStyle]}>
-              <Text
-                variant="bodyLarge"
-                theme={theme}
-                selectable={false}
-                numberOfLines={titleNumberOfLines}
-                style={[
-                  {
-                    color: titleTextColor,
-                  },
-                  titleStyle,
-                ]}
-                maxFontSizeMultiplier={titleMaxFontSizeMultiplier}
-              >
-                {title}
-              </Text>
-              {description ? (
+            <View
+              style={[styles.row, containerStyle]}
+              pointerEvents={pointerEvents}
+            >
+              {left
+                ? left({
+                    color: theme.colors[ListTokens.leadingIconColor],
+                    style: getLeftStyles(isDescriptionMultiline, description),
+                  })
+                : null}
+              <View style={[styles.contentItem, styles.content, contentStyle]}>
                 <Text
-                  variant="bodyMedium"
+                  variant="bodyLarge"
                   theme={theme}
                   selectable={false}
-                  numberOfLines={descriptionNumberOfLines}
+                  numberOfLines={titleNumberOfLines}
                   style={[
                     {
-                      color: descriptionColor,
+                      color: titleTextColor,
                     },
-                    descriptionStyle,
+                    titleStyle,
                   ]}
-                  onTextLayout={onDescriptionTextLayout}
-                  maxFontSizeMultiplier={descriptionMaxFontSizeMultiplier}
+                  maxFontSizeMultiplier={titleMaxFontSizeMultiplier}
                 >
-                  {description}
+                  {title}
                 </Text>
-              ) : null}
+                {description ? (
+                  <Text
+                    variant="bodyMedium"
+                    theme={theme}
+                    selectable={false}
+                    numberOfLines={descriptionNumberOfLines}
+                    style={[
+                      {
+                        color: descriptionColor,
+                      },
+                      descriptionStyle,
+                    ]}
+                    onTextLayout={onDescriptionTextLayout}
+                    maxFontSizeMultiplier={descriptionMaxFontSizeMultiplier}
+                  >
+                    {description}
+                  </Text>
+                ) : null}
+              </View>
+              <View style={styles.trailingItem}>
+                {right ? (
+                  right({
+                    isExpanded: isExpanded,
+                  })
+                ) : (
+                  <MaterialCommunityIcon
+                    name={isExpanded ? 'chevron-up' : 'chevron-down'}
+                    color={theme.colors[ListTokens.expandTrailingIconColor]}
+                    size={24}
+                    direction={direction}
+                  />
+                )}
+              </View>
             </View>
-            <View style={styles.trailingItem}>
-              {right ? (
-                right({
-                  isExpanded: isExpanded,
-                })
-              ) : (
-                <MaterialCommunityIcon
-                  name={isExpanded ? 'chevron-up' : 'chevron-down'}
-                  color={theme.colors[ListTokens.expandTrailingIconColor]}
-                  size={24}
-                  direction={direction}
-                />
-              )}
-            </View>
-          </View>
-        </TouchableRipple>
+          </TouchableRipple>
+        </ListRowContext.Provider>
       </View>
 
       {isExpanded
@@ -361,6 +374,9 @@ const styles = StyleSheet.create({
   containerTwoLine: {
     minHeight: ListTokens.twoLineContainerHeight,
   },
+  containerThreeLine: {
+    paddingVertical: ListTokens.threeLineVerticalPadding,
+  },
   row: {
     flexDirection: 'row',
   },
@@ -369,7 +385,7 @@ const styles = StyleSheet.create({
   },
   trailingItem: {
     alignSelf: 'center',
-    paddingLeft: 8,
+    paddingLeft: ListTokens.leadingSpace,
   },
   child: {
     paddingLeft: 40,

--- a/src/components/List/ListAccordion.tsx
+++ b/src/components/List/ListAccordion.tsx
@@ -15,7 +15,7 @@ import type {
 import { ListAccordionGroupContext } from './ListAccordionGroup';
 import { ListTokens } from './tokens';
 import type { ListChildProps, Style } from './utils';
-import { getLeftStyles } from './utils';
+import { getAccordionColors, getLeftStyles } from './utils';
 import { useLocale } from '../../core/locale';
 import { useInternalTheme } from '../../core/theming';
 import type { ThemeProp } from '../../theme/types';
@@ -234,8 +234,7 @@ const ListAccordion = ({
     ? groupContext.expandedId === id
     : expandedInternal;
 
-  const titleTextColor = theme.colors[ListTokens.headlineColor];
-  const descriptionColor = theme.colors[ListTokens.supportingTextColor];
+  const { descriptionColor, titleTextColor } = getAccordionColors({ theme });
 
   const handlePress =
     groupContext && id !== undefined

--- a/src/components/List/ListIcon.tsx
+++ b/src/components/List/ListIcon.tsx
@@ -1,6 +1,8 @@
+import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
 import type { ColorValue, StyleProp, ViewStyle } from 'react-native';
 
+import { ListItemContext } from './ListItemContext';
 import { useInternalTheme } from '../../core/theming';
 import type { ThemeProp } from '../../theme/types';
 import Icon from '../Icon';
@@ -50,10 +52,12 @@ const ListIcon = ({
   theme: themeOverrides,
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
+  const listItem = React.useContext(ListItemContext);
+  const color = iconColor ?? listItem?.color;
 
   return (
     <View style={[styles.item, style]} pointerEvents="box-none">
-      <Icon source={icon} size={ICON_SIZE} color={iconColor} theme={theme} />
+      <Icon source={icon} size={ICON_SIZE} color={color} theme={theme} />
     </View>
   );
 };

--- a/src/components/List/ListImage.tsx
+++ b/src/components/List/ListImage.tsx
@@ -1,6 +1,9 @@
+import * as React from 'react';
 import { StyleSheet, Image } from 'react-native';
 import type { StyleProp, ImageSourcePropType, ImageStyle } from 'react-native';
 
+import { ListTokens } from './tokens';
+import { ListRowContext } from './utils';
 import type { ThemeProp } from '../../theme/types';
 
 export type Props = {
@@ -37,9 +40,17 @@ const ListImage = ({
   variant = 'image',
   theme: _theme,
 }: Props) => {
+  const { verticalPadding } = React.useContext(ListRowContext);
+
   const getStyles = () => {
     if (variant === 'video') {
-      return [style, styles.video];
+      return [
+        style,
+        styles.video,
+        {
+          marginVertical: ListTokens.threeLineVerticalPadding - verticalPadding,
+        },
+      ];
     }
 
     return [style, styles.image];

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -59,6 +59,10 @@ export type Props = Omit<
    */
   right?: (props: { color: ColorValue; style?: Style }) => React.ReactNode;
   /**
+   * Whether to highlight the list item as selected.
+   */
+  selected?: boolean;
+  /**
    * Function to execute on press.
    */
   onPress?: (e: GestureResponderEvent) => void;
@@ -149,6 +153,7 @@ const ListItem = ({
   right,
   title,
   description,
+  selected,
   onPress,
   theme: themeOverrides,
   style,
@@ -176,6 +181,13 @@ const ListItem = ({
     const { nativeEvent } = event;
     setIsDescriptionMultiline(nativeEvent.lines.length >= 2);
   };
+
+  const backgroundColor = selected
+    ? theme.colors[ListTokens.selectedContainerColor]
+    : undefined;
+  const titleColor = selected
+    ? theme.colors[ListTokens.selectedContentColor]
+    : theme.colors[ListTokens.headlineColor];
 
   const renderDescription = (
     descriptionColor: ColorValue,
@@ -205,8 +217,6 @@ const ListItem = ({
   };
 
   const renderTitle = () => {
-    const titleColor = theme.colors[ListTokens.headlineColor];
-
     return typeof title === 'function' ? (
       title({
         selectable: false,
@@ -229,7 +239,9 @@ const ListItem = ({
     );
   };
 
-  const descriptionColor = theme.colors[ListTokens.supportingTextColor];
+  const descriptionColor = selected
+    ? theme.colors[ListTokens.selectedContentColor]
+    : theme.colors[ListTokens.supportingTextColor];
 
   const rowContext = React.useMemo(
     () => ({
@@ -249,16 +261,20 @@ const ListItem = ({
           styles.container,
           description ? styles.containerTwoLine : styles.containerOneLine,
           isDescriptionMultiline && styles.containerThreeLine,
+          { backgroundColor },
           style,
         ]}
         onPress={onPress}
+        aria-selected={selected}
         theme={theme}
         testID={testID}
       >
         <View style={[styles.row, containerStyle]}>
           {left
             ? left({
-                color: theme.colors[ListTokens.leadingIconColor],
+                color: selected
+                  ? theme.colors[ListTokens.selectedContentColor]
+                  : theme.colors[ListTokens.leadingIconColor],
                 style: getLeftStyles(isDescriptionMultiline, description),
               })
             : null}
@@ -274,7 +290,9 @@ const ListItem = ({
           </View>
           {right
             ? right({
-                color: theme.colors[ListTokens.trailingIconColor],
+                color: selected
+                  ? theme.colors[ListTokens.selectedContentColor]
+                  : theme.colors[ListTokens.trailingIconColor],
                 style: getRightStyles(isDescriptionMultiline, description),
               })
             : null}

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -11,6 +11,7 @@ import type {
   ViewStyle,
 } from 'react-native';
 
+import { ListTokens } from './tokens';
 import { getLeftStyles, getRightStyles } from './utils';
 import type { Style } from './utils';
 import { useInternalTheme } from '../../core/theming';
@@ -184,18 +185,15 @@ const ListItem = ({
         selectable: false,
         ellipsizeMode: descriptionEllipsizeMode,
         color: descriptionColor,
-        fontSize: styles.description.fontSize,
+        fontSize: theme.fonts.bodyMedium.fontSize,
       })
     ) : (
       <Text
+        variant="bodyMedium"
         selectable={false}
         numberOfLines={descriptionNumberOfLines}
         ellipsizeMode={descriptionEllipsizeMode}
-        style={[
-          styles.description,
-          { color: descriptionColor },
-          descriptionStyle,
-        ]}
+        style={[{ color: descriptionColor }, descriptionStyle]}
         onTextLayout={onDescriptionTextLayout}
         maxFontSizeMultiplier={descriptionMaxFontSizeMultiplier}
       >
@@ -205,21 +203,22 @@ const ListItem = ({
   };
 
   const renderTitle = () => {
-    const titleColor = theme.colors.onSurface;
+    const titleColor = theme.colors[ListTokens.headlineColor];
 
     return typeof title === 'function' ? (
       title({
         selectable: false,
         ellipsizeMode: titleEllipsizeMode,
         color: titleColor,
-        fontSize: styles.title.fontSize,
+        fontSize: theme.fonts.bodyLarge.fontSize,
       })
     ) : (
       <Text
+        variant="bodyLarge"
         selectable={false}
         ellipsizeMode={titleEllipsizeMode}
         numberOfLines={titleNumberOfLines}
-        style={[styles.title, { color: titleColor }, titleStyle]}
+        style={[{ color: titleColor }, titleStyle]}
         maxFontSizeMultiplier={titleMaxFontSizeMultiplier}
       >
         {title}
@@ -227,13 +226,17 @@ const ListItem = ({
     );
   };
 
-  const descriptionColor = theme.colors.onSurfaceVariant;
+  const descriptionColor = theme.colors[ListTokens.supportingTextColor];
 
   return (
     <TouchableRipple
       {...rest}
       ref={ref}
-      style={[styles.container, style]}
+      style={[
+        styles.container,
+        description ? styles.containerTwoLine : styles.containerOneLine,
+        style,
+      ]}
       onPress={onPress}
       theme={theme}
       testID={testID}
@@ -270,22 +273,20 @@ ListItem.displayName = 'List.Item';
 
 const styles = StyleSheet.create({
   container: {
-    paddingVertical: 8,
-    paddingRight: 24,
+    paddingRight: ListTokens.trailingSpace,
+  },
+  containerOneLine: {
+    paddingVertical: ListTokens.oneLineVerticalPadding,
+  },
+  containerTwoLine: {
+    paddingVertical: ListTokens.twoLineVerticalPadding,
   },
   row: {
     width: '100%',
     flexDirection: 'row',
-    marginVertical: 6,
-  },
-  title: {
-    fontSize: 16,
-  },
-  description: {
-    fontSize: 14,
   },
   item: {
-    paddingLeft: 16,
+    paddingLeft: ListTokens.leadingSpace,
   },
   content: {
     flexShrink: 1,

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -12,7 +12,7 @@ import type {
 } from 'react-native';
 
 import { ListTokens } from './tokens';
-import { getLeftStyles, getRightStyles } from './utils';
+import { ListRowContext, getLeftStyles, getRightStyles } from './utils';
 import type { Style } from './utils';
 import { useInternalTheme } from '../../core/theming';
 import type { ThemeProp } from '../../theme/types';
@@ -231,44 +231,56 @@ const ListItem = ({
 
   const descriptionColor = theme.colors[ListTokens.supportingTextColor];
 
-  return (
-    <TouchableRipple
-      {...rest}
-      ref={ref}
-      style={[
-        styles.container,
-        description ? styles.containerTwoLine : styles.containerOneLine,
-        style,
-      ]}
-      onPress={onPress}
-      theme={theme}
-      testID={testID}
-    >
-      <View style={[styles.row, containerStyle]}>
-        {left
-          ? left({
-              color: theme.colors[ListTokens.leadingIconColor],
-              style: getLeftStyles(isDescriptionMultiline, description),
-            })
-          : null}
-        <View
-          style={[styles.item, styles.content, contentStyle]}
-          testID={testID ? `${testID}-content` : undefined}
-        >
-          {renderTitle()}
+  const rowContext = React.useMemo(
+    () => ({
+      verticalPadding: isDescriptionMultiline
+        ? ListTokens.threeLineVerticalPadding
+        : ListTokens.verticalPadding,
+    }),
+    [isDescriptionMultiline]
+  );
 
-          {description
-            ? renderDescription(descriptionColor, description)
+  return (
+    <ListRowContext.Provider value={rowContext}>
+      <TouchableRipple
+        {...rest}
+        ref={ref}
+        style={[
+          styles.container,
+          description ? styles.containerTwoLine : styles.containerOneLine,
+          isDescriptionMultiline && styles.containerThreeLine,
+          style,
+        ]}
+        onPress={onPress}
+        theme={theme}
+        testID={testID}
+      >
+        <View style={[styles.row, containerStyle]}>
+          {left
+            ? left({
+                color: theme.colors[ListTokens.leadingIconColor],
+                style: getLeftStyles(isDescriptionMultiline, description),
+              })
+            : null}
+          <View
+            style={[styles.item, styles.content, contentStyle]}
+            testID={testID ? `${testID}-content` : undefined}
+          >
+            {renderTitle()}
+
+            {description
+              ? renderDescription(descriptionColor, description)
+              : null}
+          </View>
+          {right
+            ? right({
+                color: theme.colors[ListTokens.trailingIconColor],
+                style: getRightStyles(isDescriptionMultiline, description),
+              })
             : null}
         </View>
-        {right
-          ? right({
-              color: theme.colors[ListTokens.trailingIconColor],
-              style: getRightStyles(isDescriptionMultiline, description),
-            })
-          : null}
-      </View>
-    </TouchableRipple>
+      </TouchableRipple>
+    </ListRowContext.Provider>
   );
 };
 
@@ -285,6 +297,9 @@ const styles = StyleSheet.create({
   },
   containerTwoLine: {
     minHeight: ListTokens.twoLineContainerHeight,
+  },
+  containerThreeLine: {
+    paddingVertical: ListTokens.threeLineVerticalPadding,
   },
   row: {
     width: '100%',

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -11,6 +11,7 @@ import type {
   ViewStyle,
 } from 'react-native';
 
+import { ListItemContext } from './ListItemContext';
 import { ListTokens } from './tokens';
 import { ListRowContext, getLeftStyles, getRightStyles } from './utils';
 import type { Style } from './utils';
@@ -50,6 +51,14 @@ export type Props = Omit<
    * Description text for the list item or callback which returns a React element to display the description.
    */
   description?: Description;
+  /**
+   * Element to display in the leading slot. Takes precedence over `left`.
+   */
+  leading?: React.ReactNode;
+  /**
+   * Element to display in the trailing slot. Takes precedence over `right`.
+   */
+  trailing?: React.ReactNode;
   /**
    * Callback which returns a React element to display on the left side.
    */
@@ -151,6 +160,8 @@ export type Props = Omit<
 const ListItem = ({
   left,
   right,
+  leading,
+  trailing,
   title,
   description,
   selected,
@@ -252,6 +263,45 @@ const ListItem = ({
     [isDescriptionMultiline]
   );
 
+  const accessoryContext = React.useMemo(
+    () => ({ color: descriptionColor }),
+    [descriptionColor]
+  );
+
+  const renderLeading = () => {
+    const accessoryStyle = getLeftStyles(isDescriptionMultiline, description);
+
+    if (leading) {
+      return <View style={accessoryStyle}>{leading}</View>;
+    }
+
+    return left
+      ? left({
+          color: selected
+            ? theme.colors[ListTokens.selectedContentColor]
+            : theme.colors[ListTokens.leadingIconColor],
+          style: accessoryStyle,
+        })
+      : null;
+  };
+
+  const renderTrailing = () => {
+    const accessoryStyle = getRightStyles(isDescriptionMultiline, description);
+
+    if (trailing) {
+      return <View style={accessoryStyle}>{trailing}</View>;
+    }
+
+    return right
+      ? right({
+          color: selected
+            ? theme.colors[ListTokens.selectedContentColor]
+            : theme.colors[ListTokens.trailingIconColor],
+          style: accessoryStyle,
+        })
+      : null;
+  };
+
   return (
     <ListRowContext.Provider value={rowContext}>
       <TouchableRipple
@@ -269,34 +319,22 @@ const ListItem = ({
         theme={theme}
         testID={testID}
       >
-        <View style={[styles.row, containerStyle]}>
-          {left
-            ? left({
-                color: selected
-                  ? theme.colors[ListTokens.selectedContentColor]
-                  : theme.colors[ListTokens.leadingIconColor],
-                style: getLeftStyles(isDescriptionMultiline, description),
-              })
-            : null}
-          <View
-            style={[styles.item, styles.content, contentStyle]}
-            testID={testID ? `${testID}-content` : undefined}
-          >
-            {renderTitle()}
+        <ListItemContext.Provider value={accessoryContext}>
+          <View style={[styles.row, containerStyle]}>
+            {renderLeading()}
+            <View
+              style={[styles.item, styles.content, contentStyle]}
+              testID={testID ? `${testID}-content` : undefined}
+            >
+              {renderTitle()}
 
-            {description
-              ? renderDescription(descriptionColor, description)
-              : null}
+              {description
+                ? renderDescription(descriptionColor, description)
+                : null}
+            </View>
+            {renderTrailing()}
           </View>
-          {right
-            ? right({
-                color: selected
-                  ? theme.colors[ListTokens.selectedContentColor]
-                  : theme.colors[ListTokens.trailingIconColor],
-                style: getRightStyles(isDescriptionMultiline, description),
-              })
-            : null}
-        </View>
+        </ListItemContext.Provider>
       </TouchableRipple>
     </ListRowContext.Provider>
   );

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -177,16 +177,6 @@ const ListItem = ({
     setIsDescriptionMultiline(nativeEvent.lines.length >= 2);
   };
 
-  const getVerticalPaddingStyle = () => {
-    if (!description) {
-      return styles.containerOneLine;
-    }
-
-    return isDescriptionMultiline
-      ? styles.containerThreeLine
-      : styles.containerTwoLine;
-  };
-
   const renderDescription = (
     descriptionColor: ColorValue,
     description?: Description | null
@@ -245,7 +235,11 @@ const ListItem = ({
     <TouchableRipple
       {...rest}
       ref={ref}
-      style={[styles.container, getVerticalPaddingStyle(), style]}
+      style={[
+        styles.container,
+        description ? styles.containerTwoLine : styles.containerOneLine,
+        style,
+      ]}
       onPress={onPress}
       theme={theme}
       testID={testID}
@@ -282,16 +276,15 @@ ListItem.displayName = 'List.Item';
 
 const styles = StyleSheet.create({
   container: {
+    paddingVertical: ListTokens.verticalPadding,
     paddingRight: ListTokens.trailingSpace,
+    justifyContent: 'center',
   },
   containerOneLine: {
-    paddingVertical: ListTokens.oneLineVerticalPadding,
+    minHeight: ListTokens.oneLineContainerHeight,
   },
   containerTwoLine: {
-    paddingVertical: ListTokens.twoLineVerticalPadding,
-  },
-  containerThreeLine: {
-    paddingVertical: ListTokens.threeLineVerticalPadding,
+    minHeight: ListTokens.twoLineContainerHeight,
   },
   row: {
     width: '100%',

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -167,13 +167,24 @@ const ListItem = ({
   ...rest
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
-  const [alignToTop, setAlignToTop] = React.useState(false);
+  const [isDescriptionMultiline, setIsDescriptionMultiline] =
+    React.useState(false);
 
   const onDescriptionTextLayout = (
     event: NativeSyntheticEvent<TextLayoutEventData>
   ) => {
     const { nativeEvent } = event;
-    setAlignToTop(nativeEvent.lines.length >= 2);
+    setIsDescriptionMultiline(nativeEvent.lines.length >= 2);
+  };
+
+  const getVerticalPaddingStyle = () => {
+    if (!description) {
+      return styles.containerOneLine;
+    }
+
+    return isDescriptionMultiline
+      ? styles.containerThreeLine
+      : styles.containerTwoLine;
   };
 
   const renderDescription = (
@@ -190,6 +201,7 @@ const ListItem = ({
     ) : (
       <Text
         variant="bodyMedium"
+        theme={theme}
         selectable={false}
         numberOfLines={descriptionNumberOfLines}
         ellipsizeMode={descriptionEllipsizeMode}
@@ -215,6 +227,7 @@ const ListItem = ({
     ) : (
       <Text
         variant="bodyLarge"
+        theme={theme}
         selectable={false}
         ellipsizeMode={titleEllipsizeMode}
         numberOfLines={titleNumberOfLines}
@@ -232,11 +245,7 @@ const ListItem = ({
     <TouchableRipple
       {...rest}
       ref={ref}
-      style={[
-        styles.container,
-        description ? styles.containerTwoLine : styles.containerOneLine,
-        style,
-      ]}
+      style={[styles.container, getVerticalPaddingStyle(), style]}
       onPress={onPress}
       theme={theme}
       testID={testID}
@@ -244,8 +253,8 @@ const ListItem = ({
       <View style={[styles.row, containerStyle]}>
         {left
           ? left({
-              color: descriptionColor,
-              style: getLeftStyles(alignToTop, description),
+              color: theme.colors[ListTokens.leadingIconColor],
+              style: getLeftStyles(isDescriptionMultiline, description),
             })
           : null}
         <View
@@ -260,8 +269,8 @@ const ListItem = ({
         </View>
         {right
           ? right({
-              color: descriptionColor,
-              style: getRightStyles(alignToTop, description),
+              color: theme.colors[ListTokens.trailingIconColor],
+              style: getRightStyles(isDescriptionMultiline, description),
             })
           : null}
       </View>
@@ -280,6 +289,9 @@ const styles = StyleSheet.create({
   },
   containerTwoLine: {
     paddingVertical: ListTokens.twoLineVerticalPadding,
+  },
+  containerThreeLine: {
+    paddingVertical: ListTokens.threeLineVerticalPadding,
   },
   row: {
     width: '100%',

--- a/src/components/List/ListItemContext.tsx
+++ b/src/components/List/ListItemContext.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import type { ColorValue } from 'react-native';
+
+export type ListItemContextType = {
+  color: ColorValue;
+};
+
+export const ListItemContext = React.createContext<ListItemContextType | null>(
+  null
+);

--- a/src/components/List/tokens.ts
+++ b/src/components/List/tokens.ts
@@ -1,7 +1,8 @@
 import type { ColorRole } from '../../theme/types';
 
 const sizes = {
-  verticalPadding: 12,
+  verticalPadding: 8,
+  threeLineVerticalPadding: 12,
   oneLineContainerHeight: 56,
   twoLineContainerHeight: 72,
   leadingSpace: 16,

--- a/src/components/List/tokens.ts
+++ b/src/components/List/tokens.ts
@@ -5,7 +5,7 @@ const sizes = {
   twoLineVerticalPadding: 14,
   threeLineVerticalPadding: 12,
   leadingSpace: 16,
-  trailingSpace: 24,
+  trailingSpace: 16,
 } as const;
 
 const colors = {

--- a/src/components/List/tokens.ts
+++ b/src/components/List/tokens.ts
@@ -1,0 +1,18 @@
+import type { ColorRole } from '../../theme/types';
+
+const sizes = {
+  oneLineVerticalPadding: 16,
+  twoLineVerticalPadding: 14,
+  leadingSpace: 16,
+  trailingSpace: 24,
+} as const;
+
+const colors = {
+  containerColor: 'surface',
+  headlineColor: 'onSurface',
+  supportingTextColor: 'onSurfaceVariant',
+  leadingIconColor: 'onSurfaceVariant',
+  trailingIconColor: 'onSurfaceVariant',
+} as const satisfies Record<string, ColorRole>;
+
+export const ListTokens = { ...sizes, ...colors };

--- a/src/components/List/tokens.ts
+++ b/src/components/List/tokens.ts
@@ -16,6 +16,8 @@ const colors = {
   leadingIconColor: 'onSurfaceVariant',
   trailingIconColor: 'onSurfaceVariant',
   expandTrailingIconColor: 'onSurface',
+  selectedContainerColor: 'primaryContainer',
+  selectedContentColor: 'onPrimaryContainer',
 } as const satisfies Record<string, ColorRole>;
 
 export const ListTokens = { ...sizes, ...colors };

--- a/src/components/List/tokens.ts
+++ b/src/components/List/tokens.ts
@@ -1,9 +1,9 @@
 import type { ColorRole } from '../../theme/types';
 
 const sizes = {
-  oneLineVerticalPadding: 16,
-  twoLineVerticalPadding: 14,
-  threeLineVerticalPadding: 12,
+  verticalPadding: 12,
+  oneLineContainerHeight: 56,
+  twoLineContainerHeight: 72,
   leadingSpace: 16,
   trailingSpace: 16,
 } as const;
@@ -14,6 +14,7 @@ const colors = {
   supportingTextColor: 'onSurfaceVariant',
   leadingIconColor: 'onSurfaceVariant',
   trailingIconColor: 'onSurfaceVariant',
+  expandTrailingIconColor: 'onSurface',
 } as const satisfies Record<string, ColorRole>;
 
 export const ListTokens = { ...sizes, ...colors };

--- a/src/components/List/tokens.ts
+++ b/src/components/List/tokens.ts
@@ -3,6 +3,7 @@ import type { ColorRole } from '../../theme/types';
 const sizes = {
   oneLineVerticalPadding: 16,
   twoLineVerticalPadding: 14,
+  threeLineVerticalPadding: 12,
   leadingSpace: 16,
   trailingSpace: 24,
 } as const;

--- a/src/components/List/utils.ts
+++ b/src/components/List/utils.ts
@@ -55,7 +55,27 @@ export const ListRowContext = React.createContext<{ verticalPadding: number }>({
   verticalPadding: ListTokens.verticalPadding,
 });
 
-export const getAccordionColors = ({ theme }: { theme: InternalTheme }) => ({
-  titleTextColor: theme.colors[ListTokens.headlineColor],
-  descriptionColor: theme.colors[ListTokens.supportingTextColor],
-});
+export const getAccordionColors = ({
+  theme,
+  selected,
+}: {
+  theme: InternalTheme;
+  selected?: boolean;
+}) => {
+  const selectedContentColor = theme.colors[ListTokens.selectedContentColor];
+
+  return {
+    titleTextColor: selected
+      ? selectedContentColor
+      : theme.colors[ListTokens.headlineColor],
+    descriptionColor: selected
+      ? selectedContentColor
+      : theme.colors[ListTokens.supportingTextColor],
+    leadingIconColor: selected
+      ? selectedContentColor
+      : theme.colors[ListTokens.leadingIconColor],
+    trailingIconColor: selected
+      ? selectedContentColor
+      : theme.colors[ListTokens.expandTrailingIconColor],
+  };
+};

--- a/src/components/List/utils.ts
+++ b/src/components/List/utils.ts
@@ -1,7 +1,7 @@
 import type { StyleProp, TextProps, ViewStyle } from 'react-native';
 
 import { ListTokens } from './tokens';
-import type { ThemeProp } from '../../theme/types';
+import type { InternalTheme, ThemeProp } from '../../theme/types';
 
 type Description =
   | React.ReactNode
@@ -44,3 +44,8 @@ export const getLeftStyles = (alignToTop: boolean, description: Description) =>
 
 export const getRightStyles = (alignToTop: boolean, description: Description) =>
   getAccessoryStyles(alignToTop, description);
+
+export const getAccordionColors = ({ theme }: { theme: InternalTheme }) => ({
+  titleTextColor: theme.colors[ListTokens.headlineColor],
+  descriptionColor: theme.colors[ListTokens.supportingTextColor],
+});

--- a/src/components/List/utils.ts
+++ b/src/components/List/utils.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from 'react-native';
 import type { StyleProp, TextProps, ViewStyle } from 'react-native';
 
-import type { InternalTheme, ThemeProp } from '../../theme/types';
+import { ListTokens } from './tokens';
+import type { ThemeProp } from '../../theme/types';
 
 type Description =
   | React.ReactNode
@@ -26,82 +26,21 @@ export type Style = {
   alignSelf?: 'flex-start' | 'center';
 };
 
-const stylesV3Left = {
-  marginRight: 0,
-  marginLeft: 16,
-};
-
-const stylesV3Right = {
-  marginLeft: 16,
-};
-
-export const getLeftStyles = (
+const getAccessoryStyles = (
   alignToTop: boolean,
   description: Description
-) => {
-  const stylesV3: Style = {
-    ...stylesV3Left,
+): Style => {
+  const style: Style = {
+    marginLeft: ListTokens.leadingSpace,
+    marginRight: 0,
     alignSelf: alignToTop ? 'flex-start' : 'center',
   };
 
-  if (!description) {
-    return {
-      ...styles.iconMarginLeft,
-      ...styles.marginVerticalNone,
-      ...stylesV3,
-    };
-  }
-
-  return {
-    ...styles.iconMarginLeft,
-    ...stylesV3,
-  };
+  return description ? style : { ...style, marginVertical: 0 };
 };
 
-export const getRightStyles = (
-  alignToTop: boolean,
-  description: Description
-) => {
-  const stylesV3: Style = {
-    ...stylesV3Right,
-    alignSelf: alignToTop ? 'flex-start' : 'center',
-  };
+export const getLeftStyles = (alignToTop: boolean, description: Description) =>
+  getAccessoryStyles(alignToTop, description);
 
-  if (!description) {
-    return {
-      ...styles.iconMarginRight,
-      ...styles.marginVerticalNone,
-      ...stylesV3,
-    };
-  }
-
-  return {
-    ...styles.iconMarginRight,
-    ...stylesV3,
-  };
-};
-
-const styles = StyleSheet.create({
-  marginVerticalNone: { marginVertical: 0 },
-  iconMarginLeft: { marginLeft: 0, marginRight: 16 },
-  iconMarginRight: { marginRight: 0 },
-});
-
-export const getAccordionColors = ({
-  theme,
-  isExpanded,
-}: {
-  theme: InternalTheme;
-  isExpanded?: boolean;
-}) => {
-  const titleColor = theme.colors.onSurface;
-
-  const descriptionColor = theme.colors.onSurfaceVariant;
-
-  const titleTextColor = isExpanded ? theme.colors?.primary : titleColor;
-
-  return {
-    descriptionColor,
-    titleTextColor,
-  };
-};
+export const getRightStyles = (alignToTop: boolean, description: Description) =>
+  getAccessoryStyles(alignToTop, description);

--- a/src/components/List/utils.ts
+++ b/src/components/List/utils.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import type { StyleProp, TextProps, ViewStyle } from 'react-native';
 
 import { ListTokens } from './tokens';
@@ -44,6 +45,15 @@ export const getLeftStyles = (alignToTop: boolean, description: Description) =>
 
 export const getRightStyles = (alignToTop: boolean, description: Description) =>
   getAccessoryStyles(alignToTop, description);
+
+/**
+ * Rows change their vertical padding with the number of lines, so a leading
+ * element taller than the default slot needs to know how much of the MD3
+ * height the row already covers.
+ */
+export const ListRowContext = React.createContext<{ verticalPadding: number }>({
+  verticalPadding: ListTokens.verticalPadding,
+});
 
 export const getAccordionColors = ({ theme }: { theme: InternalTheme }) => ({
   titleTextColor: theme.colors[ListTokens.headlineColor],

--- a/src/components/__tests__/ListAccordion.test.tsx
+++ b/src/components/__tests__/ListAccordion.test.tsx
@@ -153,7 +153,7 @@ describe('ListAccordion', () => {
 
     expect(screen.getByTestId('list-accordion')).toHaveStyle({
       minHeight: 56,
-      paddingVertical: 12,
+      paddingVertical: 8,
     });
   });
 
@@ -170,7 +170,7 @@ describe('ListAccordion', () => {
 
     expect(screen.getByTestId('list-accordion')).toHaveStyle({
       minHeight: 72,
-      paddingVertical: 12,
+      paddingVertical: 8,
     });
 
     await fireEvent(

--- a/src/components/__tests__/ListAccordion.test.tsx
+++ b/src/components/__tests__/ListAccordion.test.tsx
@@ -217,4 +217,19 @@ describe('ListAccordion', () => {
       fontSize: 77,
     });
   });
+
+  it('renders a selected accordion on the primary container', async () => {
+    await render(
+      <ListAccordion title="Accordion item 1" description="Supporting" selected>
+        <ListItem title="List item 1" />
+      </ListAccordion>
+    );
+
+    expect(screen.getByText('Accordion item 1')).toHaveStyle({
+      color: getTheme().colors.onPrimaryContainer,
+    });
+    expect(screen.getByText('Supporting')).toHaveStyle({
+      color: getTheme().colors.onPrimaryContainer,
+    });
+  });
 });

--- a/src/components/__tests__/ListAccordion.test.tsx
+++ b/src/components/__tests__/ListAccordion.test.tsx
@@ -144,7 +144,20 @@ describe('ListAccordion', () => {
     });
   });
 
-  it('drops to 12dp padding once the description wraps to a third line', async () => {
+  it('hits the container heights without measuring the description', async () => {
+    await render(
+      <ListAccordion title="Accordion item 1" testID="list-accordion">
+        <ListItem title="List item 1" />
+      </ListAccordion>
+    );
+
+    expect(screen.getByTestId('list-accordion')).toHaveStyle({
+      minHeight: 56,
+      paddingVertical: 12,
+    });
+  });
+
+  it('keeps the two line container height once a description is present', async () => {
     await render(
       <ListAccordion
         title="Accordion item 1"
@@ -156,7 +169,8 @@ describe('ListAccordion', () => {
     );
 
     expect(screen.getByTestId('list-accordion')).toHaveStyle({
-      paddingVertical: 14,
+      minHeight: 72,
+      paddingVertical: 12,
     });
 
     await fireEvent(
@@ -166,7 +180,22 @@ describe('ListAccordion', () => {
     );
 
     expect(screen.getByTestId('list-accordion')).toHaveStyle({
+      minHeight: 72,
       paddingVertical: 12,
+    });
+  });
+
+  it('uses the expand token for the chevron', async () => {
+    await render(
+      <ListAccordion title="Accordion item 1">
+        <ListItem title="List item 1" />
+      </ListAccordion>
+    );
+
+    expect(
+      screen.getByText('chevron-down', { includeHiddenElements: true })
+    ).toHaveStyle({
+      color: getTheme().colors.onSurface,
     });
   });
 

--- a/src/components/__tests__/ListAccordion.test.tsx
+++ b/src/components/__tests__/ListAccordion.test.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, View } from 'react-native';
 import { describe, expect, it } from '@jest/globals';
 
 import { getTheme } from '../../core/theming';
-import { render, screen } from '../../test-utils';
+import { fireEvent, render, screen } from '../../test-utils';
 import { red500 } from '../../theme/colors';
 import ListAccordion from '../List/ListAccordion';
 import ListAccordionGroup from '../List/ListAccordionGroup';
@@ -141,6 +141,51 @@ describe('ListAccordion', () => {
 
     expect(screen.getByText('Accordion item 1')).toHaveStyle({
       color: getTheme().colors.onSurface,
+    });
+  });
+
+  it('drops to 12dp padding once the description wraps to a third line', async () => {
+    await render(
+      <ListAccordion
+        title="Accordion item 1"
+        description="Describes the expandable list item"
+        testID="list-accordion"
+      >
+        <ListItem title="List item 1" />
+      </ListAccordion>
+    );
+
+    expect(screen.getByTestId('list-accordion')).toHaveStyle({
+      paddingVertical: 14,
+    });
+
+    await fireEvent(
+      screen.getByText('Describes the expandable list item'),
+      'textLayout',
+      { nativeEvent: { lines: [{}, {}] } }
+    );
+
+    expect(screen.getByTestId('list-accordion')).toHaveStyle({
+      paddingVertical: 12,
+    });
+  });
+
+  it('applies the theme override to title and description typography', async () => {
+    await render(
+      <ListAccordion
+        title="Accordion item 1"
+        description="Describes the expandable list item"
+        theme={{
+          fonts: { bodyLarge: { fontSize: 99 }, bodyMedium: { fontSize: 77 } },
+        }}
+      >
+        <ListItem title="List item 1" />
+      </ListAccordion>
+    );
+
+    expect(screen.getByText('Accordion item 1')).toHaveStyle({ fontSize: 99 });
+    expect(screen.getByText('Describes the expandable list item')).toHaveStyle({
+      fontSize: 77,
     });
   });
 });

--- a/src/components/__tests__/ListAccordion.test.tsx
+++ b/src/components/__tests__/ListAccordion.test.tsx
@@ -3,13 +3,12 @@ import { StyleSheet, View } from 'react-native';
 import { describe, expect, it } from '@jest/globals';
 
 import { getTheme } from '../../core/theming';
-import { render } from '../../test-utils';
+import { render, screen } from '../../test-utils';
 import { red500 } from '../../theme/colors';
 import ListAccordion from '../List/ListAccordion';
 import ListAccordionGroup from '../List/ListAccordionGroup';
 import ListIcon from '../List/ListIcon';
 import ListItem from '../List/ListItem';
-import { getAccordionColors } from '../List/utils';
 
 const styles = StyleSheet.create({
   coloring: {
@@ -120,39 +119,28 @@ describe('ListAccordion', () => {
       'List.Accordion is used inside a List.AccordionGroup without specifying an id prop.'
     );
   });
-});
 
-describe('getAccordionColors - description color', () => {
-  it('should return theme color, for theme version 3', () => {
-    expect(
-      getAccordionColors({
-        theme: getTheme(),
-      })
-    ).toMatchObject({
-      descriptionColor: getTheme().colors.onSurfaceVariant,
-    });
-  });
-});
+  it('keeps the title on onSurface when collapsed', async () => {
+    await render(
+      <ListAccordion title="Accordion item 1">
+        <ListItem title="List item 1" />
+      </ListAccordion>
+    );
 
-describe('getAccordionColors - title text color', () => {
-  it('should return theme color, for theme version 3', () => {
-    expect(
-      getAccordionColors({
-        theme: getTheme(),
-      })
-    ).toMatchObject({
-      titleTextColor: getTheme().colors.onSurface,
+    expect(screen.getByText('Accordion item 1')).toHaveStyle({
+      color: getTheme().colors.onSurface,
     });
   });
 
-  it('should return primary color if it is expanded', () => {
-    expect(
-      getAccordionColors({
-        theme: getTheme(),
-        isExpanded: true,
-      })
-    ).toMatchObject({
-      titleTextColor: getTheme().colors?.primary,
+  it('keeps the title on onSurface when expanded', async () => {
+    await render(
+      <ListAccordion title="Accordion item 1" expanded>
+        <ListItem title="List item 1" />
+      </ListAccordion>
+    );
+
+    expect(screen.getByText('Accordion item 1')).toHaveStyle({
+      color: getTheme().colors.onSurface,
     });
   });
 });

--- a/src/components/__tests__/ListImage.test.tsx
+++ b/src/components/__tests__/ListImage.test.tsx
@@ -14,6 +14,7 @@ const styles = StyleSheet.create({
     width: 114,
     height: 64,
     marginLeft: 0,
+    marginVertical: 4,
   },
   container: {
     width: 30,

--- a/src/components/__tests__/ListItem.test.tsx
+++ b/src/components/__tests__/ListItem.test.tsx
@@ -10,6 +10,7 @@ import { red500 } from '../../theme/colors';
 import Chip from '../Chip/Chip';
 import IconButton from '../IconButton/IconButton';
 import ListIcon from '../List/ListIcon';
+import ListImage from '../List/ListImage';
 import ListItem from '../List/ListItem';
 
 const styles = StyleSheet.create({
@@ -21,6 +22,14 @@ const styles = StyleSheet.create({
   },
   content: {
     paddingLeft: 0,
+  },
+  avatar: {
+    width: 40,
+    height: 40,
+  },
+  image: {
+    width: 56,
+    height: 56,
   },
 });
 
@@ -183,7 +192,7 @@ it('hits the one line container height without measuring the description', async
 
   expect(screen.getByTestId(testID)).toHaveStyle({
     minHeight: 56,
-    paddingVertical: 12,
+    paddingVertical: 8,
   });
 });
 
@@ -198,7 +207,7 @@ it('hits the two and three line container heights without measuring', async () =
 
   expect(screen.getByTestId(testID)).toHaveStyle({
     minHeight: 72,
-    paddingVertical: 12,
+    paddingVertical: 8,
   });
 
   await fireEvent(screen.getByText('Item description'), 'textLayout', {
@@ -208,6 +217,95 @@ it('hits the two and three line container heights without measuring', async () =
   expect(screen.getByTestId(testID)).toHaveStyle({
     minHeight: 72,
     paddingVertical: 12,
+  });
+});
+
+it('leaves a 40dp leading element on the one line container height', async () => {
+  await render(
+    <ListItem
+      title="First Item"
+      left={(props) => (
+        <View testID="left-accessory" style={[props.style, styles.avatar]} />
+      )}
+      testID={testID}
+    />
+  );
+
+  expect(screen.getByTestId(testID)).toHaveStyle({
+    minHeight: 56,
+    paddingVertical: 8,
+  });
+  expect(screen.getByTestId('left-accessory')).toHaveStyle({ height: 40 });
+});
+
+it('leaves a 56dp leading image on the two line container height', async () => {
+  await render(
+    <ListItem
+      title="First Item"
+      description="Item description"
+      left={(props) => (
+        <View testID="left-accessory" style={[props.style, styles.image]} />
+      )}
+      testID={testID}
+    />
+  );
+
+  expect(screen.getByTestId(testID)).toHaveStyle({
+    minHeight: 72,
+    paddingVertical: 8,
+  });
+  expect(screen.getByTestId('left-accessory')).toHaveStyle({ height: 56 });
+});
+
+it('pads a 64dp leading video to the three line container height', async () => {
+  await render(
+    <ListItem
+      title="First Item"
+      left={(props) => (
+        <ListImage
+          variant="video"
+          style={props.style}
+          source={{ uri: 'https://www.someurl.com/apple' }}
+        />
+      )}
+      testID={testID}
+    />
+  );
+
+  expect(screen.getByTestId(testID)).toHaveStyle({
+    minHeight: 56,
+    paddingVertical: 8,
+  });
+  expect(screen.getByTestId('list-image')).toHaveStyle({
+    height: 64,
+    marginVertical: 4,
+  });
+});
+
+it('keeps a 64dp leading video on the same height once the description wraps', async () => {
+  await render(
+    <ListItem
+      title="First Item"
+      description="Item description"
+      left={(props) => (
+        <ListImage
+          variant="video"
+          style={props.style}
+          source={{ uri: 'https://www.someurl.com/apple' }}
+        />
+      )}
+      testID={testID}
+    />
+  );
+
+  await fireEvent(screen.getByText('Item description'), 'textLayout', {
+    nativeEvent: { lines: [{}, {}] },
+  });
+
+  expect(screen.getByTestId(testID)).toHaveStyle({ paddingVertical: 12 });
+  expect(screen.getByTestId('list-image')).toHaveStyle({
+    height: 64,
+    marginVertical: 0,
   });
 });
 

--- a/src/components/__tests__/ListItem.test.tsx
+++ b/src/components/__tests__/ListItem.test.tsx
@@ -5,6 +5,7 @@ import { Text, View } from 'react-native';
 import { expect, it, jest } from '@jest/globals';
 import { userEvent } from '@testing-library/react-native';
 
+import { getTheme } from '../../core/theming';
 import { fireEvent, render, screen } from '../../test-utils';
 import { red500 } from '../../theme/colors';
 import Chip from '../Chip/Chip';
@@ -346,4 +347,42 @@ it('applies the theme override to title and description typography', async () =>
 
   expect(screen.getByText('First Item')).toHaveStyle({ fontSize: 99 });
   expect(screen.getByText('Item description')).toHaveStyle({ fontSize: 77 });
+});
+
+it('renders an unselected list item on surface colors', async () => {
+  await render(
+    <ListItem
+      title="First Item"
+      description="Item description"
+      testID={testID}
+    />
+  );
+
+  expect(screen.getByText('First Item')).toHaveStyle({
+    color: getTheme().colors.onSurface,
+  });
+  expect(screen.getByText('Item description')).toHaveStyle({
+    color: getTheme().colors.onSurfaceVariant,
+  });
+});
+
+it('renders a selected list item on the primary container', async () => {
+  await render(
+    <ListItem
+      title="First Item"
+      description="Item description"
+      selected
+      testID={testID}
+    />
+  );
+
+  expect(screen.getByTestId(testID)).toHaveStyle({
+    backgroundColor: getTheme().colors.primaryContainer,
+  });
+  expect(screen.getByText('First Item')).toHaveStyle({
+    color: getTheme().colors.onPrimaryContainer,
+  });
+  expect(screen.getByText('Item description')).toHaveStyle({
+    color: getTheme().colors.onPrimaryContainer,
+  });
 });

--- a/src/components/__tests__/ListItem.test.tsx
+++ b/src/components/__tests__/ListItem.test.tsx
@@ -178,7 +178,16 @@ it('renders list item with custom content style', async () => {
   expect(screen.getByTestId('list-item-content')).toHaveStyle(styles.content);
 });
 
-it('drops to 12dp padding once the description wraps to a third line', async () => {
+it('hits the one line container height without measuring the description', async () => {
+  await render(<ListItem title="First Item" testID={testID} />);
+
+  expect(screen.getByTestId(testID)).toHaveStyle({
+    minHeight: 56,
+    paddingVertical: 12,
+  });
+});
+
+it('hits the two and three line container heights without measuring', async () => {
   await render(
     <ListItem
       title="First Item"
@@ -187,13 +196,42 @@ it('drops to 12dp padding once the description wraps to a third line', async () 
     />
   );
 
-  expect(screen.getByTestId(testID)).toHaveStyle({ paddingVertical: 14 });
+  expect(screen.getByTestId(testID)).toHaveStyle({
+    minHeight: 72,
+    paddingVertical: 12,
+  });
 
   await fireEvent(screen.getByText('Item description'), 'textLayout', {
     nativeEvent: { lines: [{}, {}] },
   });
 
-  expect(screen.getByTestId(testID)).toHaveStyle({ paddingVertical: 12 });
+  expect(screen.getByTestId(testID)).toHaveStyle({
+    minHeight: 72,
+    paddingVertical: 12,
+  });
+});
+
+it('top aligns the accessories once the description wraps', async () => {
+  await render(
+    <ListItem
+      title="First Item"
+      description="Item description"
+      left={(props) => <View testID="left-accessory" style={props.style} />}
+      testID={testID}
+    />
+  );
+
+  expect(screen.getByTestId('left-accessory')).toHaveStyle({
+    alignSelf: 'center',
+  });
+
+  await fireEvent(screen.getByText('Item description'), 'textLayout', {
+    nativeEvent: { lines: [{}, {}] },
+  });
+
+  expect(screen.getByTestId('left-accessory')).toHaveStyle({
+    alignSelf: 'flex-start',
+  });
 });
 
 it('applies the theme override to title and description typography', async () => {

--- a/src/components/__tests__/ListItem.test.tsx
+++ b/src/components/__tests__/ListItem.test.tsx
@@ -5,7 +5,7 @@ import { Text, View } from 'react-native';
 import { expect, it, jest } from '@jest/globals';
 import { userEvent } from '@testing-library/react-native';
 
-import { render, screen } from '../../test-utils';
+import { fireEvent, render, screen } from '../../test-utils';
 import { red500 } from '../../theme/colors';
 import Chip from '../Chip/Chip';
 import IconButton from '../IconButton/IconButton';
@@ -176,4 +176,38 @@ it('renders list item with custom content style', async () => {
   );
 
   expect(screen.getByTestId('list-item-content')).toHaveStyle(styles.content);
+});
+
+it('drops to 12dp padding once the description wraps to a third line', async () => {
+  await render(
+    <ListItem
+      title="First Item"
+      description="Item description"
+      testID={testID}
+    />
+  );
+
+  expect(screen.getByTestId(testID)).toHaveStyle({ paddingVertical: 14 });
+
+  await fireEvent(screen.getByText('Item description'), 'textLayout', {
+    nativeEvent: { lines: [{}, {}] },
+  });
+
+  expect(screen.getByTestId(testID)).toHaveStyle({ paddingVertical: 12 });
+});
+
+it('applies the theme override to title and description typography', async () => {
+  await render(
+    <ListItem
+      title="First Item"
+      description="Item description"
+      testID={testID}
+      theme={{
+        fonts: { bodyLarge: { fontSize: 99 }, bodyMedium: { fontSize: 77 } },
+      }}
+    />
+  );
+
+  expect(screen.getByText('First Item')).toHaveStyle({ fontSize: 99 });
+  expect(screen.getByText('Item description')).toHaveStyle({ fontSize: 77 });
 });

--- a/src/components/__tests__/ListItem.test.tsx
+++ b/src/components/__tests__/ListItem.test.tsx
@@ -310,6 +310,50 @@ it('keeps a 64dp leading video on the same height once the description wraps', a
   });
 });
 
+it('colors a leading List.Icon from the list item context', async () => {
+  await render(
+    <ListItem
+      title="First Item"
+      leading={<ListIcon icon="folder" />}
+      testID={testID}
+    />
+  );
+
+  expect(
+    screen.getByText('folder', { includeHiddenElements: true })
+  ).toHaveStyle({ color: getTheme().colors.onSurfaceVariant });
+});
+
+it('renders the trailing slot', async () => {
+  await render(
+    <ListItem
+      title="First Item"
+      trailing={<Text>Trailing</Text>}
+      testID={testID}
+    />
+  );
+
+  expect(screen.getByText('Trailing')).toBeOnTheScreen();
+});
+
+it('prefers the typed slots over the left and right render props', async () => {
+  await render(
+    <ListItem
+      title="First Item"
+      leading={<Text>Leading slot</Text>}
+      trailing={<Text>Trailing slot</Text>}
+      left={() => <Text>Left render prop</Text>}
+      right={() => <Text>Right render prop</Text>}
+      testID={testID}
+    />
+  );
+
+  expect(screen.getByText('Leading slot')).toBeOnTheScreen();
+  expect(screen.getByText('Trailing slot')).toBeOnTheScreen();
+  expect(screen.queryByText('Left render prop')).not.toBeOnTheScreen();
+  expect(screen.queryByText('Right render prop')).not.toBeOnTheScreen();
+});
+
 it('top aligns the accessories once the description wraps', async () => {
   await render(
     <ListItem

--- a/src/components/__tests__/Tooltip.test.tsx
+++ b/src/components/__tests__/Tooltip.test.tsx
@@ -163,7 +163,7 @@ describe('Tooltip', () => {
       it('hides the tooltip when the user stop pressing the component', async () => {
         const {
           wrapper: { queryByText, getByText, findByText },
-        } = await setup({ enterTouchDelay: 50, leaveTouchDelay: 0 });
+        } = await setup({ enterTouchDelay: 50, leaveTouchDelay: 100 });
 
         await userEvent.longPress(getTrigger(getByText));
 

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
@@ -202,6 +202,9 @@ exports[`renders expanded accordion 1`] = `
             "minHeight": 56,
           },
           false,
+          {
+            "backgroundColor": undefined,
+          },
           undefined,
         ],
       ]

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
@@ -48,7 +48,9 @@ exports[`renders expanded accordion 1`] = `
           [
             {
               "paddingRight": 24,
-              "paddingVertical": 8,
+            },
+            {
+              "paddingVertical": 16,
             },
             undefined,
           ],
@@ -61,7 +63,6 @@ exports[`renders expanded accordion 1`] = `
           [
             {
               "flexDirection": "row",
-              "marginVertical": 6,
             },
             undefined,
           ]
@@ -91,21 +92,22 @@ exports[`renders expanded accordion 1`] = `
                 },
                 {
                   "color": "rgba(29, 27, 32, 1)",
-                  "fontFamily": "System",
-                  "fontWeight": "400",
-                  "letterSpacing": 0,
-                },
-                {
                   "writingDirection": "ltr",
                 },
                 [
                   {
+                    "fontFamily": "System",
                     "fontSize": 16,
+                    "fontWeight": "400",
+                    "letterSpacing": 0.5,
+                    "lineHeight": 24,
                   },
-                  {
-                    "color": "rgba(103, 80, 164, 1)",
-                  },
-                  undefined,
+                  [
+                    {
+                      "color": "rgba(29, 27, 32, 1)",
+                    },
+                    undefined,
+                  ],
                 ],
               ]
             }
@@ -115,13 +117,10 @@ exports[`renders expanded accordion 1`] = `
         </View>
         <View
           style={
-            [
-              {
-                "marginVertical": 6,
-                "paddingLeft": 8,
-              },
-              undefined,
-            ]
+            {
+              "alignSelf": "center",
+              "paddingLeft": 8,
+            }
           }
         >
           <Text
@@ -193,7 +192,9 @@ exports[`renders expanded accordion 1`] = `
         [
           {
             "paddingRight": 24,
-            "paddingVertical": 8,
+          },
+          {
+            "paddingVertical": 16,
           },
           undefined,
         ],
@@ -205,7 +206,6 @@ exports[`renders expanded accordion 1`] = `
         [
           {
             "flexDirection": "row",
-            "marginVertical": 6,
             "width": "100%",
           },
           undefined,
@@ -237,21 +237,22 @@ exports[`renders expanded accordion 1`] = `
               },
               {
                 "color": "rgba(29, 27, 32, 1)",
-                "fontFamily": "System",
-                "fontWeight": "400",
-                "letterSpacing": 0,
-              },
-              {
                 "writingDirection": "ltr",
               },
               [
                 {
+                  "fontFamily": "System",
                   "fontSize": 16,
+                  "fontWeight": "400",
+                  "letterSpacing": 0.5,
+                  "lineHeight": 24,
                 },
-                {
-                  "color": "rgba(29, 27, 32, 1)",
-                },
-                undefined,
+                [
+                  {
+                    "color": "rgba(29, 27, 32, 1)",
+                  },
+                  undefined,
+                ],
               ],
             ]
           }
@@ -312,7 +313,9 @@ exports[`renders list accordion with children 1`] = `
           [
             {
               "paddingRight": 24,
-              "paddingVertical": 8,
+            },
+            {
+              "paddingVertical": 16,
             },
             undefined,
           ],
@@ -325,7 +328,6 @@ exports[`renders list accordion with children 1`] = `
           [
             {
               "flexDirection": "row",
-              "marginVertical": 6,
             },
             undefined,
           ]
@@ -402,21 +404,22 @@ exports[`renders list accordion with children 1`] = `
                 },
                 {
                   "color": "rgba(29, 27, 32, 1)",
-                  "fontFamily": "System",
-                  "fontWeight": "400",
-                  "letterSpacing": 0,
-                },
-                {
                   "writingDirection": "ltr",
                 },
                 [
                   {
+                    "fontFamily": "System",
                     "fontSize": 16,
+                    "fontWeight": "400",
+                    "letterSpacing": 0.5,
+                    "lineHeight": 24,
                   },
-                  {
-                    "color": "rgba(29, 27, 32, 1)",
-                  },
-                  undefined,
+                  [
+                    {
+                      "color": "rgba(29, 27, 32, 1)",
+                    },
+                    undefined,
+                  ],
                 ],
               ]
             }
@@ -426,13 +429,10 @@ exports[`renders list accordion with children 1`] = `
         </View>
         <View
           style={
-            [
-              {
-                "marginVertical": 6,
-                "paddingLeft": 8,
-              },
-              undefined,
-            ]
+            {
+              "alignSelf": "center",
+              "paddingLeft": 8,
+            }
           }
         >
           <Text
@@ -519,7 +519,9 @@ exports[`renders list accordion with custom title and description styles 1`] = `
           [
             {
               "paddingRight": 24,
-              "paddingVertical": 8,
+            },
+            {
+              "paddingVertical": 14,
             },
             undefined,
           ],
@@ -532,7 +534,6 @@ exports[`renders list accordion with custom title and description styles 1`] = `
           [
             {
               "flexDirection": "row",
-              "marginVertical": 6,
             },
             undefined,
           ]
@@ -562,23 +563,24 @@ exports[`renders list accordion with custom title and description styles 1`] = `
                 },
                 {
                   "color": "rgba(29, 27, 32, 1)",
-                  "fontFamily": "System",
-                  "fontWeight": "400",
-                  "letterSpacing": 0,
-                },
-                {
                   "writingDirection": "ltr",
                 },
                 [
                   {
+                    "fontFamily": "System",
                     "fontSize": 16,
+                    "fontWeight": "400",
+                    "letterSpacing": 0.5,
+                    "lineHeight": 24,
                   },
-                  {
-                    "color": "rgba(29, 27, 32, 1)",
-                  },
-                  {
-                    "color": "#f44336",
-                  },
+                  [
+                    {
+                      "color": "rgba(29, 27, 32, 1)",
+                    },
+                    {
+                      "color": "#f44336",
+                    },
+                  ],
                 ],
               ]
             }
@@ -596,23 +598,24 @@ exports[`renders list accordion with custom title and description styles 1`] = `
                 },
                 {
                   "color": "rgba(29, 27, 32, 1)",
-                  "fontFamily": "System",
-                  "fontWeight": "400",
-                  "letterSpacing": 0,
-                },
-                {
                   "writingDirection": "ltr",
                 },
                 [
                   {
+                    "fontFamily": "System",
                     "fontSize": 14,
+                    "fontWeight": "400",
+                    "letterSpacing": 0.25,
+                    "lineHeight": 20,
                   },
-                  {
-                    "color": "rgba(73, 69, 79, 1)",
-                  },
-                  {
-                    "color": "#f44336",
-                  },
+                  [
+                    {
+                      "color": "rgba(73, 69, 79, 1)",
+                    },
+                    {
+                      "color": "#f44336",
+                    },
+                  ],
                 ],
               ]
             }
@@ -622,17 +625,10 @@ exports[`renders list accordion with custom title and description styles 1`] = `
         </View>
         <View
           style={
-            [
-              {
-                "marginVertical": 6,
-                "paddingLeft": 8,
-              },
-              {
-                "alignItems": "center",
-                "height": 40,
-                "justifyContent": "center",
-              },
-            ]
+            {
+              "alignSelf": "center",
+              "paddingLeft": 8,
+            }
           }
         >
           <Text
@@ -719,7 +715,9 @@ exports[`renders list accordion with left items 1`] = `
           [
             {
               "paddingRight": 24,
-              "paddingVertical": 8,
+            },
+            {
+              "paddingVertical": 16,
             },
             undefined,
           ],
@@ -732,7 +730,6 @@ exports[`renders list accordion with left items 1`] = `
           [
             {
               "flexDirection": "row",
-              "marginVertical": 6,
             },
             undefined,
           ]
@@ -809,21 +806,22 @@ exports[`renders list accordion with left items 1`] = `
                 },
                 {
                   "color": "rgba(29, 27, 32, 1)",
-                  "fontFamily": "System",
-                  "fontWeight": "400",
-                  "letterSpacing": 0,
-                },
-                {
                   "writingDirection": "ltr",
                 },
                 [
                   {
+                    "fontFamily": "System",
                     "fontSize": 16,
+                    "fontWeight": "400",
+                    "letterSpacing": 0.5,
+                    "lineHeight": 24,
                   },
-                  {
-                    "color": "rgba(29, 27, 32, 1)",
-                  },
-                  undefined,
+                  [
+                    {
+                      "color": "rgba(29, 27, 32, 1)",
+                    },
+                    undefined,
+                  ],
                 ],
               ]
             }
@@ -833,13 +831,10 @@ exports[`renders list accordion with left items 1`] = `
         </View>
         <View
           style={
-            [
-              {
-                "marginVertical": 6,
-                "paddingLeft": 8,
-              },
-              undefined,
-            ]
+            {
+              "alignSelf": "center",
+              "paddingLeft": 8,
+            }
           }
         >
           <Text
@@ -926,7 +921,9 @@ exports[`renders multiline list accordion 1`] = `
           [
             {
               "paddingRight": 24,
-              "paddingVertical": 8,
+            },
+            {
+              "paddingVertical": 14,
             },
             undefined,
           ],
@@ -939,7 +936,6 @@ exports[`renders multiline list accordion 1`] = `
           [
             {
               "flexDirection": "row",
-              "marginVertical": 6,
             },
             undefined,
           ]
@@ -969,21 +965,22 @@ exports[`renders multiline list accordion 1`] = `
                 },
                 {
                   "color": "rgba(29, 27, 32, 1)",
-                  "fontFamily": "System",
-                  "fontWeight": "400",
-                  "letterSpacing": 0,
-                },
-                {
                   "writingDirection": "ltr",
                 },
                 [
                   {
+                    "fontFamily": "System",
                     "fontSize": 16,
+                    "fontWeight": "400",
+                    "letterSpacing": 0.5,
+                    "lineHeight": 24,
                   },
-                  {
-                    "color": "rgba(29, 27, 32, 1)",
-                  },
-                  undefined,
+                  [
+                    {
+                      "color": "rgba(29, 27, 32, 1)",
+                    },
+                    undefined,
+                  ],
                 ],
               ]
             }
@@ -1001,21 +998,22 @@ exports[`renders multiline list accordion 1`] = `
                 },
                 {
                   "color": "rgba(29, 27, 32, 1)",
-                  "fontFamily": "System",
-                  "fontWeight": "400",
-                  "letterSpacing": 0,
-                },
-                {
                   "writingDirection": "ltr",
                 },
                 [
                   {
+                    "fontFamily": "System",
                     "fontSize": 14,
+                    "fontWeight": "400",
+                    "letterSpacing": 0.25,
+                    "lineHeight": 20,
                   },
-                  {
-                    "color": "rgba(73, 69, 79, 1)",
-                  },
-                  undefined,
+                  [
+                    {
+                      "color": "rgba(73, 69, 79, 1)",
+                    },
+                    undefined,
+                  ],
                 ],
               ]
             }
@@ -1025,17 +1023,10 @@ exports[`renders multiline list accordion 1`] = `
         </View>
         <View
           style={
-            [
-              {
-                "marginVertical": 6,
-                "paddingLeft": 8,
-              },
-              {
-                "alignItems": "center",
-                "height": 40,
-                "justifyContent": "center",
-              },
-            ]
+            {
+              "alignSelf": "center",
+              "paddingLeft": 8,
+            }
           }
         >
           <Text

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
@@ -47,10 +47,12 @@ exports[`renders expanded accordion 1`] = `
           },
           [
             {
+              "justifyContent": "center",
               "paddingRight": 16,
+              "paddingVertical": 12,
             },
             {
-              "paddingVertical": 16,
+              "minHeight": 56,
             },
             undefined,
           ],
@@ -131,7 +133,7 @@ exports[`renders expanded accordion 1`] = `
             style={
               [
                 {
-                  "color": "rgba(73, 69, 79, 1)",
+                  "color": "rgba(29, 27, 32, 1)",
                   "fontSize": 24,
                 },
                 [
@@ -191,10 +193,12 @@ exports[`renders expanded accordion 1`] = `
         false,
         [
           {
+            "justifyContent": "center",
             "paddingRight": 16,
+            "paddingVertical": 12,
           },
           {
-            "paddingVertical": 16,
+            "minHeight": 56,
           },
           undefined,
         ],
@@ -312,10 +316,12 @@ exports[`renders list accordion with children 1`] = `
           },
           [
             {
+              "justifyContent": "center",
               "paddingRight": 16,
+              "paddingVertical": 12,
             },
             {
-              "paddingVertical": 16,
+              "minHeight": 56,
             },
             undefined,
           ],
@@ -443,7 +449,7 @@ exports[`renders list accordion with children 1`] = `
             style={
               [
                 {
-                  "color": "rgba(73, 69, 79, 1)",
+                  "color": "rgba(29, 27, 32, 1)",
                   "fontSize": 24,
                 },
                 [
@@ -518,10 +524,12 @@ exports[`renders list accordion with custom title and description styles 1`] = `
           },
           [
             {
+              "justifyContent": "center",
               "paddingRight": 16,
+              "paddingVertical": 12,
             },
             {
-              "paddingVertical": 14,
+              "minHeight": 72,
             },
             undefined,
           ],
@@ -639,7 +647,7 @@ exports[`renders list accordion with custom title and description styles 1`] = `
             style={
               [
                 {
-                  "color": "rgba(73, 69, 79, 1)",
+                  "color": "rgba(29, 27, 32, 1)",
                   "fontSize": 24,
                 },
                 [
@@ -714,10 +722,12 @@ exports[`renders list accordion with left items 1`] = `
           },
           [
             {
+              "justifyContent": "center",
               "paddingRight": 16,
+              "paddingVertical": 12,
             },
             {
-              "paddingVertical": 16,
+              "minHeight": 56,
             },
             undefined,
           ],
@@ -845,7 +855,7 @@ exports[`renders list accordion with left items 1`] = `
             style={
               [
                 {
-                  "color": "rgba(73, 69, 79, 1)",
+                  "color": "rgba(29, 27, 32, 1)",
                   "fontSize": 24,
                 },
                 [
@@ -920,10 +930,12 @@ exports[`renders multiline list accordion 1`] = `
           },
           [
             {
+              "justifyContent": "center",
               "paddingRight": 16,
+              "paddingVertical": 12,
             },
             {
-              "paddingVertical": 14,
+              "minHeight": 72,
             },
             undefined,
           ],
@@ -1037,7 +1049,7 @@ exports[`renders multiline list accordion 1`] = `
             style={
               [
                 {
-                  "color": "rgba(73, 69, 79, 1)",
+                  "color": "rgba(29, 27, 32, 1)",
                   "fontSize": 24,
                 },
                 [

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
@@ -126,98 +126,114 @@ exports[`renders expanded accordion 1`] = `
             }
           }
         >
-          <Text
-            accessibilityElementsHidden={true}
-            importantForAccessibility="no-hide-descendants"
-            pointerEvents="none"
-            selectable={false}
+          <View
+            collapsable={false}
             style={
               [
                 {
-                  "color": "rgba(29, 27, 32, 1)",
-                  "fontSize": 24,
+                  "transform": [
+                    {
+                      "rotate": "180deg",
+                    },
+                  ],
                 },
-                [
-                  {
-                    "lineHeight": 24,
-                    "transform": [
-                      {
-                        "scaleX": 1,
-                      },
-                    ],
-                  },
-                  {
-                    "backgroundColor": "transparent",
-                  },
-                ],
               ]
             }
           >
-            chevron-up
-          </Text>
+            <Text
+              accessibilityElementsHidden={true}
+              importantForAccessibility="no-hide-descendants"
+              pointerEvents="none"
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "rgba(29, 27, 32, 1)",
+                    "fontSize": 24,
+                  },
+                  [
+                    {
+                      "lineHeight": 24,
+                      "transform": [
+                        {
+                          "scaleX": 1,
+                        },
+                      ],
+                    },
+                    {
+                      "backgroundColor": "transparent",
+                    },
+                  ],
+                ]
+              }
+            >
+              chevron-down
+            </Text>
+          </View>
         </View>
       </View>
     </View>
   </View>
   <View
-    accessibilityState={
-      {
-        "busy": undefined,
-        "checked": undefined,
-        "disabled": true,
-        "expanded": undefined,
-        "selected": undefined,
-      }
-    }
-    accessibilityValue={
-      {
-        "max": undefined,
-        "min": undefined,
-        "now": undefined,
-        "text": undefined,
-      }
-    }
-    accessible={true}
     collapsable={false}
-    focusable={true}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
+    entering={[Function]}
+    exiting={[Function]}
     style={
       [
-        false,
-        [
-          {
-            "justifyContent": "center",
-            "paddingRight": 16,
-            "paddingVertical": 8,
-          },
-          {
-            "minHeight": 56,
-          },
-          false,
-          {
-            "backgroundColor": undefined,
-          },
-          undefined,
-        ],
+        {
+          "overflow": "hidden",
+        },
       ]
     }
   >
     <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": true,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
         [
-          {
-            "flexDirection": "row",
-            "width": "100%",
-          },
-          undefined,
+          false,
+          [
+            {
+              "justifyContent": "center",
+              "paddingRight": 16,
+              "paddingVertical": 8,
+            },
+            {
+              "minHeight": 56,
+            },
+            false,
+            {
+              "backgroundColor": undefined,
+            },
+            undefined,
+          ],
         ]
       }
     >
@@ -225,49 +241,61 @@ exports[`renders expanded accordion 1`] = `
         style={
           [
             {
-              "paddingLeft": 16,
-            },
-            {
-              "flexGrow": 1,
-              "flexShrink": 1,
-              "justifyContent": "center",
+              "flexDirection": "row",
+              "width": "100%",
             },
             undefined,
           ]
         }
       >
-        <Text
-          numberOfLines={1}
-          selectable={false}
+        <View
           style={
             [
               {
-                "textAlign": "left",
+                "paddingLeft": 16,
               },
               {
-                "color": "rgba(29, 27, 32, 1)",
-                "writingDirection": "ltr",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "justifyContent": "center",
               },
-              [
-                {
-                  "fontFamily": "System",
-                  "fontSize": 16,
-                  "fontWeight": "400",
-                  "letterSpacing": 0.5,
-                  "lineHeight": 24,
-                },
-                [
-                  {
-                    "color": "rgba(29, 27, 32, 1)",
-                  },
-                  undefined,
-                ],
-              ],
+              undefined,
             ]
           }
         >
-          List item 1
-        </Text>
+          <Text
+            numberOfLines={1}
+            selectable={false}
+            style={
+              [
+                {
+                  "textAlign": "left",
+                },
+                {
+                  "color": "rgba(29, 27, 32, 1)",
+                  "writingDirection": "ltr",
+                },
+                [
+                  {
+                    "fontFamily": "System",
+                    "fontSize": 16,
+                    "fontWeight": "400",
+                    "letterSpacing": 0.5,
+                    "lineHeight": 24,
+                  },
+                  [
+                    {
+                      "color": "rgba(29, 27, 32, 1)",
+                    },
+                    undefined,
+                  ],
+                ],
+              ]
+            }
+          >
+            List item 1
+          </Text>
+        </View>
       </View>
     </View>
   </View>
@@ -447,35 +475,50 @@ exports[`renders list accordion with children 1`] = `
             }
           }
         >
-          <Text
-            accessibilityElementsHidden={true}
-            importantForAccessibility="no-hide-descendants"
-            pointerEvents="none"
-            selectable={false}
+          <View
+            collapsable={false}
             style={
               [
                 {
-                  "color": "rgba(29, 27, 32, 1)",
-                  "fontSize": 24,
+                  "transform": [
+                    {
+                      "rotate": "0deg",
+                    },
+                  ],
                 },
-                [
-                  {
-                    "lineHeight": 24,
-                    "transform": [
-                      {
-                        "scaleX": 1,
-                      },
-                    ],
-                  },
-                  {
-                    "backgroundColor": "transparent",
-                  },
-                ],
               ]
             }
           >
-            chevron-down
-          </Text>
+            <Text
+              accessibilityElementsHidden={true}
+              importantForAccessibility="no-hide-descendants"
+              pointerEvents="none"
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "rgba(29, 27, 32, 1)",
+                    "fontSize": 24,
+                  },
+                  [
+                    {
+                      "lineHeight": 24,
+                      "transform": [
+                        {
+                          "scaleX": 1,
+                        },
+                      ],
+                    },
+                    {
+                      "backgroundColor": "transparent",
+                    },
+                  ],
+                ]
+              }
+            >
+              chevron-down
+            </Text>
+          </View>
         </View>
       </View>
     </View>
@@ -646,35 +689,50 @@ exports[`renders list accordion with custom title and description styles 1`] = `
             }
           }
         >
-          <Text
-            accessibilityElementsHidden={true}
-            importantForAccessibility="no-hide-descendants"
-            pointerEvents="none"
-            selectable={false}
+          <View
+            collapsable={false}
             style={
               [
                 {
-                  "color": "rgba(29, 27, 32, 1)",
-                  "fontSize": 24,
+                  "transform": [
+                    {
+                      "rotate": "0deg",
+                    },
+                  ],
                 },
-                [
-                  {
-                    "lineHeight": 24,
-                    "transform": [
-                      {
-                        "scaleX": 1,
-                      },
-                    ],
-                  },
-                  {
-                    "backgroundColor": "transparent",
-                  },
-                ],
               ]
             }
           >
-            chevron-down
-          </Text>
+            <Text
+              accessibilityElementsHidden={true}
+              importantForAccessibility="no-hide-descendants"
+              pointerEvents="none"
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "rgba(29, 27, 32, 1)",
+                    "fontSize": 24,
+                  },
+                  [
+                    {
+                      "lineHeight": 24,
+                      "transform": [
+                        {
+                          "scaleX": 1,
+                        },
+                      ],
+                    },
+                    {
+                      "backgroundColor": "transparent",
+                    },
+                  ],
+                ]
+              }
+            >
+              chevron-down
+            </Text>
+          </View>
         </View>
       </View>
     </View>
@@ -855,35 +913,50 @@ exports[`renders list accordion with left items 1`] = `
             }
           }
         >
-          <Text
-            accessibilityElementsHidden={true}
-            importantForAccessibility="no-hide-descendants"
-            pointerEvents="none"
-            selectable={false}
+          <View
+            collapsable={false}
             style={
               [
                 {
-                  "color": "rgba(29, 27, 32, 1)",
-                  "fontSize": 24,
+                  "transform": [
+                    {
+                      "rotate": "0deg",
+                    },
+                  ],
                 },
-                [
-                  {
-                    "lineHeight": 24,
-                    "transform": [
-                      {
-                        "scaleX": 1,
-                      },
-                    ],
-                  },
-                  {
-                    "backgroundColor": "transparent",
-                  },
-                ],
               ]
             }
           >
-            chevron-down
-          </Text>
+            <Text
+              accessibilityElementsHidden={true}
+              importantForAccessibility="no-hide-descendants"
+              pointerEvents="none"
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "rgba(29, 27, 32, 1)",
+                    "fontSize": 24,
+                  },
+                  [
+                    {
+                      "lineHeight": 24,
+                      "transform": [
+                        {
+                          "scaleX": 1,
+                        },
+                      ],
+                    },
+                    {
+                      "backgroundColor": "transparent",
+                    },
+                  ],
+                ]
+              }
+            >
+              chevron-down
+            </Text>
+          </View>
         </View>
       </View>
     </View>
@@ -1050,35 +1123,50 @@ exports[`renders multiline list accordion 1`] = `
             }
           }
         >
-          <Text
-            accessibilityElementsHidden={true}
-            importantForAccessibility="no-hide-descendants"
-            pointerEvents="none"
-            selectable={false}
+          <View
+            collapsable={false}
             style={
               [
                 {
-                  "color": "rgba(29, 27, 32, 1)",
-                  "fontSize": 24,
+                  "transform": [
+                    {
+                      "rotate": "0deg",
+                    },
+                  ],
                 },
-                [
-                  {
-                    "lineHeight": 24,
-                    "transform": [
-                      {
-                        "scaleX": 1,
-                      },
-                    ],
-                  },
-                  {
-                    "backgroundColor": "transparent",
-                  },
-                ],
               ]
             }
           >
-            chevron-down
-          </Text>
+            <Text
+              accessibilityElementsHidden={true}
+              importantForAccessibility="no-hide-descendants"
+              pointerEvents="none"
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "rgba(29, 27, 32, 1)",
+                    "fontSize": 24,
+                  },
+                  [
+                    {
+                      "lineHeight": 24,
+                      "transform": [
+                        {
+                          "scaleX": 1,
+                        },
+                      ],
+                    },
+                    {
+                      "backgroundColor": "transparent",
+                    },
+                  ],
+                ]
+              }
+            >
+              chevron-down
+            </Text>
+          </View>
         </View>
       </View>
     </View>

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`renders expanded accordion 1`] = `
           },
           [
             {
-              "paddingRight": 24,
+              "paddingRight": 16,
             },
             {
               "paddingVertical": 16,
@@ -191,7 +191,7 @@ exports[`renders expanded accordion 1`] = `
         false,
         [
           {
-            "paddingRight": 24,
+            "paddingRight": 16,
           },
           {
             "paddingVertical": 16,
@@ -312,7 +312,7 @@ exports[`renders list accordion with children 1`] = `
           },
           [
             {
-              "paddingRight": 24,
+              "paddingRight": 16,
             },
             {
               "paddingVertical": 16,
@@ -518,7 +518,7 @@ exports[`renders list accordion with custom title and description styles 1`] = `
           },
           [
             {
-              "paddingRight": 24,
+              "paddingRight": 16,
             },
             {
               "paddingVertical": 14,
@@ -714,7 +714,7 @@ exports[`renders list accordion with left items 1`] = `
           },
           [
             {
-              "paddingRight": 24,
+              "paddingRight": 16,
             },
             {
               "paddingVertical": 16,
@@ -920,7 +920,7 @@ exports[`renders multiline list accordion 1`] = `
           },
           [
             {
-              "paddingRight": 24,
+              "paddingRight": 16,
             },
             {
               "paddingVertical": 14,

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
@@ -49,11 +49,12 @@ exports[`renders expanded accordion 1`] = `
             {
               "justifyContent": "center",
               "paddingRight": 16,
-              "paddingVertical": 12,
+              "paddingVertical": 8,
             },
             {
               "minHeight": 56,
             },
+            false,
             undefined,
           ],
         ]
@@ -121,7 +122,7 @@ exports[`renders expanded accordion 1`] = `
           style={
             {
               "alignSelf": "center",
-              "paddingLeft": 8,
+              "paddingLeft": 16,
             }
           }
         >
@@ -195,11 +196,12 @@ exports[`renders expanded accordion 1`] = `
           {
             "justifyContent": "center",
             "paddingRight": 16,
-            "paddingVertical": 12,
+            "paddingVertical": 8,
           },
           {
             "minHeight": 56,
           },
+          false,
           undefined,
         ],
       ]
@@ -318,11 +320,12 @@ exports[`renders list accordion with children 1`] = `
             {
               "justifyContent": "center",
               "paddingRight": 16,
-              "paddingVertical": 12,
+              "paddingVertical": 8,
             },
             {
               "minHeight": 56,
             },
+            false,
             undefined,
           ],
         ]
@@ -437,7 +440,7 @@ exports[`renders list accordion with children 1`] = `
           style={
             {
               "alignSelf": "center",
-              "paddingLeft": 8,
+              "paddingLeft": 16,
             }
           }
         >
@@ -526,11 +529,12 @@ exports[`renders list accordion with custom title and description styles 1`] = `
             {
               "justifyContent": "center",
               "paddingRight": 16,
-              "paddingVertical": 12,
+              "paddingVertical": 8,
             },
             {
               "minHeight": 72,
             },
+            false,
             undefined,
           ],
         ]
@@ -635,7 +639,7 @@ exports[`renders list accordion with custom title and description styles 1`] = `
           style={
             {
               "alignSelf": "center",
-              "paddingLeft": 8,
+              "paddingLeft": 16,
             }
           }
         >
@@ -724,11 +728,12 @@ exports[`renders list accordion with left items 1`] = `
             {
               "justifyContent": "center",
               "paddingRight": 16,
-              "paddingVertical": 12,
+              "paddingVertical": 8,
             },
             {
               "minHeight": 56,
             },
+            false,
             undefined,
           ],
         ]
@@ -843,7 +848,7 @@ exports[`renders list accordion with left items 1`] = `
           style={
             {
               "alignSelf": "center",
-              "paddingLeft": 8,
+              "paddingLeft": 16,
             }
           }
         >
@@ -932,11 +937,12 @@ exports[`renders multiline list accordion 1`] = `
             {
               "justifyContent": "center",
               "paddingRight": 16,
-              "paddingVertical": 12,
+              "paddingVertical": 8,
             },
             {
               "minHeight": 72,
             },
+            false,
             undefined,
           ],
         ]
@@ -1037,7 +1043,7 @@ exports[`renders multiline list accordion 1`] = `
           style={
             {
               "alignSelf": "center",
-              "paddingLeft": 8,
+              "paddingLeft": 16,
             }
           }
         >

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -36,10 +36,12 @@ exports[`renders list item with custom description 1`] = `
       false,
       [
         {
+          "justifyContent": "center",
           "paddingRight": 16,
+          "paddingVertical": 12,
         },
         {
-          "paddingVertical": 14,
+          "minHeight": 72,
         },
         undefined,
       ],
@@ -419,10 +421,12 @@ exports[`renders list item with custom title and description styles 1`] = `
       false,
       [
         {
+          "justifyContent": "center",
           "paddingRight": 16,
+          "paddingVertical": 12,
         },
         {
-          "paddingVertical": 14,
+          "minHeight": 72,
         },
         undefined,
       ],
@@ -567,10 +571,12 @@ exports[`renders list item with left and right items 1`] = `
       false,
       [
         {
+          "justifyContent": "center",
           "paddingRight": 16,
+          "paddingVertical": 12,
         },
         {
-          "paddingVertical": 14,
+          "minHeight": 72,
         },
         undefined,
       ],
@@ -760,10 +766,12 @@ exports[`renders list item with left item 1`] = `
       false,
       [
         {
+          "justifyContent": "center",
           "paddingRight": 16,
+          "paddingVertical": 12,
         },
         {
-          "paddingVertical": 16,
+          "minHeight": 56,
         },
         undefined,
       ],
@@ -918,10 +926,12 @@ exports[`renders list item with right item 1`] = `
       false,
       [
         {
+          "justifyContent": "center",
           "paddingRight": 16,
+          "paddingVertical": 12,
         },
         {
-          "paddingVertical": 16,
+          "minHeight": 56,
         },
         undefined,
       ],
@@ -1032,10 +1042,12 @@ exports[`renders list item with title and description 1`] = `
       false,
       [
         {
+          "justifyContent": "center",
           "paddingRight": 16,
+          "paddingVertical": 12,
         },
         {
-          "paddingVertical": 14,
+          "minHeight": 72,
         },
         undefined,
       ],
@@ -1176,10 +1188,12 @@ exports[`renders with a description with typeof number 1`] = `
       false,
       [
         {
+          "justifyContent": "center",
           "paddingRight": 16,
+          "paddingVertical": 12,
         },
         {
-          "paddingVertical": 14,
+          "minHeight": 72,
         },
         undefined,
       ],

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -38,11 +38,12 @@ exports[`renders list item with custom description 1`] = `
         {
           "justifyContent": "center",
           "paddingRight": 16,
-          "paddingVertical": 12,
+          "paddingVertical": 8,
         },
         {
           "minHeight": 72,
         },
+        false,
         undefined,
       ],
     ]
@@ -423,11 +424,12 @@ exports[`renders list item with custom title and description styles 1`] = `
         {
           "justifyContent": "center",
           "paddingRight": 16,
-          "paddingVertical": 12,
+          "paddingVertical": 8,
         },
         {
           "minHeight": 72,
         },
+        false,
         undefined,
       ],
     ]
@@ -573,11 +575,12 @@ exports[`renders list item with left and right items 1`] = `
         {
           "justifyContent": "center",
           "paddingRight": 16,
-          "paddingVertical": 12,
+          "paddingVertical": 8,
         },
         {
           "minHeight": 72,
         },
+        false,
         undefined,
       ],
     ]
@@ -768,11 +771,12 @@ exports[`renders list item with left item 1`] = `
         {
           "justifyContent": "center",
           "paddingRight": 16,
-          "paddingVertical": 12,
+          "paddingVertical": 8,
         },
         {
           "minHeight": 56,
         },
+        false,
         undefined,
       ],
     ]
@@ -928,11 +932,12 @@ exports[`renders list item with right item 1`] = `
         {
           "justifyContent": "center",
           "paddingRight": 16,
-          "paddingVertical": 12,
+          "paddingVertical": 8,
         },
         {
           "minHeight": 56,
         },
+        false,
         undefined,
       ],
     ]
@@ -1044,11 +1049,12 @@ exports[`renders list item with title and description 1`] = `
         {
           "justifyContent": "center",
           "paddingRight": 16,
-          "paddingVertical": 12,
+          "paddingVertical": 8,
         },
         {
           "minHeight": 72,
         },
+        false,
         undefined,
       ],
     ]
@@ -1190,11 +1196,12 @@ exports[`renders with a description with typeof number 1`] = `
         {
           "justifyContent": "center",
           "paddingRight": 16,
-          "paddingVertical": 12,
+          "paddingVertical": 8,
         },
         {
           "minHeight": 72,
         },
+        false,
         undefined,
       ],
     ]

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`renders list item with custom description 1`] = `
       false,
       [
         {
-          "paddingRight": 24,
+          "paddingRight": 16,
         },
         {
           "paddingVertical": 14,
@@ -419,7 +419,7 @@ exports[`renders list item with custom title and description styles 1`] = `
       false,
       [
         {
-          "paddingRight": 24,
+          "paddingRight": 16,
         },
         {
           "paddingVertical": 14,
@@ -567,7 +567,7 @@ exports[`renders list item with left and right items 1`] = `
       false,
       [
         {
-          "paddingRight": 24,
+          "paddingRight": 16,
         },
         {
           "paddingVertical": 14,
@@ -760,7 +760,7 @@ exports[`renders list item with left item 1`] = `
       false,
       [
         {
-          "paddingRight": 24,
+          "paddingRight": 16,
         },
         {
           "paddingVertical": 16,
@@ -918,7 +918,7 @@ exports[`renders list item with right item 1`] = `
       false,
       [
         {
-          "paddingRight": 24,
+          "paddingRight": 16,
         },
         {
           "paddingVertical": 16,
@@ -1032,7 +1032,7 @@ exports[`renders list item with title and description 1`] = `
       false,
       [
         {
-          "paddingRight": 24,
+          "paddingRight": 16,
         },
         {
           "paddingVertical": 14,
@@ -1176,7 +1176,7 @@ exports[`renders with a description with typeof number 1`] = `
       false,
       [
         {
-          "paddingRight": 24,
+          "paddingRight": 16,
         },
         {
           "paddingVertical": 14,

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -44,6 +44,9 @@ exports[`renders list item with custom description 1`] = `
           "minHeight": 72,
         },
         false,
+        {
+          "backgroundColor": undefined,
+        },
         undefined,
       ],
     ]
@@ -430,6 +433,9 @@ exports[`renders list item with custom title and description styles 1`] = `
           "minHeight": 72,
         },
         false,
+        {
+          "backgroundColor": undefined,
+        },
         undefined,
       ],
     ]
@@ -581,6 +587,9 @@ exports[`renders list item with left and right items 1`] = `
           "minHeight": 72,
         },
         false,
+        {
+          "backgroundColor": undefined,
+        },
         undefined,
       ],
     ]
@@ -777,6 +786,9 @@ exports[`renders list item with left item 1`] = `
           "minHeight": 56,
         },
         false,
+        {
+          "backgroundColor": undefined,
+        },
         undefined,
       ],
     ]
@@ -938,6 +950,9 @@ exports[`renders list item with right item 1`] = `
           "minHeight": 56,
         },
         false,
+        {
+          "backgroundColor": undefined,
+        },
         undefined,
       ],
     ]
@@ -1055,6 +1070,9 @@ exports[`renders list item with title and description 1`] = `
           "minHeight": 72,
         },
         false,
+        {
+          "backgroundColor": undefined,
+        },
         undefined,
       ],
     ]
@@ -1202,6 +1220,9 @@ exports[`renders with a description with typeof number 1`] = `
           "minHeight": 72,
         },
         false,
+        {
+          "backgroundColor": undefined,
+        },
         undefined,
       ],
     ]

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -37,7 +37,9 @@ exports[`renders list item with custom description 1`] = `
       [
         {
           "paddingRight": 24,
-          "paddingVertical": 8,
+        },
+        {
+          "paddingVertical": 14,
         },
         undefined,
       ],
@@ -50,7 +52,6 @@ exports[`renders list item with custom description 1`] = `
       [
         {
           "flexDirection": "row",
-          "marginVertical": 6,
           "width": "100%",
         },
         undefined,
@@ -83,21 +84,22 @@ exports[`renders list item with custom description 1`] = `
             },
             {
               "color": "rgba(29, 27, 32, 1)",
-              "fontFamily": "System",
-              "fontWeight": "400",
-              "letterSpacing": 0,
-            },
-            {
               "writingDirection": "ltr",
             },
             [
               {
+                "fontFamily": "System",
                 "fontSize": 16,
+                "fontWeight": "400",
+                "letterSpacing": 0.5,
+                "lineHeight": 24,
               },
-              {
-                "color": "rgba(29, 27, 32, 1)",
-              },
-              undefined,
+              [
+                {
+                  "color": "rgba(29, 27, 32, 1)",
+                },
+                undefined,
+              ],
             ],
           ]
         }
@@ -418,7 +420,9 @@ exports[`renders list item with custom title and description styles 1`] = `
       [
         {
           "paddingRight": 24,
-          "paddingVertical": 8,
+        },
+        {
+          "paddingVertical": 14,
         },
         undefined,
       ],
@@ -431,7 +435,6 @@ exports[`renders list item with custom title and description styles 1`] = `
       [
         {
           "flexDirection": "row",
-          "marginVertical": 6,
           "width": "100%",
         },
         undefined,
@@ -464,23 +467,24 @@ exports[`renders list item with custom title and description styles 1`] = `
             },
             {
               "color": "rgba(29, 27, 32, 1)",
-              "fontFamily": "System",
-              "fontWeight": "400",
-              "letterSpacing": 0,
-            },
-            {
               "writingDirection": "ltr",
             },
             [
               {
+                "fontFamily": "System",
                 "fontSize": 16,
+                "fontWeight": "400",
+                "letterSpacing": 0.5,
+                "lineHeight": 24,
               },
-              {
-                "color": "rgba(29, 27, 32, 1)",
-              },
-              {
-                "fontSize": 20,
-              },
+              [
+                {
+                  "color": "rgba(29, 27, 32, 1)",
+                },
+                {
+                  "fontSize": 20,
+                },
+              ],
             ],
           ]
         }
@@ -498,23 +502,24 @@ exports[`renders list item with custom title and description styles 1`] = `
             },
             {
               "color": "rgba(29, 27, 32, 1)",
-              "fontFamily": "System",
-              "fontWeight": "400",
-              "letterSpacing": 0,
-            },
-            {
               "writingDirection": "ltr",
             },
             [
               {
+                "fontFamily": "System",
                 "fontSize": 14,
+                "fontWeight": "400",
+                "letterSpacing": 0.25,
+                "lineHeight": 20,
               },
-              {
-                "color": "rgba(73, 69, 79, 1)",
-              },
-              {
-                "color": "#f44336",
-              },
+              [
+                {
+                  "color": "rgba(73, 69, 79, 1)",
+                },
+                {
+                  "color": "#f44336",
+                },
+              ],
             ],
           ]
         }
@@ -563,7 +568,9 @@ exports[`renders list item with left and right items 1`] = `
       [
         {
           "paddingRight": 24,
-          "paddingVertical": 8,
+        },
+        {
+          "paddingVertical": 14,
         },
         undefined,
       ],
@@ -576,7 +583,6 @@ exports[`renders list item with left and right items 1`] = `
       [
         {
           "flexDirection": "row",
-          "marginVertical": 6,
           "width": "100%",
         },
         undefined,
@@ -612,21 +618,22 @@ exports[`renders list item with left and right items 1`] = `
             },
             {
               "color": "rgba(29, 27, 32, 1)",
-              "fontFamily": "System",
-              "fontWeight": "400",
-              "letterSpacing": 0,
-            },
-            {
               "writingDirection": "ltr",
             },
             [
               {
+                "fontFamily": "System",
                 "fontSize": 16,
+                "fontWeight": "400",
+                "letterSpacing": 0.5,
+                "lineHeight": 24,
               },
-              {
-                "color": "rgba(29, 27, 32, 1)",
-              },
-              undefined,
+              [
+                {
+                  "color": "rgba(29, 27, 32, 1)",
+                },
+                undefined,
+              ],
             ],
           ]
         }
@@ -644,21 +651,22 @@ exports[`renders list item with left and right items 1`] = `
             },
             {
               "color": "rgba(29, 27, 32, 1)",
-              "fontFamily": "System",
-              "fontWeight": "400",
-              "letterSpacing": 0,
-            },
-            {
               "writingDirection": "ltr",
             },
             [
               {
+                "fontFamily": "System",
                 "fontSize": 14,
+                "fontWeight": "400",
+                "letterSpacing": 0.25,
+                "lineHeight": 20,
               },
-              {
-                "color": "rgba(73, 69, 79, 1)",
-              },
-              undefined,
+              [
+                {
+                  "color": "rgba(73, 69, 79, 1)",
+                },
+                undefined,
+              ],
             ],
           ]
         }
@@ -753,7 +761,9 @@ exports[`renders list item with left item 1`] = `
       [
         {
           "paddingRight": 24,
-          "paddingVertical": 8,
+        },
+        {
+          "paddingVertical": 16,
         },
         undefined,
       ],
@@ -766,7 +776,6 @@ exports[`renders list item with left item 1`] = `
       [
         {
           "flexDirection": "row",
-          "marginVertical": 6,
           "width": "100%",
         },
         undefined,
@@ -846,21 +855,22 @@ exports[`renders list item with left item 1`] = `
             },
             {
               "color": "rgba(29, 27, 32, 1)",
-              "fontFamily": "System",
-              "fontWeight": "400",
-              "letterSpacing": 0,
-            },
-            {
               "writingDirection": "ltr",
             },
             [
               {
+                "fontFamily": "System",
                 "fontSize": 16,
+                "fontWeight": "400",
+                "letterSpacing": 0.5,
+                "lineHeight": 24,
               },
-              {
-                "color": "rgba(29, 27, 32, 1)",
-              },
-              undefined,
+              [
+                {
+                  "color": "rgba(29, 27, 32, 1)",
+                },
+                undefined,
+              ],
             ],
           ]
         }
@@ -909,7 +919,9 @@ exports[`renders list item with right item 1`] = `
       [
         {
           "paddingRight": 24,
-          "paddingVertical": 8,
+        },
+        {
+          "paddingVertical": 16,
         },
         undefined,
       ],
@@ -922,7 +934,6 @@ exports[`renders list item with right item 1`] = `
       [
         {
           "flexDirection": "row",
-          "marginVertical": 6,
           "width": "100%",
         },
         undefined,
@@ -955,21 +966,22 @@ exports[`renders list item with right item 1`] = `
             },
             {
               "color": "rgba(29, 27, 32, 1)",
-              "fontFamily": "System",
-              "fontWeight": "400",
-              "letterSpacing": 0,
-            },
-            {
               "writingDirection": "ltr",
             },
             [
               {
+                "fontFamily": "System",
                 "fontSize": 16,
+                "fontWeight": "400",
+                "letterSpacing": 0.5,
+                "lineHeight": 24,
               },
-              {
-                "color": "rgba(29, 27, 32, 1)",
-              },
-              undefined,
+              [
+                {
+                  "color": "rgba(29, 27, 32, 1)",
+                },
+                undefined,
+              ],
             ],
           ]
         }
@@ -1021,7 +1033,9 @@ exports[`renders list item with title and description 1`] = `
       [
         {
           "paddingRight": 24,
-          "paddingVertical": 8,
+        },
+        {
+          "paddingVertical": 14,
         },
         undefined,
       ],
@@ -1034,7 +1048,6 @@ exports[`renders list item with title and description 1`] = `
       [
         {
           "flexDirection": "row",
-          "marginVertical": 6,
           "width": "100%",
         },
         undefined,
@@ -1067,21 +1080,22 @@ exports[`renders list item with title and description 1`] = `
             },
             {
               "color": "rgba(29, 27, 32, 1)",
-              "fontFamily": "System",
-              "fontWeight": "400",
-              "letterSpacing": 0,
-            },
-            {
               "writingDirection": "ltr",
             },
             [
               {
+                "fontFamily": "System",
                 "fontSize": 16,
+                "fontWeight": "400",
+                "letterSpacing": 0.5,
+                "lineHeight": 24,
               },
-              {
-                "color": "rgba(29, 27, 32, 1)",
-              },
-              undefined,
+              [
+                {
+                  "color": "rgba(29, 27, 32, 1)",
+                },
+                undefined,
+              ],
             ],
           ]
         }
@@ -1099,21 +1113,22 @@ exports[`renders list item with title and description 1`] = `
             },
             {
               "color": "rgba(29, 27, 32, 1)",
-              "fontFamily": "System",
-              "fontWeight": "400",
-              "letterSpacing": 0,
-            },
-            {
               "writingDirection": "ltr",
             },
             [
               {
+                "fontFamily": "System",
                 "fontSize": 14,
+                "fontWeight": "400",
+                "letterSpacing": 0.25,
+                "lineHeight": 20,
               },
-              {
-                "color": "rgba(73, 69, 79, 1)",
-              },
-              undefined,
+              [
+                {
+                  "color": "rgba(73, 69, 79, 1)",
+                },
+                undefined,
+              ],
             ],
           ]
         }
@@ -1162,7 +1177,9 @@ exports[`renders with a description with typeof number 1`] = `
       [
         {
           "paddingRight": 24,
-          "paddingVertical": 8,
+        },
+        {
+          "paddingVertical": 14,
         },
         undefined,
       ],
@@ -1175,7 +1192,6 @@ exports[`renders with a description with typeof number 1`] = `
       [
         {
           "flexDirection": "row",
-          "marginVertical": 6,
           "width": "100%",
         },
         undefined,
@@ -1208,23 +1224,24 @@ exports[`renders with a description with typeof number 1`] = `
             },
             {
               "color": "rgba(29, 27, 32, 1)",
-              "fontFamily": "System",
-              "fontWeight": "400",
-              "letterSpacing": 0,
-            },
-            {
               "writingDirection": "ltr",
             },
             [
               {
+                "fontFamily": "System",
                 "fontSize": 16,
+                "fontWeight": "400",
+                "letterSpacing": 0.5,
+                "lineHeight": 24,
               },
-              {
-                "color": "rgba(29, 27, 32, 1)",
-              },
-              {
-                "fontSize": 20,
-              },
+              [
+                {
+                  "color": "rgba(29, 27, 32, 1)",
+                },
+                {
+                  "fontSize": 20,
+                },
+              ],
             ],
           ]
         }
@@ -1242,23 +1259,24 @@ exports[`renders with a description with typeof number 1`] = `
             },
             {
               "color": "rgba(29, 27, 32, 1)",
-              "fontFamily": "System",
-              "fontWeight": "400",
-              "letterSpacing": 0,
-            },
-            {
               "writingDirection": "ltr",
             },
             [
               {
+                "fontFamily": "System",
                 "fontSize": 14,
+                "fontWeight": "400",
+                "letterSpacing": 0.25,
+                "lineHeight": 20,
               },
-              {
-                "color": "rgba(73, 69, 79, 1)",
-              },
-              {
-                "color": "#f44336",
-              },
+              [
+                {
+                  "color": "rgba(73, 69, 79, 1)",
+                },
+                {
+                  "color": "#f44336",
+                },
+              ],
             ],
           ]
         }

--- a/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
@@ -488,7 +488,7 @@ exports[`renders list section with custom title style 1`] = `
         false,
         [
           {
-            "paddingRight": 24,
+            "paddingRight": 16,
           },
           {
             "paddingVertical": 16,
@@ -643,7 +643,7 @@ exports[`renders list section with custom title style 1`] = `
         false,
         [
           {
-            "paddingRight": 24,
+            "paddingRight": 16,
           },
           {
             "paddingVertical": 16,
@@ -1252,7 +1252,7 @@ exports[`renders list section with subheader 1`] = `
         false,
         [
           {
-            "paddingRight": 24,
+            "paddingRight": 16,
           },
           {
             "paddingVertical": 16,
@@ -1407,7 +1407,7 @@ exports[`renders list section with subheader 1`] = `
         false,
         [
           {
-            "paddingRight": 24,
+            "paddingRight": 16,
           },
           {
             "paddingVertical": 16,
@@ -1976,7 +1976,7 @@ exports[`renders list section without subheader 1`] = `
         false,
         [
           {
-            "paddingRight": 24,
+            "paddingRight": 16,
           },
           {
             "paddingVertical": 16,
@@ -2131,7 +2131,7 @@ exports[`renders list section without subheader 1`] = `
         false,
         [
           {
-            "paddingRight": 24,
+            "paddingRight": 16,
           },
           {
             "paddingVertical": 16,

--- a/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
@@ -490,11 +490,12 @@ exports[`renders list section with custom title style 1`] = `
           {
             "justifyContent": "center",
             "paddingRight": 16,
-            "paddingVertical": 12,
+            "paddingVertical": 8,
           },
           {
             "minHeight": 56,
           },
+          false,
           undefined,
         ],
       ]
@@ -647,11 +648,12 @@ exports[`renders list section with custom title style 1`] = `
           {
             "justifyContent": "center",
             "paddingRight": 16,
-            "paddingVertical": 12,
+            "paddingVertical": 8,
           },
           {
             "minHeight": 56,
           },
+          false,
           undefined,
         ],
       ]
@@ -1258,11 +1260,12 @@ exports[`renders list section with subheader 1`] = `
           {
             "justifyContent": "center",
             "paddingRight": 16,
-            "paddingVertical": 12,
+            "paddingVertical": 8,
           },
           {
             "minHeight": 56,
           },
+          false,
           undefined,
         ],
       ]
@@ -1415,11 +1418,12 @@ exports[`renders list section with subheader 1`] = `
           {
             "justifyContent": "center",
             "paddingRight": 16,
-            "paddingVertical": 12,
+            "paddingVertical": 8,
           },
           {
             "minHeight": 56,
           },
+          false,
           undefined,
         ],
       ]
@@ -1986,11 +1990,12 @@ exports[`renders list section without subheader 1`] = `
           {
             "justifyContent": "center",
             "paddingRight": 16,
-            "paddingVertical": 12,
+            "paddingVertical": 8,
           },
           {
             "minHeight": 56,
           },
+          false,
           undefined,
         ],
       ]
@@ -2143,11 +2148,12 @@ exports[`renders list section without subheader 1`] = `
           {
             "justifyContent": "center",
             "paddingRight": 16,
-            "paddingVertical": 12,
+            "paddingVertical": 8,
           },
           {
             "minHeight": 56,
           },
+          false,
           undefined,
         ],
       ]

--- a/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
@@ -496,6 +496,9 @@ exports[`renders list section with custom title style 1`] = `
             "minHeight": 56,
           },
           false,
+          {
+            "backgroundColor": undefined,
+          },
           undefined,
         ],
       ]
@@ -654,6 +657,9 @@ exports[`renders list section with custom title style 1`] = `
             "minHeight": 56,
           },
           false,
+          {
+            "backgroundColor": undefined,
+          },
           undefined,
         ],
       ]
@@ -1266,6 +1272,9 @@ exports[`renders list section with subheader 1`] = `
             "minHeight": 56,
           },
           false,
+          {
+            "backgroundColor": undefined,
+          },
           undefined,
         ],
       ]
@@ -1424,6 +1433,9 @@ exports[`renders list section with subheader 1`] = `
             "minHeight": 56,
           },
           false,
+          {
+            "backgroundColor": undefined,
+          },
           undefined,
         ],
       ]
@@ -1996,6 +2008,9 @@ exports[`renders list section without subheader 1`] = `
             "minHeight": 56,
           },
           false,
+          {
+            "backgroundColor": undefined,
+          },
           undefined,
         ],
       ]
@@ -2154,6 +2169,9 @@ exports[`renders list section without subheader 1`] = `
             "minHeight": 56,
           },
           false,
+          {
+            "backgroundColor": undefined,
+          },
           undefined,
         ],
       ]

--- a/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
@@ -488,10 +488,12 @@ exports[`renders list section with custom title style 1`] = `
         false,
         [
           {
+            "justifyContent": "center",
             "paddingRight": 16,
+            "paddingVertical": 12,
           },
           {
-            "paddingVertical": 16,
+            "minHeight": 56,
           },
           undefined,
         ],
@@ -643,10 +645,12 @@ exports[`renders list section with custom title style 1`] = `
         false,
         [
           {
+            "justifyContent": "center",
             "paddingRight": 16,
+            "paddingVertical": 12,
           },
           {
-            "paddingVertical": 16,
+            "minHeight": 56,
           },
           undefined,
         ],
@@ -1252,10 +1256,12 @@ exports[`renders list section with subheader 1`] = `
         false,
         [
           {
+            "justifyContent": "center",
             "paddingRight": 16,
+            "paddingVertical": 12,
           },
           {
-            "paddingVertical": 16,
+            "minHeight": 56,
           },
           undefined,
         ],
@@ -1407,10 +1413,12 @@ exports[`renders list section with subheader 1`] = `
         false,
         [
           {
+            "justifyContent": "center",
             "paddingRight": 16,
+            "paddingVertical": 12,
           },
           {
-            "paddingVertical": 16,
+            "minHeight": 56,
           },
           undefined,
         ],
@@ -1976,10 +1984,12 @@ exports[`renders list section without subheader 1`] = `
         false,
         [
           {
+            "justifyContent": "center",
             "paddingRight": 16,
+            "paddingVertical": 12,
           },
           {
-            "paddingVertical": 16,
+            "minHeight": 56,
           },
           undefined,
         ],
@@ -2131,10 +2141,12 @@ exports[`renders list section without subheader 1`] = `
         false,
         [
           {
+            "justifyContent": "center",
             "paddingRight": 16,
+            "paddingVertical": 12,
           },
           {
-            "paddingVertical": 16,
+            "minHeight": 56,
           },
           undefined,
         ],

--- a/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
@@ -489,7 +489,9 @@ exports[`renders list section with custom title style 1`] = `
         [
           {
             "paddingRight": 24,
-            "paddingVertical": 8,
+          },
+          {
+            "paddingVertical": 16,
           },
           undefined,
         ],
@@ -502,7 +504,6 @@ exports[`renders list section with custom title style 1`] = `
         [
           {
             "flexDirection": "row",
-            "marginVertical": 6,
             "width": "100%",
           },
           undefined,
@@ -582,21 +583,22 @@ exports[`renders list section with custom title style 1`] = `
               },
               {
                 "color": "rgba(29, 27, 32, 1)",
-                "fontFamily": "System",
-                "fontWeight": "400",
-                "letterSpacing": 0,
-              },
-              {
                 "writingDirection": "ltr",
               },
               [
                 {
+                  "fontFamily": "System",
                   "fontSize": 16,
+                  "fontWeight": "400",
+                  "letterSpacing": 0.5,
+                  "lineHeight": 24,
                 },
-                {
-                  "color": "rgba(29, 27, 32, 1)",
-                },
-                undefined,
+                [
+                  {
+                    "color": "rgba(29, 27, 32, 1)",
+                  },
+                  undefined,
+                ],
               ],
             ]
           }
@@ -642,7 +644,9 @@ exports[`renders list section with custom title style 1`] = `
         [
           {
             "paddingRight": 24,
-            "paddingVertical": 8,
+          },
+          {
+            "paddingVertical": 16,
           },
           undefined,
         ],
@@ -655,7 +659,6 @@ exports[`renders list section with custom title style 1`] = `
         [
           {
             "flexDirection": "row",
-            "marginVertical": 6,
             "width": "100%",
           },
           undefined,
@@ -735,21 +738,22 @@ exports[`renders list section with custom title style 1`] = `
               },
               {
                 "color": "rgba(29, 27, 32, 1)",
-                "fontFamily": "System",
-                "fontWeight": "400",
-                "letterSpacing": 0,
-              },
-              {
                 "writingDirection": "ltr",
               },
               [
                 {
+                  "fontFamily": "System",
                   "fontSize": 16,
+                  "fontWeight": "400",
+                  "letterSpacing": 0.5,
+                  "lineHeight": 24,
                 },
-                {
-                  "color": "rgba(29, 27, 32, 1)",
-                },
-                undefined,
+                [
+                  {
+                    "color": "rgba(29, 27, 32, 1)",
+                  },
+                  undefined,
+                ],
               ],
             ]
           }
@@ -1249,7 +1253,9 @@ exports[`renders list section with subheader 1`] = `
         [
           {
             "paddingRight": 24,
-            "paddingVertical": 8,
+          },
+          {
+            "paddingVertical": 16,
           },
           undefined,
         ],
@@ -1262,7 +1268,6 @@ exports[`renders list section with subheader 1`] = `
         [
           {
             "flexDirection": "row",
-            "marginVertical": 6,
             "width": "100%",
           },
           undefined,
@@ -1342,21 +1347,22 @@ exports[`renders list section with subheader 1`] = `
               },
               {
                 "color": "rgba(29, 27, 32, 1)",
-                "fontFamily": "System",
-                "fontWeight": "400",
-                "letterSpacing": 0,
-              },
-              {
                 "writingDirection": "ltr",
               },
               [
                 {
+                  "fontFamily": "System",
                   "fontSize": 16,
+                  "fontWeight": "400",
+                  "letterSpacing": 0.5,
+                  "lineHeight": 24,
                 },
-                {
-                  "color": "rgba(29, 27, 32, 1)",
-                },
-                undefined,
+                [
+                  {
+                    "color": "rgba(29, 27, 32, 1)",
+                  },
+                  undefined,
+                ],
               ],
             ]
           }
@@ -1402,7 +1408,9 @@ exports[`renders list section with subheader 1`] = `
         [
           {
             "paddingRight": 24,
-            "paddingVertical": 8,
+          },
+          {
+            "paddingVertical": 16,
           },
           undefined,
         ],
@@ -1415,7 +1423,6 @@ exports[`renders list section with subheader 1`] = `
         [
           {
             "flexDirection": "row",
-            "marginVertical": 6,
             "width": "100%",
           },
           undefined,
@@ -1495,21 +1502,22 @@ exports[`renders list section with subheader 1`] = `
               },
               {
                 "color": "rgba(29, 27, 32, 1)",
-                "fontFamily": "System",
-                "fontWeight": "400",
-                "letterSpacing": 0,
-              },
-              {
                 "writingDirection": "ltr",
               },
               [
                 {
+                  "fontFamily": "System",
                   "fontSize": 16,
+                  "fontWeight": "400",
+                  "letterSpacing": 0.5,
+                  "lineHeight": 24,
                 },
-                {
-                  "color": "rgba(29, 27, 32, 1)",
-                },
-                undefined,
+                [
+                  {
+                    "color": "rgba(29, 27, 32, 1)",
+                  },
+                  undefined,
+                ],
               ],
             ]
           }
@@ -1969,7 +1977,9 @@ exports[`renders list section without subheader 1`] = `
         [
           {
             "paddingRight": 24,
-            "paddingVertical": 8,
+          },
+          {
+            "paddingVertical": 16,
           },
           undefined,
         ],
@@ -1982,7 +1992,6 @@ exports[`renders list section without subheader 1`] = `
         [
           {
             "flexDirection": "row",
-            "marginVertical": 6,
             "width": "100%",
           },
           undefined,
@@ -2062,21 +2071,22 @@ exports[`renders list section without subheader 1`] = `
               },
               {
                 "color": "rgba(29, 27, 32, 1)",
-                "fontFamily": "System",
-                "fontWeight": "400",
-                "letterSpacing": 0,
-              },
-              {
                 "writingDirection": "ltr",
               },
               [
                 {
+                  "fontFamily": "System",
                   "fontSize": 16,
+                  "fontWeight": "400",
+                  "letterSpacing": 0.5,
+                  "lineHeight": 24,
                 },
-                {
-                  "color": "rgba(29, 27, 32, 1)",
-                },
-                undefined,
+                [
+                  {
+                    "color": "rgba(29, 27, 32, 1)",
+                  },
+                  undefined,
+                ],
               ],
             ]
           }
@@ -2122,7 +2132,9 @@ exports[`renders list section without subheader 1`] = `
         [
           {
             "paddingRight": 24,
-            "paddingVertical": 8,
+          },
+          {
+            "paddingVertical": 16,
           },
           undefined,
         ],
@@ -2135,7 +2147,6 @@ exports[`renders list section without subheader 1`] = `
         [
           {
             "flexDirection": "row",
-            "marginVertical": 6,
             "width": "100%",
           },
           undefined,
@@ -2215,21 +2226,22 @@ exports[`renders list section without subheader 1`] = `
               },
               {
                 "color": "rgba(29, 27, 32, 1)",
-                "fontFamily": "System",
-                "fontWeight": "400",
-                "letterSpacing": 0,
-              },
-              {
                 "writingDirection": "ltr",
               },
               [
                 {
+                  "fontFamily": "System",
                   "fontSize": 16,
+                  "fontWeight": "400",
+                  "letterSpacing": 0.5,
+                  "lineHeight": 24,
                 },
-                {
-                  "color": "rgba(29, 27, 32, 1)",
-                },
-                undefined,
+                [
+                  {
+                    "color": "rgba(29, 27, 32, 1)",
+                  },
+                  undefined,
+                ],
               ],
             ]
           }


### PR DESCRIPTION
### Motivation

`List.Item` layout is tied to the `left` and `right` render props: they hand the caller a `style` and a `color` and trust them to apply both. `leading` and `trailing` take a node instead, so `List.Item` owns the layout. They take precedence over `left` and `right` when both are passed.

### Related issue

Related to #4930 and #4976

Draft, stacked on #5041 and #5057.

### Test plan

Open the List example, check the leading and trailing slots render and pick up the item color, including in a selected row.
