### PR TITLE
fix(banner): make hidden content inert and fix live region semantics

### DIFF
--- a/example/src/Examples/BannerExample.tsx
+++ b/example/src/Examples/BannerExample.tsx
@@ -13,6 +13,7 @@ const PHOTOS = Array.from({ length: 24 }).map(
 const BannerExample = () => {
   const [visible, setVisible] = React.useState<boolean>(true);
   const [useCustomTheme, setUseCustomTheme] = React.useState<boolean>(false);
+  const [urgent, setUrgent] = React.useState<boolean>(false);
   const defaultTheme = useTheme();
 
   const [height, setHeight] = React.useState(0);
@@ -52,8 +53,14 @@ const BannerExample = () => {
         </View>
       </ScreenWrapper>
       <FAB icon="eye" style={styles.fab} onPress={() => setVisible(!visible)} />
+      <FAB
+        icon="alert"
+        style={styles.urgentFab}
+        onPress={() => setUrgent(!urgent)}
+      />
       <Banner
         onLayout={handleLayout}
+        urgent={urgent}
         actions={[
           {
             label: `Set ${useCustomTheme ? 'default' : 'custom'} theme`,
@@ -75,8 +82,9 @@ const BannerExample = () => {
         theme={useCustomTheme ? customTheme : defaultTheme}
         style={styles.banner}
       >
-        Two line text string with two actions. One to two lines is preferable on
-        mobile.
+        {urgent
+          ? 'Urgent: this message interrupts the screen reader.'
+          : 'Two line text string with two actions. One to two lines is preferable on mobile.'}
       </Banner>
     </>
   );
@@ -124,6 +132,12 @@ const styles = StyleSheet.create({
   },
   fab: {
     alignSelf: 'center',
+    position: 'absolute',
+    bottom: 0,
+    margin: 16,
+  },
+  urgentFab: {
+    alignSelf: 'flex-end',
     position: 'absolute',
     bottom: 0,
     margin: 16,

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -7,7 +7,7 @@ import {
   StyleSheet,
   View,
 } from 'react-native';
-import type { StyleProp, ViewStyle } from 'react-native';
+import type { StyleProp, ViewProps, ViewStyle } from 'react-native';
 import type { LayoutChangeEvent } from 'react-native';
 
 import useLatestCallback from 'use-latest-callback';
@@ -23,6 +23,27 @@ import type { $Omit, $RemoveChildren, Theme, ThemeProp } from '../types';
 const DEFAULT_MAX_WIDTH = 960;
 // banners carry at most two actions per the material spec
 const MAX_ACTIONS = 2;
+// a tradeoff, not a safe number: too short and the set and clear can batch into
+// one a11y update, too long and a talkback swipe hears the message twice
+const ANNOUNCE_CLEAR_DELAY = 3000;
+
+// only android and web have a real live region. everywhere else announces by hand
+const hasLiveRegion = () => Platform.OS === 'android' || Platform.OS === 'web';
+
+// a nested <Text> would otherwise be dropped from the announcement
+const extractText = (node: React.ReactNode): string =>
+  React.Children.toArray(node)
+    .map((child) => {
+      if (typeof child === 'string' || typeof child === 'number') {
+        return String(child);
+      }
+      if (React.isValidElement(child)) {
+        const { children } = child.props as { children?: React.ReactNode };
+        return extractText(children);
+      }
+      return '';
+    })
+    .join('');
 
 export type Props = $Omit<$RemoveChildren<typeof Surface>, 'mode'> & {
   /**
@@ -37,6 +58,12 @@ export type Props = $Omit<$RemoveChildren<typeof Surface>, 'mode'> & {
    * Icon to display for the `Banner`. Can be an image.
    */
   icon?: IconSource;
+  /**
+   * Accessibility label for the icon. Leave it out when the icon is decorative
+   * and the message already says everything - the icon is then hidden from
+   * screen readers instead of being read out as an unlabelled image.
+   */
+  iconAccessibilityLabel?: string;
   /**
    * Action items to shown in the banner.
    * An action item should contain the following properties:
@@ -139,6 +166,7 @@ export type Props = $Omit<$RemoveChildren<typeof Surface>, 'mode'> & {
 const Banner = ({
   visible,
   icon,
+  iconAccessibilityLabel,
   children,
   actions = [],
   contentStyle,
@@ -233,22 +261,39 @@ const Banner = ({
     }
   }, [actions.length]);
 
-  const liveRegion = urgent ? 'assertive' : 'polite';
-  const message = React.Children.toArray(children)
-    .filter((child) => typeof child === 'string' || typeof child === 'number')
-    .join('');
+  const region = urgent
+    ? ({ role: 'alert', live: 'assertive' } as const)
+    : ({ role: 'status', live: 'polite' } as const);
+  const message = extractText(children);
 
-  // aria-live only reaches a real live region on android and web. ios has no
-  // equivalent, so announce there by hand whenever the message becomes
-  // available. doing it everywhere would double up with the live region
   React.useEffect(() => {
-    if (Platform.OS !== 'ios' || !visible || !message) {
+    if (hasLiveRegion() || !visible || !message) {
       return;
     }
 
     AccessibilityInfo.announceForAccessibilityWithOptions(message, {
       queue: !urgent,
     });
+  }, [visible, message, urgent]);
+
+  // a region only fires when its text changes while it is already in the tree.
+  // the banner unmounts when hidden, so the message can never be that change
+  const [announcement, setAnnouncement] = React.useState('');
+  React.useEffect(() => {
+    if (!hasLiveRegion() || !visible || !message) {
+      setAnnouncement('');
+      return;
+    }
+
+    // re-setting the same string is not a render, so empty it first or an
+    // unchanged message announces nothing
+    setAnnouncement('');
+    const fill = setTimeout(() => setAnnouncement(message), 0);
+    const clear = setTimeout(() => setAnnouncement(''), ANNOUNCE_CLEAR_DELAY);
+    return () => {
+      clearTimeout(fill);
+      clearTimeout(clear);
+    };
   }, [visible, message, urgent]);
 
   // one stable ref per action slot; the cap is what bounds the array
@@ -265,13 +310,16 @@ const Banner = ({
       return;
     }
 
+    // rnw's findNodeHandle throws, and the ref is already the dom node there
+    if (Platform.OS === 'web') {
+      (node as unknown as { focus?: () => void }).focus?.();
+      return;
+    }
+
     const handle = findNodeHandle(node);
     if (handle !== null) {
       AccessibilityInfo.setAccessibilityFocus(handle);
     }
-
-    // rnw resolves the ref to the dom node, which takes focus directly
-    (node as unknown as { focus?: () => void }).focus?.();
   };
 
   // a removed action would otherwise strand focus at the top of the document
@@ -322,6 +370,10 @@ const Banner = ({
   // tree and the tab order. native ignores the unknown prop
   const inertProps = visible ? null : ({ inert: true } as object);
 
+  // annotated, not cast: the literal -1 widens to number on its own
+  const messageFocusProps: Pick<ViewProps, 'tabIndex' | 'accessible'> =
+    Platform.OS === 'web' ? { tabIndex: -1 } : { accessible: true };
+
   return (
     <Surface
       {...rest}
@@ -358,20 +410,23 @@ const Banner = ({
               {/* icon and message travel together as one flex item, so only
                   the actions can be wrapped onto the next line */}
               <View style={styles.body}>
+                {/* rnw gives the icon role="img" with no name */}
                 {icon ? (
-                  <View style={styles.icon}>
+                  <View
+                    testID={`${testID ?? 'banner'}-icon`}
+                    style={styles.icon}
+                    aria-hidden={!iconAccessibilityLabel}
+                    accessible={iconAccessibilityLabel ? true : undefined}
+                    aria-label={iconAccessibilityLabel}
+                  >
                     <Icon source={icon} size={40} />
                   </View>
                 ) : null}
-                {/* the region is scoped to the message: status/alert imply
-                    aria-atomic, so keeping the actions out of it stops their
-                    labels from re-announcing the whole banner */}
                 <View
                   ref={messageRef}
                   testID={`${testID ?? 'banner'}-message`}
                   style={styles.message}
-                  role={urgent ? 'alert' : 'status'}
-                  aria-live={visible ? liveRegion : 'off'}
+                  {...messageFocusProps}
                 >
                   <Text
                     variant="bodyMedium"
@@ -415,6 +470,17 @@ const Banner = ({
             </View>
           </Animated.View>
         )}
+        {/* last, so a screen reader reaches the real message first */}
+        {hasLiveRegion() ? (
+          <View
+            testID={`${testID ?? 'banner'}-announcer`}
+            style={styles.announcer}
+            role={region.role}
+            aria-live={region.live}
+          >
+            <Text>{announcement}</Text>
+          </View>
+        ) : null}
       </View>
     </Surface>
   );
@@ -468,6 +534,14 @@ const styles = StyleSheet.create({
   },
   transparent: {
     opacity: 0,
+  },
+  announcer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: 1,
+    height: 1,
+    overflow: 'hidden',
   },
 });
 

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -19,6 +19,7 @@ import Surface from './Surface';
 import Text from './Typography/Text';
 import { useInternalTheme } from '../core/theming';
 import type { $Omit, $RemoveChildren, Theme, ThemeProp } from '../types';
+import { mergeRefs } from '../utils/mergeRefs';
 
 const DEFAULT_MAX_WIDTH = 960;
 // banners carry at most two actions per the material spec
@@ -450,7 +451,10 @@ const Banner = ({
                       textColor={colors.primary}
                       theme={theme}
                       {...others}
-                      touchableRef={actionRefs.current[i]}
+                      touchableRef={mergeRefs(
+                        actionRefs.current[i],
+                        others.touchableRef
+                      )}
                       onFocus={(e) => {
                         focusedAction.current = i;
                         others.onFocus?.(e);

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -20,10 +20,14 @@ import Text from './Typography/Text';
 import { useInternalTheme } from '../core/theming';
 import type { $Omit, $RemoveChildren, Theme, ThemeProp } from '../types';
 import { mergeRefs } from '../utils/mergeRefs';
+import useLayout from '../utils/useLayout';
 
 const DEFAULT_MAX_WIDTH = 960;
 // banners carry at most two actions per the material spec
 const MAX_ACTIONS = 2;
+// md3's compact window size class. md3 has no banner spec, so where the
+// actions go is a choice, not a spec value
+const COMPACT_BREAKPOINT = 600;
 // a tradeoff, not a safe number: too short and the set and clear can batch into
 // one a11y update, too long and a talkback swipe hears the message twice
 const ANNOUNCE_CLEAR_DELAY = 3000;
@@ -301,6 +305,7 @@ const Banner = ({
   for (let i = 0; i < MAX_ACTIONS; i++) {
     actionRefs.current[i] ??= React.createRef<View>();
   }
+  const [row, onRowLayout] = useLayout();
   const messageRef = React.useRef<View>(null);
   const focusedAction = React.useRef<number | null>(null);
 
@@ -369,6 +374,8 @@ const Banner = ({
   // tree and the tab order. native ignores the unknown prop
   const inertProps: { inert?: boolean } = visible ? {} : { inert: true };
 
+  const stacked = !row.measured || row.width < COMPACT_BREAKPOINT;
+
   // annotated, not cast: the literal -1 widens to number on its own
   const messageFocusProps: Pick<ViewProps, 'tabIndex' | 'accessible'> =
     Platform.OS === 'web' ? { tabIndex: -1 } : { accessible: true };
@@ -405,10 +412,12 @@ const Banner = ({
                 : null,
             ]}
           >
-            <View style={styles.content}>
-              {/* icon and message travel together as one flex item, so only
-                  the actions can be wrapped onto the next line */}
-              <View style={styles.body}>
+            <View
+              testID={`${testID ?? 'banner'}-row`}
+              onLayout={onRowLayout}
+              style={[styles.content, stacked ? styles.contentStacked : null]}
+            >
+              <View style={[styles.body, stacked ? null : styles.bodyInline]}>
                 {/* rnw gives the icon role="img" with no name */}
                 {icon ? (
                   <View
@@ -436,8 +445,6 @@ const Banner = ({
                   </Text>
                 </View>
               </View>
-              {/* same wrapping row as the message, so the actions sit inline
-                  when they fit and drop to their own line when they don't */}
               {visibleActions.length ? (
                 <View style={styles.actions}>
                   {visibleActions.map(({ label, ...others }, i) => (
@@ -501,27 +508,29 @@ const styles = StyleSheet.create({
   },
   content: {
     flexDirection: 'row',
-    flexWrap: 'wrap',
     alignItems: 'center',
-    justifyContent: 'flex-end',
     marginHorizontal: 8,
     marginTop: 16,
     marginBottom: 0,
   },
+  contentStacked: {
+    flexDirection: 'column',
+    alignItems: 'stretch',
+  },
   body: {
     flexDirection: 'row',
     alignItems: 'center',
-    flexGrow: 1,
     flexShrink: 1,
-    flexBasis: 'auto',
+  },
+  bodyInline: {
+    flexGrow: 1,
+    flexBasis: 0,
   },
   icon: {
     margin: 8,
   },
   message: {
-    flexGrow: 1,
-    flexShrink: 1,
-    flexBasis: 'auto',
+    flex: 1,
     margin: 8,
   },
   actions: {

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -25,11 +25,10 @@ import useLayout from '../utils/useLayout';
 const DEFAULT_MAX_WIDTH = 960;
 // banners carry at most two actions per the material spec
 const MAX_ACTIONS = 2;
-// md3's compact window size class. md3 has no banner spec, so where the
-// actions go is a choice, not a spec value
+// md3's compact window size class. md3 has no banner spec, so this is a choice
 const COMPACT_BREAKPOINT = 600;
-// a tradeoff, not a safe number: too short and the set and clear can batch into
-// one a11y update, too long and a talkback swipe hears the message twice
+// too short and the set and clear batch into one a11y update, too long and a
+// talkback swipe hears the message twice
 const ANNOUNCE_CLEAR_DELAY = 3000;
 
 // only android and web have a real live region. everywhere else announces by hand
@@ -196,8 +195,8 @@ const Banner = ({
     height: 0,
     measured: false,
   });
-  // content is dropped from the tree once it's fully hidden, so it can't be
-  // read, focused or pressed. the spacer stays behind to keep the layout
+  // hidden content leaves the tree so it can't be read, focused or pressed.
+  // the spacer stays behind to keep the layout
   const [exited, setExited] = React.useState(false);
 
   const showCallback = useLatestCallback(onShowAnimationFinished);
@@ -213,8 +212,7 @@ const Banner = ({
   const prevVisible = React.useRef<boolean | null>(null);
 
   React.useEffect(() => {
-    // only animate for transitions that actually happened, so the callbacks
-    // don't fire on mount or when unrelated deps (e.g. scale) change
+    // don't fire the callbacks on mount or when scale changes
     if (prevVisible.current === visible) {
       return;
     }
@@ -280,7 +278,7 @@ const Banner = ({
     });
   }, [visible, message, urgent]);
 
-  // a region only fires when its text changes while it is already in the tree.
+  // a region only fires when its text changes while already in the tree, and
   // the banner unmounts when hidden, so the message can never be that change
   const [announcement, setAnnouncement] = React.useState('');
   React.useEffect(() => {
@@ -289,8 +287,7 @@ const Banner = ({
       return;
     }
 
-    // re-setting the same string is not a render, so empty it first or an
-    // unchanged message announces nothing
+    // re-setting the same string is not a render, so empty it first
     setAnnouncement('');
     const fill = setTimeout(() => setAnnouncement(message), 0);
     const clear = setTimeout(() => setAnnouncement(''), ANNOUNCE_CLEAR_DELAY);
@@ -300,11 +297,27 @@ const Banner = ({
     };
   }, [visible, message, urgent]);
 
-  // one stable ref per action slot; the cap is what bounds the array
+  // one stable ref per action slot
   const actionRefs = React.useRef<Array<React.RefObject<View | null>>>([]);
   for (let i = 0; i < MAX_ACTIONS; i++) {
     actionRefs.current[i] ??= React.createRef<View>();
   }
+  // fixed length, so the dep list below keeps a constant size
+  const touchableRefs = Array.from(
+    { length: MAX_ACTIONS },
+    (_, i) => visibleActions[i]?.touchableRef
+  );
+  // a new callback each render would detach and reattach on every commit,
+  // handing a consumer's callback null each time
+  const mergedActionRefs = React.useMemo(
+    () =>
+      touchableRefs.map((touchableRef, i) =>
+        mergeRefs(actionRefs.current[i], touchableRef)
+      ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    touchableRefs
+  );
+
   const [row, onRowLayout] = useLayout();
   const messageRef = React.useRef<View>(null);
   const focusedAction = React.useRef<number | null>(null);
@@ -328,14 +341,15 @@ const Banner = ({
 
   // a removed action would otherwise strand focus at the top of the document
   React.useEffect(() => {
-    const focused = focusedAction.current;
-
-    if (focused === null || focused < actionCount) {
+    // the index is stale once hidden, and a later show would act on it
+    if (!visible) {
+      focusedAction.current = null;
       return;
     }
 
-    if (!visible) {
-      focusedAction.current = null;
+    const focused = focusedAction.current;
+
+    if (focused === null || focused < actionCount) {
       return;
     }
 
@@ -350,8 +364,7 @@ const Banner = ({
 
     setLayout({ height, measured: true });
 
-    // mounted hidden: we only render to measure the spacer height, so drop the
-    // content again right after. later measurements happen mid-transition
+    // mounted hidden: we rendered only to measure the spacer, so drop it again
     if (isFirstMeasure && !visible) {
       setExited(true);
     }
@@ -370,13 +383,16 @@ const Banner = ({
     Animated.add(position, -1),
     layout.height
   );
-  // rnw forwards `inert` to the dom, which drops the subtree from the a11y
-  // tree and the tab order. native ignores the unknown prop
+  // rnw forwards `inert` to the dom, dropping the subtree from the a11y tree
+  // and the tab order. native ignores the unknown prop
   const inertProps: { inert?: boolean } = visible ? {} : { inert: true };
 
   const stacked = !row.measured || row.width < COMPACT_BREAKPOINT;
 
-  // annotated, not cast: the literal -1 widens to number on its own
+  // no default: it would land on every banner and collide with the consumer's
+  const subTestID = (suffix: string) =>
+    testID ? `${testID}-${suffix}` : undefined;
+
   const messageFocusProps: Pick<ViewProps, 'tabIndex' | 'accessible'> =
     Platform.OS === 'web' ? { tabIndex: -1 } : { accessible: true };
 
@@ -393,7 +409,7 @@ const Banner = ({
         <Animated.View style={{ height }} />
         {exited ? null : (
           <Animated.View
-            testID={`${testID ?? 'banner'}-content`}
+            testID={subTestID('content')}
             onLayout={handleLayout}
             aria-hidden={!visible}
             pointerEvents={visible ? 'auto' : 'none'}
@@ -413,26 +429,28 @@ const Banner = ({
             ]}
           >
             <View
-              testID={`${testID ?? 'banner'}-row`}
+              testID={subTestID('row')}
               onLayout={onRowLayout}
               style={[styles.content, stacked ? styles.contentStacked : null]}
             >
               <View style={[styles.body, stacked ? null : styles.bodyInline]}>
-                {/* rnw gives the icon role="img" with no name */}
+                {/* rnw renders this View as a plain div, which cannot take a
+                    name, and gives the inner icon role="img" with none */}
                 {icon ? (
                   <View
-                    testID={`${testID ?? 'banner'}-icon`}
+                    testID={subTestID('icon')}
                     style={styles.icon}
                     aria-hidden={!iconAccessibilityLabel}
                     accessible={iconAccessibilityLabel ? true : undefined}
                     aria-label={iconAccessibilityLabel}
+                    role={iconAccessibilityLabel ? 'img' : undefined}
                   >
                     <Icon source={icon} size={40} />
                   </View>
                 ) : null}
                 <View
                   ref={messageRef}
-                  testID={`${testID ?? 'banner'}-message`}
+                  testID={subTestID('message')}
                   style={styles.message}
                   {...messageFocusProps}
                 >
@@ -456,10 +474,7 @@ const Banner = ({
                       textColor={colors.primary}
                       theme={theme}
                       {...others}
-                      touchableRef={mergeRefs(
-                        actionRefs.current[i],
-                        others.touchableRef
-                      )}
+                      touchableRef={mergedActionRefs[i]}
                       onFocus={(e) => {
                         focusedAction.current = i;
                         others.onFocus?.(e);
@@ -482,7 +497,7 @@ const Banner = ({
         {/* last, so a screen reader reaches the real message first */}
         {hasLiveRegion() ? (
           <View
-            testID={`${testID ?? 'banner'}-announcer`}
+            testID={subTestID('announcer')}
             style={styles.announcer}
             {...region}
           >

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -202,7 +202,11 @@ const Banner = ({
         duration: 250 * scale,
         toValue: 1,
         useNativeDriver: false,
-      }).start(showCallback);
+      }).start((result) => {
+        if (result.finished) {
+          showCallback(result);
+        }
+      });
     } else {
       // hide
       Animated.timing(position, {
@@ -212,8 +216,8 @@ const Banner = ({
       }).start((result) => {
         if (result.finished) {
           setExited(true);
+          hideCallback(result);
         }
-        hideCallback(result);
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -38,9 +38,8 @@ const extractText = (node: React.ReactNode): string =>
       if (typeof child === 'string' || typeof child === 'number') {
         return String(child);
       }
-      if (React.isValidElement(child)) {
-        const { children } = child.props as { children?: React.ReactNode };
-        return extractText(children);
+      if (React.isValidElement<{ children?: React.ReactNode }>(child)) {
+        return extractText(child.props.children);
       }
       return '';
     })
@@ -262,9 +261,9 @@ const Banner = ({
     }
   }, [actions.length]);
 
-  const region = urgent
-    ? ({ role: 'alert', live: 'assertive' } as const)
-    : ({ role: 'status', live: 'polite' } as const);
+  const region: Pick<ViewProps, 'role' | 'aria-live'> = urgent
+    ? { role: 'alert', 'aria-live': 'assertive' }
+    : { role: 'status', 'aria-live': 'polite' };
   const message = extractText(children);
 
   React.useEffect(() => {
@@ -298,10 +297,9 @@ const Banner = ({
   }, [visible, message, urgent]);
 
   // one stable ref per action slot; the cap is what bounds the array
-  const actionRefs = React.useRef<Array<React.RefObject<View>>>([]);
+  const actionRefs = React.useRef<Array<React.RefObject<View | null>>>([]);
   for (let i = 0; i < MAX_ACTIONS; i++) {
-    // Button types touchableRef as non-nullable, but a ref always starts null
-    actionRefs.current[i] ??= React.createRef<View>() as React.RefObject<View>;
+    actionRefs.current[i] ??= React.createRef<View>();
   }
   const messageRef = React.useRef<View>(null);
   const focusedAction = React.useRef<number | null>(null);
@@ -313,7 +311,7 @@ const Banner = ({
 
     // rnw's findNodeHandle throws, and the ref is already the dom node there
     if (Platform.OS === 'web') {
-      (node as unknown as { focus?: () => void }).focus?.();
+      node.focus();
       return;
     }
 
@@ -369,7 +367,7 @@ const Banner = ({
   );
   // rnw forwards `inert` to the dom, which drops the subtree from the a11y
   // tree and the tab order. native ignores the unknown prop
-  const inertProps = visible ? null : ({ inert: true } as object);
+  const inertProps: { inert?: boolean } = visible ? {} : { inert: true };
 
   // annotated, not cast: the literal -1 widens to number on its own
   const messageFocusProps: Pick<ViewProps, 'tabIndex' | 'accessible'> =
@@ -479,8 +477,7 @@ const Banner = ({
           <View
             testID={`${testID ?? 'banner'}-announcer`}
             style={styles.announcer}
-            role={region.role}
-            aria-live={region.live}
+            {...region}
           >
             <Text>{announcement}</Text>
           </View>

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { Animated, StyleSheet, View } from 'react-native';
+import {
+  AccessibilityInfo,
+  Animated,
+  findNodeHandle,
+  Platform,
+  StyleSheet,
+  View,
+} from 'react-native';
 import type { StyleProp, ViewStyle } from 'react-native';
 import type { LayoutChangeEvent } from 'react-native';
 
@@ -14,6 +21,8 @@ import { useInternalTheme } from '../core/theming';
 import type { $Omit, $RemoveChildren, Theme, ThemeProp } from '../types';
 
 const DEFAULT_MAX_WIDTH = 960;
+// banners carry at most two actions per the material spec
+const MAX_ACTIONS = 2;
 
 export type Props = $Omit<$RemoveChildren<typeof Surface>, 'mode'> & {
   /**
@@ -36,6 +45,9 @@ export type Props = $Omit<$RemoveChildren<typeof Surface>, 'mode'> & {
    * - `onPress`: callback that is called when button is pressed (required)
    *
    * To customize button you can pass other props that button component takes.
+   *
+   * A maximum of 2 actions is supported, per the Material spec. Any further
+   * actions are ignored, with a warning in development.
    */
   actions?: Array<
     {
@@ -52,6 +64,12 @@ export type Props = $Omit<$RemoveChildren<typeof Surface>, 'mode'> & {
    * Changes Banner shadow and background on iOS and Android.
    */
   elevation?: 0 | 1 | 2 | 3 | 4 | 5 | Animated.Value;
+  /**
+   * Whether the message should interrupt whatever the screen reader is saying
+   * instead of waiting for it to finish. Use it for messages that need
+   * immediate attention, such as errors.
+   */
+  urgent?: boolean;
   /**
    * Specifies the largest possible scale a text font can reach.
    */
@@ -130,6 +148,8 @@ const Banner = ({
   onShowAnimationFinished = () => {},
   onHideAnimationFinished = () => {},
   maxFontSizeMultiplier,
+  urgent = false,
+  testID,
   ...rest
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
@@ -144,6 +164,9 @@ const Banner = ({
     height: 0,
     measured: false,
   });
+  // content is dropped from the tree once it's fully hidden, so it can't be
+  // read, focused or pressed. the spacer stays behind to keep the layout
+  const [exited, setExited] = React.useState(false);
 
   const showCallback = useLatestCallback(onShowAnimationFinished);
   const hideCallback = useLatestCallback(onHideAnimationFinished);
@@ -155,9 +178,26 @@ const Banner = ({
     outputRange: [0, 1, 1],
   });
 
+  const prevVisible = React.useRef<boolean | null>(null);
+
   React.useEffect(() => {
+    // only animate for transitions that actually happened, so the callbacks
+    // don't fire on mount or when unrelated deps (e.g. scale) change
+    if (prevVisible.current === visible) {
+      return;
+    }
+
+    const isFirstRender = prevVisible.current === null;
+    prevVisible.current = visible;
+
+    // position is already initialised to the matching end state
+    if (isFirstRender) {
+      return;
+    }
+
     if (visible) {
       // show
+      setExited(false);
       Animated.timing(position, {
         duration: 250 * scale,
         toValue: 1,
@@ -169,14 +209,96 @@ const Banner = ({
         duration: 200 * scale,
         toValue: 0,
         useNativeDriver: false,
-      }).start(hideCallback);
+      }).start((result) => {
+        if (result.finished) {
+          setExited(true);
+        }
+        hideCallback(result);
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible, position, scale]);
 
+  const visibleActions = actions.slice(0, MAX_ACTIONS);
+  const actionCount = visibleActions.length;
+  React.useEffect(() => {
+    if (process.env.NODE_ENV !== 'production' && actions.length > MAX_ACTIONS) {
+      console.warn(
+        `Banner supports a maximum of ${MAX_ACTIONS} actions, received ${actions.length}. The extra actions are ignored.`
+      );
+    }
+  }, [actions.length]);
+
+  const liveRegion = urgent ? 'assertive' : 'polite';
+  const message = React.Children.toArray(children)
+    .filter((child) => typeof child === 'string' || typeof child === 'number')
+    .join('');
+
+  // aria-live only reaches a real live region on android and web. ios has no
+  // equivalent, so announce there by hand whenever the message becomes
+  // available. doing it everywhere would double up with the live region
+  React.useEffect(() => {
+    if (Platform.OS !== 'ios' || !visible || !message) {
+      return;
+    }
+
+    AccessibilityInfo.announceForAccessibilityWithOptions(message, {
+      queue: !urgent,
+    });
+  }, [visible, message, urgent]);
+
+  // one stable ref per action slot; the cap is what bounds the array
+  const actionRefs = React.useRef<Array<React.RefObject<View>>>([]);
+  for (let i = 0; i < MAX_ACTIONS; i++) {
+    // Button types touchableRef as non-nullable, but a ref always starts null
+    actionRefs.current[i] ??= React.createRef<View>() as React.RefObject<View>;
+  }
+  const messageRef = React.useRef<View>(null);
+  const focusedAction = React.useRef<number | null>(null);
+
+  const focusNode = (node: View | null) => {
+    if (!node) {
+      return;
+    }
+
+    const handle = findNodeHandle(node);
+    if (handle !== null) {
+      AccessibilityInfo.setAccessibilityFocus(handle);
+    }
+
+    // rnw resolves the ref to the dom node, which takes focus directly
+    (node as unknown as { focus?: () => void }).focus?.();
+  };
+
+  // a removed action would otherwise strand focus at the top of the document
+  React.useEffect(() => {
+    const focused = focusedAction.current;
+
+    if (focused === null || focused < actionCount) {
+      return;
+    }
+
+    if (!visible) {
+      focusedAction.current = null;
+      return;
+    }
+
+    const next = actionCount - 1;
+    focusedAction.current = next < 0 ? null : next;
+    focusNode(next < 0 ? messageRef.current : actionRefs.current[next].current);
+  }, [actionCount, visible]);
+
   const handleLayout = ({ nativeEvent }: LayoutChangeEvent) => {
     const { height } = nativeEvent.layout;
+    const isFirstMeasure = !layout.measured;
+
     setLayout({ height, measured: true });
+
+    // mounted hidden: we only render to measure the spacer height, so drop the
+    // content again right after. later measurements happen mid-transition
+    if (isFirstMeasure && !visible) {
+      setExited(true);
+    }
   };
 
   // The banner animation has 2 parts:
@@ -192,9 +314,14 @@ const Banner = ({
     Animated.add(position, -1),
     layout.height
   );
+  // rnw forwards `inert` to the dom, which drops the subtree from the a11y
+  // tree and the tab order. native ignores the unknown prop
+  const inertProps = visible ? null : ({ inert: true } as object);
+
   return (
     <Surface
       {...rest}
+      testID={testID}
       style={[{ opacity }, style]}
       theme={theme}
       container
@@ -202,59 +329,88 @@ const Banner = ({
     >
       <View style={[styles.wrapper, contentStyle]}>
         <Animated.View style={{ height }} />
-        <Animated.View
-          onLayout={handleLayout}
-          style={[
-            layout.measured || !visible
-              ? // If we have measured banner's height or it's invisible,
-                // Position it absolutely, the layout will be taken care of the spacer
-                [styles.absolute, { transform: [{ translateY }] }]
-              : // Otherwise position it normally
-                null,
-            !layout.measured && !visible
-              ? // If we haven't measured banner's height yet and it's invisible,
-                // hide it with opacity: 0 so user doesn't see it
-                styles.transparent
-              : null,
-          ]}
-        >
-          <View style={styles.content}>
-            {icon ? (
-              <View style={styles.icon}>
-                <Icon source={icon} size={40} />
+        {exited ? null : (
+          <Animated.View
+            testID={`${testID ?? 'banner'}-content`}
+            onLayout={handleLayout}
+            aria-hidden={!visible}
+            pointerEvents={visible ? 'auto' : 'none'}
+            {...inertProps}
+            style={[
+              layout.measured || !visible
+                ? // If we have measured banner's height or it's invisible,
+                  // Position it absolutely, the layout will be taken care of the spacer
+                  [styles.absolute, { transform: [{ translateY }] }]
+                : // Otherwise position it normally
+                  null,
+              !layout.measured && !visible
+                ? // If we haven't measured banner's height yet and it's invisible,
+                  // hide it with opacity: 0 so user doesn't see it
+                  styles.transparent
+                : null,
+            ]}
+          >
+            <View style={styles.content}>
+              {/* icon and message travel together as one flex item, so only
+                  the actions can be wrapped onto the next line */}
+              <View style={styles.body}>
+                {icon ? (
+                  <View style={styles.icon}>
+                    <Icon source={icon} size={40} />
+                  </View>
+                ) : null}
+                {/* the region is scoped to the message: status/alert imply
+                    aria-atomic, so keeping the actions out of it stops their
+                    labels from re-announcing the whole banner */}
+                <View
+                  ref={messageRef}
+                  testID={`${testID ?? 'banner'}-message`}
+                  style={styles.message}
+                  role={urgent ? 'alert' : 'status'}
+                  aria-live={visible ? liveRegion : 'off'}
+                >
+                  <Text
+                    variant="bodyMedium"
+                    style={{ color: colors.onSurface }}
+                    maxFontSizeMultiplier={maxFontSizeMultiplier}
+                  >
+                    {children}
+                  </Text>
+                </View>
               </View>
-            ) : null}
-            <Text
-              variant="bodyMedium"
-              style={[
-                styles.message,
-                {
-                  color: colors.onSurface,
-                },
-              ]}
-              aria-live={visible ? 'polite' : 'off'}
-              role="alert"
-              maxFontSizeMultiplier={maxFontSizeMultiplier}
-            >
-              {children}
-            </Text>
-          </View>
-          <View style={styles.actions}>
-            {actions.map(({ label, ...others }, i) => (
-              <Button
-                key={i}
-                compact
-                mode="text"
-                style={styles.button}
-                textColor={colors.primary}
-                theme={theme}
-                {...others}
-              >
-                {label}
-              </Button>
-            ))}
-          </View>
-        </Animated.View>
+              {/* same wrapping row as the message, so the actions sit inline
+                  when they fit and drop to their own line when they don't */}
+              {visibleActions.length ? (
+                <View style={styles.actions}>
+                  {visibleActions.map(({ label, ...others }, i) => (
+                    <Button
+                      key={i}
+                      compact
+                      mode="text"
+                      style={styles.button}
+                      textColor={colors.primary}
+                      theme={theme}
+                      {...others}
+                      touchableRef={actionRefs.current[i]}
+                      onFocus={(e) => {
+                        focusedAction.current = i;
+                        others.onFocus?.(e);
+                      }}
+                      onBlur={(e) => {
+                        if (focusedAction.current === i) {
+                          focusedAction.current = null;
+                        }
+                        others.onBlur?.(e);
+                      }}
+                    >
+                      {label}
+                    </Button>
+                  ))}
+                </View>
+              ) : null}
+            </View>
+          </Animated.View>
+        )}
       </View>
     </Surface>
   );
@@ -274,20 +430,32 @@ const styles = StyleSheet.create({
   },
   content: {
     flexDirection: 'row',
-    justifyContent: 'flex-start',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
     marginHorizontal: 8,
     marginTop: 16,
     marginBottom: 0,
+  },
+  body: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexGrow: 1,
+    flexShrink: 1,
+    flexBasis: 'auto',
   },
   icon: {
     margin: 8,
   },
   message: {
-    flex: 1,
+    flexGrow: 1,
+    flexShrink: 1,
+    flexBasis: 'auto',
     margin: 8,
   },
   actions: {
     flexDirection: 'row',
+    flexShrink: 0,
     justifyContent: 'flex-end',
     margin: 4,
   },

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -134,7 +134,7 @@ export type Props = $Omit<React.ComponentProps<typeof Surface>, 'mode'> & {
   /**
    * Reference for the touchable
    */
-  touchableRef?: React.RefObject<View>;
+  touchableRef?: React.Ref<View>;
   ref?: React.Ref<View>;
   /**
    * testID to be used on tests.

--- a/src/components/__tests__/Banner.test.tsx
+++ b/src/components/__tests__/Banner.test.tsx
@@ -532,6 +532,78 @@ describe('actions', () => {
     setFocus.mockRestore();
   });
 
+  it('does not move focus into the banner when it is shown again', async () => {
+    // the remembered index is stale once hidden, so a later show must ignore it
+    const setFocus = jest
+      .spyOn(AccessibilityInfo, 'setAccessibilityFocus')
+      .mockImplementation(() => {});
+    setFocus.mockClear();
+
+    const view = await render(
+      <Banner
+        visible
+        actions={[
+          { label: 'first', onPress: () => {}, testID: 'action-first' },
+        ]}
+      >
+        Message
+      </Banner>
+    );
+
+    await fireEvent(screen.getByTestId('action-first-container'), 'focus');
+
+    await view.rerender(
+      <Banner
+        visible={false}
+        actions={[
+          { label: 'first', onPress: () => {}, testID: 'action-first' },
+        ]}
+      >
+        Message
+      </Banner>
+    );
+
+    await view.rerender(
+      <Banner visible actions={[]}>
+        Message
+      </Banner>
+    );
+
+    expect(setFocus).not.toHaveBeenCalled();
+    setFocus.mockRestore();
+  });
+
+  it('holds on to a consumer touchableRef across re-renders', async () => {
+    // a callback rebuilt every render hands the consumer null between commits
+    const nodes: Array<View | null> = [];
+    const touchableRef = (node: View | null) => {
+      nodes.push(node);
+    };
+
+    const view = await render(
+      <Banner
+        visible
+        actions={[{ label: 'first', onPress: () => {}, touchableRef }]}
+      >
+        Message
+      </Banner>
+    );
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]).not.toBeNull();
+
+    await view.rerender(
+      <Banner
+        visible
+        actions={[{ label: 'first', onPress: () => {}, touchableRef }]}
+      >
+        Message
+      </Banner>
+    );
+
+    expect(nodes).toHaveLength(1);
+  });
+
   it('still calls a consumer onFocus handler on an action', async () => {
     const onFocus = jest.fn();
 
@@ -911,6 +983,59 @@ describe('icon', () => {
     expect(wrapper).toHaveProp('aria-hidden', false);
     expect(wrapper).toHaveProp('accessible', true);
     expect(wrapper).toHaveProp('aria-label', 'Payment failed');
+    // a generic element cannot carry a name, so the label alone is dropped
+    expect(wrapper).toHaveProp('role', 'img');
+  });
+
+  it('leaves a decorative icon without a role', async () => {
+    await render(
+      <Banner visible icon="camera" testID="banner">
+        Message
+      </Banner>
+    );
+
+    expect(
+      screen.getByTestId('banner-icon', { includeHiddenElements: true })
+    ).not.toHaveProp('role', 'img');
+  });
+});
+
+describe('test ids', () => {
+  const ALL = { includeHiddenElements: true };
+  const originalPlatform = Platform.OS;
+
+  // the preset runs as ios, which renders no live region to give an id to
+  beforeEach(() => {
+    Platform.OS = 'android';
+  });
+
+  afterEach(() => {
+    Platform.OS = originalPlatform;
+  });
+
+  it('derives ids for the inner parts from the one it was given', async () => {
+    await render(
+      <Banner visible icon="camera" testID="notice">
+        Message
+      </Banner>
+    );
+
+    for (const part of ['content', 'row', 'icon', 'message', 'announcer']) {
+      expect(screen.getByTestId(`notice-${part}`, ALL)).toBeTruthy();
+    }
+  });
+
+  it('leaves the inner parts without ids when it was given none', async () => {
+    // a default would collide with the consumer's own ids
+    await render(
+      <Banner visible icon="camera">
+        Message
+      </Banner>
+    );
+
+    for (const part of ['content', 'row', 'icon', 'message', 'announcer']) {
+      expect(screen.queryByTestId(`banner-${part}`, ALL)).toBeNull();
+    }
   });
 });
 

--- a/src/components/__tests__/Banner.test.tsx
+++ b/src/components/__tests__/Banner.test.tsx
@@ -1,8 +1,8 @@
-import { Animated, Image } from 'react-native';
+import { AccessibilityInfo, Animated, Image, Platform } from 'react-native';
 
 import {
   afterAll,
-  beforeAll,
+  afterEach,
   beforeEach,
   describe,
   expect,
@@ -11,7 +11,7 @@ import {
 } from '@jest/globals';
 import { act } from '@testing-library/react-native';
 
-import { render, screen } from '../../test-utils';
+import { fireEvent, render, screen, within } from '../../test-utils';
 import Banner from '../Banner';
 
 it('renders hidden banner, without action buttons and without image', async () => {
@@ -126,6 +126,598 @@ it('render visible banner, with custom theme', async () => {
   expect(tree).toMatchSnapshot();
 });
 
+describe('inert when hidden', () => {
+  const ACTIONS = [{ label: 'Fix it', onPress: () => {} }];
+  // queries are a11y-aware by default, so opt in explicitly to tell
+  // "hidden from screen readers" apart from "not in the tree at all"
+  const ALL = { includeHiddenElements: true };
+
+  it('exposes the content while visible', async () => {
+    await render(
+      <Banner visible actions={ACTIONS} testID="banner">
+        Message
+      </Banner>
+    );
+    await act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(screen.getByText('Message')).toBeOnTheScreen();
+    expect(screen.getByText('Fix it')).toBeOnTheScreen();
+    expect(screen.getByTestId('banner-content')).toHaveProp(
+      'aria-hidden',
+      false
+    );
+    expect(screen.getByTestId('banner-content')).toHaveProp(
+      'pointerEvents',
+      'auto'
+    );
+  });
+
+  it('keeps the content inert while the hide animation is running', async () => {
+    const view = await render(
+      <Banner visible actions={ACTIONS} testID="banner">
+        Message
+      </Banner>
+    );
+    await act(() => {
+      jest.runAllTimers();
+    });
+
+    await view.rerender(
+      <Banner visible={false} actions={ACTIONS} testID="banner">
+        Message
+      </Banner>
+    );
+
+    // animation still in flight, so the content is mounted but must be dead
+    const content = screen.getByTestId('banner-content', ALL);
+    expect(content).toHaveProp('aria-hidden', true);
+    expect(content).toHaveProp('pointerEvents', 'none');
+    expect(content).toHaveProp('inert', true);
+
+    // and already unreachable through a11y-aware queries
+    expect(screen.queryByText('Message')).toBeNull();
+    expect(screen.queryByText('Fix it')).toBeNull();
+  });
+
+  it('unmounts the content once the hide animation finishes', async () => {
+    const view = await render(
+      <Banner visible actions={ACTIONS} testID="banner">
+        Message
+      </Banner>
+    );
+    await act(() => {
+      jest.runAllTimers();
+    });
+
+    await view.rerender(
+      <Banner visible={false} actions={ACTIONS} testID="banner">
+        Message
+      </Banner>
+    );
+    await act(() => {
+      jest.runAllTimers();
+    });
+
+    // ALL, so null means genuinely gone rather than merely hidden
+    expect(screen.queryByText('Message', ALL)).toBeNull();
+    expect(screen.queryByText('Fix it', ALL)).toBeNull();
+    expect(screen.queryByTestId('banner-content', ALL)).toBeNull();
+  });
+
+  it('measures once then unmounts the content when mounted hidden', async () => {
+    await render(
+      <Banner visible={false} actions={ACTIONS} testID="banner">
+        Message
+      </Banner>
+    );
+
+    // the measuring pass must not be reachable either
+    const content = screen.getByTestId('banner-content', ALL);
+    expect(content).toHaveProp('aria-hidden', true);
+    expect(screen.queryByText('Message')).toBeNull();
+
+    await fireEvent(content, 'layout', {
+      nativeEvent: { layout: { height: 80, width: 320 } },
+    });
+
+    expect(screen.queryByTestId('banner-content', ALL)).toBeNull();
+  });
+
+  it('keeps the content mounted when the hide animation is interrupted', async () => {
+    // a hide interrupted by a re-show reports finished:false; acting on it
+    // would unmount the content while the banner is on its way back in
+    let hideDone: ((result: { finished: boolean }) => void) | undefined;
+    const timing = jest
+      .spyOn(Animated, 'timing')
+      .mockImplementation((_value: any, config: any) => {
+        return {
+          start: (cb?: (result: { finished: boolean }) => void) => {
+            if (config.toValue === 0) {
+              hideDone = cb;
+            }
+          },
+          stop: () => {},
+          reset: () => {},
+        } as any;
+      });
+
+    const view = await render(
+      <Banner visible actions={ACTIONS} testID="banner">
+        Message
+      </Banner>
+    );
+
+    await view.rerender(
+      <Banner visible={false} actions={ACTIONS} testID="banner">
+        Message
+      </Banner>
+    );
+    // banner comes back before the hide finishes
+    await view.rerender(
+      <Banner visible actions={ACTIONS} testID="banner">
+        Message
+      </Banner>
+    );
+
+    await act(() => {
+      hideDone?.({ finished: false });
+    });
+
+    expect(screen.getByTestId('banner-content', ALL)).toBeTruthy();
+    expect(screen.getByText('Message')).toBeOnTheScreen();
+
+    timing.mockRestore();
+  });
+
+  it('remounts the content when shown again', async () => {
+    const view = await render(
+      <Banner visible={false} actions={ACTIONS} testID="banner">
+        Message
+      </Banner>
+    );
+    await act(() => {
+      jest.runAllTimers();
+    });
+
+    await view.rerender(
+      <Banner visible actions={ACTIONS} testID="banner">
+        Message
+      </Banner>
+    );
+    await act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(screen.getByText('Message')).toBeOnTheScreen();
+    expect(screen.getByTestId('banner-content')).toHaveProp(
+      'aria-hidden',
+      false
+    );
+  });
+});
+
+describe('actions', () => {
+  let warn: jest.SpiedFunction<typeof console.warn>;
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    warn.mockClear();
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it('renders every action up to the two the spec allows', async () => {
+    await render(
+      <Banner
+        visible
+        actions={[
+          { label: 'first', onPress: () => {} },
+          { label: 'second', onPress: () => {} },
+        ]}
+      >
+        Message
+      </Banner>
+    );
+
+    expect(screen.getByText('first')).toBeOnTheScreen();
+    expect(screen.getByText('second')).toBeOnTheScreen();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('drops actions beyond the second one', async () => {
+    await render(
+      <Banner
+        visible
+        actions={[
+          { label: 'first', onPress: () => {} },
+          { label: 'second', onPress: () => {} },
+          { label: 'third', onPress: () => {} },
+        ]}
+      >
+        Message
+      </Banner>
+    );
+
+    expect(screen.getByText('first')).toBeOnTheScreen();
+    expect(screen.getByText('second')).toBeOnTheScreen();
+    expect(screen.queryByText('third')).toBeNull();
+  });
+
+  it('moves focus to a surviving action when the focused one disappears', async () => {
+    const setFocus = jest
+      .spyOn(AccessibilityInfo, 'setAccessibilityFocus')
+      .mockImplementation(() => {});
+    setFocus.mockClear();
+
+    const view = await render(
+      <Banner
+        visible
+        actions={[
+          { label: 'first', onPress: () => {}, testID: 'action-first' },
+          { label: 'second', onPress: () => {}, testID: 'action-second' },
+        ]}
+      >
+        Message
+      </Banner>
+    );
+
+    await fireEvent(screen.getByTestId('action-second-container'), 'focus');
+    expect(setFocus).not.toHaveBeenCalled();
+
+    await view.rerender(
+      <Banner
+        visible
+        actions={[
+          { label: 'first', onPress: () => {}, testID: 'action-first' },
+        ]}
+      >
+        Message
+      </Banner>
+    );
+
+    expect(setFocus).toHaveBeenCalledTimes(1);
+    setFocus.mockRestore();
+  });
+
+  it('leaves focus alone when the focused action survives a shrink', async () => {
+    const setFocus = jest
+      .spyOn(AccessibilityInfo, 'setAccessibilityFocus')
+      .mockImplementation(() => {});
+    setFocus.mockClear();
+
+    const view = await render(
+      <Banner
+        visible
+        actions={[
+          { label: 'first', onPress: () => {}, testID: 'action-first' },
+          { label: 'second', onPress: () => {}, testID: 'action-second' },
+        ]}
+      >
+        Message
+      </Banner>
+    );
+
+    // focus the first action, then drop the second: the count changes, so the
+    // effect runs, but the focused index is still valid and must be left alone
+    await fireEvent(screen.getByTestId('action-first-container'), 'focus');
+    await view.rerender(
+      <Banner
+        visible
+        actions={[
+          { label: 'first', onPress: () => {}, testID: 'action-first' },
+        ]}
+      >
+        Message
+      </Banner>
+    );
+
+    expect(screen.getByText('first')).toBeOnTheScreen();
+    expect(setFocus).not.toHaveBeenCalled();
+    setFocus.mockRestore();
+  });
+
+  it('does not move focus into the banner once it starts hiding', async () => {
+    // the content is inert from the moment it hides, so focusing it would be
+    // worse than releasing focus. returning focus to wherever it came from
+    // needs an api the consumer owns
+    const setFocus = jest
+      .spyOn(AccessibilityInfo, 'setAccessibilityFocus')
+      .mockImplementation(() => {});
+    setFocus.mockClear();
+
+    const view = await render(
+      <Banner
+        visible
+        actions={[
+          { label: 'first', onPress: () => {}, testID: 'action-first' },
+        ]}
+      >
+        Message
+      </Banner>
+    );
+
+    await fireEvent(screen.getByTestId('action-first-container'), 'focus');
+
+    await view.rerender(
+      <Banner
+        visible={false}
+        actions={[
+          { label: 'first', onPress: () => {}, testID: 'action-first' },
+        ]}
+      >
+        Message
+      </Banner>
+    );
+
+    expect(setFocus).not.toHaveBeenCalled();
+    setFocus.mockRestore();
+  });
+
+  it('moves focus off the last action when every action is removed', async () => {
+    const setFocus = jest
+      .spyOn(AccessibilityInfo, 'setAccessibilityFocus')
+      .mockImplementation(() => {});
+    setFocus.mockClear();
+
+    const view = await render(
+      <Banner
+        visible
+        actions={[
+          { label: 'first', onPress: () => {}, testID: 'action-first' },
+        ]}
+      >
+        Message
+      </Banner>
+    );
+
+    await fireEvent(screen.getByTestId('action-first-container'), 'focus');
+
+    await view.rerender(
+      <Banner visible actions={[]} testID="banner">
+        Message
+      </Banner>
+    );
+
+    // nothing left to focus inside the actions, so land on the message
+    expect(setFocus).toHaveBeenCalledTimes(1);
+    setFocus.mockRestore();
+  });
+
+  it('still calls a consumer onFocus handler on an action', async () => {
+    const onFocus = jest.fn();
+
+    await render(
+      <Banner
+        visible
+        actions={[
+          {
+            label: 'first',
+            onPress: () => {},
+            onFocus,
+            testID: 'action-first',
+          },
+        ]}
+      >
+        Message
+      </Banner>
+    );
+
+    await fireEvent(screen.getByTestId('action-first-container'), 'focus');
+
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns when given more actions than it can render', async () => {
+    await render(
+      <Banner
+        visible
+        actions={[
+          { label: 'first', onPress: () => {} },
+          { label: 'second', onPress: () => {} },
+          { label: 'third', onPress: () => {} },
+        ]}
+      >
+        Message
+      </Banner>
+    );
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Banner supports a maximum of 2 actions')
+    );
+  });
+});
+
+describe('live region', () => {
+  const ALL = { includeHiddenElements: true };
+
+  it('is a polite status region by default', async () => {
+    await render(
+      <Banner visible testID="banner">
+        Message
+      </Banner>
+    );
+
+    const region = screen.getByTestId('banner-message');
+    expect(region).toHaveProp('role', 'status');
+    expect(region).toHaveProp('aria-live', 'polite');
+  });
+
+  it('is an assertive alert region when urgent', async () => {
+    await render(
+      <Banner visible urgent testID="banner">
+        Message
+      </Banner>
+    );
+
+    const region = screen.getByTestId('banner-message');
+    expect(region).toHaveProp('role', 'alert');
+    expect(region).toHaveProp('aria-live', 'assertive');
+  });
+
+  it('silences the region while hidden', async () => {
+    await render(
+      <Banner visible={false} testID="banner">
+        Message
+      </Banner>
+    );
+
+    expect(screen.getByTestId('banner-message', ALL)).toHaveProp(
+      'aria-live',
+      'off'
+    );
+  });
+
+  it('scopes the region to the message so actions do not re-announce it', async () => {
+    // status/alert imply aria-atomic, so anything inside the region is
+    // re-announced whenever it changes - keep the buttons out of it
+    await render(
+      <Banner
+        visible
+        testID="banner"
+        actions={[{ label: 'Fix it', onPress: () => {} }]}
+      >
+        Message
+      </Banner>
+    );
+
+    const region = screen.getByTestId('banner-message');
+    expect(within(region).getByText('Message')).toBeOnTheScreen();
+    expect(within(region).queryByText('Fix it')).toBeNull();
+  });
+
+  it('does not leave the live region on the message text', async () => {
+    await render(
+      <Banner visible testID="banner">
+        Message
+      </Banner>
+    );
+
+    // react-native only maps aria-live -> accessibilityLiveRegion on View,
+    // so leaving it on Text is a no-op on android
+    const message = screen.getByText('Message');
+    expect(message).not.toHaveProp('aria-live');
+    expect(message).not.toHaveProp('role');
+  });
+});
+
+describe('announcements', () => {
+  const originalPlatform = Platform.OS;
+  let announce: jest.SpiedFunction<
+    typeof AccessibilityInfo.announceForAccessibilityWithOptions
+  >;
+
+  beforeEach(() => {
+    Platform.OS = 'ios';
+    // the rn jest preset already mocks AccessibilityInfo, so spyOn hands back
+    // that mock with every earlier test's calls still on it
+    announce = jest
+      .spyOn(AccessibilityInfo, 'announceForAccessibilityWithOptions')
+      .mockImplementation(() => {});
+    announce.mockClear();
+  });
+
+  afterEach(() => {
+    Platform.OS = originalPlatform;
+    announce.mockRestore();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('announces on ios when mounted visible', async () => {
+    await render(<Banner visible>Something went wrong</Banner>);
+
+    expect(announce).toHaveBeenCalledTimes(1);
+    // polite by default: queue behind whatever the screen reader is saying
+    expect(announce).toHaveBeenCalledWith('Something went wrong', {
+      queue: true,
+    });
+  });
+
+  it('does not announce on ios while hidden', async () => {
+    const view = await render(<Banner visible={false}>Quiet</Banner>);
+
+    expect(announce).not.toHaveBeenCalled();
+
+    await view.rerender(<Banner visible>Quiet</Banner>);
+    expect(announce).toHaveBeenCalledTimes(1);
+    expect(announce).toHaveBeenCalledWith('Quiet', { queue: true });
+  });
+
+  it('re-announces on ios when the message changes while visible', async () => {
+    const view = await render(<Banner visible>First</Banner>);
+    expect(announce).toHaveBeenCalledTimes(1);
+
+    await view.rerender(<Banner visible>Second</Banner>);
+
+    expect(announce).toHaveBeenCalledTimes(2);
+    expect(announce).toHaveBeenLastCalledWith('Second', { queue: true });
+  });
+
+  it('does not announce again when an unrelated prop changes', async () => {
+    const view = await render(<Banner visible>Same</Banner>);
+    expect(announce).toHaveBeenCalledTimes(1);
+
+    await view.rerender(
+      <Banner visible elevation={3}>
+        Same
+      </Banner>
+    );
+
+    expect(announce).toHaveBeenCalledTimes(1);
+  });
+
+  it('interrupts the screen reader on ios when urgent', async () => {
+    await render(
+      <Banner visible urgent>
+        Your payment failed
+      </Banner>
+    );
+
+    expect(announce).toHaveBeenCalledWith('Your payment failed', {
+      queue: false,
+    });
+  });
+
+  it('re-announces on ios when urgency changes while visible', async () => {
+    const view = await render(<Banner visible>Same message</Banner>);
+    expect(announce).toHaveBeenCalledTimes(1);
+
+    await view.rerender(
+      <Banner visible urgent>
+        Same message
+      </Banner>
+    );
+
+    expect(announce).toHaveBeenCalledTimes(2);
+    expect(announce).toHaveBeenLastCalledWith('Same message', {
+      queue: false,
+    });
+  });
+
+  it('announces children that are not a plain string', async () => {
+    const name = 'Ada';
+    await render(<Banner visible>Hello {name}, your card was declined</Banner>);
+
+    expect(announce).toHaveBeenCalledWith('Hello Ada, your card was declined', {
+      queue: true,
+    });
+  });
+
+  it('leaves announcing to the live region off ios', async () => {
+    Platform.OS = 'android';
+
+    await render(<Banner visible>Handled by the live region</Banner>);
+
+    expect(announce).not.toHaveBeenCalled();
+  });
+});
+
 describe('animations', () => {
   let showCallback: (() => void) | undefined,
     hideCallback: (() => void) | undefined;
@@ -135,19 +727,13 @@ describe('animations', () => {
     hideCallback = jest.fn();
   });
 
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
-
   afterAll(() => {
-    jest.useRealTimers();
     showCallback = undefined;
     hideCallback = undefined;
   });
 
   describe('when component is rendered hidden', () => {
-    // This behaviour is probably a bug. Needs triage before next version.
-    it('will fire onHideAnimationFinished on mount', async () => {
+    it('will not fire any callback on mount', async () => {
       await render(
         <Banner
           onShowAnimationFinished={showCallback}
@@ -165,7 +751,7 @@ describe('animations', () => {
         jest.runAllTimers();
       });
       expect(showCallback).not.toHaveBeenCalled();
-      expect(hideCallback).toHaveBeenCalled();
+      expect(hideCallback).not.toHaveBeenCalled();
     });
 
     it('should fire onShowAnimationFinished upon opening', async () => {
@@ -183,7 +769,7 @@ describe('animations', () => {
         jest.runAllTimers();
       });
       expect(showCallback).toHaveBeenCalledTimes(0);
-      expect(hideCallback).toHaveBeenCalledTimes(1);
+      expect(hideCallback).toHaveBeenCalledTimes(0);
 
       await view.rerender(
         <Banner
@@ -198,13 +784,12 @@ describe('animations', () => {
         jest.runAllTimers();
       });
       expect(showCallback).toHaveBeenCalledTimes(1);
-      expect(hideCallback).toHaveBeenCalledTimes(1);
+      expect(hideCallback).toHaveBeenCalledTimes(0);
     });
   });
 
   describe('when component is rendered visible', () => {
-    // This behaviour is probably a bug. Needs triage before next version.
-    it('will fire onShowAnimationFinished on mount', async () => {
+    it('will not fire any callback on mount', async () => {
       await render(
         <Banner
           onShowAnimationFinished={showCallback}
@@ -221,7 +806,7 @@ describe('animations', () => {
       await act(() => {
         jest.runAllTimers();
       });
-      expect(showCallback).toHaveBeenCalled();
+      expect(showCallback).not.toHaveBeenCalled();
       expect(hideCallback).not.toHaveBeenCalled();
     });
 
@@ -239,7 +824,7 @@ describe('animations', () => {
       await act(() => {
         jest.runAllTimers();
       });
-      expect(showCallback).toHaveBeenCalledTimes(1);
+      expect(showCallback).toHaveBeenCalledTimes(0);
       expect(hideCallback).toHaveBeenCalledTimes(0);
 
       await view.rerender(
@@ -254,7 +839,7 @@ describe('animations', () => {
       await act(() => {
         jest.runAllTimers();
       });
-      expect(showCallback).toHaveBeenCalledTimes(1);
+      expect(showCallback).toHaveBeenCalledTimes(0);
       expect(hideCallback).toHaveBeenCalledTimes(1);
     });
   });
@@ -274,7 +859,7 @@ describe('animations', () => {
       await act(() => {
         jest.runAllTimers();
       });
-      expect(showCallback).toHaveBeenCalledTimes(1);
+      expect(showCallback).toHaveBeenCalledTimes(0);
       expect(hideCallback).toHaveBeenCalledTimes(0);
 
       const nextShowCallback = jest.fn();
@@ -293,7 +878,7 @@ describe('animations', () => {
       await act(() => {
         jest.runAllTimers();
       });
-      expect(showCallback).toHaveBeenCalledTimes(1);
+      expect(showCallback).toHaveBeenCalledTimes(0);
       expect(hideCallback).toHaveBeenCalledTimes(0);
       expect(nextShowCallback).toHaveBeenCalledTimes(0);
       expect(nextHideCallback).toHaveBeenCalledTimes(0);
@@ -313,7 +898,7 @@ describe('animations', () => {
       await act(() => {
         jest.runAllTimers();
       });
-      expect(showCallback).toHaveBeenCalledTimes(1);
+      expect(showCallback).toHaveBeenCalledTimes(0);
       expect(hideCallback).toHaveBeenCalledTimes(0);
 
       const nextShowCallback = jest.fn();
@@ -332,7 +917,7 @@ describe('animations', () => {
       await act(() => {
         jest.runAllTimers();
       });
-      expect(showCallback).toHaveBeenCalledTimes(1);
+      expect(showCallback).toHaveBeenCalledTimes(0);
       expect(hideCallback).toHaveBeenCalledTimes(0);
       expect(nextShowCallback).toHaveBeenCalledTimes(0);
       expect(nextHideCallback).toHaveBeenCalledTimes(0);
@@ -350,11 +935,45 @@ describe('animations', () => {
       await act(() => {
         jest.runAllTimers();
       });
-      expect(showCallback).toHaveBeenCalledTimes(1);
+      expect(showCallback).toHaveBeenCalledTimes(0);
       expect(hideCallback).toHaveBeenCalledTimes(0);
       expect(nextShowCallback).toHaveBeenCalledTimes(0);
       expect(nextHideCallback).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it('should not fire callbacks when only the theme animation scale changes', async () => {
+    const view = await render(
+      <Banner
+        onShowAnimationFinished={showCallback}
+        onHideAnimationFinished={hideCallback}
+        theme={{ animation: { scale: 1 } }}
+        visible
+      >
+        Text
+      </Banner>
+    );
+
+    await act(() => {
+      jest.runAllTimers();
+    });
+
+    await view.rerender(
+      <Banner
+        onShowAnimationFinished={showCallback}
+        onHideAnimationFinished={hideCallback}
+        theme={{ animation: { scale: 2 } }}
+        visible
+      >
+        Text
+      </Banner>
+    );
+    await act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(showCallback).not.toHaveBeenCalled();
+    expect(hideCallback).not.toHaveBeenCalled();
   });
 
   it('animated value changes correctly', async () => {

--- a/src/components/__tests__/Banner.test.tsx
+++ b/src/components/__tests__/Banner.test.tsx
@@ -1,9 +1,11 @@
+import * as React from 'react';
 import {
   AccessibilityInfo,
   Animated,
   Image,
   Platform,
   Text,
+  View,
 } from 'react-native';
 
 import {
@@ -351,6 +353,43 @@ describe('actions', () => {
     expect(screen.getByText('first')).toBeOnTheScreen();
     expect(screen.getByText('second')).toBeOnTheScreen();
     expect(screen.queryByText('third')).toBeNull();
+  });
+
+  it('keeps a touchableRef passed through an action', async () => {
+    const setFocus = jest
+      .spyOn(AccessibilityInfo, 'setAccessibilityFocus')
+      .mockImplementation(() => {});
+    setFocus.mockClear();
+    const touchableRef = React.createRef<View>();
+
+    const view = await render(
+      <Banner
+        visible
+        actions={[
+          {
+            label: 'first',
+            onPress: () => {},
+            testID: 'action-first',
+            touchableRef,
+          },
+        ]}
+      >
+        Message
+      </Banner>
+    );
+
+    // the consumer gets the node, and the internal ref still restores focus
+    expect(touchableRef.current).not.toBeNull();
+
+    await fireEvent(screen.getByTestId('action-first-container'), 'focus');
+    await view.rerender(
+      <Banner visible actions={[]}>
+        Message
+      </Banner>
+    );
+
+    expect(setFocus).toHaveBeenCalledTimes(1);
+    setFocus.mockRestore();
   });
 
   it('moves focus to a surviving action when the focused one disappears', async () => {

--- a/src/components/__tests__/Banner.test.tsx
+++ b/src/components/__tests__/Banner.test.tsx
@@ -239,16 +239,16 @@ describe('inert when hidden', () => {
     let hideDone: ((result: { finished: boolean }) => void) | undefined;
     const timing = jest
       .spyOn(Animated, 'timing')
-      .mockImplementation((_value: any, config: any) => {
+      .mockImplementation((_value, config) => {
         return {
-          start: (cb?: (result: { finished: boolean }) => void) => {
+          start: (cb) => {
             if (config.toValue === 0) {
               hideDone = cb;
             }
           },
           stop: () => {},
           reset: () => {},
-        } as any;
+        };
       });
 
     const view = await render(
@@ -1318,9 +1318,9 @@ describe('interrupted animations', () => {
     hideDone = undefined;
     timing = jest
       .spyOn(Animated, 'timing')
-      .mockImplementation((_value: any, config: any) => {
+      .mockImplementation((_value, config) => {
         return {
-          start: (cb?: (result: { finished: boolean }) => void) => {
+          start: (cb) => {
             if (config.toValue === 1) {
               showDone = cb;
             } else if (config.toValue === 0) {
@@ -1329,7 +1329,7 @@ describe('interrupted animations', () => {
           },
           stop: () => {},
           reset: () => {},
-        } as any;
+        };
       });
   });
 

--- a/src/components/__tests__/Banner.test.tsx
+++ b/src/components/__tests__/Banner.test.tsx
@@ -1,4 +1,10 @@
-import { AccessibilityInfo, Animated, Image, Platform } from 'react-native';
+import {
+  AccessibilityInfo,
+  Animated,
+  Image,
+  Platform,
+  Text,
+} from 'react-native';
 
 import {
   afterAll,
@@ -533,6 +539,27 @@ describe('actions', () => {
 
 describe('live region', () => {
   const ALL = { includeHiddenElements: true };
+  const originalPlatform = Platform.OS;
+
+  // the preset runs as ios, which has no live region and announces by hand
+  beforeEach(() => {
+    Platform.OS = 'android';
+  });
+
+  afterEach(() => {
+    Platform.OS = originalPlatform;
+  });
+
+  // the announcer empties itself first and fills on a later task, so the text
+  // is never there on the render pass itself
+  const flush = () =>
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+  const announcerHas = (text: string) =>
+    within(screen.getByTestId('banner-announcer', ALL)).queryByText(text) !==
+    null;
 
   it('is a polite status region by default', async () => {
     await render(
@@ -541,7 +568,7 @@ describe('live region', () => {
       </Banner>
     );
 
-    const region = screen.getByTestId('banner-message');
+    const region = screen.getByTestId('banner-announcer');
     expect(region).toHaveProp('role', 'status');
     expect(region).toHaveProp('aria-live', 'polite');
   });
@@ -553,25 +580,149 @@ describe('live region', () => {
       </Banner>
     );
 
-    const region = screen.getByTestId('banner-message');
+    const region = screen.getByTestId('banner-announcer');
     expect(region).toHaveProp('role', 'alert');
     expect(region).toHaveProp('aria-live', 'assertive');
   });
 
-  it('silences the region while hidden', async () => {
+  it('stays mounted and empty while the banner is hidden', async () => {
     await render(
       <Banner visible={false} testID="banner">
         Message
       </Banner>
     );
+    await flush();
 
-    expect(screen.getByTestId('banner-message', ALL)).toHaveProp(
-      'aria-live',
-      'off'
-    );
+    expect(screen.getByTestId('banner-announcer', ALL)).toBeOnTheScreen();
+    expect(announcerHas('Message')).toBe(false);
   });
 
-  it('scopes the region to the message so actions do not re-announce it', async () => {
+  it('announces again every time the banner is shown', async () => {
+    const view = await render(
+      <Banner visible testID="banner">
+        Message
+      </Banner>
+    );
+    await flush();
+    expect(announcerHas('Message')).toBe(true);
+
+    await view.rerender(
+      <Banner visible={false} testID="banner">
+        Message
+      </Banner>
+    );
+    // finish the hide so the content really unmounts, which the bug needed
+    await act(() => {
+      jest.runAllTimers();
+    });
+    expect(screen.queryByTestId('banner-content', ALL)).toBeNull();
+    expect(announcerHas('Message')).toBe(false);
+
+    await view.rerender(
+      <Banner visible testID="banner">
+        Message
+      </Banner>
+    );
+    await flush();
+    expect(announcerHas('Message')).toBe(true);
+  });
+
+  it('announces an unchanged message again on every show', async () => {
+    const view = await render(
+      <Banner visible={false} testID="banner">
+        Same text
+      </Banner>
+    );
+
+    for (let i = 0; i < 2; i++) {
+      await view.rerender(
+        <Banner visible testID="banner">
+          Same text
+        </Banner>
+      );
+      await flush();
+      expect(announcerHas('Same text')).toBe(true);
+
+      await view.rerender(
+        <Banner visible={false} testID="banner">
+          Same text
+        </Banner>
+      );
+      await act(() => {
+        jest.runAllTimers();
+      });
+      expect(announcerHas('Same text')).toBe(false);
+    }
+  });
+
+  it('re-announces when the message changes while visible', async () => {
+    const view = await render(
+      <Banner visible testID="banner">
+        First
+      </Banner>
+    );
+    await flush();
+    expect(announcerHas('First')).toBe(true);
+
+    await view.rerender(
+      <Banner visible testID="banner">
+        Second
+      </Banner>
+    );
+    await flush();
+    expect(announcerHas('Second')).toBe(true);
+  });
+
+  it('re-announces when urgency changes while visible', async () => {
+    const view = await render(
+      <Banner visible testID="banner">
+        Message
+      </Banner>
+    );
+    await act(() => {
+      jest.runAllTimers();
+    });
+    expect(announcerHas('Message')).toBe(false);
+
+    await view.rerender(
+      <Banner visible urgent testID="banner">
+        Message
+      </Banner>
+    );
+    await flush();
+
+    expect(screen.getByTestId('banner-announcer')).toHaveProp('role', 'alert');
+    expect(announcerHas('Message')).toBe(true);
+  });
+
+  it('announces text nested inside elements', async () => {
+    await render(
+      <Banner visible testID="banner">
+        Your card <Text>ending 4242</Text> was declined
+      </Banner>
+    );
+    await flush();
+
+    expect(announcerHas('Your card ending 4242 was declined')).toBe(true);
+  });
+
+  it('drops the text again so it is not a second copy of the message', async () => {
+    await render(
+      <Banner visible testID="banner">
+        Message
+      </Banner>
+    );
+    await act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(announcerHas('Message')).toBe(false);
+    expect(
+      within(screen.getByTestId('banner-message')).getByText('Message')
+    ).toBeOnTheScreen();
+  });
+
+  it('carries the message only, so action labels never re-announce it', async () => {
     // status/alert imply aria-atomic, so anything inside the region is
     // re-announced whenever it changes - keep the buttons out of it
     await render(
@@ -583,24 +734,139 @@ describe('live region', () => {
         Message
       </Banner>
     );
+    await flush();
 
-    const region = screen.getByTestId('banner-message');
+    const region = screen.getByTestId('banner-announcer');
     expect(within(region).getByText('Message')).toBeOnTheScreen();
     expect(within(region).queryByText('Fix it')).toBeNull();
   });
 
-  it('does not leave the live region on the message text', async () => {
+  it('leaves the region off the message and its text', async () => {
+    // the message is a focus target now, not a region
     await render(
       <Banner visible testID="banner">
         Message
       </Banner>
     );
 
-    // react-native only maps aria-live -> accessibilityLiveRegion on View,
-    // so leaving it on Text is a no-op on android
-    const message = screen.getByText('Message');
-    expect(message).not.toHaveProp('aria-live');
-    expect(message).not.toHaveProp('role');
+    const container = screen.getByTestId('banner-message');
+    expect(container).not.toHaveProp('aria-live');
+    expect(container).not.toHaveProp('role');
+
+    const text = within(container).getByText('Message');
+    expect(text).not.toHaveProp('aria-live');
+    expect(text).not.toHaveProp('role');
+  });
+
+  it('is left out on ios, which announces by hand instead', async () => {
+    Platform.OS = 'ios';
+
+    await render(
+      <Banner visible testID="banner">
+        Message
+      </Banner>
+    );
+
+    expect(screen.queryByTestId('banner-announcer', ALL)).toBeNull();
+  });
+});
+
+describe('icon', () => {
+  it('hides a decorative icon from screen readers', async () => {
+    // an unlabelled icon reads as a bare "image"
+    await render(
+      <Banner visible icon="camera" testID="banner">
+        Message
+      </Banner>
+    );
+
+    expect(screen.queryByTestId('banner-icon')).toBeNull();
+    expect(
+      screen.getByTestId('banner-icon', { includeHiddenElements: true })
+    ).toHaveProp('aria-hidden', true);
+  });
+
+  it('exposes the icon when it is given a label', async () => {
+    await render(
+      <Banner
+        visible
+        icon="camera"
+        iconAccessibilityLabel="Payment failed"
+        testID="banner"
+      >
+        Message
+      </Banner>
+    );
+
+    const wrapper = screen.getByTestId('banner-icon');
+    expect(wrapper).toHaveProp('aria-hidden', false);
+    expect(wrapper).toHaveProp('accessible', true);
+    expect(wrapper).toHaveProp('aria-label', 'Payment failed');
+  });
+});
+
+describe('message focus', () => {
+  const originalPlatform = Platform.OS;
+
+  afterEach(() => {
+    Platform.OS = originalPlatform;
+  });
+
+  it('makes the message focusable on web', async () => {
+    Platform.OS = 'web';
+
+    await render(
+      <Banner visible testID="banner">
+        Message
+      </Banner>
+    );
+
+    expect(screen.getByTestId('banner-message')).toHaveProp('tabIndex', -1);
+  });
+
+  it('makes the message an accessibility element on native', async () => {
+    Platform.OS = 'ios';
+
+    await render(
+      <Banner visible testID="banner">
+        Message
+      </Banner>
+    );
+
+    expect(screen.getByTestId('banner-message')).toHaveProp('accessible', true);
+  });
+
+  it('does not reach for a native handle on web', async () => {
+    // rnw's findNodeHandle throws, and calling it took the whole tree down
+    Platform.OS = 'web';
+    const setFocus = jest
+      .spyOn(AccessibilityInfo, 'setAccessibilityFocus')
+      .mockImplementation(() => {});
+    setFocus.mockClear();
+
+    const view = await render(
+      <Banner
+        visible
+        testID="banner"
+        actions={[
+          { label: 'first', onPress: () => {}, testID: 'action-first' },
+        ]}
+      >
+        Message
+      </Banner>
+    );
+
+    await fireEvent(screen.getByTestId('action-first-container'), 'focus');
+
+    await view.rerender(
+      <Banner visible actions={[]} testID="banner">
+        Message
+      </Banner>
+    );
+
+    expect(setFocus).not.toHaveBeenCalled();
+    expect(screen.getByTestId('banner-message')).toBeOnTheScreen();
+    setFocus.mockRestore();
   });
 });
 
@@ -623,10 +889,6 @@ describe('announcements', () => {
   afterEach(() => {
     Platform.OS = originalPlatform;
     announce.mockRestore();
-  });
-
-  afterAll(() => {
-    jest.useRealTimers();
   });
 
   it('announces on ios when mounted visible', async () => {

--- a/src/components/__tests__/Banner.test.tsx
+++ b/src/components/__tests__/Banner.test.tsx
@@ -1006,3 +1006,97 @@ describe('animations', () => {
     });
   });
 });
+
+describe('interrupted animations', () => {
+  let showDone: ((result: { finished: boolean }) => void) | undefined;
+  let hideDone: ((result: { finished: boolean }) => void) | undefined;
+  let timing: jest.SpiedFunction<typeof Animated.timing>;
+
+  beforeEach(() => {
+    showDone = undefined;
+    hideDone = undefined;
+    timing = jest
+      .spyOn(Animated, 'timing')
+      .mockImplementation((_value: any, config: any) => {
+        return {
+          start: (cb?: (result: { finished: boolean }) => void) => {
+            if (config.toValue === 1) {
+              showDone = cb;
+            } else if (config.toValue === 0) {
+              hideDone = cb;
+            }
+          },
+          stop: () => {},
+          reset: () => {},
+        } as any;
+      });
+  });
+
+  afterEach(() => {
+    timing.mockRestore();
+  });
+
+  it('does not fire onHideAnimationFinished when hide is interrupted', async () => {
+    const onHideAnimationFinished = jest.fn();
+    const onShowAnimationFinished = jest.fn();
+
+    const view = await render(
+      <Banner
+        visible
+        onShowAnimationFinished={onShowAnimationFinished}
+        onHideAnimationFinished={onHideAnimationFinished}
+      >
+        Text
+      </Banner>
+    );
+
+    await view.rerender(
+      <Banner
+        visible={false}
+        onShowAnimationFinished={onShowAnimationFinished}
+        onHideAnimationFinished={onHideAnimationFinished}
+      >
+        Text
+      </Banner>
+    );
+
+    await act(() => {
+      hideDone?.({ finished: false });
+    });
+
+    expect(onShowAnimationFinished).not.toHaveBeenCalled();
+    expect(onHideAnimationFinished).not.toHaveBeenCalled();
+  });
+
+  it('does not fire onShowAnimationFinished when show is interrupted', async () => {
+    const onHideAnimationFinished = jest.fn();
+    const onShowAnimationFinished = jest.fn();
+
+    const view = await render(
+      <Banner
+        visible={false}
+        onShowAnimationFinished={onShowAnimationFinished}
+        onHideAnimationFinished={onHideAnimationFinished}
+      >
+        Text
+      </Banner>
+    );
+
+    await view.rerender(
+      <Banner
+        visible
+        onShowAnimationFinished={onShowAnimationFinished}
+        onHideAnimationFinished={onHideAnimationFinished}
+      >
+        Text
+      </Banner>
+    );
+
+    await act(() => {
+      showDone?.({ finished: false });
+    });
+
+    expect(onShowAnimationFinished).not.toHaveBeenCalled();
+    expect(onHideAnimationFinished).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/Banner.test.tsx
+++ b/src/components/__tests__/Banner.test.tsx
@@ -576,6 +576,76 @@ describe('actions', () => {
   });
 });
 
+describe('reflow', () => {
+  const ACTIONS_TWO = [
+    { label: 'first', onPress: () => {} },
+    { label: 'second', onPress: () => {} },
+  ];
+
+  const measure = (width: number) =>
+    fireEvent(screen.getByTestId('banner-row'), 'layout', {
+      nativeEvent: { layout: { height: 80, width } },
+    });
+
+  it('stacks the actions below the message on a phone width', async () => {
+    await render(
+      <Banner visible actions={ACTIONS_TWO} testID="banner">
+        Two line text string with two actions.
+      </Banner>
+    );
+
+    await measure(400);
+
+    expect(screen.getByTestId('banner-row')).toHaveStyle({
+      flexDirection: 'column',
+    });
+  });
+
+  it('puts the actions inline once there is room', async () => {
+    await render(
+      <Banner visible actions={ACTIONS_TWO} testID="banner">
+        Two line text string with two actions.
+      </Banner>
+    );
+
+    await measure(800);
+
+    expect(screen.getByTestId('banner-row')).toHaveStyle({
+      flexDirection: 'row',
+    });
+  });
+
+  it('stacks until the banner has been measured', async () => {
+    await render(
+      <Banner visible actions={ACTIONS_TWO} testID="banner">
+        Two line text string with two actions.
+      </Banner>
+    );
+
+    expect(screen.getByTestId('banner-row')).toHaveStyle({
+      flexDirection: 'column',
+    });
+  });
+
+  it('reflows again when the banner is resized', async () => {
+    await render(
+      <Banner visible actions={ACTIONS_TWO} testID="banner">
+        Two line text string with two actions.
+      </Banner>
+    );
+
+    await measure(800);
+    expect(screen.getByTestId('banner-row')).toHaveStyle({
+      flexDirection: 'row',
+    });
+
+    await measure(400);
+    expect(screen.getByTestId('banner-row')).toHaveStyle({
+      flexDirection: 'column',
+    });
+  });
+});
+
 describe('live region', () => {
   const ALL = { includeHiddenElements: true };
   const originalPlatform = Platform.OS;

--- a/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
@@ -57,95 +57,96 @@ exports[`render visible banner, with custom theme 1`] = `
         }
       />
       <View
+        aria-hidden={false}
         collapsable={false}
         onLayout={[Function]}
+        pointerEvents="auto"
         style={{}}
+        testID="banner-content"
       >
         <View
           style={
             {
+              "alignItems": "center",
               "flexDirection": "row",
-              "justifyContent": "flex-start",
+              "flexWrap": "wrap",
+              "justifyContent": "flex-end",
               "marginBottom": 0,
               "marginHorizontal": 8,
               "marginTop": 16,
             }
           }
         >
-          <Text
-            aria-live="polite"
-            role="alert"
-            style={
-              [
-                {
-                  "textAlign": "left",
-                },
-                {
-                  "color": "rgba(29, 27, 32, 1)",
-                  "writingDirection": "ltr",
-                },
-                [
-                  {
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                    "letterSpacing": 0.25,
-                    "lineHeight": 20,
-                  },
-                  [
-                    {
-                      "flex": 1,
-                      "margin": 8,
-                    },
-                    {
-                      "color": "#00f",
-                    },
-                  ],
-                ],
-              ]
-            }
-          >
-            Custom theme
-          </Text>
-        </View>
-        <View
-          style={
-            {
-              "flexDirection": "row",
-              "justifyContent": "flex-end",
-              "margin": 4,
-            }
-          }
-        >
           <View
-            collapsable={false}
             style={
               {
-                "backgroundColor": "transparent",
-                "borderRadius": 20,
-                "margin": 4,
-                "shadowColor": "rgba(0, 0, 0, 1)",
-                "shadowOffset": {
-                  "height": 0,
-                  "width": 0,
-                },
-                "shadowOpacity": 0,
-                "shadowRadius": 0,
+                "alignItems": "center",
+                "flexBasis": "auto",
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
               }
             }
-            testID="button-container-outer-layer"
+          >
+            <View
+              aria-live="polite"
+              role="status"
+              style={
+                {
+                  "flexBasis": "auto",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "margin": 8,
+                }
+              }
+              testID="banner-message"
+            >
+              <Text
+                style={
+                  [
+                    {
+                      "textAlign": "left",
+                    },
+                    {
+                      "color": "rgba(29, 27, 32, 1)",
+                      "writingDirection": "ltr",
+                    },
+                    [
+                      {
+                        "fontFamily": "System",
+                        "fontSize": 14,
+                        "fontWeight": "400",
+                        "letterSpacing": 0.25,
+                        "lineHeight": 20,
+                      },
+                      {
+                        "color": "#00f",
+                      },
+                    ],
+                  ]
+                }
+              >
+                Custom theme
+              </Text>
+            </View>
+          </View>
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "flexShrink": 0,
+                "justifyContent": "flex-end",
+                "margin": 4,
+              }
+            }
           >
             <View
               collapsable={false}
               style={
                 {
                   "backgroundColor": "transparent",
-                  "borderColor": "transparent",
                   "borderRadius": 20,
-                  "borderStyle": "solid",
-                  "borderWidth": 0,
-                  "flex": undefined,
-                  "minWidth": "auto",
+                  "margin": 4,
                   "shadowColor": "rgba(0, 0, 0, 1)",
                   "shadowOffset": {
                     "height": 0,
@@ -155,116 +156,141 @@ exports[`render visible banner, with custom theme 1`] = `
                   "shadowRadius": 0,
                 }
               }
-              testID="button-container"
+              testID="button-container-outer-layer"
             >
               <View
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": false,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
                 collapsable={false}
-                focusable={true}
                 onBlur={[Function]}
-                onClick={[Function]}
                 onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                role="button"
                 style={
-                  [
-                    {
-                      "overflow": "hidden",
+                  {
+                    "backgroundColor": "transparent",
+                    "borderColor": "transparent",
+                    "borderRadius": 20,
+                    "borderStyle": "solid",
+                    "borderWidth": 0,
+                    "flex": undefined,
+                    "minWidth": "auto",
+                    "shadowColor": "rgba(0, 0, 0, 1)",
+                    "shadowOffset": {
+                      "height": 0,
+                      "width": 0,
                     },
-                    {
-                      "borderRadius": 20,
-                    },
-                  ]
+                    "shadowOpacity": 0,
+                    "shadowRadius": 0,
+                  }
                 }
-                testID="button"
+                testID="button-container"
               >
                 <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  role="button"
                   style={
                     [
                       {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                        "justifyContent": "center",
+                        "overflow": "hidden",
                       },
                       {
-                        "opacity": 1,
+                        "borderRadius": 20,
                       },
-                      undefined,
                     ]
                   }
+                  testID="button"
                 >
-                  <Text
-                    numberOfLines={1}
-                    selectable={false}
+                  <View
                     style={
                       [
                         {
-                          "textAlign": "left",
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "justifyContent": "center",
                         },
                         {
-                          "color": "rgba(29, 27, 32, 1)",
-                          "writingDirection": "ltr",
+                          "opacity": 1,
                         },
+                        undefined,
+                      ]
+                    }
+                  >
+                    <Text
+                      numberOfLines={1}
+                      selectable={false}
+                      style={
                         [
                           {
-                            "fontFamily": "System",
-                            "fontSize": 14,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.1,
-                            "lineHeight": 20,
+                            "textAlign": "left",
+                          },
+                          {
+                            "color": "rgba(29, 27, 32, 1)",
+                            "writingDirection": "ltr",
                           },
                           [
                             {
-                              "marginHorizontal": 16,
-                              "marginVertical": 9,
-                              "textAlign": "center",
-                            },
-                            {
-                              "marginHorizontal": 12,
-                            },
-                            {
-                              "marginHorizontal": 8,
-                            },
-                            false,
-                            {
-                              "color": "#043",
                               "fontFamily": "System",
                               "fontSize": 14,
                               "fontWeight": "500",
                               "letterSpacing": 0.1,
                               "lineHeight": 20,
                             },
-                            undefined,
+                            [
+                              {
+                                "marginHorizontal": 16,
+                                "marginVertical": 9,
+                                "textAlign": "center",
+                              },
+                              {
+                                "marginHorizontal": 12,
+                              },
+                              {
+                                "marginHorizontal": 8,
+                              },
+                              false,
+                              {
+                                "color": "#043",
+                                "fontFamily": "System",
+                                "fontSize": 14,
+                                "fontWeight": "500",
+                                "letterSpacing": 0.1,
+                                "lineHeight": 20,
+                              },
+                              undefined,
+                            ],
                           ],
-                        ],
-                      ]
-                    }
-                    testID="button-text"
-                  >
-                    first
-                  </Text>
+                        ]
+                      }
+                      testID="button-text"
+                    >
+                      first
+                    </Text>
+                  </View>
                 </View>
               </View>
             </View>
@@ -333,8 +359,11 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
         }
       />
       <View
+        aria-hidden={true}
         collapsable={false}
+        inert={true}
         onLayout={[Function]}
+        pointerEvents="none"
         style={
           {
             "opacity": 0,
@@ -348,63 +377,75 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
             "width": "100%",
           }
         }
+        testID="banner-content"
       >
         <View
           style={
             {
+              "alignItems": "center",
               "flexDirection": "row",
-              "justifyContent": "flex-start",
+              "flexWrap": "wrap",
+              "justifyContent": "flex-end",
               "marginBottom": 0,
               "marginHorizontal": 8,
               "marginTop": 16,
             }
           }
         >
-          <Text
-            aria-live="off"
-            role="alert"
+          <View
             style={
-              [
+              {
+                "alignItems": "center",
+                "flexBasis": "auto",
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
+              }
+            }
+          >
+            <View
+              aria-live="off"
+              role="status"
+              style={
                 {
-                  "textAlign": "left",
-                },
-                {
-                  "color": "rgba(29, 27, 32, 1)",
-                  "writingDirection": "ltr",
-                },
-                [
-                  {
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                    "letterSpacing": 0.25,
-                    "lineHeight": 20,
-                  },
+                  "flexBasis": "auto",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "margin": 8,
+                }
+              }
+              testID="banner-message"
+            >
+              <Text
+                style={
                   [
                     {
-                      "flex": 1,
-                      "margin": 8,
+                      "textAlign": "left",
                     },
                     {
                       "color": "rgba(29, 27, 32, 1)",
+                      "writingDirection": "ltr",
                     },
-                  ],
-                ],
-              ]
-            }
-          >
-            Two line text string with two actions. One to two lines is preferable on mobile.
-          </Text>
+                    [
+                      {
+                        "fontFamily": "System",
+                        "fontSize": 14,
+                        "fontWeight": "400",
+                        "letterSpacing": 0.25,
+                        "lineHeight": 20,
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                      },
+                    ],
+                  ]
+                }
+              >
+                Two line text string with two actions. One to two lines is preferable on mobile.
+              </Text>
+            </View>
+          </View>
         </View>
-        <View
-          style={
-            {
-              "flexDirection": "row",
-              "justifyContent": "flex-end",
-              "margin": 4,
-            }
-          }
-        />
       </View>
     </View>
   </View>
@@ -468,15 +509,20 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
         }
       />
       <View
+        aria-hidden={false}
         collapsable={false}
         onLayout={[Function]}
+        pointerEvents="auto"
         style={{}}
+        testID="banner-content"
       >
         <View
           style={
             {
+              "alignItems": "center",
               "flexDirection": "row",
-              "justifyContent": "flex-start",
+              "flexWrap": "wrap",
+              "justifyContent": "flex-end",
               "marginBottom": 0,
               "marginHorizontal": 8,
               "marginTop": 16,
@@ -486,99 +532,95 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
           <View
             style={
               {
-                "margin": 8,
+                "alignItems": "center",
+                "flexBasis": "auto",
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
               }
             }
           >
-            <Image
-              accessibilityIgnoresInvertColors={true}
-              source={
-                {
-                  "uri": "https://callstack.com/images/team/Satya.png",
-                }
-              }
+            <View
               style={
                 {
-                  "height": 40,
-                  "width": 40,
+                  "margin": 8,
                 }
               }
-            />
-          </View>
-          <Text
-            aria-live="polite"
-            role="alert"
-            style={
-              [
-                {
-                  "textAlign": "left",
-                },
-                {
-                  "color": "rgba(29, 27, 32, 1)",
-                  "writingDirection": "ltr",
-                },
-                [
+            >
+              <Image
+                accessibilityIgnoresInvertColors={true}
+                source={
                   {
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                    "letterSpacing": 0.25,
-                    "lineHeight": 20,
-                  },
+                    "uri": "https://callstack.com/images/team/Satya.png",
+                  }
+                }
+                style={
+                  {
+                    "height": 40,
+                    "width": 40,
+                  }
+                }
+              />
+            </View>
+            <View
+              aria-live="polite"
+              role="status"
+              style={
+                {
+                  "flexBasis": "auto",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "margin": 8,
+                }
+              }
+              testID="banner-message"
+            >
+              <Text
+                style={
                   [
                     {
-                      "flex": 1,
-                      "margin": 8,
+                      "textAlign": "left",
                     },
                     {
                       "color": "rgba(29, 27, 32, 1)",
+                      "writingDirection": "ltr",
                     },
-                  ],
-                ],
-              ]
-            }
-          >
-            Two line text string with two actions. One to two lines is preferable on mobile.
-          </Text>
-        </View>
-        <View
-          style={
-            {
-              "flexDirection": "row",
-              "justifyContent": "flex-end",
-              "margin": 4,
-            }
-          }
-        >
+                    [
+                      {
+                        "fontFamily": "System",
+                        "fontSize": 14,
+                        "fontWeight": "400",
+                        "letterSpacing": 0.25,
+                        "lineHeight": 20,
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                      },
+                    ],
+                  ]
+                }
+              >
+                Two line text string with two actions. One to two lines is preferable on mobile.
+              </Text>
+            </View>
+          </View>
           <View
-            collapsable={false}
             style={
               {
-                "backgroundColor": "transparent",
-                "borderRadius": 20,
+                "flexDirection": "row",
+                "flexShrink": 0,
+                "justifyContent": "flex-end",
                 "margin": 4,
-                "shadowColor": "rgba(0, 0, 0, 1)",
-                "shadowOffset": {
-                  "height": 0,
-                  "width": 0,
-                },
-                "shadowOpacity": 0,
-                "shadowRadius": 0,
               }
             }
-            testID="button-container-outer-layer"
           >
             <View
               collapsable={false}
               style={
                 {
                   "backgroundColor": "transparent",
-                  "borderColor": "transparent",
                   "borderRadius": 20,
-                  "borderStyle": "solid",
-                  "borderWidth": 0,
-                  "flex": undefined,
-                  "minWidth": "auto",
+                  "margin": 4,
                   "shadowColor": "rgba(0, 0, 0, 1)",
                   "shadowOffset": {
                     "height": 0,
@@ -588,116 +630,141 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                   "shadowRadius": 0,
                 }
               }
-              testID="button-container"
+              testID="button-container-outer-layer"
             >
               <View
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": false,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
                 collapsable={false}
-                focusable={true}
                 onBlur={[Function]}
-                onClick={[Function]}
                 onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                role="button"
                 style={
-                  [
-                    {
-                      "overflow": "hidden",
+                  {
+                    "backgroundColor": "transparent",
+                    "borderColor": "transparent",
+                    "borderRadius": 20,
+                    "borderStyle": "solid",
+                    "borderWidth": 0,
+                    "flex": undefined,
+                    "minWidth": "auto",
+                    "shadowColor": "rgba(0, 0, 0, 1)",
+                    "shadowOffset": {
+                      "height": 0,
+                      "width": 0,
                     },
-                    {
-                      "borderRadius": 20,
-                    },
-                  ]
+                    "shadowOpacity": 0,
+                    "shadowRadius": 0,
+                  }
                 }
-                testID="button"
+                testID="button-container"
               >
                 <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  role="button"
                   style={
                     [
                       {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                        "justifyContent": "center",
+                        "overflow": "hidden",
                       },
                       {
-                        "opacity": 1,
+                        "borderRadius": 20,
                       },
-                      undefined,
                     ]
                   }
+                  testID="button"
                 >
-                  <Text
-                    numberOfLines={1}
-                    selectable={false}
+                  <View
                     style={
                       [
                         {
-                          "textAlign": "left",
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "justifyContent": "center",
                         },
                         {
-                          "color": "rgba(29, 27, 32, 1)",
-                          "writingDirection": "ltr",
+                          "opacity": 1,
                         },
+                        undefined,
+                      ]
+                    }
+                  >
+                    <Text
+                      numberOfLines={1}
+                      selectable={false}
+                      style={
                         [
                           {
-                            "fontFamily": "System",
-                            "fontSize": 14,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.1,
-                            "lineHeight": 20,
+                            "textAlign": "left",
+                          },
+                          {
+                            "color": "rgba(29, 27, 32, 1)",
+                            "writingDirection": "ltr",
                           },
                           [
                             {
-                              "marginHorizontal": 16,
-                              "marginVertical": 9,
-                              "textAlign": "center",
-                            },
-                            {
-                              "marginHorizontal": 12,
-                            },
-                            {
-                              "marginHorizontal": 8,
-                            },
-                            false,
-                            {
-                              "color": "rgba(103, 80, 164, 1)",
                               "fontFamily": "System",
                               "fontSize": 14,
                               "fontWeight": "500",
                               "letterSpacing": 0.1,
                               "lineHeight": 20,
                             },
-                            undefined,
+                            [
+                              {
+                                "marginHorizontal": 16,
+                                "marginVertical": 9,
+                                "textAlign": "center",
+                              },
+                              {
+                                "marginHorizontal": 12,
+                              },
+                              {
+                                "marginHorizontal": 8,
+                              },
+                              false,
+                              {
+                                "color": "rgba(103, 80, 164, 1)",
+                                "fontFamily": "System",
+                                "fontSize": 14,
+                                "fontWeight": "500",
+                                "letterSpacing": 0.1,
+                                "lineHeight": 20,
+                              },
+                              undefined,
+                            ],
                           ],
-                        ],
-                      ]
-                    }
-                    testID="button-text"
-                  >
-                    first
-                  </Text>
+                        ]
+                      }
+                      testID="button-text"
+                    >
+                      first
+                    </Text>
+                  </View>
                 </View>
               </View>
             </View>
@@ -766,247 +833,96 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
         }
       />
       <View
+        aria-hidden={false}
         collapsable={false}
         onLayout={[Function]}
+        pointerEvents="auto"
         style={{}}
+        testID="banner-content"
       >
         <View
           style={
             {
+              "alignItems": "center",
               "flexDirection": "row",
-              "justifyContent": "flex-start",
+              "flexWrap": "wrap",
+              "justifyContent": "flex-end",
               "marginBottom": 0,
               "marginHorizontal": 8,
               "marginTop": 16,
             }
           }
         >
-          <Text
-            aria-live="polite"
-            role="alert"
+          <View
             style={
-              [
+              {
+                "alignItems": "center",
+                "flexBasis": "auto",
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
+              }
+            }
+          >
+            <View
+              aria-live="polite"
+              role="status"
+              style={
                 {
-                  "textAlign": "left",
-                },
-                {
-                  "color": "rgba(29, 27, 32, 1)",
-                  "writingDirection": "ltr",
-                },
-                [
-                  {
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                    "letterSpacing": 0.25,
-                    "lineHeight": 20,
-                  },
+                  "flexBasis": "auto",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "margin": 8,
+                }
+              }
+              testID="banner-message"
+            >
+              <Text
+                style={
                   [
                     {
-                      "flex": 1,
-                      "margin": 8,
+                      "textAlign": "left",
                     },
                     {
                       "color": "rgba(29, 27, 32, 1)",
+                      "writingDirection": "ltr",
                     },
-                  ],
-                ],
-              ]
-            }
-          >
-            Two line text string with two actions. One to two lines is preferable on mobile.
-          </Text>
-        </View>
-        <View
-          style={
-            {
-              "flexDirection": "row",
-              "justifyContent": "flex-end",
-              "margin": 4,
-            }
-          }
-        >
-          <View
-            collapsable={false}
-            style={
-              {
-                "backgroundColor": "transparent",
-                "borderRadius": 20,
-                "margin": 4,
-                "shadowColor": "rgba(0, 0, 0, 1)",
-                "shadowOffset": {
-                  "height": 0,
-                  "width": 0,
-                },
-                "shadowOpacity": 0,
-                "shadowRadius": 0,
-              }
-            }
-            testID="button-container-outer-layer"
-          >
-            <View
-              collapsable={false}
-              style={
-                {
-                  "backgroundColor": "transparent",
-                  "borderColor": "transparent",
-                  "borderRadius": 20,
-                  "borderStyle": "solid",
-                  "borderWidth": 0,
-                  "flex": undefined,
-                  "minWidth": "auto",
-                  "shadowColor": "rgba(0, 0, 0, 1)",
-                  "shadowOffset": {
-                    "height": 0,
-                    "width": 0,
-                  },
-                  "shadowOpacity": 0,
-                  "shadowRadius": 0,
-                }
-              }
-              testID="button-container"
-            >
-              <View
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": false,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
-                collapsable={false}
-                focusable={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                role="button"
-                style={
-                  [
-                    {
-                      "overflow": "hidden",
-                    },
-                    {
-                      "borderRadius": 20,
-                    },
-                  ]
-                }
-                testID="button"
-              >
-                <View
-                  style={
                     [
                       {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                        "justifyContent": "center",
+                        "fontFamily": "System",
+                        "fontSize": 14,
+                        "fontWeight": "400",
+                        "letterSpacing": 0.25,
+                        "lineHeight": 20,
                       },
                       {
-                        "opacity": 1,
+                        "color": "rgba(29, 27, 32, 1)",
                       },
-                      undefined,
-                    ]
-                  }
-                >
-                  <Text
-                    numberOfLines={1}
-                    selectable={false}
-                    style={
-                      [
-                        {
-                          "textAlign": "left",
-                        },
-                        {
-                          "color": "rgba(29, 27, 32, 1)",
-                          "writingDirection": "ltr",
-                        },
-                        [
-                          {
-                            "fontFamily": "System",
-                            "fontSize": 14,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.1,
-                            "lineHeight": 20,
-                          },
-                          [
-                            {
-                              "marginHorizontal": 16,
-                              "marginVertical": 9,
-                              "textAlign": "center",
-                            },
-                            {
-                              "marginHorizontal": 12,
-                            },
-                            {
-                              "marginHorizontal": 8,
-                            },
-                            false,
-                            {
-                              "color": "rgba(103, 80, 164, 1)",
-                              "fontFamily": "System",
-                              "fontSize": 14,
-                              "fontWeight": "500",
-                              "letterSpacing": 0.1,
-                              "lineHeight": 20,
-                            },
-                            undefined,
-                          ],
-                        ],
-                      ]
-                    }
-                    testID="button-text"
-                  >
-                    first
-                  </Text>
-                </View>
-              </View>
+                    ],
+                  ]
+                }
+              >
+                Two line text string with two actions. One to two lines is preferable on mobile.
+              </Text>
             </View>
           </View>
           <View
-            collapsable={false}
             style={
               {
-                "backgroundColor": "transparent",
-                "borderRadius": 20,
+                "flexDirection": "row",
+                "flexShrink": 0,
+                "justifyContent": "flex-end",
                 "margin": 4,
-                "shadowColor": "rgba(0, 0, 0, 1)",
-                "shadowOffset": {
-                  "height": 0,
-                  "width": 0,
-                },
-                "shadowOpacity": 0,
-                "shadowRadius": 0,
               }
             }
-            testID="button-container-outer-layer"
           >
             <View
               collapsable={false}
               style={
                 {
                   "backgroundColor": "transparent",
-                  "borderColor": "transparent",
                   "borderRadius": 20,
-                  "borderStyle": "solid",
-                  "borderWidth": 0,
-                  "flex": undefined,
-                  "minWidth": "auto",
+                  "margin": 4,
                   "shadowColor": "rgba(0, 0, 0, 1)",
                   "shadowOffset": {
                     "height": 0,
@@ -1016,116 +932,295 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   "shadowRadius": 0,
                 }
               }
-              testID="button-container"
+              testID="button-container-outer-layer"
             >
               <View
-                accessibilityState={
-                  {
-                    "busy": undefined,
-                    "checked": undefined,
-                    "disabled": false,
-                    "expanded": undefined,
-                    "selected": undefined,
-                  }
-                }
-                accessibilityValue={
-                  {
-                    "max": undefined,
-                    "min": undefined,
-                    "now": undefined,
-                    "text": undefined,
-                  }
-                }
-                accessible={true}
                 collapsable={false}
-                focusable={true}
                 onBlur={[Function]}
-                onClick={[Function]}
                 onFocus={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                role="button"
                 style={
-                  [
-                    {
-                      "overflow": "hidden",
+                  {
+                    "backgroundColor": "transparent",
+                    "borderColor": "transparent",
+                    "borderRadius": 20,
+                    "borderStyle": "solid",
+                    "borderWidth": 0,
+                    "flex": undefined,
+                    "minWidth": "auto",
+                    "shadowColor": "rgba(0, 0, 0, 1)",
+                    "shadowOffset": {
+                      "height": 0,
+                      "width": 0,
                     },
-                    {
-                      "borderRadius": 20,
-                    },
-                  ]
+                    "shadowOpacity": 0,
+                    "shadowRadius": 0,
+                  }
                 }
-                testID="button"
+                testID="button-container"
               >
                 <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  role="button"
                   style={
                     [
                       {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                        "justifyContent": "center",
+                        "overflow": "hidden",
                       },
                       {
-                        "opacity": 1,
+                        "borderRadius": 20,
                       },
-                      undefined,
                     ]
                   }
+                  testID="button"
                 >
-                  <Text
-                    numberOfLines={1}
-                    selectable={false}
+                  <View
                     style={
                       [
                         {
-                          "textAlign": "left",
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "justifyContent": "center",
                         },
                         {
-                          "color": "rgba(29, 27, 32, 1)",
-                          "writingDirection": "ltr",
+                          "opacity": 1,
                         },
+                        undefined,
+                      ]
+                    }
+                  >
+                    <Text
+                      numberOfLines={1}
+                      selectable={false}
+                      style={
                         [
                           {
-                            "fontFamily": "System",
-                            "fontSize": 14,
-                            "fontWeight": "500",
-                            "letterSpacing": 0.1,
-                            "lineHeight": 20,
+                            "textAlign": "left",
+                          },
+                          {
+                            "color": "rgba(29, 27, 32, 1)",
+                            "writingDirection": "ltr",
                           },
                           [
                             {
-                              "marginHorizontal": 16,
-                              "marginVertical": 9,
-                              "textAlign": "center",
-                            },
-                            {
-                              "marginHorizontal": 12,
-                            },
-                            {
-                              "marginHorizontal": 8,
-                            },
-                            false,
-                            {
-                              "color": "rgba(103, 80, 164, 1)",
                               "fontFamily": "System",
                               "fontSize": 14,
                               "fontWeight": "500",
                               "letterSpacing": 0.1,
                               "lineHeight": 20,
                             },
-                            undefined,
+                            [
+                              {
+                                "marginHorizontal": 16,
+                                "marginVertical": 9,
+                                "textAlign": "center",
+                              },
+                              {
+                                "marginHorizontal": 12,
+                              },
+                              {
+                                "marginHorizontal": 8,
+                              },
+                              false,
+                              {
+                                "color": "rgba(103, 80, 164, 1)",
+                                "fontFamily": "System",
+                                "fontSize": 14,
+                                "fontWeight": "500",
+                                "letterSpacing": 0.1,
+                                "lineHeight": 20,
+                              },
+                              undefined,
+                            ],
                           ],
-                        ],
+                        ]
+                      }
+                      testID="button-text"
+                    >
+                      first
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            </View>
+            <View
+              collapsable={false}
+              style={
+                {
+                  "backgroundColor": "transparent",
+                  "borderRadius": 20,
+                  "margin": 4,
+                  "shadowColor": "rgba(0, 0, 0, 1)",
+                  "shadowOffset": {
+                    "height": 0,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0,
+                  "shadowRadius": 0,
+                }
+              }
+              testID="button-container-outer-layer"
+            >
+              <View
+                collapsable={false}
+                onBlur={[Function]}
+                onFocus={[Function]}
+                style={
+                  {
+                    "backgroundColor": "transparent",
+                    "borderColor": "transparent",
+                    "borderRadius": 20,
+                    "borderStyle": "solid",
+                    "borderWidth": 0,
+                    "flex": undefined,
+                    "minWidth": "auto",
+                    "shadowColor": "rgba(0, 0, 0, 1)",
+                    "shadowOffset": {
+                      "height": 0,
+                      "width": 0,
+                    },
+                    "shadowOpacity": 0,
+                    "shadowRadius": 0,
+                  }
+                }
+                testID="button-container"
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  role="button"
+                  style={
+                    [
+                      {
+                        "overflow": "hidden",
+                      },
+                      {
+                        "borderRadius": 20,
+                      },
+                    ]
+                  }
+                  testID="button"
+                >
+                  <View
+                    style={
+                      [
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "justifyContent": "center",
+                        },
+                        {
+                          "opacity": 1,
+                        },
+                        undefined,
                       ]
                     }
-                    testID="button-text"
                   >
-                    second
-                  </Text>
+                    <Text
+                      numberOfLines={1}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "textAlign": "left",
+                          },
+                          {
+                            "color": "rgba(29, 27, 32, 1)",
+                            "writingDirection": "ltr",
+                          },
+                          [
+                            {
+                              "fontFamily": "System",
+                              "fontSize": 14,
+                              "fontWeight": "500",
+                              "letterSpacing": 0.1,
+                              "lineHeight": 20,
+                            },
+                            [
+                              {
+                                "marginHorizontal": 16,
+                                "marginVertical": 9,
+                                "textAlign": "center",
+                              },
+                              {
+                                "marginHorizontal": 12,
+                              },
+                              {
+                                "marginHorizontal": 8,
+                              },
+                              false,
+                              {
+                                "color": "rgba(103, 80, 164, 1)",
+                                "fontFamily": "System",
+                                "fontSize": 14,
+                                "fontWeight": "500",
+                                "letterSpacing": 0.1,
+                                "lineHeight": 20,
+                              },
+                              undefined,
+                            ],
+                          ],
+                        ]
+                      }
+                      testID="button-text"
+                    >
+                      second
+                    </Text>
+                  </View>
                 </View>
               </View>
             </View>
@@ -1194,15 +1289,20 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
         }
       />
       <View
+        aria-hidden={false}
         collapsable={false}
         onLayout={[Function]}
+        pointerEvents="auto"
         style={{}}
+        testID="banner-content"
       >
         <View
           style={
             {
+              "alignItems": "center",
               "flexDirection": "row",
-              "justifyContent": "flex-start",
+              "flexWrap": "wrap",
+              "justifyContent": "flex-end",
               "marginBottom": 0,
               "marginHorizontal": 8,
               "marginTop": 16,
@@ -1212,70 +1312,79 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
           <View
             style={
               {
-                "margin": 8,
+                "alignItems": "center",
+                "flexBasis": "auto",
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
               }
             }
           >
-            <Image
-              accessibilityIgnoresInvertColors={true}
-              source={
-                {
-                  "uri": "https://callstack.com/images/team/Satya.png",
-                }
-              }
+            <View
               style={
                 {
-                  "height": 40,
-                  "width": 40,
+                  "margin": 8,
                 }
               }
-            />
-          </View>
-          <Text
-            aria-live="polite"
-            role="alert"
-            style={
-              [
-                {
-                  "textAlign": "left",
-                },
-                {
-                  "color": "rgba(29, 27, 32, 1)",
-                  "writingDirection": "ltr",
-                },
-                [
+            >
+              <Image
+                accessibilityIgnoresInvertColors={true}
+                source={
                   {
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                    "letterSpacing": 0.25,
-                    "lineHeight": 20,
-                  },
+                    "uri": "https://callstack.com/images/team/Satya.png",
+                  }
+                }
+                style={
+                  {
+                    "height": 40,
+                    "width": 40,
+                  }
+                }
+              />
+            </View>
+            <View
+              aria-live="polite"
+              role="status"
+              style={
+                {
+                  "flexBasis": "auto",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "margin": 8,
+                }
+              }
+              testID="banner-message"
+            >
+              <Text
+                style={
                   [
                     {
-                      "flex": 1,
-                      "margin": 8,
+                      "textAlign": "left",
                     },
                     {
                       "color": "rgba(29, 27, 32, 1)",
+                      "writingDirection": "ltr",
                     },
-                  ],
-                ],
-              ]
-            }
-          >
-            Two line text string with two actions. One to two lines is preferable on mobile.
-          </Text>
+                    [
+                      {
+                        "fontFamily": "System",
+                        "fontSize": 14,
+                        "fontWeight": "400",
+                        "letterSpacing": 0.25,
+                        "lineHeight": 20,
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                      },
+                    ],
+                  ]
+                }
+              >
+                Two line text string with two actions. One to two lines is preferable on mobile.
+              </Text>
+            </View>
+          </View>
         </View>
-        <View
-          style={
-            {
-              "flexDirection": "row",
-              "justifyContent": "flex-end",
-              "margin": 4,
-            }
-          }
-        />
       </View>
     </View>
   </View>
@@ -1339,66 +1448,80 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
         }
       />
       <View
+        aria-hidden={false}
         collapsable={false}
         onLayout={[Function]}
+        pointerEvents="auto"
         style={{}}
+        testID="banner-content"
       >
         <View
           style={
             {
+              "alignItems": "center",
               "flexDirection": "row",
-              "justifyContent": "flex-start",
+              "flexWrap": "wrap",
+              "justifyContent": "flex-end",
               "marginBottom": 0,
               "marginHorizontal": 8,
               "marginTop": 16,
             }
           }
         >
-          <Text
-            aria-live="polite"
-            role="alert"
+          <View
             style={
-              [
+              {
+                "alignItems": "center",
+                "flexBasis": "auto",
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "flexShrink": 1,
+              }
+            }
+          >
+            <View
+              aria-live="polite"
+              role="status"
+              style={
                 {
-                  "textAlign": "left",
-                },
-                {
-                  "color": "rgba(29, 27, 32, 1)",
-                  "writingDirection": "ltr",
-                },
-                [
-                  {
-                    "fontFamily": "System",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                    "letterSpacing": 0.25,
-                    "lineHeight": 20,
-                  },
+                  "flexBasis": "auto",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "margin": 8,
+                }
+              }
+              testID="banner-message"
+            >
+              <Text
+                style={
                   [
                     {
-                      "flex": 1,
-                      "margin": 8,
+                      "textAlign": "left",
                     },
                     {
                       "color": "rgba(29, 27, 32, 1)",
+                      "writingDirection": "ltr",
                     },
-                  ],
-                ],
-              ]
-            }
-          >
-            Two line text string with two actions. One to two lines is preferable on mobile.
-          </Text>
+                    [
+                      {
+                        "fontFamily": "System",
+                        "fontSize": 14,
+                        "fontWeight": "400",
+                        "letterSpacing": 0.25,
+                        "lineHeight": 20,
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                      },
+                    ],
+                  ]
+                }
+              >
+                Two line text string with two actions. One to two lines is preferable on mobile.
+              </Text>
+            </View>
+          </View>
         </View>
-        <View
-          style={
-            {
-              "flexDirection": "row",
-              "justifyContent": "flex-end",
-              "margin": 4,
-            }
-          }
-        />
       </View>
     </View>
   </View>

--- a/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
@@ -65,36 +65,41 @@ exports[`render visible banner, with custom theme 1`] = `
         testID="banner-content"
       >
         <View
+          onLayout={[Function]}
           style={
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "flexWrap": "wrap",
-              "justifyContent": "flex-end",
-              "marginBottom": 0,
-              "marginHorizontal": 8,
-              "marginTop": 16,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "marginBottom": 0,
+                "marginHorizontal": 8,
+                "marginTop": 16,
+              },
+              {
+                "alignItems": "stretch",
+                "flexDirection": "column",
+              },
+            ]
           }
+          testID="banner-row"
         >
           <View
             style={
-              {
-                "alignItems": "center",
-                "flexBasis": "auto",
-                "flexDirection": "row",
-                "flexGrow": 1,
-                "flexShrink": 1,
-              }
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "flexShrink": 1,
+                },
+                null,
+              ]
             }
           >
             <View
               accessible={true}
               style={
                 {
-                  "flexBasis": "auto",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flex": 1,
                   "margin": 8,
                 }
               }
@@ -379,36 +384,41 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
         testID="banner-content"
       >
         <View
+          onLayout={[Function]}
           style={
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "flexWrap": "wrap",
-              "justifyContent": "flex-end",
-              "marginBottom": 0,
-              "marginHorizontal": 8,
-              "marginTop": 16,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "marginBottom": 0,
+                "marginHorizontal": 8,
+                "marginTop": 16,
+              },
+              {
+                "alignItems": "stretch",
+                "flexDirection": "column",
+              },
+            ]
           }
+          testID="banner-row"
         >
           <View
             style={
-              {
-                "alignItems": "center",
-                "flexBasis": "auto",
-                "flexDirection": "row",
-                "flexGrow": 1,
-                "flexShrink": 1,
-              }
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "flexShrink": 1,
+                },
+                null,
+              ]
             }
           >
             <View
               accessible={true}
               style={
                 {
-                  "flexBasis": "auto",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flex": 1,
                   "margin": 8,
                 }
               }
@@ -515,27 +525,34 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
         testID="banner-content"
       >
         <View
+          onLayout={[Function]}
           style={
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "flexWrap": "wrap",
-              "justifyContent": "flex-end",
-              "marginBottom": 0,
-              "marginHorizontal": 8,
-              "marginTop": 16,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "marginBottom": 0,
+                "marginHorizontal": 8,
+                "marginTop": 16,
+              },
+              {
+                "alignItems": "stretch",
+                "flexDirection": "column",
+              },
+            ]
           }
+          testID="banner-row"
         >
           <View
             style={
-              {
-                "alignItems": "center",
-                "flexBasis": "auto",
-                "flexDirection": "row",
-                "flexGrow": 1,
-                "flexShrink": 1,
-              }
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "flexShrink": 1,
+                },
+                null,
+              ]
             }
           >
             <View
@@ -566,9 +583,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
               accessible={true}
               style={
                 {
-                  "flexBasis": "auto",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flex": 1,
                   "margin": 8,
                 }
               }
@@ -840,36 +855,41 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
         testID="banner-content"
       >
         <View
+          onLayout={[Function]}
           style={
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "flexWrap": "wrap",
-              "justifyContent": "flex-end",
-              "marginBottom": 0,
-              "marginHorizontal": 8,
-              "marginTop": 16,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "marginBottom": 0,
+                "marginHorizontal": 8,
+                "marginTop": 16,
+              },
+              {
+                "alignItems": "stretch",
+                "flexDirection": "column",
+              },
+            ]
           }
+          testID="banner-row"
         >
           <View
             style={
-              {
-                "alignItems": "center",
-                "flexBasis": "auto",
-                "flexDirection": "row",
-                "flexGrow": 1,
-                "flexShrink": 1,
-              }
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "flexShrink": 1,
+                },
+                null,
+              ]
             }
           >
             <View
               accessible={true}
               style={
                 {
-                  "flexBasis": "auto",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flex": 1,
                   "margin": 8,
                 }
               }
@@ -1295,27 +1315,34 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
         testID="banner-content"
       >
         <View
+          onLayout={[Function]}
           style={
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "flexWrap": "wrap",
-              "justifyContent": "flex-end",
-              "marginBottom": 0,
-              "marginHorizontal": 8,
-              "marginTop": 16,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "marginBottom": 0,
+                "marginHorizontal": 8,
+                "marginTop": 16,
+              },
+              {
+                "alignItems": "stretch",
+                "flexDirection": "column",
+              },
+            ]
           }
+          testID="banner-row"
         >
           <View
             style={
-              {
-                "alignItems": "center",
-                "flexBasis": "auto",
-                "flexDirection": "row",
-                "flexGrow": 1,
-                "flexShrink": 1,
-              }
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "flexShrink": 1,
+                },
+                null,
+              ]
             }
           >
             <View
@@ -1346,9 +1373,7 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
               accessible={true}
               style={
                 {
-                  "flexBasis": "auto",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flex": 1,
                   "margin": 8,
                 }
               }
@@ -1455,36 +1480,41 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
         testID="banner-content"
       >
         <View
+          onLayout={[Function]}
           style={
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "flexWrap": "wrap",
-              "justifyContent": "flex-end",
-              "marginBottom": 0,
-              "marginHorizontal": 8,
-              "marginTop": 16,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "marginBottom": 0,
+                "marginHorizontal": 8,
+                "marginTop": 16,
+              },
+              {
+                "alignItems": "stretch",
+                "flexDirection": "column",
+              },
+            ]
           }
+          testID="banner-row"
         >
           <View
             style={
-              {
-                "alignItems": "center",
-                "flexBasis": "auto",
-                "flexDirection": "row",
-                "flexGrow": 1,
-                "flexShrink": 1,
-              }
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "flexShrink": 1,
+                },
+                null,
+              ]
             }
           >
             <View
               accessible={true}
               style={
                 {
-                  "flexBasis": "auto",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flex": 1,
                   "margin": 8,
                 }
               }

--- a/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
@@ -62,7 +62,6 @@ exports[`render visible banner, with custom theme 1`] = `
         onLayout={[Function]}
         pointerEvents="auto"
         style={{}}
-        testID="banner-content"
       >
         <View
           onLayout={[Function]}
@@ -81,7 +80,6 @@ exports[`render visible banner, with custom theme 1`] = `
               },
             ]
           }
-          testID="banner-row"
         >
           <View
             style={
@@ -103,7 +101,6 @@ exports[`render visible banner, with custom theme 1`] = `
                   "margin": 8,
                 }
               }
-              testID="banner-message"
             >
               <Text
                 style={
@@ -381,7 +378,6 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
             "width": "100%",
           }
         }
-        testID="banner-content"
       >
         <View
           onLayout={[Function]}
@@ -400,7 +396,6 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
               },
             ]
           }
-          testID="banner-row"
         >
           <View
             style={
@@ -422,7 +417,6 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
                   "margin": 8,
                 }
               }
-              testID="banner-message"
             >
               <Text
                 style={
@@ -522,7 +516,6 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
         onLayout={[Function]}
         pointerEvents="auto"
         style={{}}
-        testID="banner-content"
       >
         <View
           onLayout={[Function]}
@@ -541,7 +534,6 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
               },
             ]
           }
-          testID="banner-row"
         >
           <View
             style={
@@ -562,7 +554,6 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                   "margin": 8,
                 }
               }
-              testID="banner-icon"
             >
               <Image
                 accessibilityIgnoresInvertColors={true}
@@ -587,7 +578,6 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                   "margin": 8,
                 }
               }
-              testID="banner-message"
             >
               <Text
                 style={
@@ -852,7 +842,6 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
         onLayout={[Function]}
         pointerEvents="auto"
         style={{}}
-        testID="banner-content"
       >
         <View
           onLayout={[Function]}
@@ -871,7 +860,6 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
               },
             ]
           }
-          testID="banner-row"
         >
           <View
             style={
@@ -893,7 +881,6 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   "margin": 8,
                 }
               }
-              testID="banner-message"
             >
               <Text
                 style={
@@ -1312,7 +1299,6 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
         onLayout={[Function]}
         pointerEvents="auto"
         style={{}}
-        testID="banner-content"
       >
         <View
           onLayout={[Function]}
@@ -1331,7 +1317,6 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
               },
             ]
           }
-          testID="banner-row"
         >
           <View
             style={
@@ -1352,7 +1337,6 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
                   "margin": 8,
                 }
               }
-              testID="banner-icon"
             >
               <Image
                 accessibilityIgnoresInvertColors={true}
@@ -1377,7 +1361,6 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
                   "margin": 8,
                 }
               }
-              testID="banner-message"
             >
               <Text
                 style={
@@ -1477,7 +1460,6 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
         onLayout={[Function]}
         pointerEvents="auto"
         style={{}}
-        testID="banner-content"
       >
         <View
           onLayout={[Function]}
@@ -1496,7 +1478,6 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
               },
             ]
           }
-          testID="banner-row"
         >
           <View
             style={
@@ -1518,7 +1499,6 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
                   "margin": 8,
                 }
               }
-              testID="banner-message"
             >
               <Text
                 style={

--- a/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
@@ -89,8 +89,7 @@ exports[`render visible banner, with custom theme 1`] = `
             }
           >
             <View
-              aria-live="polite"
-              role="status"
+              accessible={true}
               style={
                 {
                   "flexBasis": "auto",
@@ -404,8 +403,7 @@ exports[`renders hidden banner, without action buttons and without image 1`] = `
             }
           >
             <View
-              aria-live="off"
-              role="status"
+              accessible={true}
               style={
                 {
                   "flexBasis": "auto",
@@ -541,11 +539,13 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
             }
           >
             <View
+              aria-hidden={true}
               style={
                 {
                   "margin": 8,
                 }
               }
+              testID="banner-icon"
             >
               <Image
                 accessibilityIgnoresInvertColors={true}
@@ -563,8 +563,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
               />
             </View>
             <View
-              aria-live="polite"
-              role="status"
+              accessible={true}
               style={
                 {
                   "flexBasis": "auto",
@@ -865,8 +864,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
             }
           >
             <View
-              aria-live="polite"
-              role="status"
+              accessible={true}
               style={
                 {
                   "flexBasis": "auto",
@@ -1321,11 +1319,13 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
             }
           >
             <View
+              aria-hidden={true}
               style={
                 {
                   "margin": 8,
                 }
               }
+              testID="banner-icon"
             >
               <Image
                 accessibilityIgnoresInvertColors={true}
@@ -1343,8 +1343,7 @@ exports[`renders visible banner, without action buttons and with image 1`] = `
               />
             </View>
             <View
-              aria-live="polite"
-              role="status"
+              accessible={true}
               style={
                 {
                   "flexBasis": "auto",
@@ -1480,8 +1479,7 @@ exports[`renders visible banner, without action buttons and without image 1`] = 
             }
           >
             <View
-              aria-live="polite"
-              role="status"
+              accessible={true}
               style={
                 {
                   "flexBasis": "auto",

--- a/src/utils/__tests__/mergeRefs.test.ts
+++ b/src/utils/__tests__/mergeRefs.test.ts
@@ -1,0 +1,38 @@
+import { createRef } from 'react';
+
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { mergeRefs } from '../mergeRefs';
+
+describe('mergeRefs', () => {
+  it('writes the node to object refs and calls callback refs', () => {
+    const object = createRef<string>();
+    const callback = jest.fn<(node: string | null) => void>();
+
+    mergeRefs<string>(object, callback)('node');
+
+    expect(object.current).toBe('node');
+    expect(callback).toHaveBeenCalledWith('node');
+  });
+
+  it('skips refs that were not passed', () => {
+    const object = createRef<string>();
+
+    expect(() =>
+      mergeRefs<string>(undefined, object, null)('node')
+    ).not.toThrow();
+    expect(object.current).toBe('node');
+  });
+
+  it('clears every ref when react detaches it', () => {
+    const object = createRef<string>();
+    const callback = jest.fn<(node: string | null) => void>();
+    const merged = mergeRefs<string>(object, callback);
+
+    merged('node');
+    merged(null);
+
+    expect(object.current).toBeNull();
+    expect(callback).toHaveBeenLastCalledWith(null);
+  });
+});

--- a/src/utils/mergeRefs.ts
+++ b/src/utils/mergeRefs.ts
@@ -1,0 +1,14 @@
+import type * as React from 'react';
+
+/** Feeds a node to every ref, so an internal ref doesn't drop the consumer's. */
+export const mergeRefs =
+  <T>(...refs: Array<React.Ref<T> | undefined>): React.RefCallback<T> =>
+  (node) => {
+    refs.forEach((ref) => {
+      if (typeof ref === 'function') {
+        ref(node);
+      } else if (ref) {
+        ref.current = node;
+      }
+    });
+  };


### PR DESCRIPTION
### Motivation

`Banner` was only visually hidden but content stayed mounted, screen readers could still reach it, and action buttons remained tabbable. The live region also had conflicting semantics and simply didn't work on Android.

- **Hidden content was still reachable.** The banner was just translated off-screen and clipped - no `aria-hidden`, `pointerEvents` guard or `inert`. With `visible={false}`, both actions still had `tabIndex: 0` and accepted focus in the browser a11y tree.
- **`role="alert"` + `aria-live="polite"` didn't agree.** `alert` implies assertive + atomic, while Chrome ended up with `alert atomic live="polite"`.
- **The live region was dead on Android.** RN maps `aria-live` → `accessibilityLiveRegion` on `View`, not `Text`, so the prop was ignored by the native text node. In practice it only worked on web.
- **iOS has no live regions**, so nothing announced the message there either.
- **`actions` was unbounded**, and animation callbacks fired on mount and on `theme.animation.scale` changes even when visibility didn't change. Two existing tests already called this out as probably a bug.

### Related issue

Fixes #5055  
Part of #4990

### Changes

**Inertness.** Content becomes `aria-hidden` + `pointerEvents="none"` + `inert` on web as soon as hiding starts, then unmounts after the exit animation - basically the same lifecycle `Snackbar` already uses. There's still one inert measuring pass when mounting hidden so the spacer gets the right height. Layout stays the same.

**Live region.** Moved from `Text` to a `View`, which makes it actually work on Android. It's also scoped to the message only, so action labels don't re-announce the whole banner. `role` and `aria-live` now match.

**New `urgent` prop.**

```jsx
<Banner visible urgent actions={[...]}>
  Your payment failed.
</Banner>
```

- `false` by default: `role="status"` + `aria-live="polite"`
- `true`: `role="alert"` + `aria-live="assertive"`

On iOS the message is announced explicitly with `announceForAccessibilityWithOptions({ queue: !urgent })`: queued for normal banners, interrupting for urgent ones. This is iOS-only to avoid double announcements elsewhere. Interpolated children like `<Banner>Hello {name}</Banner>` are flattened before announcing.

**Actions.** Limited to 2, with a development warning for extras. They can now sit inline with the message when there's enough room instead of always dropping below it.

**Focus.** If a focused action disappears, focus moves to the nearest remaining action, or the message region if there are none. During hiding the content is inert, so focus is simply released. Restoring it to whatever opened the banner needs consumer-owned API/state and is out of scope here.

**Callbacks.** `onShowAnimationFinished` / `onHideAnimationFinished` now only run after actual `visible` transitions - not on mount, animation-scale changes, or interrupted animations.

### Breaking changes

- Banner children unmount once hidden, so local child state is lost.
- More than 2 actions are ignored, with a dev warning.
- Actions may render inline instead of always below the message.

### Test plan

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test` - 55 suites, 760 tests. Banner coverage went from 13 to 41 tests; the two "probably a bug" tests were inverted rather than removed.
- [x] Chrome browser accessibility tree (`expo start --web`)
- [x] Mobile Safari (iOS 18.3 simulator) + Chrome (Android 16 emulator)
- [x] Android native + **TalkBack**
- [x] iOS native + **VoiceOver**

**Hidden state, browser a11y tree.** Before, both actions were still focusable:

```text
{"totalTabbablesOnPage":60,
 "bannerActionsStillTabbable":[
  {"label":"Set custom theme","tabIndex":0,"receivedFocus":true,"insideInert":false,"insideAriaHidden":false},
  {"label":"Fix it","tabIndex":0,"receivedFocus":true,"insideInert":false,"insideAriaHidden":false}]}
```

Afterwards the message and actions disappear from the tree completely. The page tab count drops by exactly those two buttons (from 31 to 29), then returns when the banner is shown again.

**Visible state.** `alert atomic live="polite"` becomes `status atomic live="polite"`. The live region contains only the message; buttons are siblings.

**Android / TalkBack.** The native a11y tree contains `banner-content`, message and actions while visible, and none of them while hidden.

**iOS / VoiceOver.** Full show > hide > show cycle gives message + actions > `[]` > message + actions again. The `urgent` announcement was also checked.