### PR TITLE
Add `material-color-react-native` in the recommended libraries doc

### DIFF
--- a/docs/5.x/docs/guides/recommended-libraries.md
+++ b/docs/5.x/docs/guides/recommended-libraries.md
@@ -40,3 +40,6 @@ Material Design themed [time picker](https://material.io/components/time-pickers
 
 [pchmn/expo-material3-theme](https://github.com/pchmn/expo-material3-theme)
 Retrieve Material 3 system colors from Android 12+ devices
+
+[rakadoank/material-color-react-native](https://github.com/RakaDoank/material-color-react-native)
+Bring Material color utilities including builder from a source image, and theming with Paper


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I want to add a new library, called [material-color-react-native](https://github.com/RakaDoank/material-color-react-native).
Compatible for Expo and bare React Native because it is using Turbo Modules.

- The library is useful if users want to get Material color utilities including **builder from a source image** in Android, iOS, macOS, and Web. Similar as how user generates material color from the [Material Theme Builder website](https://material-foundation.github.io/material-theme-builder) with a source image
- It also has the Android Dynamic Color to enable users to personalize their color experience in their app

The main thing of this PR is that the library provides an adapter for [seamless theming with Paper](https://rakadoank.github.io/material-color-react-native/docs/theming-with-react-native-paper).

I am the maintainer of the library, and still active to maintain.
Feel free to try the library, especially the material color builder from a source image.