### PR TITLE
fix: add missing Platform import in MD3 font section

### DIFF
--- a/docs/5.x/docs/guides/fonts.md
+++ b/docs/5.x/docs/guides/fonts.md
@@ -418,6 +418,7 @@ import {
   MD3LightTheme,
   PaperProvider,
 } from 'react-native-paper';
+import { Platform } from 'react-native';
 import App from './App';
 
 const fontConfig = {


### PR DESCRIPTION
### Motivation
The customVariant example under "Material Design 3 -> Using configureFonts helper" uses Platform.select() but never imports Platform from react-native. Copy-pasting the code throws `ReferenceError: Platform is not defined`.

### Related issue
None.

### Test plan
Reproduced the ReferenceError by running the snippet as originally written (Platform used without import). Confirmed it's fixed by adding the import.