### PR TITLE
fix(tooltip): propagate press and hover event objects to children

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -6,7 +6,12 @@ import {
   Platform,
   Pressable,
 } from 'react-native';
-import type { LayoutChangeEvent, ViewStyle } from 'react-native';
+import type {
+  GestureResponderEvent,
+  LayoutChangeEvent,
+  MouseEvent,
+  ViewStyle,
+} from 'react-native';
 
 import { getTooltipPosition } from './utils';
 import type { Measurement, TooltipChildProps } from './utils';
@@ -146,29 +151,38 @@ const Tooltip = ({
     hideTooltipTimer.current.push(id);
   }, [leaveTouchDelay]);
 
-  const handlePress = React.useCallback(() => {
-    if (touched.current) {
-      return null;
-    }
-    if (!isValidChild) return null;
-    const props = children.props as TooltipChildProps;
-    if (props.disabled) return null;
-    return props.onPress?.();
-  }, [children.props, isValidChild]);
+  const handlePress = React.useCallback(
+    (event: GestureResponderEvent) => {
+      if (touched.current) {
+        return null;
+      }
+      if (!isValidChild) return null;
+      const props = children.props as TooltipChildProps;
+      if (props.disabled) return null;
+      return props.onPress?.(event);
+    },
+    [children.props, isValidChild]
+  );
 
-  const handleHoverIn = React.useCallback(() => {
-    handleTouchStart();
-    if (isValidChild) {
-      (children.props as TooltipChildProps).onHoverIn?.();
-    }
-  }, [children.props, handleTouchStart, isValidChild]);
+  const handleHoverIn = React.useCallback(
+    (event: MouseEvent) => {
+      handleTouchStart();
+      if (isValidChild) {
+        (children.props as TooltipChildProps).onHoverIn?.(event);
+      }
+    },
+    [children.props, handleTouchStart, isValidChild]
+  );
 
-  const handleHoverOut = React.useCallback(() => {
-    handleTouchEnd();
-    if (isValidChild) {
-      (children.props as TooltipChildProps).onHoverOut?.();
-    }
-  }, [children.props, handleTouchEnd, isValidChild]);
+  const handleHoverOut = React.useCallback(
+    (event: MouseEvent) => {
+      handleTouchEnd();
+      if (isValidChild) {
+        (children.props as TooltipChildProps).onHoverOut?.(event);
+      }
+    },
+    [children.props, handleTouchEnd, isValidChild]
+  );
 
   const handleOnLayout = ({ nativeEvent: { layout } }: LayoutChangeEvent) => {
     childrenWrapperRef.current?.measure(

--- a/src/components/Tooltip/utils.ts
+++ b/src/components/Tooltip/utils.ts
@@ -1,5 +1,11 @@
 import { Dimensions, StyleSheet } from 'react-native';
-import type { LayoutRectangle, StyleProp, ViewStyle } from 'react-native';
+import type {
+  GestureResponderEvent,
+  LayoutRectangle,
+  MouseEvent,
+  StyleProp,
+  ViewStyle,
+} from 'react-native';
 
 type ChildrenMeasurement = {
   width: number;
@@ -19,9 +25,9 @@ export type Measurement = {
 export type TooltipChildProps = {
   style: StyleProp<ViewStyle>;
   disabled?: boolean;
-  onPress?: () => void;
-  onHoverIn?: () => void;
-  onHoverOut?: () => void;
+  onPress?: (event: GestureResponderEvent) => void;
+  onHoverIn?: (event: MouseEvent) => void;
+  onHoverOut?: (event: MouseEvent) => void;
 };
 
 /**

--- a/src/components/__tests__/Tooltip.test.tsx
+++ b/src/components/__tests__/Tooltip.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { Dimensions, Text, View, Platform } from 'react-native';
-import type { ViewProps } from 'react-native';
+import type {
+  GestureResponderEvent,
+  MouseEvent,
+  ViewProps,
+} from 'react-native';
 
 import {
   afterAll,
@@ -30,6 +34,9 @@ const DummyComponent = ({
   ...props
 }: ViewProps & {
   ref?: React.RefObject<View | null>;
+  onPress?: (event: GestureResponderEvent) => void;
+  onHoverIn?: (event: MouseEvent) => void;
+  onHoverOut?: (event: MouseEvent) => void;
 }) => (
   <View {...props} ref={ref}>
     <Text>dummy component</Text>
@@ -156,6 +163,23 @@ describe('Tooltip', () => {
         await userEvent.longPress(trigger);
 
         expect(global.clearTimeout).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('press', () => {
+      it("passes the event object to the children's onPress", async () => {
+        const onPress = jest.fn();
+
+        const {
+          wrapper: { getByText },
+        } = await setup({ children: <DummyComponent onPress={onPress} /> });
+
+        await userEvent.press(getTrigger(getByText));
+
+        expect(onPress).toHaveBeenCalledTimes(1);
+        expect(onPress).toHaveBeenCalledWith(
+          expect.objectContaining({ nativeEvent: expect.anything() })
+        );
       });
     });
 
@@ -350,6 +374,19 @@ describe('Tooltip', () => {
 
         expect(global.clearTimeout).toHaveBeenCalledTimes(2);
       });
+
+      it("passes the event object to the children's onHoverIn", async () => {
+        const onHoverIn = jest.fn();
+        const event = { nativeEvent: {} };
+
+        const {
+          wrapper: { getByText },
+        } = await setup({ children: <DummyComponent onHoverIn={onHoverIn} /> });
+
+        await fireEvent(getTrigger(getByText), 'hoverIn', event);
+
+        expect(onHoverIn).toHaveBeenCalledWith(event);
+      });
     });
 
     describe('hoverOut', () => {
@@ -367,6 +404,21 @@ describe('Tooltip', () => {
         await runTimers();
 
         expect(queryByText('some tooltip text')).not.toBeOnTheScreen();
+      });
+
+      it("passes the event object to the children's onHoverOut", async () => {
+        const onHoverOut = jest.fn();
+        const event = { nativeEvent: {} };
+
+        const {
+          wrapper: { getByText },
+        } = await setup({
+          children: <DummyComponent onHoverOut={onHoverOut} />,
+        });
+
+        await fireEvent(getTrigger(getByText), 'hoverOut', event);
+
+        expect(onHoverOut).toHaveBeenCalledWith(event);
       });
     });
 


### PR DESCRIPTION
### Motivation

`Tooltip` invokes the wrapped children's handlers itself, but it called them without any arguments:

```ts
return props.onPress?.();
```

So any consumer callback wrapped in a `Tooltip` received `undefined` instead of the event, e.g. `onPress={(e) => e.nativeEvent...}` crashed or silently misbehaved on Android/iOS. The same applied to `onHoverIn`/`onHoverOut` on web.

This PR forwards the original `GestureResponderEvent`/`MouseEvent` to the children handlers and types `TooltipChildProps` accordingly, so the event object reaches parent callbacks.

### Related issue

Closes #5003

### Test plan

- `yarn test`, `yarn lint` and `yarn typecheck` pass.
- Added unit tests in `src/components/__tests__/Tooltip.test.tsx`:
  - mobile: pressing the trigger calls the children's `onPress` with an event object (this test fails on `main`),
  - web: `onHoverIn`/`onHoverOut` receive the event object.
- Repro from the issue (https://snack.expo.dev/@szado/rnp-tooltip-onpress-bug): the child's `onPress` now receives the event instead of `undefined`.

No API change other than the widened (previously argument-less) handler types on `TooltipChildProps`.
