### PR TITLE
fix: apply bold fontWeight to active BottomNavigation.Bar label

### DIFF
--- a/src/components/BottomNavigation/BottomNavigationBar.tsx
+++ b/src/components/BottomNavigation/BottomNavigationBar.tsx
@@ -4,6 +4,7 @@ import type {
   ColorValue,
   EasingFunction,
   StyleProp,
+  TextStyle,
   ViewStyle,
 } from 'react-native';
 
@@ -713,6 +714,7 @@ const BottomNavigationBar = <Route extends BaseRoute>({
                               styles.label,
                               {
                                 color: activeLabelColor,
+                                fontWeight: '700' as TextStyle['fontWeight'],
                                 ...font,
                               },
                             ]}

--- a/src/components/BottomNavigation/BottomNavigationBar.tsx
+++ b/src/components/BottomNavigation/BottomNavigationBar.tsx
@@ -714,8 +714,8 @@ const BottomNavigationBar = <Route extends BaseRoute>({
                               styles.label,
                               {
                                 color: activeLabelColor,
-                                fontWeight: '700' as TextStyle['fontWeight'],
                                 ...font,
+                                fontWeight: '700' as TextStyle['fontWeight'],
                               },
                             ]}
                           >


### PR DESCRIPTION
Fixes #4780

MD3 spec requires the active navigation bar label to be bold (weight 700). Previously the same font was applied to both active and inactive labels.

Added `fontWeight: 700` to the active label Text style in `BottomNavigationBar.tsx`.