### PR TITLE
fix(theme): keep flat font properties in a mixed configureFonts config

### DIFF
--- a/src/theme/__tests__/fonts.test.js
+++ b/src/theme/__tests__/fonts.test.js
@@ -340,6 +340,50 @@ describe('configureFonts', () => {
     });
   });
 
+  it('applies flat properties to every variant when the config also has per-variant entries', () => {
+    mockPlatform('ios');
+    const { configureFonts, typescale } = loadFonts();
+
+    const fonts = configureFonts({
+      config: {
+        fontFamily: 'NotoSans',
+        bodyLarge: {
+          fontSize: 18,
+        },
+      },
+    });
+
+    expect(fonts).toEqual({
+      ...Object.fromEntries(
+        Object.entries(typescale).map(([variantName, variantProperties]) => [
+          variantName,
+          { ...variantProperties, fontFamily: 'NotoSans' },
+        ])
+      ),
+      bodyLarge: {
+        ...typescale.bodyLarge,
+        fontFamily: 'NotoSans',
+        fontSize: 18,
+      },
+    });
+  });
+
+  it('does not add flat properties of a mixed config as typescale variants', () => {
+    mockPlatform('ios');
+    const { configureFonts } = loadFonts();
+
+    const fonts = configureFonts({
+      config: {
+        fontFamily: 'NotoSans',
+        bodyLarge: {
+          fontSize: 18,
+        },
+      },
+    });
+
+    expect(fonts.fontFamily).toBeUndefined();
+  });
+
   it('should be deterministic', () => {
     mockPlatform('ios');
     const { configureFonts } = loadFonts();

--- a/src/theme/fonts.tsx
+++ b/src/theme/fonts.tsx
@@ -13,34 +13,41 @@ function configureFontsConfig(
     return typescale;
   }
 
-  const isFlatConfig = Object.values(config).every(
-    (value) => typeof value !== 'object'
-  );
+  // A config entry is either a whole variant (an object, e.g. `bodyLarge: { fontSize: 18 }`)
+  // or a single font property shared by every variant (e.g. `fontFamily: 'NotoSans'`).
+  // Both may appear in the same config, so they are collected separately instead of
+  // classifying the config as a whole.
+  const sharedProperties: Record<string, unknown> = {};
+  const variantOverrides: Record<string, object> = {};
 
-  if (isFlatConfig) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    return Object.fromEntries(
-      Object.entries(typescale).map(([variantName, variantProperties]) => [
-        variantName,
-        { ...variantProperties, ...config },
-      ])
-    ) as Typescale;
+  for (const [key, value] of Object.entries(config)) {
+    if (typeof value === 'object' && value !== null) {
+      variantOverrides[key] = value;
+    } else {
+      sharedProperties[key] = value;
+    }
   }
 
   const typescaleByVariant: Partial<
     Record<string, Typescale[keyof Typescale]>
   > = typescale;
 
-  return Object.assign(
-    {},
-    typescale,
-    ...Object.entries(config).map(([variantName, variantProperties]) => ({
-      [variantName]: {
+  const variantNames = new Set([
+    ...Object.keys(typescale),
+    ...Object.keys(variantOverrides),
+  ]);
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  return Object.fromEntries(
+    Array.from(variantNames, (variantName) => [
+      variantName,
+      {
         ...typescaleByVariant[variantName],
-        ...variantProperties,
+        ...sharedProperties,
+        ...variantOverrides[variantName],
       },
-    }))
-  );
+    ])
+  ) as Typescale;
 }
 
 export default function configureFonts(params?: {
@@ -49,6 +56,11 @@ export default function configureFonts(params?: {
 // eslint-disable-next-line no-redeclare
 export default function configureFonts(params?: {
   config?: Partial<Record<TypescaleKey, Partial<TypescaleStyle>>>;
+}): Typescale;
+// eslint-disable-next-line no-redeclare
+export default function configureFonts(params: {
+  config: Partial<TypescaleStyle> &
+    Partial<Record<TypescaleKey, Partial<TypescaleStyle>>>;
 }): Typescale;
 // eslint-disable-next-line no-redeclare
 export default function configureFonts(params: {


### PR DESCRIPTION
## The bug

`configureFontsConfig` classifies the config as a whole:

```js
const isFlatConfig = Object.values(config).every((value) => typeof value !== 'object');
```

A config may legitimately contain both shapes at once — a font property that should apply to every variant, plus a tweak to one variant. A single per-variant object flips `isFlatConfig` to `false` for the *whole* config, and the `Object.assign` branch below then spreads every top-level entry as if it were a variant.

Repro:

```js
configureFonts({
  config: {
    fontFamily: 'NotoSans',
    bodyLarge: { fontSize: 18 },
  },
});
```

Two things go wrong:

1. The requested `fontFamily` is silently dropped from every variant — `bodyLarge.fontFamily` is still `"System"`.
2. The result grows a junk typescale entry from spreading the string into an object:

```js
fontFamily: { "0": "N", "1": "o", "2": "t", "3": "o", "4": "S", "5": "a", "6": "n", "7": "s" }
```

No error, no warning. From the app's point of view the custom font just does not apply.

The same shape is also rejected by the type overloads today, so a TS user gets `TS2769: No overload matches this call` and has to call `configureFonts` twice or hand-build the object.

## The fix

Partition `Object.entries(config)` into scalar entries (shared font properties) and object entries (per-variant overrides), instead of classifying the config as a whole. Build every variant as `{ ...typescale[variant], ...sharedProperties, ...variantOverrides[variant] }`.

The two previous branches are special cases of this, so the `isFlatConfig` early return and the `Object.assign` both go away:

- config with only scalars → `variantOverrides` is empty → every variant gets the scalars (old flat branch)
- config with only objects → `sharedProperties` is empty → named variants are merged, others untouched (old per-variant branch)
- unknown keys with object values still create new custom variants, as before

I also added a third overload for the mixed shape:

```ts
export default function configureFonts(params: {
  config: Partial<TypescaleStyle> &
    Partial<Record<TypescaleKey, Partial<TypescaleStyle>>>;
}): Typescale;
```

It is placed after the two existing `Partial` overloads and before the `Record<string, TypescaleStyle>` one. Neither existing overload accepts a mixed literal (each rejects the other's keys as excess properties), and the custom-variant overload does not either, so this signature only picks up calls that previously failed to compile — existing call sites keep resolving to the overload they resolved to before. I verified both directions: the mixed literal is `TS2769` on `main` and clean with this change, while the flat-only and per-variant-only literals compile on both.

## About #4589

I could **not** reproduce the reporter's `Variant titleLarge was not provided properly` from this bug, and I don't think this closes it — the warning there lists `regular, medium, light, thin`, i.e. an MD2-shaped `fonts` object, which is a different path entirely. Listing it as *possibly related* only, deliberately not `Fixes`.

## Test plan

Two cases added to `src/theme/__tests__/fonts.test.js`:

- a mixed config applies the flat properties to every variant and still applies the per-variant override on top
- the flat property does not leak into the result as a typescale key

Before the change both fail; the second reports `Received: {"0": "N", "1": "o", "2": "t", "3": "o", "4": "S", "5": "a", "6": "n", "7": "s"}`. The four existing `configureFonts` tests pass unchanged, before and after.

`yarn test`: 55 suites, 737 passed / 1 skipped, 169 snapshots — no snapshot churn. `yarn lint` and `yarn typecheck` clean.
