### PR TITLE
fix: don't expose handler-less TouchableRipple as a disabled control

### DIFF
--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -202,7 +202,10 @@ const IconButton = ({
         testID={testID}
         {...rest}
       >
-        <View style={{ opacity: iconOpacity }}>
+        <View
+          testID={`${testID}-icon-opacity`}
+          style={{ opacity: iconOpacity }}
+        >
           {loading ? (
             <ActivityIndicator size={size} color={iconColor} />
           ) : (

--- a/src/components/IconButton/utils.ts
+++ b/src/components/IconButton/utils.ts
@@ -61,14 +61,12 @@ const getIconColor = ({
   selected,
   customIconColor,
 }: BaseProps & { customIconColor?: ColorValue }) => {
-  // An explicitly passed color is an instruction, so it outranks the disabled
-  // default. Disabled is still conveyed by the reduced icon opacity.
-  if (typeof customIconColor !== 'undefined') {
-    return customIconColor;
-  }
-
   if (disabled) {
     return theme.colors.onSurface;
+  }
+
+  if (typeof customIconColor !== 'undefined') {
+    return customIconColor;
   }
 
   if (isMode('contained')) {

--- a/src/components/IconButton/utils.ts
+++ b/src/components/IconButton/utils.ts
@@ -61,12 +61,14 @@ const getIconColor = ({
   selected,
   customIconColor,
 }: BaseProps & { customIconColor?: ColorValue }) => {
-  if (disabled) {
-    return theme.colors.onSurface;
-  }
-
+  // An explicitly passed color is an instruction, so it outranks the disabled
+  // default. Disabled is still conveyed by the reduced icon opacity.
   if (typeof customIconColor !== 'undefined') {
     return customIconColor;
+  }
+
+  if (disabled) {
+    return theme.colors.onSurface;
   }
 
   if (isMode('contained')) {

--- a/src/components/TextInput/TextInputIcon.tsx
+++ b/src/components/TextInput/TextInputIcon.tsx
@@ -78,8 +78,6 @@ const TextInputIcon = ({
     isDisabled: disabled,
   });
 
-  const onPressHandler = disabled ? undefined : onPress;
-
   return (
     <View style={styles.iconWrapper}>
       <IconButton
@@ -88,7 +86,8 @@ const TextInputIcon = ({
         iconColor={color}
         size={iconSize}
         style={[styles.icon, style]}
-        onPress={onPressHandler}
+        disabled={disabled}
+        onPress={onPress}
       />
     </View>
   );

--- a/src/components/TextInput/TextInputIcon.tsx
+++ b/src/components/TextInput/TextInputIcon.tsx
@@ -97,7 +97,15 @@ const TextInputIcon = ({
         icon={icon}
         iconColor={color}
         size={iconSize}
-        style={[styles.icon, style]}
+        style={[
+          styles.icon,
+          style,
+          // TextInput already dims the whole accessory when the field is
+          // disabled. Forwarding `disabled` makes IconButton dim the icon too,
+          // and the two multiply, so let IconButton own it and cancel the outer
+          // one. A decorative icon keeps it, nothing else dims it.
+          isInteractive && disabled ? styles.notDimmed : null,
+        ]}
         disabled={isInteractive ? disabled : undefined}
         onPress={onPress}
       />

--- a/src/components/TextInput/TextInputIcon.tsx
+++ b/src/components/TextInput/TextInputIcon.tsx
@@ -7,6 +7,7 @@ import { styles } from './styles';
 import { getIconColor } from './utils';
 import { useInternalTheme } from '../../core/theming';
 import type { $Omit } from '../../types';
+import hasTouchHandler from '../../utils/hasTouchHandler';
 import IconButton from '../IconButton/IconButton';
 
 export type TextInputAccessoryProps = {
@@ -78,6 +79,17 @@ const TextInputIcon = ({
     isDisabled: disabled,
   });
 
+  // A decorative icon is not a control, so `disabled` would only announce it as
+  // a disabled button. Must match TouchableRipple's predicate, or an icon with
+  // only `onLongPress` stays pressable on a disabled field.
+  const { onLongPress, onPressIn, onPressOut } = rest;
+  const isInteractive = hasTouchHandler({
+    onPress,
+    onLongPress,
+    onPressIn,
+    onPressOut,
+  });
+
   return (
     <View style={styles.iconWrapper}>
       <IconButton
@@ -86,7 +98,7 @@ const TextInputIcon = ({
         iconColor={color}
         size={iconSize}
         style={[styles.icon, style]}
-        disabled={disabled}
+        disabled={isInteractive ? disabled : undefined}
         onPress={onPress}
       />
     </View>

--- a/src/components/TextInput/styles.ts
+++ b/src/components/TextInput/styles.ts
@@ -73,6 +73,9 @@ export const styles = StyleSheet.create({
   icon: {
     margin: 0,
   },
+  notDimmed: {
+    opacity: 1,
+  },
 });
 
 export const filledStyles = StyleSheet.create({

--- a/src/components/TouchableRipple/TouchableRipple.native.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.native.tsx
@@ -15,7 +15,9 @@ import { SettingsContext } from '../../core/settings';
 import type { Settings } from '../../core/settings';
 import { useInternalTheme } from '../../core/theming';
 import type { ThemeProp } from '../../types';
-import hasTouchHandler from '../../utils/hasTouchHandler';
+import hasTouchHandler, {
+  ACTIVATABLE_ROLES,
+} from '../../utils/hasTouchHandler';
 
 const ANDROID_VERSION_LOLLIPOP = 21;
 const ANDROID_VERSION_PIE = 28;
@@ -68,6 +70,12 @@ const TouchableRipple = ({
   const isControl = hasPassedTouchHandler || Boolean(disabledProp);
   const isInteractive = hasPassedTouchHandler && !disabledProp;
 
+  // `role` wins over `accessibilityRole` on every platform, so resolve it the
+  // same way instead of testing both.
+  const effectiveRole: string | undefined = rest.role ?? rest.accessibilityRole;
+  const claimsActivatable =
+    effectiveRole !== undefined && ACTIVATABLE_ROLES.includes(effectiveRole);
+
   const { calculatedRippleColor, calculatedUnderlayColor } =
     getTouchableRippleColors({
       theme,
@@ -95,6 +103,8 @@ const TouchableRipple = ({
         // Pressable defaults this to true, so keep it to preserve any role and
         // state the caller set, e.g. a read only checked CheckboxItem.
         accessible={rest.accessible !== false}
+        // Drop the claim, keep the element so its label is still announced.
+        role={claimsActivatable ? 'none' : rest.role}
         // A consumer role of button makes react-native-web render a real
         // <button>, which is tabbable by default. Nothing to activate here.
         focusable={rest.focusable ?? false}

--- a/src/components/TouchableRipple/TouchableRipple.native.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.native.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Platform, StyleSheet, View } from 'react-native';
+import { Animated, Platform, StyleSheet, View } from 'react-native';
 import type {
   PressableAndroidRippleConfig,
   StyleProp,
@@ -61,7 +61,12 @@ const TouchableRipple = ({
     onPressOut,
   });
 
-  const disabled = disabledProp || !hasPassedTouchHandler;
+  // With no touch handler and no explicit disabled this is not a control, so it
+  // renders as a plain View. A Pressable is wrong here either way: keep the old
+  // disabled flag and it gets announced as a disabled control, drop the flag and
+  // it starts claiming the touch, swallowing taps meant for whatever wraps it.
+  const isControl = hasPassedTouchHandler || Boolean(disabledProp);
+  const isInteractive = hasPassedTouchHandler && !disabledProp;
 
   const { calculatedRippleColor, calculatedUnderlayColor } =
     getTouchableRippleColors({
@@ -78,21 +83,44 @@ const TouchableRipple = ({
   const useForeground =
     Platform.OS === 'android' && Platform.Version >= ANDROID_VERSION_PIE;
 
+  const containerStyle = TouchableRipple.supported
+    ? [useForeground && styles.overflowHidden, style]
+    : [borderless && styles.overflowHidden, style];
+
+  if (!isControl) {
+    return (
+      <Animated.View
+        {...rest}
+        ref={ref}
+        // Pressable defaults this to true, so keep it to preserve any role and
+        // state the caller set, e.g. a read only checked CheckboxItem.
+        accessible={rest.accessible !== false}
+        // A consumer role of button makes react-native-web render a real
+        // <button>, which is tabbable by default. Nothing to activate here.
+        focusable={rest.focusable ?? false}
+        style={containerStyle}
+      >
+        {React.Children.only(children)}
+      </Animated.View>
+    );
+  }
+
   if (TouchableRipple.supported) {
-    const androidRipple = rippleEffectEnabled
-      ? (background ?? {
-          color: calculatedRippleColor,
-          borderless,
-          foreground: useForeground,
-        })
-      : undefined;
+    const androidRipple =
+      rippleEffectEnabled && isInteractive
+        ? (background ?? {
+            color: calculatedRippleColor,
+            borderless,
+            foreground: useForeground,
+          })
+        : undefined;
 
     return (
       <Pressable
         {...rest}
         ref={ref}
-        disabled={disabled}
-        style={[useForeground && styles.overflowHidden, style]}
+        disabled={disabledProp}
+        style={containerStyle}
         android_ripple={androidRipple}
       >
         {React.Children.only(children)}
@@ -104,12 +132,12 @@ const TouchableRipple = ({
     <Pressable
       {...rest}
       ref={ref}
-      disabled={disabled}
-      style={[borderless && styles.overflowHidden, style]}
+      disabled={disabledProp}
+      style={containerStyle}
     >
       {({ pressed }) => (
         <>
-          {pressed && rippleEffectEnabled && (
+          {pressed && rippleEffectEnabled && isInteractive && (
             <View
               testID="touchable-ripple-underlay"
               style={[

--- a/src/components/TouchableRipple/TouchableRipple.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.tsx
@@ -16,7 +16,9 @@ import { SettingsContext } from '../../core/settings';
 import type { Settings } from '../../core/settings';
 import { useInternalTheme } from '../../core/theming';
 import type { ThemeProp } from '../../types';
-import hasTouchHandler from '../../utils/hasTouchHandler';
+import hasTouchHandler, {
+  ACTIVATABLE_ROLES,
+} from '../../utils/hasTouchHandler';
 
 export type Props = PressableProps & {
   /**
@@ -143,6 +145,12 @@ const TouchableRipple = ({
   // it starts claiming the touch, swallowing taps meant for whatever wraps it.
   const isControl = hasPassedTouchHandler || Boolean(disabledProp);
   const isInteractive = hasPassedTouchHandler && !disabledProp;
+
+  // `role` wins over `accessibilityRole` on every platform, so resolve it the
+  // same way instead of testing both.
+  const effectiveRole: string | undefined = rest.role ?? rest.accessibilityRole;
+  const claimsActivatable =
+    effectiveRole !== undefined && ACTIVATABLE_ROLES.includes(effectiveRole);
 
   const handlePressIn = React.useCallback(
     (e: any) => {
@@ -289,6 +297,8 @@ const TouchableRipple = ({
         // Pressable defaults this to true, so keep it to preserve any role and
         // state the caller set, e.g. a read only checked CheckboxItem.
         accessible={rest.accessible !== false}
+        // Drop the claim, keep the element so its label is still announced.
+        role={claimsActivatable ? 'none' : rest.role}
         // A consumer role of button makes react-native-web render a real
         // <button>, which is tabbable by default. Nothing to activate here.
         focusable={rest.focusable ?? false}

--- a/src/components/TouchableRipple/TouchableRipple.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Platform, StyleSheet, View } from 'react-native';
+import { Animated, Platform, StyleSheet, View } from 'react-native';
 import type {
   ColorValue,
   GestureResponderEvent,
@@ -37,7 +37,8 @@ export type Props = PressableProps & {
    */
   disabled?: boolean;
   /**
-   * Function to execute on press. If not set, will cause the touchable to be disabled.
+   * Function to execute on press. If not set, the touchable renders as a plain
+   * container and is not exposed as a control.
    */
   onPress?: (e: GestureResponderEvent) => void;
   /**
@@ -128,6 +129,20 @@ const TouchableRipple = ({
   const { rippleEffectEnabled } = React.useContext<Settings>(SettingsContext);
 
   const { onPress, onLongPress, onPressIn, onPressOut } = rest;
+
+  const hasPassedTouchHandler = hasTouchHandler({
+    onPress,
+    onLongPress,
+    onPressIn,
+    onPressOut,
+  });
+
+  // With no touch handler and no explicit disabled this is not a control, so it
+  // renders as a plain View. A Pressable is wrong here either way: keep the old
+  // disabled flag and it gets announced as a disabled control, drop the flag and
+  // it starts claiming the touch, swallowing taps meant for whatever wraps it.
+  const isControl = hasPassedTouchHandler || Boolean(disabledProp);
+  const isInteractive = hasPassedTouchHandler && !disabledProp;
 
   const handlePressIn = React.useCallback(
     (e: any) => {
@@ -264,14 +279,32 @@ const TouchableRipple = ({
     [onPressOut, rippleEffectEnabled]
   );
 
-  const hasPassedTouchHandler = hasTouchHandler({
-    onPress,
-    onLongPress,
-    onPressIn,
-    onPressOut,
-  });
+  if (!isControl) {
+    const state = { pressed: false, hovered: false, focused: false };
 
-  const disabled = disabledProp || !hasPassedTouchHandler;
+    return (
+      <Animated.View
+        {...rest}
+        ref={ref}
+        // Pressable defaults this to true, so keep it to preserve any role and
+        // state the caller set, e.g. a read only checked CheckboxItem.
+        accessible={rest.accessible !== false}
+        // A consumer role of button makes react-native-web render a real
+        // <button>, which is tabbable by default. Nothing to activate here.
+        focusable={rest.focusable ?? false}
+        style={[
+          styles.touchable,
+          borderless && styles.borderless,
+          styles.disabled,
+          typeof style === 'function' ? style(state) : style,
+        ]}
+      >
+        {React.Children.only(
+          typeof children === 'function' ? children(state) : children
+        )}
+      </Animated.View>
+    );
+  }
 
   return (
     <Pressable
@@ -279,14 +312,14 @@ const TouchableRipple = ({
       ref={ref}
       onPressIn={handlePressIn}
       onPressOut={handlePressOut}
-      disabled={disabled}
+      disabled={disabledProp}
       style={(state) => [
         styles.touchable,
         borderless && styles.borderless,
         // focused state is not ready yet: https://github.com/necolas/react-native-web/issues/1849
         // state.focused && { backgroundColor: ___ },
-        state.hovered && { backgroundColor: hoverColor },
-        disabled && styles.disabled,
+        state.hovered && isInteractive && { backgroundColor: hoverColor },
+        !isInteractive && styles.disabled,
         typeof style === 'function' ? style(state) : style,
       ]}
     >

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
@@ -122,28 +122,11 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
             testID="search-bar-icon-container"
           >
             <View
-              accessibilityLabel="search"
-              accessibilityState={
-                {
-                  "busy": undefined,
-                  "checked": undefined,
-                  "disabled": true,
-                  "expanded": undefined,
-                  "selected": undefined,
-                }
-              }
-              accessibilityValue={
-                {
-                  "max": undefined,
-                  "min": undefined,
-                  "now": undefined,
-                  "text": undefined,
-                }
-              }
               accessible={true}
+              aria-label="search"
               centered={true}
               collapsable={false}
-              focusable={true}
+              focusable={false}
               hitSlop={
                 {
                   "bottom": 6,
@@ -152,30 +135,14 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                   "top": 6,
                 }
               }
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               role="button"
               style={
-                [
-                  {
-                    "overflow": "hidden",
-                  },
-                  [
-                    {
-                      "alignItems": "center",
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    },
-                    undefined,
-                  ],
-                ]
+                {
+                  "alignItems": "center",
+                  "flexGrow": 1,
+                  "justifyContent": "center",
+                  "overflow": "hidden",
+                }
               }
               testID="search-bar-icon"
             >
@@ -317,7 +284,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": false,
+                    "disabled": undefined,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -506,7 +473,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             {
               "busy": undefined,
               "checked": undefined,
-              "disabled": false,
+              "disabled": undefined,
               "expanded": undefined,
               "selected": undefined,
             }
@@ -749,7 +716,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
             {
               "busy": undefined,
               "checked": undefined,
-              "disabled": false,
+              "disabled": undefined,
               "expanded": undefined,
               "selected": undefined,
             }

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
@@ -135,7 +135,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                   "top": 6,
                 }
               }
-              role="button"
+              role="none"
               style={
                 {
                   "alignItems": "center",

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
@@ -152,6 +152,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                     "opacity": 1,
                   }
                 }
+                testID="search-bar-icon-icon-opacity"
               >
                 <Text
                   accessibilityElementsHidden={true}
@@ -342,6 +343,7 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
                       "opacity": 1,
                     }
                   }
+                  testID="search-bar-clear-icon-icon-opacity"
                 >
                   <Text
                     accessibilityElementsHidden={true}
@@ -531,6 +533,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
                 "opacity": 1,
               }
             }
+            testID="icon-button-icon-opacity"
           >
             <View
               style={
@@ -774,6 +777,7 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
                 "opacity": 1,
               }
             }
+            testID="icon-button-icon-opacity"
           >
             <View
               style={

--- a/src/components/__tests__/Button.test.tsx
+++ b/src/components/__tests__/Button.test.tsx
@@ -91,8 +91,18 @@ it('renders disabled button', async () => {
   expect(tree).toMatchSnapshot();
 });
 
-it('renders disabled button if there is no touch handler passed', async () => {
-  await render(<Button testID="disabled-button">Disabled button</Button>);
+it('does not mark a button without a touch handler as disabled', async () => {
+  await render(<Button testID="plain-button">Plain button</Button>);
+
+  expect(screen.getByTestId('plain-button')).not.toBeDisabled();
+});
+
+it('renders disabled button when the disabled prop is passed', async () => {
+  await render(
+    <Button disabled onPress={() => {}} testID="disabled-button">
+      Disabled button
+    </Button>
+  );
 
   expect(screen.getByTestId('disabled-button')).toBeDisabled();
 });

--- a/src/components/__tests__/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -2,55 +2,25 @@
 
 exports[`renders Checkbox with custom testID 1`] = `
 <View
-  accessibilityLiveRegion="polite"
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": true,
-      "disabled": true,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
   accessible={true}
+  aria-checked={true}
+  aria-disabled={false}
+  aria-live="polite"
   centered={true}
   collapsable={false}
-  focusable={true}
+  focusable={false}
   onBlur={[Function]}
-  onClick={[Function]}
   onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
   role="checkbox"
   style={
-    [
-      {
-        "overflow": "hidden",
-      },
-      [
-        {
-          "alignItems": "center",
-          "borderRadius": 20,
-          "height": 40,
-          "justifyContent": "center",
-          "width": 40,
-        },
-        undefined,
-        undefined,
-      ],
-    ]
+    {
+      "alignItems": "center",
+      "borderRadius": 20,
+      "height": 40,
+      "justifyContent": "center",
+      "overflow": "hidden",
+      "width": 40,
+    }
   }
   testID="custom:testID"
 >
@@ -188,55 +158,25 @@ exports[`renders Checkbox with custom testID 1`] = `
 
 exports[`renders checked Checkbox with color 1`] = `
 <View
-  accessibilityLiveRegion="polite"
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": true,
-      "disabled": true,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
   accessible={true}
+  aria-checked={true}
+  aria-disabled={false}
+  aria-live="polite"
   centered={true}
   collapsable={false}
-  focusable={true}
+  focusable={false}
   onBlur={[Function]}
-  onClick={[Function]}
   onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
   role="checkbox"
   style={
-    [
-      {
-        "overflow": "hidden",
-      },
-      [
-        {
-          "alignItems": "center",
-          "borderRadius": 20,
-          "height": 40,
-          "justifyContent": "center",
-          "width": 40,
-        },
-        undefined,
-        undefined,
-      ],
-    ]
+    {
+      "alignItems": "center",
+      "borderRadius": 20,
+      "height": 40,
+      "justifyContent": "center",
+      "overflow": "hidden",
+      "width": 40,
+    }
   }
 >
   <View
@@ -730,55 +670,25 @@ exports[`renders indeterminate Checkbox 1`] = `
 
 exports[`renders indeterminate Checkbox with color 1`] = `
 <View
-  accessibilityLiveRegion="polite"
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": "mixed",
-      "disabled": true,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
   accessible={true}
+  aria-checked="mixed"
+  aria-disabled={false}
+  aria-live="polite"
   centered={true}
   collapsable={false}
-  focusable={true}
+  focusable={false}
   onBlur={[Function]}
-  onClick={[Function]}
   onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
   role="checkbox"
   style={
-    [
-      {
-        "overflow": "hidden",
-      },
-      [
-        {
-          "alignItems": "center",
-          "borderRadius": 20,
-          "height": 40,
-          "justifyContent": "center",
-          "width": 40,
-        },
-        undefined,
-        undefined,
-      ],
-    ]
+    {
+      "alignItems": "center",
+      "borderRadius": 20,
+      "height": 40,
+      "justifyContent": "center",
+      "overflow": "hidden",
+      "width": 40,
+    }
   }
 >
   <View
@@ -902,55 +812,25 @@ exports[`renders indeterminate Checkbox with color 1`] = `
 
 exports[`renders unchecked Checkbox with color 1`] = `
 <View
-  accessibilityLiveRegion="polite"
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": true,
-      "disabled": true,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
   accessible={true}
+  aria-checked={true}
+  aria-disabled={false}
+  aria-live="polite"
   centered={true}
   collapsable={false}
-  focusable={true}
+  focusable={false}
   onBlur={[Function]}
-  onClick={[Function]}
   onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
   role="checkbox"
   style={
-    [
-      {
-        "overflow": "hidden",
-      },
-      [
-        {
-          "alignItems": "center",
-          "borderRadius": 20,
-          "height": 40,
-          "justifyContent": "center",
-          "width": 40,
-        },
-        undefined,
-        undefined,
-      ],
-    ]
+    {
+      "alignItems": "center",
+      "borderRadius": 20,
+      "height": 40,
+      "justifyContent": "center",
+      "overflow": "hidden",
+      "width": 40,
+    }
   }
 >
   <View

--- a/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.tsx.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.tsx.snap
@@ -2,43 +2,13 @@
 
 exports[`can render leading checkbox control 1`] = `
 <View
-  accessibilityLabel="Default with leading control"
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": false,
-      "disabled": true,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
   accessible={true}
+  aria-checked={false}
+  aria-label="Default with leading control"
   collapsable={false}
-  focusable={true}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
+  focusable={false}
   role="checkbox"
-  style={
-    [
-      false,
-      undefined,
-    ]
-  }
+  style={{}}
 >
   <View
     importantForAccessibility="no-hide-descendants"
@@ -57,53 +27,21 @@ exports[`can render leading checkbox control 1`] = `
     }
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={false}
       centered={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
-      onClick={[Function]}
       onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            {
-              "alignItems": "center",
-              "borderRadius": 20,
-              "height": 40,
-              "justifyContent": "center",
-              "width": 40,
-            },
-            undefined,
-            undefined,
-          ],
-        ]
+        {
+          "alignItems": "center",
+          "borderRadius": 20,
+          "height": 40,
+          "justifyContent": "center",
+          "overflow": "hidden",
+          "width": 40,
+        }
       }
     >
       <View
@@ -280,43 +218,13 @@ exports[`can render leading checkbox control 1`] = `
 
 exports[`renders unchecked 1`] = `
 <View
-  accessibilityLabel="Unchecked Button"
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": false,
-      "disabled": true,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
   accessible={true}
+  aria-checked={false}
+  aria-label="Unchecked Button"
   collapsable={false}
-  focusable={true}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
+  focusable={false}
   role="checkbox"
-  style={
-    [
-      false,
-      undefined,
-    ]
-  }
+  style={{}}
 >
   <View
     importantForAccessibility="no-hide-descendants"
@@ -373,53 +281,21 @@ exports[`renders unchecked 1`] = `
       Unchecked Button
     </Text>
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={false}
       centered={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
-      onClick={[Function]}
       onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            {
-              "alignItems": "center",
-              "borderRadius": 20,
-              "height": 40,
-              "justifyContent": "center",
-              "width": 40,
-            },
-            undefined,
-            undefined,
-          ],
-        ]
+        {
+          "alignItems": "center",
+          "borderRadius": 20,
+          "height": 40,
+          "justifyContent": "center",
+          "overflow": "hidden",
+          "width": 40,
+        }
       }
     >
       <View

--- a/src/components/__tests__/Chip.test.tsx
+++ b/src/components/__tests__/Chip.test.tsx
@@ -70,8 +70,18 @@ it('renders selected chip', async () => {
   expect(tree).toMatchSnapshot();
 });
 
-it('renders disabled chip if there is no touch handler passed', async () => {
-  await render(<Chip testID="disabled-chip">Disabled chip</Chip>);
+it('does not mark a chip without a touch handler as disabled', async () => {
+  await render(<Chip testID="plain-chip">Plain chip</Chip>);
+
+  expect(screen.getByTestId('plain-chip')).not.toBeDisabled();
+});
+
+it('renders disabled chip when the disabled prop is passed', async () => {
+  await render(
+    <Chip disabled onPress={() => {}} testID="disabled-chip">
+      Disabled chip
+    </Chip>
+  );
 
   expect(screen.getByTestId('disabled-chip')).toBeDisabled();
 });

--- a/src/components/__tests__/IconButton.test.tsx
+++ b/src/components/__tests__/IconButton.test.tsx
@@ -97,6 +97,21 @@ describe('getIconButtonColor - icon color', () => {
     });
   });
 
+  it('should keep an explicit icon color when disabled', () => {
+    expect(
+      getIconButtonColor({
+        theme: getTheme(),
+        disabled: true,
+        customIconColor: 'purple',
+      })
+    ).toMatchObject({
+      // disabled is still conveyed by the opacity, so it must not silently
+      // override a color the caller asked for
+      iconColor: 'purple',
+      iconOpacity: stateOpacity.disabled,
+    });
+  });
+
   it('should return correct disabled color, for theme version 3', () => {
     expect(
       getIconButtonColor({

--- a/src/components/__tests__/IconButton.test.tsx
+++ b/src/components/__tests__/IconButton.test.tsx
@@ -97,7 +97,9 @@ describe('getIconButtonColor - icon color', () => {
     });
   });
 
-  it('should keep an explicit icon color when disabled', () => {
+  it('should let the disabled color outrank an explicit icon color', () => {
+    // matches Button's `customTextColor && !disabled` and the documented
+    // `onSurfaceDisabled`
     expect(
       getIconButtonColor({
         theme: getTheme(),
@@ -105,9 +107,7 @@ describe('getIconButtonColor - icon color', () => {
         customIconColor: 'purple',
       })
     ).toMatchObject({
-      // disabled is still conveyed by the opacity, so it must not silently
-      // override a color the caller asked for
-      iconColor: 'purple',
+      iconColor: getTheme().colors.onSurface,
       iconOpacity: stateOpacity.disabled,
     });
   });

--- a/src/components/__tests__/MenuItem.test.tsx
+++ b/src/components/__tests__/MenuItem.test.tsx
@@ -54,7 +54,9 @@ describe('Menu Item', () => {
   });
 
   it('accepts aria-checked prop', async () => {
-    await render(<Menu.Item aria-checked={true} title="Option 1" />);
+    await render(
+      <Menu.Item aria-checked={true} onPress={() => {}} title="Option 1" />
+    );
 
     expect(screen.getByRole('menuitem')).toHaveProp(
       'accessibilityState',

--- a/src/components/__tests__/RadioButton/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/components/__tests__/RadioButton/__snapshots__/RadioButton.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`RadioButton RadioButton with custom testID renders properly 1`] = `
     {
       "busy": undefined,
       "checked": false,
-      "disabled": false,
+      "disabled": undefined,
       "expanded": undefined,
       "selected": undefined,
     }
@@ -94,7 +94,7 @@ exports[`RadioButton on default platform renders properly 1`] = `
     {
       "busy": undefined,
       "checked": false,
-      "disabled": false,
+      "disabled": undefined,
       "expanded": undefined,
       "selected": undefined,
     }
@@ -180,7 +180,7 @@ exports[`RadioButton on ios platform renders properly 1`] = `
     {
       "busy": undefined,
       "checked": false,
-      "disabled": false,
+      "disabled": undefined,
       "expanded": undefined,
       "selected": undefined,
     }
@@ -266,7 +266,7 @@ exports[`RadioButton when RadioButton is wrapped by RadioButtonContext.Provider 
     {
       "busy": undefined,
       "checked": true,
-      "disabled": false,
+      "disabled": undefined,
       "expanded": undefined,
       "selected": undefined,
     }

--- a/src/components/__tests__/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/components/__tests__/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`RadioButtonGroup renders properly 1`] = `
       {
         "busy": undefined,
         "checked": true,
-        "disabled": false,
+        "disabled": undefined,
         "expanded": undefined,
         "selected": undefined,
       }

--- a/src/components/__tests__/RadioButton/__snapshots__/RadioButtonItem.test.tsx.snap
+++ b/src/components/__tests__/RadioButton/__snapshots__/RadioButtonItem.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`can render leading radio button control 1`] = `
     {
       "busy": undefined,
       "checked": false,
-      "disabled": false,
+      "disabled": undefined,
       "expanded": undefined,
       "selected": undefined,
     }
@@ -61,7 +61,7 @@ exports[`can render leading radio button control 1`] = `
         {
           "busy": undefined,
           "checked": false,
-          "disabled": false,
+          "disabled": undefined,
           "expanded": undefined,
           "selected": undefined,
         }
@@ -185,7 +185,7 @@ exports[`can render the Android radio button on different platforms 1`] = `
     {
       "busy": undefined,
       "checked": false,
-      "disabled": false,
+      "disabled": undefined,
       "expanded": undefined,
       "selected": undefined,
     }
@@ -275,7 +275,7 @@ exports[`can render the Android radio button on different platforms 1`] = `
         {
           "busy": undefined,
           "checked": false,
-          "disabled": false,
+          "disabled": undefined,
           "expanded": undefined,
           "selected": undefined,
         }
@@ -337,7 +337,7 @@ exports[`can render the iOS radio button on different platforms 1`] = `
     {
       "busy": undefined,
       "checked": false,
-      "disabled": false,
+      "disabled": undefined,
       "expanded": undefined,
       "selected": undefined,
     }
@@ -427,7 +427,7 @@ exports[`can render the iOS radio button on different platforms 1`] = `
         {
           "busy": undefined,
           "checked": false,
-          "disabled": false,
+          "disabled": undefined,
           "expanded": undefined,
           "selected": undefined,
         }
@@ -515,7 +515,7 @@ exports[`renders unchecked 1`] = `
     {
       "busy": undefined,
       "checked": false,
-      "disabled": false,
+      "disabled": undefined,
       "expanded": undefined,
       "selected": undefined,
     }
@@ -605,7 +605,7 @@ exports[`renders unchecked 1`] = `
         {
           "busy": undefined,
           "checked": false,
-          "disabled": false,
+          "disabled": undefined,
           "expanded": undefined,
           "selected": undefined,
         }

--- a/src/components/__tests__/TextInput.test.tsx
+++ b/src/components/__tests__/TextInput.test.tsx
@@ -240,6 +240,66 @@ it('disables TextInput.Icon when the field is disabled', async () => {
   expect(buttons[1]).toBeDisabled();
 });
 
+it('does not expose a handler-less TextInput.Icon as a control when the field is disabled', async () => {
+  await render(
+    <TextInput
+      label="Search"
+      value="x"
+      onChangeText={() => {}}
+      disabled
+      startAccessory={(props: TextInputAccessoryProps) => (
+        <TextInput.Icon {...props} icon="magnify" testID="decorative" />
+      )}
+      endAccessory={(props: TextInputAccessoryProps) => (
+        <TextInput.Icon
+          {...props}
+          icon="close"
+          onPress={() => {}}
+          testID="clear"
+        />
+      )}
+    />
+  );
+
+  const decorative = screen.getByTestId('decorative');
+  expect(decorative).toHaveProp('role', 'none');
+  expect(decorative).not.toBeDisabled();
+
+  // control: a real handler still gets disabled
+  const clear = screen.getByTestId('clear');
+  expect(clear).toHaveProp('role', 'button');
+  expect(clear).toBeDisabled();
+});
+
+it('disables a TextInput.Icon that only has onLongPress when the field is disabled', async () => {
+  const onLongPress = jest.fn<(e: GestureResponderEvent) => void>();
+  await render(
+    <TextInput
+      label="Search"
+      value="x"
+      onChangeText={() => {}}
+      disabled
+      endAccessory={(props: TextInputAccessoryProps) => (
+        <TextInput.Icon
+          {...props}
+          icon="close"
+          onLongPress={onLongPress}
+          testID="long"
+        />
+      )}
+    />
+  );
+
+  // onLongPress alone still makes this a control; keying off onPress would
+  // leave it live
+  const long = screen.getByTestId('long');
+  expect(long).toHaveProp('role', 'button');
+  expect(long).toBeDisabled();
+
+  await userEvent.longPress(long);
+  expect(onLongPress).not.toHaveBeenCalled();
+});
+
 it('does not disable TextInput.Icon when the field is read-only (editable false)', async () => {
   await render(
     <TextInput

--- a/src/components/__tests__/TextInput.test.tsx
+++ b/src/components/__tests__/TextInput.test.tsx
@@ -271,6 +271,48 @@ it('does not expose a handler-less TextInput.Icon as a control when the field is
   expect(clear).toBeDisabled();
 });
 
+it('dims a disabled TextInput.Icon exactly once', async () => {
+  await render(
+    <TextInput
+      label="Search"
+      value="x"
+      onChangeText={() => {}}
+      disabled
+      startAccessory={(props: TextInputAccessoryProps) => (
+        <TextInput.Icon {...props} icon="magnify" testID="decorative" />
+      )}
+      endAccessory={(props: TextInputAccessoryProps) => (
+        <TextInput.Icon
+          {...props}
+          icon="close"
+          onPress={() => {}}
+          testID="clear"
+        />
+      )}
+    />
+  );
+
+  const disabledOpacity = tokens.md.sys.state.opacity.disabled;
+
+  // TextInput dims the accessory wrapper and IconButton dims a disabled icon.
+  // Both firing multiplies to 0.14, so exactly one has to apply per icon.
+  // decorative: IconButton is not disabled, so the wrapper carries the dim
+  expect(screen.getByTestId('decorative-container-outer-layer')).toHaveStyle({
+    opacity: disabledOpacity,
+  });
+  expect(screen.getByTestId('decorative-icon-opacity')).toHaveStyle({
+    opacity: 1,
+  });
+
+  // interactive: IconButton carries it, so the wrapper is cancelled
+  expect(screen.getByTestId('clear-container-outer-layer')).toHaveStyle({
+    opacity: 1,
+  });
+  expect(screen.getByTestId('clear-icon-opacity')).toHaveStyle({
+    opacity: disabledOpacity,
+  });
+});
+
 it('disables a TextInput.Icon that only has onLongPress when the field is disabled', async () => {
   const onLongPress = jest.fn<(e: GestureResponderEvent) => void>();
   await render(

--- a/src/components/__tests__/TouchableRipple.test.tsx
+++ b/src/components/__tests__/TouchableRipple.test.tsx
@@ -1,5 +1,5 @@
 import { Platform, Text } from 'react-native';
-import type { GestureResponderEvent } from 'react-native';
+import type { GestureResponderEvent, Role } from 'react-native';
 
 import { describe, expect, it, jest } from '@jest/globals';
 import { userEvent } from '@testing-library/react-native';
@@ -59,6 +59,89 @@ describe('TouchableRipple', () => {
     // press to focus.
     expect(plain).not.toHaveProp('onStartShouldSetResponder');
     expect(plain).toHaveProp('focusable', false);
+  });
+
+  it('drops a button role when no touch handler is passed', async () => {
+    await render(
+      <TouchableRipple testID="plain" role="button" aria-label="Add item">
+        <Text>Not a button</Text>
+      </TouchableRipple>
+    );
+
+    const plain = screen.getByTestId('plain');
+
+    // react-native-web turns role button into a real <button>
+    expect(plain).toHaveProp('role', 'none');
+
+    // but hiding the element would silence the label, which for an icon only
+    // control is all it has to announce
+    expect(plain).toHaveProp('accessible', true);
+    expect(plain).toHaveProp('aria-label', 'Add item');
+  });
+
+  // `imagebutton` is missing here because it is native only, absent from the
+  // web `Role` union, so it arrives via `accessibilityRole` instead
+  const activatableRoles: Role[] = ['link', 'menuitem', 'tab'];
+
+  it.each(activatableRoles)(
+    'drops the %s role too when no touch handler is passed',
+    async (role) => {
+      await render(
+        <TouchableRipple testID="plain" role={role}>
+          <Text>Not a control</Text>
+        </TouchableRipple>
+      );
+
+      expect(screen.getByTestId('plain')).toHaveProp('role', 'none');
+    }
+  );
+
+  it('drops a native imagebutton accessibilityRole when no touch handler is passed', async () => {
+    await render(
+      <TouchableRipple testID="plain" accessibilityRole="imagebutton">
+        <Text>Not a control</Text>
+      </TouchableRipple>
+    );
+
+    expect(screen.getByTestId('plain')).toHaveProp('role', 'none');
+  });
+
+  it('resolves role ahead of accessibilityRole, as every platform does', async () => {
+    await render(
+      <TouchableRipple
+        testID="plain"
+        accessibilityRole="button"
+        role="checkbox"
+      >
+        <Text>Read only</Text>
+      </TouchableRipple>
+    );
+
+    expect(screen.getByTestId('plain')).toHaveProp('role', 'checkbox');
+  });
+
+  it('keeps a non button role when no touch handler is passed', async () => {
+    await render(
+      <TouchableRipple testID="readonly" role="checkbox" aria-checked>
+        <Text>Read only</Text>
+      </TouchableRipple>
+    );
+
+    const readonly = screen.getByTestId('readonly');
+
+    expect(readonly).toHaveProp('role', 'checkbox');
+    expect(readonly).toHaveProp('accessible', true);
+    expect(readonly).toHaveProp('aria-checked', true);
+  });
+
+  it('keeps the button role on a disabled control', async () => {
+    await render(
+      <TouchableRipple testID="off" role="button" disabled onPress={() => {}}>
+        <Text>Disabled</Text>
+      </TouchableRipple>
+    );
+
+    expect(screen.getByTestId('off')).toHaveProp('role', 'button');
   });
 
   it('stays a disabled control when the disabled prop is passed', async () => {

--- a/src/components/__tests__/TouchableRipple.test.tsx
+++ b/src/components/__tests__/TouchableRipple.test.tsx
@@ -44,12 +44,69 @@ describe('TouchableRipple', () => {
     expect(onPress).not.toHaveBeenCalled();
   });
 
+  it('is not exposed as a control when no touch handler is passed', async () => {
+    await render(
+      <TouchableRipple testID="plain">
+        <Text>Not a button</Text>
+      </TouchableRipple>
+    );
+
+    const plain = screen.getByTestId('plain');
+
+    expect(plain).not.toBeDisabled();
+    // no Pressable underneath, so nothing claims the touch. A responder here
+    // would swallow taps meant for whatever wraps this, e.g. TextInput's
+    // press to focus.
+    expect(plain).not.toHaveProp('onStartShouldSetResponder');
+    expect(plain).toHaveProp('focusable', false);
+  });
+
+  it('stays a disabled control when the disabled prop is passed', async () => {
+    await render(
+      <TouchableRipple testID="off" disabled onPress={() => {}}>
+        <Text>Disabled</Text>
+      </TouchableRipple>
+    );
+
+    const off = screen.getByTestId('off');
+
+    expect(off).toBeDisabled();
+    expect(off).toHaveProp('focusable', true);
+    expect(off).toHaveProp('onStartShouldSetResponder');
+  });
+
+  it('does not show press feedback when no touch handler is passed', async () => {
+    await render(
+      <TouchableRipple testOnly_pressed>
+        <Text>Not a button</Text>
+      </TouchableRipple>
+    );
+
+    expect(
+      screen.queryByTestId('touchable-ripple-underlay')
+    ).not.toBeOnTheScreen();
+  });
+
+  it('does not show press feedback on a disabled control', async () => {
+    // this one reaches the underlay branch, unlike the handler-less case above
+    // which returns a plain View before that subtree is ever built
+    await render(
+      <TouchableRipple testOnly_pressed disabled onPress={() => {}}>
+        <Text>Disabled</Text>
+      </TouchableRipple>
+    );
+
+    expect(
+      screen.queryByTestId('touchable-ripple-underlay')
+    ).not.toBeOnTheScreen();
+  });
+
   describe('on iOS', () => {
     Platform.OS = 'ios';
 
     it('displays the underlay when pressed', async () => {
       await render(
-        <TouchableRipple testOnly_pressed>
+        <TouchableRipple testOnly_pressed onPress={() => {}}>
           <Text>Press me!</Text>
         </TouchableRipple>
       );
@@ -60,7 +117,11 @@ describe('TouchableRipple', () => {
 
     it('renders custom underlay color', async () => {
       await render(
-        <TouchableRipple testOnly_pressed underlayColor="purple">
+        <TouchableRipple
+          testOnly_pressed
+          underlayColor="purple"
+          onPress={() => {}}
+        >
           <Text>Press me!</Text>
         </TouchableRipple>
       );

--- a/src/components/__tests__/TouchableRippleWeb.test.tsx
+++ b/src/components/__tests__/TouchableRippleWeb.test.tsx
@@ -1,0 +1,45 @@
+import { Text } from 'react-native';
+
+import { describe, expect, it } from '@jest/globals';
+
+import { render, screen } from '../../test-utils';
+// The bare specifier resolves to .native under the jest preset, so the web file
+// needs the extension or it never runs. There is still no DOM here, so this only
+// pins the props it computes.
+import TouchableRipple from '../TouchableRipple/TouchableRipple.tsx';
+
+describe('TouchableRipple (web file)', () => {
+  it('drops a button role but keeps the name when no touch handler is passed', async () => {
+    await render(
+      <TouchableRipple testID="plain" role="button" aria-label="Add item">
+        <Text>Not a button</Text>
+      </TouchableRipple>
+    );
+
+    const plain = screen.getByTestId('plain');
+
+    expect(plain).toHaveProp('role', 'none');
+    expect(plain).toHaveProp('accessible', true);
+    expect(plain).toHaveProp('aria-label', 'Add item');
+  });
+
+  it('keeps a state bearing role when no touch handler is passed', async () => {
+    await render(
+      <TouchableRipple testID="readonly" role="checkbox" aria-checked>
+        <Text>Read only</Text>
+      </TouchableRipple>
+    );
+
+    expect(screen.getByTestId('readonly')).toHaveProp('role', 'checkbox');
+  });
+
+  it('keeps the button role on a disabled control', async () => {
+    await render(
+      <TouchableRipple testID="off" role="button" disabled onPress={() => {}}>
+        <Text>Disabled</Text>
+      </TouchableRipple>
+    );
+
+    expect(screen.getByTestId('off')).toHaveProp('role', 'button');
+  });
+});

--- a/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
@@ -162,7 +162,7 @@ exports[`render visible banner, with custom theme 1`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": false,
+                    "disabled": undefined,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -595,7 +595,7 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": false,
+                    "disabled": undefined,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -871,7 +871,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": false,
+                    "disabled": undefined,
                     "expanded": undefined,
                     "selected": undefined,
                   }
@@ -1023,7 +1023,7 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                   {
                     "busy": undefined,
                     "checked": undefined,
-                    "disabled": false,
+                    "disabled": undefined,
                     "expanded": undefined,
                     "selected": undefined,
                   }

--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`renders button with an accessibility hint 1`] = `
       accessible={true}
       collapsable={false}
       focusable={false}
-      role="button"
+      role="none"
       style={
         {
           "borderRadius": 20,
@@ -168,7 +168,7 @@ exports[`renders button with an accessibility label 1`] = `
       accessible={true}
       collapsable={false}
       focusable={false}
-      role="button"
+      role="none"
       style={
         {
           "borderRadius": 20,
@@ -290,7 +290,7 @@ exports[`renders button with button color 1`] = `
       accessible={true}
       collapsable={false}
       focusable={false}
-      role="button"
+      role="none"
       style={
         {
           "borderRadius": 20,
@@ -412,7 +412,7 @@ exports[`renders button with color 1`] = `
       accessible={true}
       collapsable={false}
       focusable={false}
-      role="button"
+      role="none"
       style={
         {
           "borderRadius": 20,
@@ -534,7 +534,7 @@ exports[`renders button with custom testID 1`] = `
       accessible={true}
       collapsable={false}
       focusable={false}
-      role="button"
+      role="none"
       style={
         {
           "borderRadius": 20,
@@ -656,7 +656,7 @@ exports[`renders button with icon 1`] = `
       accessible={true}
       collapsable={false}
       focusable={false}
-      role="button"
+      role="none"
       style={
         {
           "borderRadius": 20,
@@ -827,7 +827,7 @@ exports[`renders button with icon in reverse order 1`] = `
       accessible={true}
       collapsable={false}
       focusable={false}
-      role="button"
+      role="none"
       style={
         {
           "borderRadius": 20,
@@ -1000,7 +1000,7 @@ exports[`renders contained contained with mode 1`] = `
       accessible={true}
       collapsable={false}
       focusable={false}
-      role="button"
+      role="none"
       style={
         {
           "borderRadius": 20,
@@ -1275,7 +1275,7 @@ exports[`renders loading button 1`] = `
       accessible={true}
       collapsable={false}
       focusable={false}
-      role="button"
+      role="none"
       style={
         {
           "borderRadius": 20,
@@ -1601,7 +1601,7 @@ exports[`renders outlined button with mode 1`] = `
       accessible={true}
       collapsable={false}
       focusable={false}
-      role="button"
+      role="none"
       style={
         {
           "borderRadius": 19,
@@ -1724,7 +1724,7 @@ exports[`renders text button by default 1`] = `
       accessible={true}
       collapsable={false}
       focusable={false}
-      role="button"
+      role="none"
       style={
         {
           "borderRadius": 20,
@@ -1846,7 +1846,7 @@ exports[`renders text button with mode 1`] = `
       accessible={true}
       collapsable={false}
       focusable={false}
-      role="button"
+      role="none"
       style={
         {
           "borderRadius": 20,

--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -42,45 +42,15 @@ exports[`renders button with an accessibility hint 1`] = `
   >
     <View
       accessibilityHint="hint"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
+      focusable={false}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          {
-            "borderRadius": 20,
-          },
-        ]
+        {
+          "borderRadius": 20,
+          "overflow": "hidden",
+        }
       }
       testID="button"
     >
@@ -195,45 +165,15 @@ exports[`renders button with an accessibility label 1`] = `
     testID="button-container"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
+      focusable={false}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          {
-            "borderRadius": 20,
-          },
-        ]
+        {
+          "borderRadius": 20,
+          "overflow": "hidden",
+        }
       }
       testID="button"
     >
@@ -347,45 +287,15 @@ exports[`renders button with button color 1`] = `
     testID="button-container"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
+      focusable={false}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          {
-            "borderRadius": 20,
-          },
-        ]
+        {
+          "borderRadius": 20,
+          "overflow": "hidden",
+        }
       }
       testID="button"
     >
@@ -499,45 +409,15 @@ exports[`renders button with color 1`] = `
     testID="button-container"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
+      focusable={false}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          {
-            "borderRadius": 20,
-          },
-        ]
+        {
+          "borderRadius": 20,
+          "overflow": "hidden",
+        }
       }
       testID="button"
     >
@@ -651,45 +531,15 @@ exports[`renders button with custom testID 1`] = `
     testID="custom:testID-container"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
+      focusable={false}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          {
-            "borderRadius": 20,
-          },
-        ]
+        {
+          "borderRadius": 20,
+          "overflow": "hidden",
+        }
       }
       testID="custom:testID"
     >
@@ -803,45 +653,15 @@ exports[`renders button with icon 1`] = `
     testID="button-container"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
+      focusable={false}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          {
-            "borderRadius": 20,
-          },
-        ]
+        {
+          "borderRadius": 20,
+          "overflow": "hidden",
+        }
       }
       testID="button"
     >
@@ -1004,45 +824,15 @@ exports[`renders button with icon in reverse order 1`] = `
     testID="button-container"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
+      focusable={false}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          {
-            "borderRadius": 20,
-          },
-        ]
+        {
+          "borderRadius": 20,
+          "overflow": "hidden",
+        }
       }
       testID="button"
     >
@@ -1207,45 +997,15 @@ exports[`renders contained contained with mode 1`] = `
     testID="button-container"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
+      focusable={false}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          {
-            "borderRadius": 20,
-          },
-        ]
+        {
+          "borderRadius": 20,
+          "overflow": "hidden",
+        }
       }
       testID="button"
     >
@@ -1512,45 +1272,15 @@ exports[`renders loading button 1`] = `
     testID="button-container"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
+      focusable={false}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          {
-            "borderRadius": 20,
-          },
-        ]
+        {
+          "borderRadius": 20,
+          "overflow": "hidden",
+        }
       }
       testID="button"
     >
@@ -1868,45 +1598,15 @@ exports[`renders outlined button with mode 1`] = `
     testID="button-container"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
+      focusable={false}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          {
-            "borderRadius": 19,
-          },
-        ]
+        {
+          "borderRadius": 19,
+          "overflow": "hidden",
+        }
       }
       testID="button"
     >
@@ -2021,45 +1721,15 @@ exports[`renders text button by default 1`] = `
     testID="button-container"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
+      focusable={false}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          {
-            "borderRadius": 20,
-          },
-        ]
+        {
+          "borderRadius": 20,
+          "overflow": "hidden",
+        }
       }
       testID="button"
     >
@@ -2173,45 +1843,15 @@ exports[`renders text button with mode 1`] = `
     testID="button-container"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
+      focusable={false}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          {
-            "borderRadius": 20,
-          },
-        ]
+        {
+          "borderRadius": 20,
+          "overflow": "hidden",
+        }
       }
       testID="button"
     >

--- a/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -41,50 +41,18 @@ exports[`renders chip with close button 1`] = `
     testID="chip-container"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": false,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
+      aria-disabled={false}
+      aria-selected={false}
       collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
+      focusable={false}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            {
-              "borderRadius": 8,
-            },
-            {
-              "width": "100%",
-            },
-          ],
-        ]
+        {
+          "borderRadius": 8,
+          "overflow": "hidden",
+          "width": "100%",
+        }
       }
       testID="chip"
     >
@@ -339,50 +307,18 @@ exports[`renders chip with custom close button 1`] = `
     testID="chip-container"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": false,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
+      aria-disabled={false}
+      aria-selected={false}
       collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
+      focusable={false}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            {
-              "borderRadius": 8,
-            },
-            {
-              "width": "100%",
-            },
-          ],
-        ]
+        {
+          "borderRadius": 8,
+          "overflow": "hidden",
+          "width": "100%",
+        }
       }
       testID="chip"
     >
@@ -637,50 +573,18 @@ exports[`renders chip with icon 1`] = `
     testID="chip-container"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": false,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
+      aria-disabled={false}
+      aria-selected={false}
       collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
+      focusable={false}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            {
-              "borderRadius": 8,
-            },
-            {
-              "width": "100%",
-            },
-          ],
-        ]
+        {
+          "borderRadius": 8,
+          "overflow": "hidden",
+          "width": "100%",
+        }
       }
       testID="chip"
     >
@@ -1162,50 +1066,18 @@ exports[`renders selected chip 1`] = `
     testID="chip-container"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": true,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
+      aria-disabled={false}
+      aria-selected={true}
       collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
+      focusable={false}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            {
-              "borderRadius": 8,
-            },
-            {
-              "width": "100%",
-            },
-          ],
-        ]
+        {
+          "borderRadius": 8,
+          "overflow": "hidden",
+          "width": "100%",
+        }
       }
       testID="chip"
     >

--- a/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`renders chip with close button 1`] = `
       aria-selected={false}
       collapsable={false}
       focusable={false}
-      role="button"
+      role="none"
       style={
         {
           "borderRadius": 8,
@@ -312,7 +312,7 @@ exports[`renders chip with custom close button 1`] = `
       aria-selected={false}
       collapsable={false}
       focusable={false}
-      role="button"
+      role="none"
       style={
         {
           "borderRadius": 8,
@@ -578,7 +578,7 @@ exports[`renders chip with icon 1`] = `
       aria-selected={false}
       collapsable={false}
       focusable={false}
-      role="button"
+      role="none"
       style={
         {
           "borderRadius": 8,
@@ -1071,7 +1071,7 @@ exports[`renders selected chip 1`] = `
       aria-selected={true}
       collapsable={false}
       focusable={false}
-      role="button"
+      role="none"
       style={
         {
           "borderRadius": 8,

--- a/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -418,6 +418,7 @@ exports[`DataTable.Pagination renders data table pagination 1`] = `
                 "opacity": 1,
               }
             }
+            testID="icon-button-icon-opacity"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -558,6 +559,7 @@ exports[`DataTable.Pagination renders data table pagination 1`] = `
                 "opacity": 1,
               }
             }
+            testID="icon-button-icon-opacity"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -756,6 +758,7 @@ exports[`DataTable.Pagination renders data table pagination with fast-forward bu
                 "opacity": 1,
               }
             }
+            testID="icon-button-icon-opacity"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -896,6 +899,7 @@ exports[`DataTable.Pagination renders data table pagination with fast-forward bu
                 "opacity": 1,
               }
             }
+            testID="icon-button-icon-opacity"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -1036,6 +1040,7 @@ exports[`DataTable.Pagination renders data table pagination with fast-forward bu
                 "opacity": 1,
               }
             }
+            testID="icon-button-icon-opacity"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -1176,6 +1181,7 @@ exports[`DataTable.Pagination renders data table pagination with fast-forward bu
                 "opacity": 1,
               }
             }
+            testID="icon-button-icon-opacity"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -1374,6 +1380,7 @@ exports[`DataTable.Pagination renders data table pagination with label 1`] = `
                 "opacity": 1,
               }
             }
+            testID="icon-button-icon-opacity"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -1514,6 +1521,7 @@ exports[`DataTable.Pagination renders data table pagination with label 1`] = `
                 "opacity": 1,
               }
             }
+            testID="icon-button-icon-opacity"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -1960,6 +1968,7 @@ exports[`DataTable.Pagination renders data table pagination with options select 
                 "opacity": 1,
               }
             }
+            testID="icon-button-icon-opacity"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -2100,6 +2109,7 @@ exports[`DataTable.Pagination renders data table pagination with options select 
                 "opacity": 1,
               }
             }
+            testID="icon-button-icon-opacity"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -2240,6 +2250,7 @@ exports[`DataTable.Pagination renders data table pagination with options select 
                 "opacity": 1,
               }
             }
+            testID="icon-button-icon-opacity"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -2380,6 +2391,7 @@ exports[`DataTable.Pagination renders data table pagination with options select 
                 "opacity": 1,
               }
             }
+            testID="icon-button-icon-opacity"
           >
             <Text
               accessibilityElementsHidden={true}

--- a/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -2,48 +2,15 @@
 
 exports[`DataTable.Cell renders data table cell 1`] = `
 <View
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": undefined,
-      "disabled": true,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
   accessible={true}
   collapsable={false}
-  focusable={true}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
+  focusable={false}
   style={
-    [
-      false,
-      [
-        {
-          "alignItems": "center",
-          "flex": 1,
-          "flexDirection": "row",
-        },
-        undefined,
-        undefined,
-      ],
-    ]
+    {
+      "alignItems": "center",
+      "flex": 1,
+      "flexDirection": "row",
+    }
   }
 >
   <Text
@@ -74,50 +41,16 @@ exports[`DataTable.Cell renders data table cell 1`] = `
 
 exports[`DataTable.Cell renders right aligned data table cell 1`] = `
 <View
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": undefined,
-      "disabled": true,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
   accessible={true}
   collapsable={false}
-  focusable={true}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
+  focusable={false}
   style={
-    [
-      false,
-      [
-        {
-          "alignItems": "center",
-          "flex": 1,
-          "flexDirection": "row",
-        },
-        {
-          "justifyContent": "flex-end",
-        },
-        undefined,
-      ],
-    ]
+    {
+      "alignItems": "center",
+      "flex": 1,
+      "flexDirection": "row",
+      "justifyContent": "flex-end",
+    }
   }
 >
   <Text
@@ -1727,7 +1660,7 @@ exports[`DataTable.Pagination renders data table pagination with options select 
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": false,
+                "disabled": undefined,
                 "expanded": undefined,
                 "selected": undefined,
               }

--- a/src/components/__tests__/__snapshots__/DrawerItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DrawerItem.test.tsx.snap
@@ -3,60 +3,22 @@
 exports[`renders DrawerItem with icon 1`] = `
 <View>
   <View
-    accessibilityState={
-      {
-        "busy": undefined,
-        "checked": undefined,
-        "disabled": true,
-        "expanded": undefined,
-        "selected": undefined,
-      }
-    }
-    accessibilityValue={
-      {
-        "max": undefined,
-        "min": undefined,
-        "now": undefined,
-        "text": undefined,
-      }
-    }
     accessible={true}
     collapsable={false}
-    focusable={true}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
+    focusable={false}
     role="button"
     style={
-      [
-        {
-          "overflow": "hidden",
-        },
-        [
-          {
-            "marginHorizontal": 10,
-            "marginVertical": 4,
-          },
-          {
-            "height": 56,
-            "justifyContent": "center",
-            "marginLeft": 12,
-            "marginRight": 12,
-            "marginVertical": 0,
-          },
-          {
-            "backgroundColor": undefined,
-            "borderRadius": 28,
-          },
-          undefined,
-        ],
-      ]
+      {
+        "backgroundColor": undefined,
+        "borderRadius": 28,
+        "height": 56,
+        "justifyContent": "center",
+        "marginHorizontal": 10,
+        "marginLeft": 12,
+        "marginRight": 12,
+        "marginVertical": 0,
+        "overflow": "hidden",
+      }
     }
   >
     <View
@@ -162,60 +124,23 @@ exports[`renders DrawerItem with icon 1`] = `
 exports[`renders active DrawerItem 1`] = `
 <View>
   <View
-    accessibilityState={
-      {
-        "busy": undefined,
-        "checked": undefined,
-        "disabled": true,
-        "expanded": undefined,
-        "selected": true,
-      }
-    }
-    accessibilityValue={
-      {
-        "max": undefined,
-        "min": undefined,
-        "now": undefined,
-        "text": undefined,
-      }
-    }
     accessible={true}
+    aria-selected={true}
     collapsable={false}
-    focusable={true}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
+    focusable={false}
     role="button"
     style={
-      [
-        {
-          "overflow": "hidden",
-        },
-        [
-          {
-            "marginHorizontal": 10,
-            "marginVertical": 4,
-          },
-          {
-            "height": 56,
-            "justifyContent": "center",
-            "marginLeft": 12,
-            "marginRight": 12,
-            "marginVertical": 0,
-          },
-          {
-            "backgroundColor": "rgba(232, 222, 248, 1)",
-            "borderRadius": 28,
-          },
-          undefined,
-        ],
-      ]
+      {
+        "backgroundColor": "rgba(232, 222, 248, 1)",
+        "borderRadius": 28,
+        "height": 56,
+        "justifyContent": "center",
+        "marginHorizontal": 10,
+        "marginLeft": 12,
+        "marginRight": 12,
+        "marginVertical": 0,
+        "overflow": "hidden",
+      }
     }
   >
     <View
@@ -325,7 +250,7 @@ exports[`renders basic DrawerItem 1`] = `
       {
         "busy": undefined,
         "checked": undefined,
-        "disabled": false,
+        "disabled": undefined,
         "expanded": undefined,
         "selected": undefined,
       }

--- a/src/components/__tests__/__snapshots__/DrawerItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DrawerItem.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`renders DrawerItem with icon 1`] = `
     accessible={true}
     collapsable={false}
     focusable={false}
-    role="button"
+    role="none"
     style={
       {
         "backgroundColor": undefined,
@@ -128,7 +128,7 @@ exports[`renders active DrawerItem 1`] = `
     aria-selected={true}
     collapsable={false}
     focusable={false}
-    role="button"
+    role="none"
     style={
       {
         "backgroundColor": "rgba(232, 222, 248, 1)",

--- a/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
@@ -52,46 +52,16 @@ exports[`renders FAB large size 1`] = `
     }
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
-      onClick={[Function]}
       onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            null,
-            null,
-          ],
-        ]
+        {
+          "overflow": "hidden",
+        }
       }
       testID="floating-action-button"
     >
@@ -224,46 +194,16 @@ exports[`renders FAB medium size 1`] = `
     }
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
-      onClick={[Function]}
       onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            null,
-            null,
-          ],
-        ]
+        {
+          "overflow": "hidden",
+        }
       }
       testID="floating-action-button"
     >
@@ -396,46 +336,16 @@ exports[`renders FAB transitioning to not visible 1`] = `
     }
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
-      onClick={[Function]}
       onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            null,
-            null,
-          ],
-        ]
+        {
+          "overflow": "hidden",
+        }
       }
       testID="floating-action-button"
     >
@@ -568,46 +478,16 @@ exports[`renders FAB transitioning to visible 1`] = `
     }
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
-      onClick={[Function]}
       onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            null,
-            null,
-          ],
-        ]
+        {
+          "overflow": "hidden",
+        }
       }
       testID="floating-action-button"
     >
@@ -740,47 +620,17 @@ exports[`renders FAB with aria-label 1`] = `
     }
   >
     <View
-      accessibilityLabel="Add item"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
+      aria-label="Add item"
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
-      onClick={[Function]}
       onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            null,
-            null,
-          ],
-        ]
+        {
+          "overflow": "hidden",
+        }
       }
       testID="floating-action-button"
     >
@@ -913,46 +763,16 @@ exports[`renders FAB with containerColor and contentColor overrides 1`] = `
     }
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
-      onClick={[Function]}
       onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            null,
-            null,
-          ],
-        ]
+        {
+          "overflow": "hidden",
+        }
       }
       testID="floating-action-button"
     >
@@ -1085,46 +905,16 @@ exports[`renders FAB with containerColor override 1`] = `
     }
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
-      onClick={[Function]}
       onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            null,
-            null,
-          ],
-        ]
+        {
+          "overflow": "hidden",
+        }
       }
       testID="floating-action-button"
     >
@@ -1257,46 +1047,16 @@ exports[`renders FAB with default props 1`] = `
     }
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
-      onClick={[Function]}
       onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            null,
-            null,
-          ],
-        ]
+        {
+          "overflow": "hidden",
+        }
       }
       testID="floating-action-button"
     >
@@ -1429,46 +1189,16 @@ exports[`renders FAB with primary variant 1`] = `
     }
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
-      onClick={[Function]}
       onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            null,
-            null,
-          ],
-        ]
+        {
+          "overflow": "hidden",
+        }
       }
       testID="floating-action-button"
     >
@@ -1601,46 +1331,16 @@ exports[`renders FAB with secondary variant 1`] = `
     }
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
-      onClick={[Function]}
       onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            null,
-            null,
-          ],
-        ]
+        {
+          "overflow": "hidden",
+        }
       }
       testID="floating-action-button"
     >
@@ -1773,46 +1473,16 @@ exports[`renders FAB with tertiary variant 1`] = `
     }
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
-      onClick={[Function]}
       onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            null,
-            null,
-          ],
-        ]
+        {
+          "overflow": "hidden",
+        }
       }
       testID="floating-action-button"
     >
@@ -1945,46 +1615,16 @@ exports[`renders FAB with tonalSecondary variant 1`] = `
     }
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
-      onClick={[Function]}
       onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            null,
-            null,
-          ],
-        ]
+        {
+          "overflow": "hidden",
+        }
       }
       testID="floating-action-button"
     >
@@ -2117,46 +1757,16 @@ exports[`renders FAB with tonalTertiary variant 1`] = `
     }
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
-      onClick={[Function]}
       onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            null,
-            null,
-          ],
-        ]
+        {
+          "overflow": "hidden",
+        }
       }
       testID="floating-action-button"
     >

--- a/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`renders FAB large size 1`] = `
       focusable={false}
       onBlur={[Function]}
       onFocus={[Function]}
-      role="button"
+      role="none"
       style={
         {
           "overflow": "hidden",
@@ -199,7 +199,7 @@ exports[`renders FAB medium size 1`] = `
       focusable={false}
       onBlur={[Function]}
       onFocus={[Function]}
-      role="button"
+      role="none"
       style={
         {
           "overflow": "hidden",
@@ -341,7 +341,7 @@ exports[`renders FAB transitioning to not visible 1`] = `
       focusable={false}
       onBlur={[Function]}
       onFocus={[Function]}
-      role="button"
+      role="none"
       style={
         {
           "overflow": "hidden",
@@ -483,7 +483,7 @@ exports[`renders FAB transitioning to visible 1`] = `
       focusable={false}
       onBlur={[Function]}
       onFocus={[Function]}
-      role="button"
+      role="none"
       style={
         {
           "overflow": "hidden",
@@ -626,7 +626,7 @@ exports[`renders FAB with aria-label 1`] = `
       focusable={false}
       onBlur={[Function]}
       onFocus={[Function]}
-      role="button"
+      role="none"
       style={
         {
           "overflow": "hidden",
@@ -768,7 +768,7 @@ exports[`renders FAB with containerColor and contentColor overrides 1`] = `
       focusable={false}
       onBlur={[Function]}
       onFocus={[Function]}
-      role="button"
+      role="none"
       style={
         {
           "overflow": "hidden",
@@ -910,7 +910,7 @@ exports[`renders FAB with containerColor override 1`] = `
       focusable={false}
       onBlur={[Function]}
       onFocus={[Function]}
-      role="button"
+      role="none"
       style={
         {
           "overflow": "hidden",
@@ -1052,7 +1052,7 @@ exports[`renders FAB with default props 1`] = `
       focusable={false}
       onBlur={[Function]}
       onFocus={[Function]}
-      role="button"
+      role="none"
       style={
         {
           "overflow": "hidden",
@@ -1194,7 +1194,7 @@ exports[`renders FAB with primary variant 1`] = `
       focusable={false}
       onBlur={[Function]}
       onFocus={[Function]}
-      role="button"
+      role="none"
       style={
         {
           "overflow": "hidden",
@@ -1336,7 +1336,7 @@ exports[`renders FAB with secondary variant 1`] = `
       focusable={false}
       onBlur={[Function]}
       onFocus={[Function]}
-      role="button"
+      role="none"
       style={
         {
           "overflow": "hidden",
@@ -1478,7 +1478,7 @@ exports[`renders FAB with tertiary variant 1`] = `
       focusable={false}
       onBlur={[Function]}
       onFocus={[Function]}
-      role="button"
+      role="none"
       style={
         {
           "overflow": "hidden",
@@ -1620,7 +1620,7 @@ exports[`renders FAB with tonalSecondary variant 1`] = `
       focusable={false}
       onBlur={[Function]}
       onFocus={[Function]}
-      role="button"
+      role="none"
       style={
         {
           "overflow": "hidden",
@@ -1762,7 +1762,7 @@ exports[`renders FAB with tonalTertiary variant 1`] = `
       focusable={false}
       onBlur={[Function]}
       onFocus={[Function]}
-      role="button"
+      role="none"
       style={
         {
           "overflow": "hidden",

--- a/src/components/__tests__/__snapshots__/FABExtended.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FABExtended.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`renders extended FAB collapsed 1`] = `
         focusable={false}
         onBlur={[Function]}
         onFocus={[Function]}
-        role="button"
+        role="none"
         style={
           {
             "overflow": "hidden",
@@ -268,7 +268,7 @@ exports[`renders extended FAB expanded 1`] = `
         focusable={false}
         onBlur={[Function]}
         onFocus={[Function]}
-        role="button"
+        role="none"
         style={
           {
             "overflow": "hidden",
@@ -477,7 +477,7 @@ exports[`renders extended FAB large size 1`] = `
         focusable={false}
         onBlur={[Function]}
         onFocus={[Function]}
-        role="button"
+        role="none"
         style={
           {
             "overflow": "hidden",
@@ -686,7 +686,7 @@ exports[`renders extended FAB medium size 1`] = `
         focusable={false}
         onBlur={[Function]}
         onFocus={[Function]}
-        role="button"
+        role="none"
         style={
           {
             "overflow": "hidden",
@@ -895,7 +895,7 @@ exports[`renders extended FAB not visible 1`] = `
         focusable={false}
         onBlur={[Function]}
         onFocus={[Function]}
-        role="button"
+        role="none"
         style={
           {
             "overflow": "hidden",
@@ -1104,7 +1104,7 @@ exports[`renders extended FAB transitioning to collapsed 1`] = `
         focusable={false}
         onBlur={[Function]}
         onFocus={[Function]}
-        role="button"
+        role="none"
         style={
           {
             "overflow": "hidden",

--- a/src/components/__tests__/__snapshots__/FABExtended.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FABExtended.test.tsx.snap
@@ -53,47 +53,17 @@ exports[`renders extended FAB collapsed 1`] = `
       }
     >
       <View
-        accessibilityLabel="New message"
-        accessibilityState={
-          {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": true,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
         accessible={true}
+        aria-label="New message"
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         role="button"
         style={
-          [
-            {
-              "overflow": "hidden",
-            },
-            [
-              null,
-              null,
-            ],
-          ]
+          {
+            "overflow": "hidden",
+          }
         }
         testID="extended-floating-action-button"
       >
@@ -292,47 +262,17 @@ exports[`renders extended FAB expanded 1`] = `
       }
     >
       <View
-        accessibilityLabel="New message"
-        accessibilityState={
-          {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": true,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
         accessible={true}
+        aria-label="New message"
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         role="button"
         style={
-          [
-            {
-              "overflow": "hidden",
-            },
-            [
-              null,
-              null,
-            ],
-          ]
+          {
+            "overflow": "hidden",
+          }
         }
         testID="extended-floating-action-button"
       >
@@ -531,47 +471,17 @@ exports[`renders extended FAB large size 1`] = `
       }
     >
       <View
-        accessibilityLabel="New message"
-        accessibilityState={
-          {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": true,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
         accessible={true}
+        aria-label="New message"
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         role="button"
         style={
-          [
-            {
-              "overflow": "hidden",
-            },
-            [
-              null,
-              null,
-            ],
-          ]
+          {
+            "overflow": "hidden",
+          }
         }
         testID="extended-floating-action-button"
       >
@@ -770,47 +680,17 @@ exports[`renders extended FAB medium size 1`] = `
       }
     >
       <View
-        accessibilityLabel="New message"
-        accessibilityState={
-          {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": true,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
         accessible={true}
+        aria-label="New message"
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         role="button"
         style={
-          [
-            {
-              "overflow": "hidden",
-            },
-            [
-              null,
-              null,
-            ],
-          ]
+          {
+            "overflow": "hidden",
+          }
         }
         testID="extended-floating-action-button"
       >
@@ -1009,47 +889,17 @@ exports[`renders extended FAB not visible 1`] = `
       }
     >
       <View
-        accessibilityLabel="New message"
-        accessibilityState={
-          {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": true,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
         accessible={true}
+        aria-label="New message"
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         role="button"
         style={
-          [
-            {
-              "overflow": "hidden",
-            },
-            [
-              null,
-              null,
-            ],
-          ]
+          {
+            "overflow": "hidden",
+          }
         }
         testID="extended-floating-action-button"
       >
@@ -1248,47 +1098,17 @@ exports[`renders extended FAB transitioning to collapsed 1`] = `
       }
     >
       <View
-        accessibilityLabel="New message"
-        accessibilityState={
-          {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": true,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessibilityValue={
-          {
-            "max": undefined,
-            "min": undefined,
-            "now": undefined,
-            "text": undefined,
-          }
-        }
         accessible={true}
+        aria-label="New message"
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onBlur={[Function]}
-        onClick={[Function]}
         onFocus={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         role="button"
         style={
-          [
-            {
-              "overflow": "hidden",
-            },
-            [
-              null,
-              null,
-            ],
-          ]
+          {
+            "overflow": "hidden",
+          }
         }
         testID="extended-floating-action-button"
       >

--- a/src/components/__tests__/__snapshots__/FABMenu.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FABMenu.test.tsx.snap
@@ -498,7 +498,7 @@ exports[`renders FAB.Menu closed 1`] = `
             focusable={false}
             onBlur={[Function]}
             onFocus={[Function]}
-            role="button"
+            role="none"
             style={
               {
                 "flex": 1,
@@ -1152,7 +1152,7 @@ exports[`renders FAB.Menu not expanded when trigger is not visible 1`] = `
             focusable={false}
             onBlur={[Function]}
             onFocus={[Function]}
-            role="button"
+            role="none"
             style={
               {
                 "flex": 1,

--- a/src/components/__tests__/__snapshots__/FABMenu.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FABMenu.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`renders FAB.Menu closed 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -269,7 +269,7 @@ exports[`renders FAB.Menu closed 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -493,48 +493,17 @@ exports[`renders FAB.Menu closed 1`] = `
             }
           />
           <View
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": true,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
             accessible={true}
             collapsable={false}
-            focusable={true}
+            focusable={false}
             onBlur={[Function]}
-            onClick={[Function]}
             onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             role="button"
             style={
-              [
-                {
-                  "overflow": "hidden",
-                },
-                [
-                  {
-                    "flex": 1,
-                  },
-                  null,
-                ],
-              ]
+              {
+                "flex": 1,
+                "overflow": "hidden",
+              }
             }
             testID="fab-shell"
           >
@@ -789,7 +758,7 @@ exports[`renders FAB.Menu not expanded when trigger is not visible 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -954,7 +923,7 @@ exports[`renders FAB.Menu not expanded when trigger is not visible 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -1178,48 +1147,17 @@ exports[`renders FAB.Menu not expanded when trigger is not visible 1`] = `
             }
           />
           <View
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": true,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
             accessible={true}
             collapsable={false}
-            focusable={true}
+            focusable={false}
             onBlur={[Function]}
-            onClick={[Function]}
             onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             role="button"
             style={
-              [
-                {
-                  "overflow": "hidden",
-                },
-                [
-                  {
-                    "flex": 1,
-                  },
-                  null,
-                ],
-              ]
+              {
+                "flex": 1,
+                "overflow": "hidden",
+              }
             }
             testID="fab-shell"
           >
@@ -1474,7 +1412,7 @@ exports[`renders FAB.Menu open 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -1639,7 +1577,7 @@ exports[`renders FAB.Menu open 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -1867,7 +1805,7 @@ exports[`renders FAB.Menu open 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": false,
+                "disabled": undefined,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -2159,7 +2097,7 @@ exports[`renders FAB.Menu with 6 items 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -2324,7 +2262,7 @@ exports[`renders FAB.Menu with 6 items 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -2489,7 +2427,7 @@ exports[`renders FAB.Menu with 6 items 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -2654,7 +2592,7 @@ exports[`renders FAB.Menu with 6 items 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -2819,7 +2757,7 @@ exports[`renders FAB.Menu with 6 items 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -2984,7 +2922,7 @@ exports[`renders FAB.Menu with 6 items 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -3212,7 +3150,7 @@ exports[`renders FAB.Menu with 6 items 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": false,
+                "disabled": undefined,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -3505,7 +3443,7 @@ exports[`renders FAB.Menu with center alignment 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -3670,7 +3608,7 @@ exports[`renders FAB.Menu with center alignment 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -3898,7 +3836,7 @@ exports[`renders FAB.Menu with center alignment 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": false,
+                "disabled": undefined,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -4190,7 +4128,7 @@ exports[`renders FAB.Menu with items having icons 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -4384,7 +4322,7 @@ exports[`renders FAB.Menu with items having icons 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -4641,7 +4579,7 @@ exports[`renders FAB.Menu with items having icons 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": false,
+                "disabled": undefined,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -4933,7 +4871,7 @@ exports[`renders FAB.Menu with start alignment 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -5098,7 +5036,7 @@ exports[`renders FAB.Menu with start alignment 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -5326,7 +5264,7 @@ exports[`renders FAB.Menu with start alignment 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": false,
+                "disabled": undefined,
                 "expanded": undefined,
                 "selected": undefined,
               }

--- a/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
@@ -198,7 +198,7 @@ exports[`renders icon button by default 1`] = `
           "top": 6,
         }
       }
-      role="button"
+      role="none"
       style={
         {
           "alignItems": "center",
@@ -307,7 +307,7 @@ exports[`renders icon button with color 1`] = `
           "top": 6,
         }
       }
-      role="button"
+      role="none"
       style={
         {
           "alignItems": "center",
@@ -416,7 +416,7 @@ exports[`renders icon button with size 1`] = `
           "top": 6,
         }
       }
-      role="button"
+      role="none"
       style={
         {
           "alignItems": "center",
@@ -525,7 +525,7 @@ exports[`renders icon change animated 1`] = `
           "top": 6,
         }
       }
-      role="button"
+      role="none"
       style={
         {
           "alignItems": "center",

--- a/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
@@ -186,27 +186,10 @@ exports[`renders icon button by default 1`] = `
     testID="icon-button-container"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       centered={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       hitSlop={
         {
           "bottom": 6,
@@ -215,30 +198,14 @@ exports[`renders icon button by default 1`] = `
           "top": 6,
         }
       }
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            {
-              "alignItems": "center",
-              "flexGrow": 1,
-              "justifyContent": "center",
-            },
-            undefined,
-          ],
-        ]
+        {
+          "alignItems": "center",
+          "flexGrow": 1,
+          "justifyContent": "center",
+          "overflow": "hidden",
+        }
       }
       testID="icon-button"
     >
@@ -328,27 +295,10 @@ exports[`renders icon button with color 1`] = `
     testID="icon-button-container"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       centered={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       hitSlop={
         {
           "bottom": 6,
@@ -357,30 +307,14 @@ exports[`renders icon button with color 1`] = `
           "top": 6,
         }
       }
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            {
-              "alignItems": "center",
-              "flexGrow": 1,
-              "justifyContent": "center",
-            },
-            undefined,
-          ],
-        ]
+        {
+          "alignItems": "center",
+          "flexGrow": 1,
+          "justifyContent": "center",
+          "overflow": "hidden",
+        }
       }
       testID="icon-button"
     >
@@ -470,27 +404,10 @@ exports[`renders icon button with size 1`] = `
     testID="icon-button-container"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       centered={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       hitSlop={
         {
           "bottom": 6,
@@ -499,30 +416,14 @@ exports[`renders icon button with size 1`] = `
           "top": 6,
         }
       }
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            {
-              "alignItems": "center",
-              "flexGrow": 1,
-              "justifyContent": "center",
-            },
-            undefined,
-          ],
-        ]
+        {
+          "alignItems": "center",
+          "flexGrow": 1,
+          "justifyContent": "center",
+          "overflow": "hidden",
+        }
       }
       testID="icon-button"
     >
@@ -612,27 +513,10 @@ exports[`renders icon change animated 1`] = `
     testID="icon-button-container"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
       accessible={true}
       centered={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       hitSlop={
         {
           "bottom": 6,
@@ -641,30 +525,14 @@ exports[`renders icon change animated 1`] = `
           "top": 6,
         }
       }
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       role="button"
       style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            {
-              "alignItems": "center",
-              "flexGrow": 1,
-              "justifyContent": "center",
-            },
-            undefined,
-          ],
-        ]
+        {
+          "alignItems": "center",
+          "flexGrow": 1,
+          "justifyContent": "center",
+          "overflow": "hidden",
+        }
       }
       testID="icon-button"
     >

--- a/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
@@ -106,6 +106,7 @@ exports[`renders disabled icon button 1`] = `
             "opacity": 0.38,
           }
         }
+        testID="icon-button-icon-opacity"
       >
         <Text
           accessibilityElementsHidden={true}
@@ -215,6 +216,7 @@ exports[`renders icon button by default 1`] = `
             "opacity": 1,
           }
         }
+        testID="icon-button-icon-opacity"
       >
         <Text
           accessibilityElementsHidden={true}
@@ -324,6 +326,7 @@ exports[`renders icon button with color 1`] = `
             "opacity": 1,
           }
         }
+        testID="icon-button-icon-opacity"
       >
         <Text
           accessibilityElementsHidden={true}
@@ -433,6 +436,7 @@ exports[`renders icon button with size 1`] = `
             "opacity": 1,
           }
         }
+        testID="icon-button-icon-opacity"
       >
         <Text
           accessibilityElementsHidden={true}
@@ -542,6 +546,7 @@ exports[`renders icon change animated 1`] = `
             "opacity": 1,
           }
         }
+        testID="icon-button-icon-opacity"
       >
         <View
           style={

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`renders expanded accordion 1`] = `
         {
           "busy": undefined,
           "checked": undefined,
-          "disabled": false,
+          "disabled": undefined,
           "expanded": true,
           "selected": undefined,
         }
@@ -158,46 +158,14 @@ exports[`renders expanded accordion 1`] = `
     </View>
   </View>
   <View
-    accessibilityState={
-      {
-        "busy": undefined,
-        "checked": undefined,
-        "disabled": true,
-        "expanded": undefined,
-        "selected": undefined,
-      }
-    }
-    accessibilityValue={
-      {
-        "max": undefined,
-        "min": undefined,
-        "now": undefined,
-        "text": undefined,
-      }
-    }
     accessible={true}
     collapsable={false}
-    focusable={true}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
+    focusable={false}
     style={
-      [
-        false,
-        [
-          {
-            "paddingRight": 24,
-            "paddingVertical": 8,
-          },
-          undefined,
-        ],
-      ]
+      {
+        "paddingRight": 24,
+        "paddingVertical": 8,
+      }
     }
   >
     <View
@@ -279,7 +247,7 @@ exports[`renders list accordion with children 1`] = `
         {
           "busy": undefined,
           "checked": undefined,
-          "disabled": false,
+          "disabled": undefined,
           "expanded": false,
           "selected": undefined,
         }
@@ -486,7 +454,7 @@ exports[`renders list accordion with custom title and description styles 1`] = `
         {
           "busy": undefined,
           "checked": undefined,
-          "disabled": false,
+          "disabled": undefined,
           "expanded": false,
           "selected": undefined,
         }
@@ -686,7 +654,7 @@ exports[`renders list accordion with left items 1`] = `
         {
           "busy": undefined,
           "checked": undefined,
-          "disabled": false,
+          "disabled": undefined,
           "expanded": false,
           "selected": undefined,
         }
@@ -893,7 +861,7 @@ exports[`renders multiline list accordion 1`] = `
         {
           "busy": undefined,
           "checked": undefined,
-          "disabled": false,
+          "disabled": undefined,
           "expanded": false,
           "selected": undefined,
         }

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -2,46 +2,14 @@
 
 exports[`renders list item with custom description 1`] = `
 <View
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": undefined,
-      "disabled": true,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
   accessible={true}
   collapsable={false}
-  focusable={true}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
+  focusable={false}
   style={
-    [
-      false,
-      [
-        {
-          "paddingRight": 24,
-          "paddingVertical": 8,
-        },
-        undefined,
-      ],
-    ]
+    {
+      "paddingRight": 24,
+      "paddingVertical": 8,
+    }
   }
   testID="list-item"
 >
@@ -328,46 +296,14 @@ exports[`renders list item with custom description 1`] = `
 
 exports[`renders list item with custom title and description styles 1`] = `
 <View
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": undefined,
-      "disabled": true,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
   accessible={true}
   collapsable={false}
-  focusable={true}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
+  focusable={false}
   style={
-    [
-      false,
-      [
-        {
-          "paddingRight": 24,
-          "paddingVertical": 8,
-        },
-        undefined,
-      ],
-    ]
+    {
+      "paddingRight": 24,
+      "paddingVertical": 8,
+    }
   }
   testID="list-item"
 >
@@ -473,46 +409,14 @@ exports[`renders list item with custom title and description styles 1`] = `
 
 exports[`renders list item with left and right items 1`] = `
 <View
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": undefined,
-      "disabled": true,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
   accessible={true}
   collapsable={false}
-  focusable={true}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
+  focusable={false}
   style={
-    [
-      false,
-      [
-        {
-          "paddingRight": 24,
-          "paddingVertical": 8,
-        },
-        undefined,
-      ],
-    ]
+    {
+      "paddingRight": 24,
+      "paddingVertical": 8,
+    }
   }
   testID="list-item"
 >
@@ -663,46 +567,14 @@ exports[`renders list item with left and right items 1`] = `
 
 exports[`renders list item with left item 1`] = `
 <View
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": undefined,
-      "disabled": true,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
   accessible={true}
   collapsable={false}
-  focusable={true}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
+  focusable={false}
   style={
-    [
-      false,
-      [
-        {
-          "paddingRight": 24,
-          "paddingVertical": 8,
-        },
-        undefined,
-      ],
-    ]
+    {
+      "paddingRight": 24,
+      "paddingVertical": 8,
+    }
   }
   testID="list-item"
 >
@@ -819,46 +691,14 @@ exports[`renders list item with left item 1`] = `
 
 exports[`renders list item with right item 1`] = `
 <View
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": undefined,
-      "disabled": true,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
   accessible={true}
   collapsable={false}
-  focusable={true}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
+  focusable={false}
   style={
-    [
-      false,
-      [
-        {
-          "paddingRight": 24,
-          "paddingVertical": 8,
-        },
-        undefined,
-      ],
-    ]
+    {
+      "paddingRight": 24,
+      "paddingVertical": 8,
+    }
   }
   testID="list-item"
 >
@@ -931,46 +771,14 @@ exports[`renders list item with right item 1`] = `
 
 exports[`renders list item with title and description 1`] = `
 <View
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": undefined,
-      "disabled": true,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
   accessible={true}
   collapsable={false}
-  focusable={true}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
+  focusable={false}
   style={
-    [
-      false,
-      [
-        {
-          "paddingRight": 24,
-          "paddingVertical": 8,
-        },
-        undefined,
-      ],
-    ]
+    {
+      "paddingRight": 24,
+      "paddingVertical": 8,
+    }
   }
   testID="list-item"
 >
@@ -1072,46 +880,14 @@ exports[`renders list item with title and description 1`] = `
 
 exports[`renders with a description with typeof number 1`] = `
 <View
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": undefined,
-      "disabled": true,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
   accessible={true}
   collapsable={false}
-  focusable={true}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
+  focusable={false}
   style={
-    [
-      false,
-      [
-        {
-          "paddingRight": 24,
-          "paddingVertical": 8,
-        },
-        undefined,
-      ],
-    ]
+    {
+      "paddingRight": 24,
+      "paddingVertical": 8,
+    }
   }
   testID="list-item"
 >

--- a/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
@@ -454,46 +454,14 @@ exports[`renders list section with custom title style 1`] = `
     Some title
   </Text>
   <View
-    accessibilityState={
-      {
-        "busy": undefined,
-        "checked": undefined,
-        "disabled": true,
-        "expanded": undefined,
-        "selected": undefined,
-      }
-    }
-    accessibilityValue={
-      {
-        "max": undefined,
-        "min": undefined,
-        "now": undefined,
-        "text": undefined,
-      }
-    }
     accessible={true}
     collapsable={false}
-    focusable={true}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
+    focusable={false}
     style={
-      [
-        false,
-        [
-          {
-            "paddingRight": 24,
-            "paddingVertical": 8,
-          },
-          undefined,
-        ],
-      ]
+      {
+        "paddingRight": 24,
+        "paddingVertical": 8,
+      }
     }
     testID="list-item"
   >
@@ -607,46 +575,14 @@ exports[`renders list section with custom title style 1`] = `
     </View>
   </View>
   <View
-    accessibilityState={
-      {
-        "busy": undefined,
-        "checked": undefined,
-        "disabled": true,
-        "expanded": undefined,
-        "selected": undefined,
-      }
-    }
-    accessibilityValue={
-      {
-        "max": undefined,
-        "min": undefined,
-        "now": undefined,
-        "text": undefined,
-      }
-    }
     accessible={true}
     collapsable={false}
-    focusable={true}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
+    focusable={false}
     style={
-      [
-        false,
-        [
-          {
-            "paddingRight": 24,
-            "paddingVertical": 8,
-          },
-          undefined,
-        ],
-      ]
+      {
+        "paddingRight": 24,
+        "paddingVertical": 8,
+      }
     }
     testID="list-item"
   >
@@ -1214,46 +1150,14 @@ exports[`renders list section with subheader 1`] = `
     Some title
   </Text>
   <View
-    accessibilityState={
-      {
-        "busy": undefined,
-        "checked": undefined,
-        "disabled": true,
-        "expanded": undefined,
-        "selected": undefined,
-      }
-    }
-    accessibilityValue={
-      {
-        "max": undefined,
-        "min": undefined,
-        "now": undefined,
-        "text": undefined,
-      }
-    }
     accessible={true}
     collapsable={false}
-    focusable={true}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
+    focusable={false}
     style={
-      [
-        false,
-        [
-          {
-            "paddingRight": 24,
-            "paddingVertical": 8,
-          },
-          undefined,
-        ],
-      ]
+      {
+        "paddingRight": 24,
+        "paddingVertical": 8,
+      }
     }
     testID="list-item"
   >
@@ -1367,46 +1271,14 @@ exports[`renders list section with subheader 1`] = `
     </View>
   </View>
   <View
-    accessibilityState={
-      {
-        "busy": undefined,
-        "checked": undefined,
-        "disabled": true,
-        "expanded": undefined,
-        "selected": undefined,
-      }
-    }
-    accessibilityValue={
-      {
-        "max": undefined,
-        "min": undefined,
-        "now": undefined,
-        "text": undefined,
-      }
-    }
     accessible={true}
     collapsable={false}
-    focusable={true}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
+    focusable={false}
     style={
-      [
-        false,
-        [
-          {
-            "paddingRight": 24,
-            "paddingVertical": 8,
-          },
-          undefined,
-        ],
-      ]
+      {
+        "paddingRight": 24,
+        "paddingVertical": 8,
+      }
     }
     testID="list-item"
   >
@@ -1934,46 +1806,14 @@ exports[`renders list section without subheader 1`] = `
   }
 >
   <View
-    accessibilityState={
-      {
-        "busy": undefined,
-        "checked": undefined,
-        "disabled": true,
-        "expanded": undefined,
-        "selected": undefined,
-      }
-    }
-    accessibilityValue={
-      {
-        "max": undefined,
-        "min": undefined,
-        "now": undefined,
-        "text": undefined,
-      }
-    }
     accessible={true}
     collapsable={false}
-    focusable={true}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
+    focusable={false}
     style={
-      [
-        false,
-        [
-          {
-            "paddingRight": 24,
-            "paddingVertical": 8,
-          },
-          undefined,
-        ],
-      ]
+      {
+        "paddingRight": 24,
+        "paddingVertical": 8,
+      }
     }
     testID="list-item"
   >
@@ -2087,46 +1927,14 @@ exports[`renders list section without subheader 1`] = `
     </View>
   </View>
   <View
-    accessibilityState={
-      {
-        "busy": undefined,
-        "checked": undefined,
-        "disabled": true,
-        "expanded": undefined,
-        "selected": undefined,
-      }
-    }
-    accessibilityValue={
-      {
-        "max": undefined,
-        "min": undefined,
-        "now": undefined,
-        "text": undefined,
-      }
-    }
     accessible={true}
     collapsable={false}
-    focusable={true}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
+    focusable={false}
     style={
-      [
-        false,
-        [
-          {
-            "paddingRight": 24,
-            "paddingVertical": 8,
-          },
-          undefined,
-        ],
-      ]
+      {
+        "paddingRight": 24,
+        "paddingVertical": 8,
+      }
     }
     testID="list-item"
   >

--- a/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`renders menu with content styles 1`] = `
             accessible={true}
             collapsable={false}
             focusable={false}
-            role="button"
+            role="none"
             style={
               {
                 "borderRadius": 19,
@@ -590,7 +590,7 @@ exports[`renders not visible menu 1`] = `
           accessible={true}
           collapsable={false}
           focusable={false}
-          role="button"
+          role="none"
           style={
             {
               "borderRadius": 19,
@@ -728,7 +728,7 @@ exports[`renders visible menu 1`] = `
             accessible={true}
             collapsable={false}
             focusable={false}
-            role="button"
+            role="none"
             style={
               {
                 "borderRadius": 19,

--- a/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -54,45 +54,15 @@ exports[`renders menu with content styles 1`] = `
           testID="button-container"
         >
           <View
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": true,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
             accessible={true}
             collapsable={false}
-            focusable={true}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+            focusable={false}
             role="button"
             style={
-              [
-                {
-                  "overflow": "hidden",
-                },
-                {
-                  "borderRadius": 19,
-                },
-              ]
+              {
+                "borderRadius": 19,
+                "overflow": "hidden",
+              }
             }
             testID="button"
           >
@@ -313,7 +283,7 @@ exports[`renders menu with content styles 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -437,7 +407,7 @@ exports[`renders menu with content styles 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -617,45 +587,15 @@ exports[`renders not visible menu 1`] = `
         testID="button-container"
       >
         <View
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": true,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
           accessible={true}
           collapsable={false}
-          focusable={true}
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
+          focusable={false}
           role="button"
           style={
-            [
-              {
-                "overflow": "hidden",
-              },
-              {
-                "borderRadius": 19,
-              },
-            ]
+            {
+              "borderRadius": 19,
+              "overflow": "hidden",
+            }
           }
           testID="button"
         >
@@ -785,45 +725,15 @@ exports[`renders visible menu 1`] = `
           testID="button-container"
         >
           <View
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": true,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
             accessible={true}
             collapsable={false}
-            focusable={true}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
+            focusable={false}
             role="button"
             style={
-              [
-                {
-                  "overflow": "hidden",
-                },
-                {
-                  "borderRadius": 19,
-                },
-              ]
+              {
+                "borderRadius": 19,
+                "overflow": "hidden",
+              }
             }
             testID="button"
           >
@@ -1040,7 +950,7 @@ exports[`renders visible menu 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }
@@ -1164,7 +1074,7 @@ exports[`renders visible menu 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }

--- a/src/components/__tests__/__snapshots__/MenuItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/MenuItem.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Menu Item renders menu item 1`] = `
       {
         "busy": undefined,
         "checked": undefined,
-        "disabled": false,
+        "disabled": undefined,
         "expanded": undefined,
         "selected": undefined,
       }
@@ -171,7 +171,7 @@ exports[`Menu Item renders menu item 1`] = `
       {
         "busy": undefined,
         "checked": undefined,
-        "disabled": false,
+        "disabled": undefined,
         "expanded": undefined,
         "selected": undefined,
       }
@@ -663,7 +663,7 @@ exports[`Menu Item renders menu item 1`] = `
       {
         "busy": undefined,
         "checked": undefined,
-        "disabled": false,
+        "disabled": undefined,
         "expanded": undefined,
         "selected": undefined,
       }

--- a/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`activity indicator snapshot test 1`] = `
               "top": 6,
             }
           }
-          role="button"
+          role="none"
           style={
             {
               "alignItems": "center",
@@ -473,7 +473,7 @@ exports[`renders with placeholder 1`] = `
               "top": 6,
             }
           }
-          role="button"
+          role="none"
           style={
             {
               "alignItems": "center",
@@ -813,7 +813,7 @@ exports[`renders with text 1`] = `
               "top": 6,
             }
           }
-          role="button"
+          role="none"
           style={
             {
               "alignItems": "center",

--- a/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
@@ -111,6 +111,7 @@ exports[`activity indicator snapshot test 1`] = `
                 "opacity": 1,
               }
             }
+            testID="search-bar-icon-icon-opacity"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -490,6 +491,7 @@ exports[`renders with placeholder 1`] = `
                 "opacity": 1,
               }
             }
+            testID="search-bar-icon-icon-opacity"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -680,6 +682,7 @@ exports[`renders with placeholder 1`] = `
                   "opacity": 1,
                 }
               }
+              testID="search-bar-clear-icon-icon-opacity"
             >
               <Text
                 accessibilityElementsHidden={true}
@@ -830,6 +833,7 @@ exports[`renders with text 1`] = `
                 "opacity": 1,
               }
             }
+            testID="search-bar-icon-icon-opacity"
           >
             <Text
               accessibilityElementsHidden={true}
@@ -1016,6 +1020,7 @@ exports[`renders with text 1`] = `
                   "opacity": 1,
                 }
               }
+              testID="search-bar-clear-icon-icon-opacity"
             >
               <Text
                 accessibilityElementsHidden={true}

--- a/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
@@ -81,28 +81,11 @@ exports[`activity indicator snapshot test 1`] = `
         testID="search-bar-icon-container"
       >
         <View
-          accessibilityLabel="search"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": true,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
           accessible={true}
+          aria-label="search"
           centered={true}
           collapsable={false}
-          focusable={true}
+          focusable={false}
           hitSlop={
             {
               "bottom": 6,
@@ -111,30 +94,14 @@ exports[`activity indicator snapshot test 1`] = `
               "top": 6,
             }
           }
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           role="button"
           style={
-            [
-              {
-                "overflow": "hidden",
-              },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                undefined,
-              ],
-            ]
+            {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+              "overflow": "hidden",
+            }
           }
           testID="search-bar-icon"
         >
@@ -493,28 +460,11 @@ exports[`renders with placeholder 1`] = `
         testID="search-bar-icon-container"
       >
         <View
-          accessibilityLabel="search"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": true,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
           accessible={true}
+          aria-label="search"
           centered={true}
           collapsable={false}
-          focusable={true}
+          focusable={false}
           hitSlop={
             {
               "bottom": 6,
@@ -523,30 +473,14 @@ exports[`renders with placeholder 1`] = `
               "top": 6,
             }
           }
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           role="button"
           style={
-            [
-              {
-                "overflow": "hidden",
-              },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                undefined,
-              ],
-            ]
+            {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+              "overflow": "hidden",
+            }
           }
           testID="search-bar-icon"
         >
@@ -688,7 +622,7 @@ exports[`renders with placeholder 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": false,
+                "disabled": undefined,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -866,28 +800,11 @@ exports[`renders with text 1`] = `
         testID="search-bar-icon-container"
       >
         <View
-          accessibilityLabel="search"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": true,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
           accessible={true}
+          aria-label="search"
           centered={true}
           collapsable={false}
-          focusable={true}
+          focusable={false}
           hitSlop={
             {
               "bottom": 6,
@@ -896,30 +813,14 @@ exports[`renders with text 1`] = `
               "top": 6,
             }
           }
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           role="button"
           style={
-            [
-              {
-                "overflow": "hidden",
-              },
-              [
-                {
-                  "alignItems": "center",
-                  "flexGrow": 1,
-                  "justifyContent": "center",
-                },
-                undefined,
-              ],
-            ]
+            {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+              "overflow": "hidden",
+            }
           }
           testID="search-bar-icon"
         >
@@ -1057,7 +958,7 @@ exports[`renders with text 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": false,
+                "disabled": undefined,
                 "expanded": undefined,
                 "selected": undefined,
               }

--- a/src/components/__tests__/__snapshots__/SegmentedButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/SegmentedButton.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`renders segmented button 1`] = `
         {
           "busy": undefined,
           "checked": true,
-          "disabled": false,
+          "disabled": undefined,
           "expanded": undefined,
           "selected": undefined,
         }
@@ -167,7 +167,7 @@ exports[`renders segmented button 1`] = `
         {
           "busy": undefined,
           "checked": false,
-          "disabled": false,
+          "disabled": undefined,
           "expanded": undefined,
           "selected": undefined,
         }

--- a/src/components/__tests__/__snapshots__/Snackbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.tsx.snap
@@ -364,7 +364,7 @@ exports[`renders snackbar with action button 1`] = `
                 {
                   "busy": undefined,
                   "checked": undefined,
-                  "disabled": false,
+                  "disabled": undefined,
                   "expanded": undefined,
                   "selected": undefined,
                 }

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -189,7 +189,6 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
         >
           <View
             accessible={true}
-            aria-disabled={false}
             centered={true}
             collapsable={false}
             focusable={false}
@@ -202,7 +201,7 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
               }
             }
             multiline={false}
-            role="button"
+            role="none"
             style={
               {
                 "alignItems": "center",
@@ -362,7 +361,6 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
         >
           <View
             accessible={true}
-            aria-disabled={false}
             centered={true}
             collapsable={false}
             focusable={false}
@@ -375,7 +373,7 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
               }
             }
             multiline={false}
-            role="button"
+            role="none"
             style={
               {
                 "alignItems": "center",
@@ -627,7 +625,6 @@ exports[`renders filled TextInput with TextInput.Icon accessories when error is 
         >
           <View
             accessible={true}
-            aria-disabled={false}
             centered={true}
             collapsable={false}
             focusable={false}
@@ -640,7 +637,7 @@ exports[`renders filled TextInput with TextInput.Icon accessories when error is 
               }
             }
             multiline={false}
-            role="button"
+            role="none"
             style={
               {
                 "alignItems": "center",
@@ -1274,7 +1271,6 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
         >
           <View
             accessible={true}
-            aria-disabled={false}
             centered={true}
             collapsable={false}
             focusable={false}
@@ -1287,7 +1283,7 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
               }
             }
             multiline={false}
-            role="button"
+            role="none"
             style={
               {
                 "alignItems": "center",
@@ -1447,7 +1443,6 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
         >
           <View
             accessible={true}
-            aria-disabled={false}
             centered={true}
             collapsable={false}
             focusable={false}
@@ -1460,7 +1455,7 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
               }
             }
             multiline={false}
-            role="button"
+            role="none"
             style={
               {
                 "alignItems": "center",
@@ -1693,7 +1688,6 @@ exports[`renders outlined TextInput with TextInput.Icon accessories when error i
         >
           <View
             accessible={true}
-            aria-disabled={false}
             centered={true}
             collapsable={false}
             focusable={false}
@@ -1706,7 +1700,7 @@ exports[`renders outlined TextInput with TextInput.Icon accessories when error i
               }
             }
             multiline={false}
-            role="button"
+            role="none"
             style={
               {
                 "alignItems": "center",

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -188,27 +188,11 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
           testID="icon-button-container"
         >
           <View
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": true,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
             accessible={true}
+            aria-disabled={false}
             centered={true}
             collapsable={false}
-            focusable={true}
+            focusable={false}
             hitSlop={
               {
                 "bottom": 6,
@@ -218,30 +202,14 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
               }
             }
             multiline={false}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             role="button"
             style={
-              [
-                {
-                  "overflow": "hidden",
-                },
-                [
-                  {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                  },
-                  undefined,
-                ],
-              ]
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+                "overflow": "hidden",
+              }
             }
             testID="icon-button"
           >
@@ -393,27 +361,11 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
           testID="icon-button-container"
         >
           <View
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": true,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
             accessible={true}
+            aria-disabled={false}
             centered={true}
             collapsable={false}
-            focusable={true}
+            focusable={false}
             hitSlop={
               {
                 "bottom": 6,
@@ -423,30 +375,14 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
               }
             }
             multiline={false}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             role="button"
             style={
-              [
-                {
-                  "overflow": "hidden",
-                },
-                [
-                  {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                  },
-                  undefined,
-                ],
-              ]
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+                "overflow": "hidden",
+              }
             }
             testID="icon-button"
           >
@@ -690,27 +626,11 @@ exports[`renders filled TextInput with TextInput.Icon accessories when error is 
           testID="icon-button-container"
         >
           <View
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": true,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
             accessible={true}
+            aria-disabled={false}
             centered={true}
             collapsable={false}
-            focusable={true}
+            focusable={false}
             hitSlop={
               {
                 "bottom": 6,
@@ -720,30 +640,14 @@ exports[`renders filled TextInput with TextInput.Icon accessories when error is 
               }
             }
             multiline={false}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             role="button"
             style={
-              [
-                {
-                  "overflow": "hidden",
-                },
-                [
-                  {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                  },
-                  undefined,
-                ],
-              ]
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+                "overflow": "hidden",
+              }
             }
             testID="icon-button"
           >
@@ -1369,27 +1273,11 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
           testID="icon-button-container"
         >
           <View
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": true,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
             accessible={true}
+            aria-disabled={false}
             centered={true}
             collapsable={false}
-            focusable={true}
+            focusable={false}
             hitSlop={
               {
                 "bottom": 6,
@@ -1399,30 +1287,14 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
               }
             }
             multiline={false}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             role="button"
             style={
-              [
-                {
-                  "overflow": "hidden",
-                },
-                [
-                  {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                  },
-                  undefined,
-                ],
-              ]
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+                "overflow": "hidden",
+              }
             }
             testID="icon-button"
           >
@@ -1574,27 +1446,11 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
           testID="icon-button-container"
         >
           <View
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": true,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
             accessible={true}
+            aria-disabled={false}
             centered={true}
             collapsable={false}
-            focusable={true}
+            focusable={false}
             hitSlop={
               {
                 "bottom": 6,
@@ -1604,30 +1460,14 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
               }
             }
             multiline={false}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             role="button"
             style={
-              [
-                {
-                  "overflow": "hidden",
-                },
-                [
-                  {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                  },
-                  undefined,
-                ],
-              ]
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+                "overflow": "hidden",
+              }
             }
             testID="icon-button"
           >
@@ -1852,27 +1692,11 @@ exports[`renders outlined TextInput with TextInput.Icon accessories when error i
           testID="icon-button-container"
         >
           <View
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": true,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
             accessible={true}
+            aria-disabled={false}
             centered={true}
             collapsable={false}
-            focusable={true}
+            focusable={false}
             hitSlop={
               {
                 "bottom": 6,
@@ -1882,30 +1706,14 @@ exports[`renders outlined TextInput with TextInput.Icon accessories when error i
               }
             }
             multiline={false}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             role="button"
             style={
-              [
-                {
-                  "overflow": "hidden",
-                },
-                [
-                  {
-                    "alignItems": "center",
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                  },
-                  undefined,
-                ],
-              ]
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+                "overflow": "hidden",
+              }
             }
             testID="icon-button"
           >

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -218,6 +218,7 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
                   "opacity": 1,
                 }
               }
+              testID="icon-button-icon-opacity"
             >
               <Text
                 accessibilityElementsHidden={true}
@@ -390,6 +391,7 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
                   "opacity": 1,
                 }
               }
+              testID="icon-button-icon-opacity"
             >
               <Text
                 accessibilityElementsHidden={true}
@@ -654,6 +656,7 @@ exports[`renders filled TextInput with TextInput.Icon accessories when error is 
                   "opacity": 1,
                 }
               }
+              testID="icon-button-icon-opacity"
             >
               <Text
                 accessibilityElementsHidden={true}
@@ -859,6 +862,7 @@ exports[`renders filled TextInput with TextInput.Icon accessories when error is 
                   "opacity": 1,
                 }
               }
+              testID="icon-button-icon-opacity"
             >
               <Text
                 accessibilityElementsHidden={true}
@@ -1300,6 +1304,7 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
                   "opacity": 1,
                 }
               }
+              testID="icon-button-icon-opacity"
             >
               <Text
                 accessibilityElementsHidden={true}
@@ -1472,6 +1477,7 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
                   "opacity": 1,
                 }
               }
+              testID="icon-button-icon-opacity"
             >
               <Text
                 accessibilityElementsHidden={true}
@@ -1717,6 +1723,7 @@ exports[`renders outlined TextInput with TextInput.Icon accessories when error i
                   "opacity": 1,
                 }
               }
+              testID="icon-button-icon-opacity"
             >
               <Text
                 accessibilityElementsHidden={true}
@@ -1922,6 +1929,7 @@ exports[`renders outlined TextInput with TextInput.Icon accessories when error i
                   "opacity": 1,
                 }
               }
+              testID="icon-button-icon-opacity"
             >
               <Text
                 accessibilityElementsHidden={true}

--- a/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -104,6 +104,7 @@ exports[`renders disabled toggle button 1`] = `
             "opacity": 0.38,
           }
         }
+        testID="icon-button-icon-opacity"
       >
         <Text
           accessibilityElementsHidden={true}
@@ -244,6 +245,7 @@ exports[`renders toggle button 1`] = `
             "opacity": 1,
           }
         }
+        testID="icon-button-icon-opacity"
       >
         <Text
           accessibilityElementsHidden={true}
@@ -384,6 +386,7 @@ exports[`renders unchecked toggle button 1`] = `
             "opacity": 0.38,
           }
         }
+        testID="icon-button-icon-opacity"
       >
         <Text
           accessibilityElementsHidden={true}

--- a/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -188,7 +188,7 @@ exports[`renders toggle button 1`] = `
         {
           "busy": undefined,
           "checked": undefined,
-          "disabled": false,
+          "disabled": undefined,
           "expanded": undefined,
           "selected": true,
         }

--- a/src/utils/hasTouchHandler.tsx
+++ b/src/utils/hasTouchHandler.tsx
@@ -21,3 +21,15 @@ export default function hasTouchHandler(
     return Boolean(touchableEventObject[event]);
   });
 }
+
+/**
+ * Roles claiming the view can be activated. State bearing roles (`checkbox`,
+ * `radio`, `switch`) are excluded: those still describe a read only view.
+ */
+export const ACTIVATABLE_ROLES: readonly string[] = [
+  'button',
+  'imagebutton',
+  'link',
+  'menuitem',
+  'tab',
+];


### PR DESCRIPTION
### Motivation

`TouchableRipple` had `const disabled = disabledProp || !hasPassedTouchHandler`, so anything without a press handler got announced as a disabled control. Split into two flags:

```ts
const isControl = hasPassedTouchHandler || Boolean(disabledProp);
const isInteractive = hasPassedTouchHandler && !disabledProp;
```

Non-controls now render a plain `Animated.View` instead of a `Pressable`.

Worth knowing why it drops the `Pressable` instead of just passing the caller's `disabled` through: `disabled` also gates touch-responder claiming (`Pressability.js:448`, `onStartShouldSetResponder: () => !disabled`). Fixing only the announcement turns claiming *on*, so handler-less ripples start swallowing taps. `TextInput` wraps its field and icons in `<Pressable onPress={focusInput}>` (`TextInput.tsx:352`), so tapping a decorative icon stopped focusing the field. Tests stayed green through that.

Two things kept on purpose, both break stuff if dropped:
- `accessible={rest.accessible !== false}`, or a checked `CheckboxItem` with no handler loses its role and state.
- `focusable={rest.focusable ?? false}`, or on web the icon lands in the tab order, since RNW turns `role="button"` into a real `<button>`.

### Related issue

Closes #5070

Supersedes #5011, which fixes the same symptom in `Chip.tsx` only by injecting an empty `onPress`. That swaps a false "disabled" for a false "enabled" and leaves the other 21 consumers broken.

### Test plan

Lint, typecheck and tests pass: 55 suites, 742 tests, 169 snapshots.

The suite can't catch this though. It renders an element tree, never a DOM or a native view, and jest never loads `TouchableRipple.tsx` at all. So it's checked on device, example app, **TextInput** screen with "Leading icon" on. Leading magnifier has no handler, trailing clear button does.

| | announced disabled | tap reaches field | clear button still works |
| --- | --- | --- | --- |
| iOS 18.3 | `enabled: false` -> `true` | yes | yes |
| Android 15 | `enabled="false"` -> `"true"` | yes, 3/3 runs | yes |
| web | `<button disabled>` -> gone | yes | yes |

Web also keeps `tabindex="-1"` on the decorative icon.

Snapshots are noisy but mechanical: 80 elements drop the `Pressable` handlers and the always-`undefined` a11y scaffolding. Checked every style key/value pair, nothing net-added. Some `aria-*` show up raw now because `View.js` does that folding at runtime and the jest preset mocks `View`.

### Two extras, worth a look

`TextInputIcon` was faking disabled by nulling its own handler, which only worked because of this bug. Now passes `disabled` through.

`IconButton.getIconColor` returned on `disabled` before reading `customIconColor`, so once `TextInputIcon` forwarded `disabled` a disabled field's icon lost its custom and error colour. Reordered so an explicit colour wins, opacity still shows disabled. No snapshot churn, so nothing else passes both, but it is a public component behaviour change and the bit I'd most want checked.
