### PR TITLE
fix(modal): move dialogs above the on-screen keyboard

### DIFF
--- a/example/src/Examples/DialogExample.tsx
+++ b/example/src/Examples/DialogExample.tsx
@@ -10,6 +10,7 @@ import {
   DialogWithLoadingIndicator,
   DialogWithLongText,
   DialogWithRadioBtns,
+  DialogWithTextInput,
   UndismissableDialog,
 } from './Dialogs';
 import ScreenWrapper from '../ScreenWrapper';
@@ -70,6 +71,13 @@ const DialogExample = () => {
       >
         With icon
       </Button>
+      <Button
+        mode="outlined"
+        onPress={_toggleDialog('dialog8')}
+        style={styles.button}
+      >
+        With text input
+      </Button>
       {Platform.OS === 'android' && (
         <Button
           mode="outlined"
@@ -106,6 +114,10 @@ const DialogExample = () => {
       <DialogWithDismissableBackButton
         visible={_getVisible('dialog7')}
         close={_toggleDialog('dialog7')}
+      />
+      <DialogWithTextInput
+        visible={_getVisible('dialog8')}
+        close={_toggleDialog('dialog8')}
       />
     </ScreenWrapper>
   );

--- a/example/src/Examples/Dialogs/DialogWithTextInput.tsx
+++ b/example/src/Examples/Dialogs/DialogWithTextInput.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { Button, Portal, Dialog, TextInput } from 'react-native-paper';
+
+import { TextComponent } from './DialogTextComponent';
+
+const DialogWithTextInput = ({
+  visible,
+  close,
+}: {
+  visible: boolean;
+  close: () => void;
+}) => {
+  const [name, setName] = React.useState('');
+
+  return (
+    <Portal>
+      <Dialog onDismiss={close} visible={visible}>
+        <Dialog.Title>Dialog with text input</Dialog.Title>
+        <Dialog.Content>
+          <TextComponent>
+            Focus the input below to check that the dialog stays above the
+            on-screen keyboard.
+          </TextComponent>
+          <TextInput
+            label="Name"
+            value={name}
+            onChangeText={setName}
+            style={styles.input}
+          />
+        </Dialog.Content>
+        <Dialog.Actions>
+          <Button onPress={close}>Cancel</Button>
+          <Button onPress={close}>Save</Button>
+        </Dialog.Actions>
+      </Dialog>
+    </Portal>
+  );
+};
+
+const styles = StyleSheet.create({
+  input: {
+    marginTop: 16,
+  },
+});
+
+export default DialogWithTextInput;

--- a/example/src/Examples/Dialogs/index.tsx
+++ b/example/src/Examples/Dialogs/index.tsx
@@ -5,3 +5,4 @@ export { default as DialogWithRadioBtns } from './DialogWithRadioBtns';
 export { default as UndismissableDialog } from './UndismissableDialog';
 export { default as DialogWithIcon } from './DialogWithIcon';
 export { default as DialogWithDismissableBackButton } from './DialogWithDismissableBackButton';
+export { default as DialogWithTextInput } from './DialogWithTextInput';

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Animated, Easing, StyleSheet, Pressable, View } from 'react-native';
-import type { StyleProp, ViewStyle } from 'react-native';
+import type { LayoutChangeEvent, StyleProp, ViewStyle } from 'react-native';
 
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import useLatestCallback from 'use-latest-callback';
@@ -12,6 +12,7 @@ import type { ThemeProp } from '../types';
 import { addEventListener } from '../utils/addEventListener';
 import { BackHandler } from '../utils/BackHandler/BackHandler';
 import useAnimatedValue from '../utils/useAnimatedValue';
+import useKeyboardOverlap from '../utils/useKeyboardOverlap';
 
 const scrimAlpha = tokens.md.sys.scrim.alpha;
 
@@ -114,6 +115,18 @@ function Modal({
   const { top, bottom } = useSafeAreaInsets();
   const opacity = useAnimatedValue(visible ? 1 : 0);
   const [visibleInternal, setVisibleInternal] = React.useState(visible);
+  const [wrapperBottom, setWrapperBottom] = React.useState<number | null>(null);
+
+  const keyboardOverlap = useKeyboardOverlap({
+    enabled: visibleInternal,
+    containerBottom: wrapperBottom,
+  });
+
+  const onWrapperLayout = React.useCallback((event: LayoutChangeEvent) => {
+    const { y, height } = event.nativeEvent.layout;
+
+    setWrapperBottom(y + height);
+  }, []);
 
   const showModalAnimation = React.useCallback(() => {
     Animated.timing(opacity, {
@@ -209,9 +222,16 @@ function Modal({
       <View
         style={[
           styles.wrapper,
-          { marginTop: top, marginBottom: bottom },
+          {
+            marginTop: top,
+            marginBottom: bottom,
+            // Keeps the content above the on-screen keyboard on platforms where
+            // the system doesn't resize the window, e.g. iOS or edge-to-edge Android.
+            paddingBottom: keyboardOverlap,
+          },
           style,
         ]}
+        onLayout={onWrapperLayout}
         pointerEvents="box-none"
         testID={`${testID}-wrapper`}
       >

--- a/src/components/__tests__/Modal.test.tsx
+++ b/src/components/__tests__/Modal.test.tsx
@@ -1,8 +1,15 @@
-import { Animated, BackHandler as RNBackHandler, Text } from 'react-native';
+import {
+  Animated,
+  BackHandler as RNBackHandler,
+  DeviceEventEmitter,
+  Dimensions,
+  Platform,
+  Text,
+} from 'react-native';
 import type { BackHandlerStatic as RNBackHandlerStatic } from 'react-native';
 
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
-import { act, userEvent } from '@testing-library/react-native';
+import { act, fireEvent, userEvent } from '@testing-library/react-native';
 
 import { render, screen } from '../../test-utils';
 import { LightTheme } from '../../theme/schemes';
@@ -574,6 +581,186 @@ describe('Modal', () => {
       });
     });
   });
+
+  // `keyboardWillShow` and `keyboardWillHide` are not emitted on Android
+  const keyboardEventsPerPlatform: Array<[typeof Platform.OS, string, string]> =
+    [
+      ['ios', 'keyboardWillShow', 'keyboardWillHide'],
+      ['android', 'keyboardDidShow', 'keyboardDidHide'],
+    ];
+
+  describe.each(keyboardEventsPerPlatform)(
+    'when the on-screen keyboard is shown on %s',
+    (platform, showEvent, hideEvent) => {
+      const KEYBOARD_HEIGHT = 300;
+      const TOP_INSET = 37;
+      const BOTTOM_INSET = 44;
+
+      const screenHeight = Dimensions.get('screen').height;
+      // Space taken by the keyboard below the bottom edge of the wrapper
+      const expectedOverlap = KEYBOARD_HEIGHT - BOTTOM_INSET;
+      const originalPlatform = Platform.OS;
+
+      beforeAll(() => {
+        Platform.OS = platform;
+      });
+
+      afterAll(() => {
+        Platform.OS = originalPlatform;
+      });
+
+      const showKeyboard = async () => {
+        await act(() => {
+          DeviceEventEmitter.emit(showEvent, {
+            endCoordinates: {
+              screenX: 0,
+              screenY: screenHeight - KEYBOARD_HEIGHT,
+              width: 750,
+              height: KEYBOARD_HEIGHT,
+            },
+          });
+        });
+      };
+
+      const hideKeyboard = async () => {
+        await act(() => {
+          DeviceEventEmitter.emit(hideEvent, {
+            endCoordinates: {
+              screenX: 0,
+              screenY: screenHeight,
+              width: 750,
+              height: 0,
+            },
+          });
+        });
+      };
+
+      const layoutWrapper = async (y: number, height: number) => {
+        await act(() =>
+          fireEvent(screen.getByTestId('modal-wrapper'), 'layout', {
+            nativeEvent: { layout: { x: 0, y, width: 750, height } },
+          })
+        );
+      };
+
+      it('should keep the content above the keyboard if the window is not resized', async () => {
+        await render(
+          <Modal visible={true} testID="modal">
+            {null}
+          </Modal>
+        );
+
+        expect(screen.getByTestId('modal-wrapper')).toHaveStyle({
+          paddingBottom: 0,
+        });
+
+        await layoutWrapper(TOP_INSET, screenHeight - TOP_INSET - BOTTOM_INSET);
+        await showKeyboard();
+
+        expect(screen.getByTestId('modal-wrapper')).toHaveStyle({
+          paddingBottom: expectedOverlap,
+        });
+      });
+
+      it('should account for a keyboard which is already open when it becomes visible', async () => {
+        // `Keyboard.metrics()` is populated from `keyboardDidShow` on every platform
+        await act(() => {
+          DeviceEventEmitter.emit('keyboardDidShow', {
+            endCoordinates: {
+              screenX: 0,
+              screenY: screenHeight - KEYBOARD_HEIGHT,
+              width: 750,
+              height: KEYBOARD_HEIGHT,
+            },
+          });
+        });
+
+        const { rerender } = await render(
+          <Modal visible={false} testID="modal">
+            {null}
+          </Modal>
+        );
+
+        await rerender(
+          <Modal visible={true} testID="modal">
+            {null}
+          </Modal>
+        );
+
+        await layoutWrapper(TOP_INSET, screenHeight - TOP_INSET - BOTTOM_INSET);
+
+        expect(screen.getByTestId('modal-wrapper')).toHaveStyle({
+          paddingBottom: expectedOverlap,
+        });
+
+        await act(() => {
+          DeviceEventEmitter.emit('keyboardDidHide', {
+            endCoordinates: {
+              screenX: 0,
+              screenY: screenHeight,
+              width: 750,
+              height: 0,
+            },
+          });
+        });
+      });
+
+      it('should not add any padding if the window is resized by the system', async () => {
+        await render(
+          <Modal visible={true} testID="modal">
+            {null}
+          </Modal>
+        );
+
+        // The system shrunk the window, so the wrapper is already above the keyboard
+        await layoutWrapper(
+          TOP_INSET,
+          screenHeight - TOP_INSET - BOTTOM_INSET - KEYBOARD_HEIGHT
+        );
+        await showKeyboard();
+
+        expect(screen.getByTestId('modal-wrapper')).toHaveStyle({
+          paddingBottom: 0,
+        });
+      });
+
+      it('should follow the wrapper if the safe area insets are overridden', async () => {
+        await render(
+          <Modal visible={true} testID="modal" style={{ marginBottom: 0 }}>
+            {null}
+          </Modal>
+        );
+
+        await layoutWrapper(TOP_INSET, screenHeight - TOP_INSET);
+        await showKeyboard();
+
+        expect(screen.getByTestId('modal-wrapper')).toHaveStyle({
+          paddingBottom: KEYBOARD_HEIGHT,
+        });
+      });
+
+      it('should restore the original padding once the keyboard is hidden', async () => {
+        await render(
+          <Modal visible={true} testID="modal">
+            {null}
+          </Modal>
+        );
+
+        await layoutWrapper(TOP_INSET, screenHeight - TOP_INSET - BOTTOM_INSET);
+        await showKeyboard();
+
+        expect(screen.getByTestId('modal-wrapper')).toHaveStyle({
+          paddingBottom: expectedOverlap,
+        });
+
+        await hideKeyboard();
+
+        expect(screen.getByTestId('modal-wrapper')).toHaveStyle({
+          paddingBottom: 0,
+        });
+      });
+    }
+  );
 
   it('animated value changes correctly', async () => {
     const value = new Animated.Value(1);

--- a/src/utils/useKeyboardOverlap.tsx
+++ b/src/utils/useKeyboardOverlap.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import { Keyboard, Platform } from 'react-native';
+import type { KeyboardEvent } from 'react-native';
+
+type KeyboardMetrics = KeyboardEvent['endCoordinates'];
+
+type Props = {
+  /**
+   * Whether the keyboard should be tracked at all, e.g. only while the container is visible.
+   */
+  enabled: boolean;
+  /**
+   * Position of the bottom edge of the container, as reported by `onLayout`.
+   */
+  containerBottom: number | null;
+};
+
+const getCurrentMetrics = () =>
+  // `metrics` is not implemented by react-native-web
+  (Keyboard.isVisible() ? Keyboard.metrics?.() : null) ?? null;
+
+/**
+ * Returns how much of a container is covered by the on-screen keyboard.
+ *
+ * Historically components rendered in a `Portal` didn't have to care about the
+ * keyboard on Android, because `android:windowSoftInputMode="adjustResize"` made
+ * the system shrink the whole window. This no longer happens in edge-to-edge mode
+ * (enforced since Android 15), where the keyboard is reported as an inset which has
+ * to be handled by the app, and it never happened on iOS.
+ *
+ * The overlap is the distance between the bottom edge of the container and the top
+ * edge of the keyboard. Both are relative to the window, so windows which are still
+ * resized by the system need no correction: the container has already been laid out
+ * above the keyboard, which puts the overlap at or below zero.
+ */
+export default function useKeyboardOverlap({
+  enabled,
+  containerBottom,
+}: Props) {
+  const [metrics, setMetrics] = React.useState<KeyboardMetrics | null>(() =>
+    enabled ? getCurrentMetrics() : null
+  );
+
+  React.useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+
+    setMetrics(getCurrentMetrics());
+
+    const onShow = (event: KeyboardEvent) => {
+      setMetrics(event.endCoordinates);
+      // `scheduleLayoutAnimation` is not implemented by react-native-web
+      Keyboard.scheduleLayoutAnimation?.(event);
+    };
+
+    const onHide = (event: KeyboardEvent) => {
+      setMetrics(null);
+      Keyboard.scheduleLayoutAnimation?.(event);
+    };
+
+    // `keyboardWillShow` and `keyboardWillHide` are not emitted on Android.
+    const subscriptions =
+      Platform.OS === 'ios'
+        ? [
+            Keyboard.addListener('keyboardWillShow', onShow),
+            Keyboard.addListener('keyboardWillHide', onHide),
+          ]
+        : [
+            Keyboard.addListener('keyboardDidShow', onShow),
+            Keyboard.addListener('keyboardDidHide', onHide),
+          ];
+
+    return () => subscriptions.forEach((subscription) => subscription.remove());
+  }, [enabled]);
+
+  if (!enabled || metrics == null || containerBottom == null) {
+    return 0;
+  }
+
+  // iOS reports a keyboard positioned at the top of the screen when the
+  // "Prefer Cross-Fade Transitions" accessibility setting is enabled.
+  if (metrics.screenY <= 0) {
+    return 0;
+  }
+
+  return Math.max(0, containerBottom - metrics.screenY);
+}


### PR DESCRIPTION
### Motivation

Components rendered in a `Portal`, such as `Modal` and `Dialog`, are not moved out of the way of the on-screen keyboard.

On Android this used to be handled by the system: React Native apps set `android:windowSoftInputMode="adjustResize"`, so the whole window was shrunk when the keyboard appeared and the modal, which fills the window, was re-centered in the remaining space. This no longer happens in edge-to-edge mode (opt-in via `edgeToEdgeEnabled`, enforced since Android 15), where the keyboard is reported as an inset that the app has to handle itself, so the keyboard covers the dialog and its actions. On iOS the window is never resized, so this never worked there at all.

`KeyboardAvoidingView` can't be used by the app as a workaround here, because the modal is rendered through a `Portal`, outside of the app's own view hierarchy.

This PR makes `Modal` track the keyboard and pad its wrapper by the part of it that the keyboard covers, so the content stays centered in the visible area. `Dialog` gets the fix for free, since it renders a `Modal`.

A few notes on the implementation:

- The overlap is the distance between the measured bottom edge of the wrapper (`onLayout`) and the top edge of the keyboard (`endCoordinates.screenY`), which is the same relation `KeyboardAvoidingView` uses. Both are relative to the window, so windows which are still resized by the system need no special casing: their wrapper is already laid out above the keyboard, which puts the overlap at or below zero. Nothing is assumed about the safe area insets either, so overriding `marginTop`/`marginBottom` through the `style` prop keeps working.
- `keyboardWillHide`/`keyboardDidHide` clear the metrics instead of feeding them back into the calculation, which is what makes `KeyboardAvoidingView` keep a stale offset on Android in edge-to-edge mode (facebook/react-native#55855).
- Nothing is subscribed or computed while the modal is hidden, and the keyboard is not tracked on the web, where no keyboard events are emitted.
- The padding change is scheduled with `Keyboard.scheduleLayoutAnimation`, so it follows the keyboard animation curve on iOS.

### Related issue

Fixes #5021
Fixes #4218

### Test plan

Automated: new unit tests in `src/components/__tests__/Modal.test.tsx` cover a window that is not resized (padding is applied), a window that is resized by the system (padding is not applied), overridden safe area insets, and hiding the keyboard (padding is restored). `yarn test`, `yarn lint` and `yarn typecheck` pass.

Manual, using the new **Dialog -> With text input** example:

1. Run the example app on Android 15/16, or on an older Android with `edgeToEdgeEnabled=true` in `android/gradle.properties`.
2. Open the `Dialog` example and press **With text input**.
3. Focus the text field: the dialog moves above the keyboard and its actions stay reachable; dismissing the keyboard restores its position.
4. Repeat with `edgeToEdgeEnabled=false` to confirm the previous behavior is unchanged, and on iOS, where the dialog now moves as well.
