### PR TITLE
fix: remove duplicate tabstop in RadioButton.Item

### DIFF
--- a/src/components/RadioButton/RadioButtonItem.tsx
+++ b/src/components/RadioButton/RadioButtonItem.tsx
@@ -165,7 +165,12 @@ const RadioButtonItem = ({
     color,
     theme,
     uncheckedColor,
-  };
+    // The outer TouchableRipple in RadioButtonItem already provides the
+    // interactive surface. Disable the inner RadioButton's focusability
+    // so there is only one tabstop per radio button item on web.
+    focusable: false,
+    tabIndex: -1,
+  } as const;
   const isLeading = position === 'leading';
   let radioButton: any;
 

--- a/src/components/RadioButton/RadioButtonItem.tsx
+++ b/src/components/RadioButton/RadioButtonItem.tsx
@@ -166,10 +166,14 @@ const RadioButtonItem = ({
     theme,
     uncheckedColor,
     // The outer TouchableRipple in RadioButtonItem already provides the
-    // interactive surface. Disable the inner RadioButton's focusability
-    // so there is only one tabstop per radio button item on web.
+    // interactive surface. Hide the inner RadioButton from the
+    // accessibility tree so screen readers only encounter one control,
+    // and keep tabIndex: -1 so web keyboard users have a single
+    // tabstop per row (matches the approach used in Checkbox.Item).
     focusable: false,
     tabIndex: -1,
+    accessible: false,
+    'aria-hidden': true,
   } as const;
   const isLeading = position === 'leading';
   let radioButton: any;

--- a/src/components/__tests__/RadioButton/RadioButtonItem.test.tsx
+++ b/src/components/__tests__/RadioButton/RadioButtonItem.test.tsx
@@ -84,3 +84,16 @@ it('should execute onLongPress', async () => {
 
   expect(onLongPress).toHaveBeenCalledTimes(1);
 });
+
+it('exposes only one radio control to screen readers', async () => {
+  await render(
+    <RadioButton.Item
+      label="Radio button"
+      value="radio"
+      status="unchecked"
+    />
+  );
+
+  expect(screen.getAllByRole('radio')).toHaveLength(1);
+});
+

--- a/src/components/__tests__/RadioButton/__snapshots__/RadioButtonItem.test.tsx.snap
+++ b/src/components/__tests__/RadioButton/__snapshots__/RadioButtonItem.test.tsx.snap
@@ -74,9 +74,10 @@ exports[`can render leading radio button control 1`] = `
           "text": undefined,
         }
       }
-      accessible={true}
+      accessible={false}
+      aria-hidden={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -288,9 +289,10 @@ exports[`can render the Android radio button on different platforms 1`] = `
           "text": undefined,
         }
       }
-      accessible={true}
+      accessible={false}
+      aria-hidden={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -440,9 +442,10 @@ exports[`can render the iOS radio button on different platforms 1`] = `
           "text": undefined,
         }
       }
-      accessible={true}
+      accessible={false}
+      aria-hidden={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -618,9 +621,10 @@ exports[`renders unchecked 1`] = `
           "text": undefined,
         }
       }
-      accessible={true}
+      accessible={false}
+      aria-hidden={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}


### PR DESCRIPTION
Fixes #4775

RadioButton.Item renders an outer TouchableRipple plus the inner RadioButton, both focusable on web. Two tabstops per item.

Disable the inner radio button focusability so only the outer touchable is a tabstop.