### PR TITLE
fix(example): render banner below the app bar on native

### DIFF
--- a/example/src/Examples/BannerExample.tsx
+++ b/example/src/Examples/BannerExample.tsx
@@ -36,7 +36,7 @@ const BannerExample = () => {
   };
 
   return (
-    <>
+    <View style={styles.container}>
       <ScreenWrapper>
         <View style={[styles.grid, { paddingTop: height }]}>
           {PHOTOS.map((uri) => (
@@ -78,13 +78,16 @@ const BannerExample = () => {
         Two line text string with two actions. One to two lines is preferable on
         mobile.
       </Banner>
-    </>
+    </View>
   );
 };
 
 BannerExample.title = 'Banner';
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
   ...Platform.select({
     web: {
       grid: {


### PR DESCRIPTION
### Motivation

The Banner example is painted behind the app bar on iOS and Android, so the screen
just shows an empty gap where the banner should be. Web is fine.

`BannerExample` returns a fragment and styles the banner `position: 'absolute',
top: 0`. On web the navigator wraps the screen in a `flex: 1` container below the
header, so that means the top of the content. On native it does not, so it means
the top of the screen, and the header's `zIndex: 1` paints over it.

Wrapping the screen in a `flex: 1` `View` gives native the same containing block, so
`top: 0` lands below the app bar on both.

### Related issue

Fixes https://github.com/callstack/react-native-paper/issues/5060

### Test plan

- [x] `yarn lint`, `yarn typecheck`, `yarn test` (733 passed) all clean
- [x] Android emulator and iOS simulator: banner renders below the app bar, hide and
      show still works, landscape fine
- [x] Web unchanged, before and after screenshots match

<details>
<summary>Before</summary>
<img width="1206" height="2622" alt="ios-before" src="https://github.com/user-attachments/assets/a2104fe1-0b69-42f9-8db8-ee0cebb4fd8c" />
</details>

<details>
<summary>After</summary>
<img width="1206" height="2622" alt="ios-after" src="https://github.com/user-attachments/assets/d52e18c3-4a79-4963-82c1-35f6ffa2cdae" />
</details>