### PR TITLE
fix(touchable-ripple): support function children and style on native

### DIFF
--- a/src/components/BottomNavigation/BottomNavigationBar.tsx
+++ b/src/components/BottomNavigation/BottomNavigationBar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports -- TODO: migrate BottomNavigation to Reanimated.
-import { Animated, Platform, StyleSheet, Pressable, View } from 'react-native';
+import { Animated, Platform, StyleSheet, View } from 'react-native';
 import type {
   ColorValue,
   EasingFunction,
@@ -24,6 +24,7 @@ import useLayout from '../../utils/useLayout';
 import Badge from '../Badge';
 import Icon from '../Icon';
 import type { IconSource } from '../Icon';
+import { Pressable } from '../TouchableRipple/Pressable';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import type { Props as TouchableRippleProps } from '../TouchableRipple/TouchableRipple';
 import Text from '../Typography/Text';

--- a/src/components/TouchableRipple/TouchableRipple.native.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.native.tsx
@@ -8,7 +8,7 @@ import type {
   ColorValue,
 } from 'react-native';
 
-import type { PressableProps } from './Pressable';
+import type { PressableProps, PressableStateCallbackType } from './Pressable';
 import { Pressable } from './Pressable';
 import { getTouchableRippleColors } from './utils';
 import { SettingsContext } from '../../core/settings';
@@ -31,8 +31,13 @@ export type Props = PressableProps & {
   onPressOut?: (e: GestureResponderEvent) => void;
   rippleColor?: ColorValue;
   underlayColor?: string;
-  children: React.ReactNode;
-  style?: StyleProp<ViewStyle>;
+  children:
+    | ((state: PressableStateCallbackType) => React.ReactNode)
+    | React.ReactNode;
+  style?:
+    | StyleProp<ViewStyle>
+    | ((state: PressableStateCallbackType) => StyleProp<ViewStyle>)
+    | undefined;
   ref?: React.Ref<View>;
   theme?: ThemeProp;
 };
@@ -78,6 +83,16 @@ const TouchableRipple = ({
   const useForeground =
     Platform.OS === 'android' && Platform.Version >= ANDROID_VERSION_PIE;
 
+  // Both `children` and `style` may be render functions, like on `Pressable`.
+  // They are kept in their static form whenever possible, because `Pressable`
+  // only tracks the pressed state when one of them is a function.
+  const resolveStyle = (
+    baseStyle: StyleProp<ViewStyle>
+  ): PressableProps['style'] =>
+    typeof style === 'function'
+      ? (state) => [baseStyle, style(state)]
+      : [baseStyle, style];
+
   if (TouchableRipple.supported) {
     const androidRipple = rippleEffectEnabled
       ? (background ?? {
@@ -92,10 +107,12 @@ const TouchableRipple = ({
         {...rest}
         ref={ref}
         disabled={disabled}
-        style={[useForeground && styles.overflowHidden, style]}
+        style={resolveStyle(useForeground && styles.overflowHidden)}
         android_ripple={androidRipple}
       >
-        {React.Children.only(children)}
+        {typeof children === 'function'
+          ? (state) => React.Children.only(children(state))
+          : React.Children.only(children)}
       </Pressable>
     );
   }
@@ -105,11 +122,11 @@ const TouchableRipple = ({
       {...rest}
       ref={ref}
       disabled={disabled}
-      style={[borderless && styles.overflowHidden, style]}
+      style={resolveStyle(borderless && styles.overflowHidden)}
     >
-      {({ pressed }) => (
+      {(state) => (
         <>
-          {pressed && rippleEffectEnabled && (
+          {state.pressed && rippleEffectEnabled && (
             <View
               testID="touchable-ripple-underlay"
               style={[
@@ -118,7 +135,9 @@ const TouchableRipple = ({
               ]}
             />
           )}
-          {React.Children.only(children)}
+          {React.Children.only(
+            typeof children === 'function' ? children(state) : children
+          )}
         </>
       )}
     </Pressable>

--- a/src/components/__tests__/TouchableRipple.test.tsx
+++ b/src/components/__tests__/TouchableRipple.test.tsx
@@ -1,7 +1,7 @@
 import { Platform, Text } from 'react-native';
 import type { GestureResponderEvent } from 'react-native';
 
-import { describe, expect, it, jest } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import { userEvent } from '@testing-library/react-native';
 
 import { render, screen } from '../../test-utils';
@@ -67,6 +67,73 @@ describe('TouchableRipple', () => {
 
       const underlay = screen.getByTestId('touchable-ripple-underlay');
       expect(underlay).toHaveStyle({ backgroundColor: 'purple' });
+    });
+  });
+
+  // Both branches of the component need to behave the same, so the tests below
+  // are run once with the native ripple effect enabled (Android >= Lollipop)
+  // and once with the highlight fallback used everywhere else.
+  describe.each([
+    { supported: false, label: 'with the highlight fallback' },
+    { supported: true, label: 'with the native ripple effect' },
+  ])('$label', ({ supported }) => {
+    const originalSupported = TouchableRipple.supported;
+
+    beforeAll(() => {
+      TouchableRipple.supported = supported;
+    });
+
+    afterAll(() => {
+      TouchableRipple.supported = originalSupported;
+    });
+
+    it('supports children as a render function', async () => {
+      await render(
+        <TouchableRipple>
+          {({ pressed }) => <Text>{pressed ? 'pressed' : 'idle'}</Text>}
+        </TouchableRipple>
+      );
+
+      expect(screen.getByText('idle')).toBeOnTheScreen();
+    });
+
+    it('passes the pressed state to the children render function', async () => {
+      await render(
+        <TouchableRipple testOnly_pressed>
+          {({ pressed }) => <Text>{pressed ? 'pressed' : 'idle'}</Text>}
+        </TouchableRipple>
+      );
+
+      expect(screen.getByText('pressed')).toBeOnTheScreen();
+    });
+
+    it('resolves style as a function', async () => {
+      await render(
+        <TouchableRipple
+          testID="touchable-ripple"
+          testOnly_pressed
+          style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1 })}
+        >
+          <Text>Press me!</Text>
+        </TouchableRipple>
+      );
+
+      expect(screen.getByTestId('touchable-ripple')).toHaveStyle({
+        opacity: 0.5,
+      });
+    });
+
+    it('keeps rendering element children with a style object', async () => {
+      await render(
+        <TouchableRipple testID="touchable-ripple" style={{ opacity: 0.5 }}>
+          <Text>Press me!</Text>
+        </TouchableRipple>
+      );
+
+      expect(screen.getByText('Press me!')).toBeOnTheScreen();
+      expect(screen.getByTestId('touchable-ripple')).toHaveStyle({
+        opacity: 0.5,
+      });
     });
   });
 });


### PR DESCRIPTION
### Motivation

`TouchableRipple` documents `children` and `style` as accepting a render function that receives the pressable state, and `TouchableRipple.tsx` (web) implements exactly that. `TouchableRipple.native.tsx` does not, so the two platforms disagree:

`src/components/TouchableRipple/TouchableRipple.native.tsx` (before this PR)

```ts
children: React.ReactNode;
style?: StyleProp<ViewStyle>;
```

vs. `src/components/TouchableRipple/TouchableRipple.tsx:66-72`

```ts
children:
  | ((state: PressableStateCallbackType) => React.ReactNode)
  | React.ReactNode;
style?:
  | StyleProp<ViewStyle>
  | ((state: PressableStateCallbackType) => StyleProp<ViewStyle>)
  | undefined;
```

Measured on `main` today:

- function `children` throws `React.Children.only expected to receive a single React element child.`, from the bare `React.Children.only(children)` calls at `TouchableRipple.native.tsx:98` (ripple branch) and `:121` (highlight-fallback branch);
- function `style` is passed straight into a plain array, so it is **silently dropped** — the rendered `props.style` is `[false, null]`, with no error at all.

The divergence dates back to #3909, which reworked the web file only.

### What this PR changes

`TouchableRipple.native.tsx` now mirrors the web contract on both of its branches. Both `React.Children.only` call sites are handled, since both are reachable — `:98` on Android >= Lollipop, `:121` everywhere else — and a fix to only one of them would just move the bug to the other platform.

One deliberate difference from a literal copy of the web file: the render-function form is used **only when the corresponding prop is actually a function**. `Pressable` derives `shouldUpdatePressed` from `typeof children === 'function' || typeof style === 'function'` ([`Pressable.js:224-225`](https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Components/Pressable/Pressable.js)), so unconditionally passing a function `style` would make every `Button`, `Card`, `List.Item`, `Chip`, `DataTable.Row`, `Menu.Item`, `IconButton`, `Checkbox`, `RadioButton`, `Drawer.Item` and `SegmentedButtons` item start re-rendering on every press-in/press-out, even though none of them use the state. Keeping the static form static makes this fix inert for the common path. The web file can pass a function unconditionally because it always needs `state.hovered`.

`React.Children.only` is kept on the resolved children, matching the web file's behaviour exactly. If #5018 lands, both call sites can be dropped together in that refactor.

The one line outside `TouchableRipple`: `BottomNavigationBar` forwards `TouchableRipple`'s `style` prop to a bare `react-native` `Pressable` on its non-ripple path, and RN's `PressableStateCallbackType` is `{ pressed }` while the wrapper's is `{ pressed, hovered, focused }`. It now imports the same `Pressable` wrapper `TouchableRipple` uses — which is `PressableNative as any`, so this is a types-only change with no runtime effect — otherwise `yarn typecheck` fails there.

### Related issue

Fixes #4873

Related: this looks like a missed entry on the v6 `React.Children` checklist in #4989 — #5018 touches 30 files and none of them is `TouchableRipple`.

There is also #4896 from @skainguyen1412, which addresses the same report, but it targets the `5.0` branch, so `main` is still affected. I'm happy to close this one if that PR gets forward-ported instead; this PR additionally covers the ripple-supported branch (`:98`), the function `style` case, and the `Pressable` pressed-state-tracking concern above.

### Test plan

`yarn lint`, `yarn typecheck` and `yarn test` all pass.

`src/components/__tests__/TouchableRipple.test.tsx` gains 8 tests, run twice via `describe.each` — once with `TouchableRipple.supported = false` (highlight fallback) and once with `true` (native ripple) — so both `React.Children.only` call sites are covered:

- `supports children as a render function`
- `passes the pressed state to the children render function` (via `testOnly_pressed`, so it proves the state is actually threaded, not just that a function is invoked)
- `resolves style as a function`
- `keeps rendering element children with a style object` — non-vacuity: the pre-existing path must be untouched

Counterfactual, with the source change reverted and the tests kept:

```
  with the highlight fallback
    ✕ supports children as a render function (7 ms)
    ✕ passes the pressed state to the children render function
    ✕ resolves style as a function (2 ms)
    ✓ keeps rendering element children with a style object (1 ms)
  with the native ripple effect
    ✕ supports children as a render function
    ✕ passes the pressed state to the children render function
    ✕ resolves style as a function
    ✓ keeps rendering element children with a style object (1 ms)

Tests:       6 failed, 7 passed, 13 total
```

The three failures per branch are `React.Children.only expected to receive a single React element child.` (thrown from `:121` and `:98` respectively) and `toHaveStyle` not finding `opacity: 0.5`. With the fix applied, all 13 pass.

Full suite before: `55 passed, 732 passed / 1 skipped, 169 snapshots`.
Full suite after: `55 passed, 740 passed / 1 skipped, 169 snapshots`.

**Snapshot churn: none.** All 169 snapshots pass unmodified, which is the check that matters here — `TouchableRipple` underpins most touchable components in the library, and the static `style` array it renders is byte-identical to before.
