### PR TITLE
fix: remove hardcoded default testIDs from components

### DIFF
--- a/docs/6.x/docs/guides/migration.md
+++ b/docs/6.x/docs/guides/migration.md
@@ -71,12 +71,61 @@ You can use the component's color prop where available, or override the correspo
 
 ### Test IDs
 
-Some hardcoded and generated test IDs have been removed for the following components:
+Hardcoded default test IDs have been removed for the components listed below. Many of these components also derive test IDs for their internal parts by appending a suffix to the `testID` prop (e.g. `${testID}-container`). Since `testID` is no longer defaulted to a hardcoded value, none of these derived test IDs are set either unless you pass a `testID` explicitly — so all queries by the IDs below will stop matching:
 
-- `Appbar.Header`: `${testID}-root-layer`
-- `Surface`: `surface` and `${testID}-outer-layer`
+- `Appbar.Content`: `appbar-content`
+  - `appbar-content-title-text`
+- `Appbar.Header`: `appbar-header`
+  - `appbar-header-root-layer`
+- `BottomNavigation`: `bottom-navigation`
+  - `bottom-navigation-bar`
+- `BottomNavigation.Bar`: `bottom-navigation-bar`
+  - `bottom-navigation-bar-content`
+  - `bottom-navigation-bar-content-wrapper`
+- `Button`: `button`
+  - `button-container`
+  - `button-icon-container`
+  - `button-text`
+- `Card`: `card`
+  - `card-container`
+  - `card-outline`
+- `Chip`: `chip`
+  - `chip-container`
+- `Drawer.CollapsedItem`: `drawer-collapsed-item`
+  - `drawer-collapsed-item-outline`
+  - `drawer-collapsed-item-container`
+- `FAB`: `floating-action-button`
+  - `floating-action-button-container`
+  - `floating-action-button-text`
+- `FAB.Extended`: `extended-floating-action-button`
+  - `extended-floating-action-button-container`
+  - `extended-floating-action-button-text`
+- `FAB.Menu`: `floating-action-button-menu`
+- `IconButton`: `icon-button`
+  - `icon-button-container`
+  - `icon-button-icon` (and `icon-button-icon-previous` / `icon-button-icon-current` when `animated`)
+- `Menu`: `menu`
+  - `menu-view`
+  - `menu-surface`
+- `Menu.Item`: `menu-item`
+  - `menu-item-title`
+- `Modal`: `modal`
+  - `modal-backdrop`
+  - `modal-wrapper`
+  - `modal-surface`
+- `ProgressBar`: `progress-bar`
+  - `progress-bar-fill`
+- `Searchbar`: `search-bar`
+  - `search-bar-container`
+  - `search-bar-icon`
+  - `search-bar-icon-wrapper`
+  - `search-bar-clear-icon`
+  - `search-bar-trailering-icon`
+  - `search-bar-divider`
+- `Surface`: `surface`
+  - `surface-outer-layer`
 
-You can specify a `testID` explicitly and use that value to query the component.
+You can specify a `testID` explicitly to restore both the component's own test ID and all of its derived test IDs above, using the same suffixes.
 
 ## Components
 

--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -95,7 +95,7 @@ const AppbarContent = ({
   titleMaxFontSizeMultiplier,
   mode = 'small',
   theme: themeOverrides,
-  testID = 'appbar-content',
+  testID,
   ...rest
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
@@ -135,7 +135,7 @@ const AppbarContent = ({
           numberOfLines={1}
           accessible
           role={onPress ? 'none' : 'heading'}
-          testID={`${testID}-title-text`}
+          testID={testID ? `${testID}-title-text` : undefined}
           maxFontSizeMultiplier={titleMaxFontSizeMultiplier}
         >
           {title}

--- a/src/components/Appbar/AppbarHeader.tsx
+++ b/src/components/Appbar/AppbarHeader.tsx
@@ -88,7 +88,7 @@ const AppbarHeader = ({
   mode = Platform.OS === 'ios' ? 'center-aligned' : 'small',
   elevated = false,
   theme: themeOverrides,
-  testID = 'appbar-header',
+  testID,
   ...rest
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -335,7 +335,7 @@ const BottomNavigation = <Route extends BaseRoute>({
   safeAreaInsets,
   labelMaxFontSizeMultiplier = 1,
   compact: compactProp,
-  testID = 'bottom-navigation',
+  testID,
   theme: themeOverrides,
   getLazy = ({ route }: { route: Route }) => route.lazy,
 }: Props<Route>) => {
@@ -579,7 +579,7 @@ const BottomNavigation = <Route extends BaseRoute>({
         safeAreaInsets={safeAreaInsets}
         labelMaxFontSizeMultiplier={labelMaxFontSizeMultiplier}
         compact={compact}
-        testID={`${testID}-bar`}
+        testID={testID ? `${testID}-bar` : undefined}
         theme={theme}
       />
     </View>

--- a/src/components/BottomNavigation/BottomNavigationBar.tsx
+++ b/src/components/BottomNavigation/BottomNavigationBar.tsx
@@ -323,7 +323,7 @@ const BottomNavigationBar = <Route extends BaseRoute>({
   safeAreaInsets,
   labelMaxFontSizeMultiplier = 1,
   compact: compactProp,
-  testID = 'bottom-navigation-bar',
+  testID,
   theme: themeOverrides,
 }: Props<Route>) => {
   const theme = useInternalTheme(themeOverrides);
@@ -495,7 +495,7 @@ const BottomNavigationBar = <Route extends BaseRoute>({
     >
       <Animated.View
         style={[styles.barContent, { backgroundColor }]}
-        testID={`${testID}-content`}
+        testID={testID ? `${testID}-content` : undefined}
       >
         <View
           style={[
@@ -509,7 +509,7 @@ const BottomNavigationBar = <Route extends BaseRoute>({
             },
           ]}
           role={'tablist'}
-          testID={`${testID}-content-wrapper`}
+          testID={testID ? `${testID}-content-wrapper` : undefined}
         >
           {routes.map((route, index) => {
             const focused = navigationState.index === index;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -184,7 +184,7 @@ const Button = ({
   uppercase: uppercaseProp,
   contentStyle,
   labelStyle,
-  testID = 'button',
+  testID,
   accessible,
   background,
   maxFontSizeMultiplier,
@@ -292,7 +292,7 @@ const Button = ({
     <Surface
       {...rest}
       ref={ref}
-      testID={`${testID}-container`}
+      testID={testID ? `${testID}-container` : undefined}
       backgroundColor={backgroundOpacity < 1 ? 'transparent' : backgroundColor}
       {...touchableStyle}
       style={[
@@ -342,7 +342,10 @@ const Button = ({
       >
         <View style={[styles.content, { opacity: textOpacity }, contentStyle]}>
           {icon && loading !== true ? (
-            <View style={iconStyle} testID={`${testID}-icon-container`}>
+            <View
+              style={iconStyle}
+              testID={testID ? `${testID}-icon-container` : undefined}
+            >
               <Icon
                 source={icon}
                 size={customLabelSize ?? iconSize}
@@ -369,7 +372,7 @@ const Button = ({
             variant="labelLarge"
             selectable={false}
             numberOfLines={1}
-            testID={`${testID}-text`}
+            testID={testID ? `${testID}-text` : undefined}
             style={[
               styles.label,
               isMode('text')

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -141,7 +141,7 @@ const Card = ({
   style,
   contentStyle,
   theme: themeOverrides,
-  testID = 'card',
+  testID,
   accessible,
   disabled,
   ref,
@@ -225,13 +225,13 @@ const Card = ({
       style={[{ borderColor }, style]}
       theme={theme}
       elevation={elevation}
-      testID={`${testID}-container`}
+      testID={testID ? `${testID}-container` : undefined}
       {...rest}
     >
       {isMode('outlined') && (
         <View
           pointerEvents="none"
-          testID={`${testID}-outline`}
+          testID={testID ? `${testID}-outline` : undefined}
           style={[
             {
               borderColor,

--- a/src/components/Checkbox/CheckboxItem.tsx
+++ b/src/components/Checkbox/CheckboxItem.tsx
@@ -174,7 +174,7 @@ const CheckboxItem = ({
         {isLeading && checkbox}
         <Text
           variant={labelVariant}
-          testID={`${testID}-text`}
+          testID={testID ? `${testID}-text` : undefined}
           maxFontSizeMultiplier={labelMaxFontSizeMultiplier}
           style={[styles.label, computedStyle, labelStyle]}
         >

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -195,7 +195,7 @@ const Chip = ({
   textStyle,
   style,
   theme: themeOverrides,
-  testID = 'chip',
+  testID,
   selectedColor,
   showSelectedCheck = true,
   ellipsizeMode,
@@ -280,7 +280,7 @@ const Chip = ({
       elevation={elevation}
       transitionDuration={elevationTransitionDuration}
       {...rest}
-      testID={`${testID}-container`}
+      testID={testID ? `${testID}-container` : undefined}
       theme={theme}
     >
       <TouchableRipple

--- a/src/components/CrossFadeIcon.tsx
+++ b/src/components/CrossFadeIcon.tsx
@@ -44,7 +44,7 @@ const CrossFadeIcon = ({
   size,
   source,
   theme: themeOverrides,
-  testID = 'cross-fade-icon',
+  testID,
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
 
@@ -109,14 +109,14 @@ const CrossFadeIcon = ({
       {hasPreviousIcon ? (
         <Animated.View
           style={[styles.icon, previousIconStyle]}
-          testID={`${testID}-previous`}
+          testID={testID ? `${testID}-previous` : undefined}
         >
           <Icon source={previousIcon} size={size} color={color} theme={theme} />
         </Animated.View>
       ) : null}
       <Animated.View
         style={[styles.icon, currentIconStyle]}
-        testID={`${testID}-current`}
+        testID={testID ? `${testID}-current` : undefined}
       >
         <Icon source={currentIcon} size={size} color={color} theme={theme} />
       </Animated.View>

--- a/src/components/DataTable/DataTableCell.tsx
+++ b/src/components/DataTable/DataTableCell.tsx
@@ -108,7 +108,7 @@ const CellContent = ({
       style={textStyle}
       numberOfLines={1}
       maxFontSizeMultiplier={maxFontSizeMultiplier}
-      testID={`${testID}-text-container`}
+      testID={testID ? `${testID}-text-container` : undefined}
     >
       {children}
     </Text>

--- a/src/components/Drawer/DrawerCollapsedItem.tsx
+++ b/src/components/Drawer/DrawerCollapsedItem.tsx
@@ -111,7 +111,7 @@ const DrawerCollapsedItem = ({
   disabled,
   'aria-label': ariaLabel,
   badge = false,
-  testID = 'drawer-collapsed-item',
+  testID,
   labelMaxFontSizeMultiplier,
   ...rest
 }: Props) => {
@@ -195,12 +195,12 @@ const DrawerCollapsedItem = ({
               style,
               animatedOutlineStyle,
             ]}
-            testID={`${testID}-outline`}
+            testID={testID ? `${testID}-outline` : undefined}
           />
 
           <View
             style={[styles.icon, { top: iconPadding }]}
-            testID={`${testID}-container`}
+            testID={testID ? `${testID}-container` : undefined}
           >
             {badge !== false && (
               <View style={styles.badgeContainer}>

--- a/src/components/FAB/Extended.tsx
+++ b/src/components/FAB/Extended.tsx
@@ -169,7 +169,7 @@ const Extended = ({
   labelMaxFontSizeMultiplier,
   background,
   style,
-  testID = 'extended-floating-action-button',
+  testID,
   theme: themeOverrides,
   ref,
 }: Props) => {

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -131,7 +131,7 @@ const FAB = ({
   'aria-expanded': ariaExpanded,
   background,
   style,
-  testID = 'floating-action-button',
+  testID,
   theme,
   ref,
 }: Props) => (

--- a/src/components/FAB/Menu.tsx
+++ b/src/components/FAB/Menu.tsx
@@ -446,7 +446,6 @@ const MorphingTrigger = ({
         },
         visible ? styles.pointerEventsBoxNone : styles.pointerEventsNone,
       ]}
-      testID={testID}
     >
       <Shell
         size={size}
@@ -456,6 +455,7 @@ const MorphingTrigger = ({
         visible={visible}
         onPress={onPress}
         aria-label={ariaLabel}
+        testID={testID}
         widthShared={widthShared}
         heightShared={heightShared}
         borderRadiusShared={borderRadiusShared}
@@ -537,7 +537,7 @@ const Menu = ({
   alignment = 'end',
   closeIcon = 'close',
   items,
-  testID = 'floating-action-button-menu',
+  testID,
   theme: themeOverrides,
 }: MenuProps) => {
   const theme = useInternalTheme(themeOverrides);

--- a/src/components/FAB/Shell.tsx
+++ b/src/components/FAB/Shell.tsx
@@ -212,7 +212,7 @@ const Shell = ({
   overlay,
   children,
   style,
-  testID = 'fab-shell',
+  testID,
   theme: themeOverrides,
   ref,
 }: ShellProps) => {
@@ -319,7 +319,7 @@ const Shell = ({
         visible ? styles.pointerEventsAuto : styles.pointerEventsNone,
       ]}
       elevation={elevation}
-      testID={`${testID}-container`}
+      testID={testID ? `${testID}-container` : undefined}
       theme={theme}
     >
       <Animated.View style={[styles.clip, clipStyle]}>

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -121,7 +121,7 @@ const IconButton = ({
   mode,
   style,
   theme: themeOverrides,
-  testID = 'icon-button',
+  testID,
   loading = false,
   contentStyle,
   ref,
@@ -157,7 +157,7 @@ const IconButton = ({
   return (
     <Animated.View
       ref={ref}
-      testID={`${testID}-container`}
+      testID={testID ? `${testID}-container` : undefined}
       style={[
         styles.container,
         {
@@ -199,7 +199,12 @@ const IconButton = ({
           {loading ? (
             <ActivityIndicator size={size} color={iconColor} />
           ) : (
-            <IconComponent color={iconColor} source={icon} size={size} />
+            <IconComponent
+              color={iconColor}
+              source={icon}
+              size={size}
+              testID={testID ? `${testID}-icon` : undefined}
+            />
           )}
         </View>
       </TouchableRipple>

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -242,7 +242,7 @@ const ListItem = ({
           : null}
         <View
           style={[styles.item, styles.content, contentStyle]}
-          testID={`${testID}-content`}
+          testID={testID ? `${testID}-content` : undefined}
         >
           {renderTitle()}
 

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -186,7 +186,7 @@ const Menu = ({
   visible,
   statusBarHeight,
   overlayAccessibilityLabel = 'Close menu',
-  testID = 'menu',
+  testID,
   anchor,
   onDismiss,
   anchorPosition,
@@ -691,7 +691,7 @@ const Menu = ({
             style={[styles.wrapper, positionStyle, style]}
             pointerEvents={pointerEvents}
             onAccessibilityEscape={onDismiss}
-            testID={`${testID}-view`}
+            testID={testID ? `${testID}-view` : undefined}
           >
             <Animated.View
               pointerEvents={pointerEvents}
@@ -707,7 +707,7 @@ const Menu = ({
                   shadowMenuAnimationStyle,
                 ]}
                 elevation={elevation}
-                testID={`${testID}-surface`}
+                testID={testID ? `${testID}-surface` : undefined}
                 theme={theme}
               >
                 <Animated.View

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -148,7 +148,7 @@ const MenuItem = ({
   containerStyle,
   contentStyle,
   titleStyle,
-  testID = 'menu-item',
+  testID,
   'aria-label': ariaLabel,
   'aria-checked': ariaChecked,
   'aria-selected': ariaSelected,
@@ -220,7 +220,7 @@ const MenuItem = ({
             variant="bodyLarge"
             selectable={false}
             numberOfLines={1}
-            testID={`${testID}-title`}
+            testID={testID ? `${testID}-title` : undefined}
             style={[titleTextStyle, titleStyle]}
             maxFontSizeMultiplier={titleMaxFontSizeMultiplier}
           >

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -135,7 +135,7 @@ function Modal({
   contentElevation,
   style,
   theme: themeOverrides,
-  testID = 'modal',
+  testID,
 }: Props) {
   const theme = useInternalTheme(themeOverrides);
 
@@ -235,7 +235,7 @@ function Modal({
         onPress={dismissable ? onDismissCallback : undefined}
         importantForAccessibility="no"
         style={[styles.backdrop, backdropStyle, backdropTransitionStyle]}
-        testID={`${testID}-backdrop`}
+        testID={testID ? `${testID}-backdrop` : undefined}
       />
       <View
         style={[
@@ -244,10 +244,10 @@ function Modal({
           style,
         ]}
         pointerEvents="box-none"
-        testID={`${testID}-wrapper`}
+        testID={testID ? `${testID}-wrapper` : undefined}
       >
         <Surface
-          testID={`${testID}-surface`}
+          testID={testID ? `${testID}-surface` : undefined}
           theme={theme}
           backgroundColor={contentBackgroundColor}
           borderRadius={contentBorderRadius}

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -77,7 +77,7 @@ const ProgressBar = ({
   animatedValue,
   style,
   fillStyle,
-  testID = 'progress-bar',
+  testID,
   ...rest
 }: Props) => {
   const isWeb = Platform.OS === 'web';
@@ -213,7 +213,7 @@ const ProgressBar = ({
       >
         {width ? (
           <Animated.View
-            testID={`${testID}-fill`}
+            testID={testID ? `${testID}-fill` : undefined}
             style={[
               styles.progressBar,
               {

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -99,7 +99,7 @@ export type Props = Omit<TextInputProps, 'style'> & {
   right?: (props: {
     color: ColorValue;
     style: Style;
-    testID: string;
+    testID?: string;
   }) => React.ReactNode;
   /**
    * @supported Available in v5.x with theme version 3
@@ -183,7 +183,7 @@ const Searchbar = ({
   theme: themeOverrides,
   value,
   loading = false,
-  testID = 'search-bar',
+  testID,
   ref,
   ...rest
 }: Props) => {
@@ -235,7 +235,7 @@ const Searchbar = ({
       backgroundColor={theme.colors.surfaceContainerHigh}
       borderRadius={isBarMode ? theme.shapes.corner.extraLarge : cornerNone}
       style={[styles.container, style]}
-      testID={`${testID}-container`}
+      testID={testID ? `${testID}-container` : undefined}
       elevation={elevation}
       theme={theme}
     >
@@ -257,7 +257,7 @@ const Searchbar = ({
         }
         theme={theme}
         aria-label={searchAccessibilityLabel}
-        testID={`${testID}-icon`}
+        testID={testID ? `${testID}-icon` : undefined}
       />
       <TextInput
         style={[
@@ -295,7 +295,7 @@ const Searchbar = ({
         // when clearing the value.
         <View
           pointerEvents={value ? 'auto' : 'none'}
-          testID={`${testID}-icon-wrapper`}
+          testID={testID ? `${testID}-icon-wrapper` : undefined}
           style={[
             !value && styles.v3ClearIcon,
             right !== undefined && styles.v3ClearIconHidden,
@@ -317,7 +317,7 @@ const Searchbar = ({
                 />
               ))
             }
-            testID={`${testID}-clear-icon`}
+            testID={testID ? `${testID}-clear-icon` : undefined}
             role="button"
             theme={theme}
           />
@@ -331,7 +331,7 @@ const Searchbar = ({
           iconColor={traileringIconColor || colors.onSurfaceVariant}
           icon={traileringIcon}
           aria-label={traileringIconAccessibilityLabel}
-          testID={`${testID}-trailering-icon`}
+          testID={testID ? `${testID}-trailering-icon` : undefined}
         />
       ) : null}
       {isBarMode &&
@@ -345,7 +345,7 @@ const Searchbar = ({
               backgroundColor: colors.outline,
             },
           ]}
-          testID={`${testID}-divider`}
+          testID={testID ? `${testID}-divider` : undefined}
         />
       )}
     </Surface>

--- a/src/components/SegmentedButtons/SegmentedButtonItem.tsx
+++ b/src/components/SegmentedButtons/SegmentedButtonItem.tsx
@@ -224,7 +224,7 @@ const SegmentedButtonItem = ({
         >
           {showCheckedIcon ? (
             <Animated.View
-              testID={`${testID}-check-icon`}
+              testID={testID ? `${testID}-check-icon` : undefined}
               style={[iconStyle, checkAnimatedStyle]}
             >
               <Icon source={'check'} size={iconSize} color={textColor} />
@@ -232,7 +232,7 @@ const SegmentedButtonItem = ({
           ) : null}
           {showIcon ? (
             <Animated.View
-              testID={`${testID}-icon`}
+              testID={testID ? `${testID}-icon` : undefined}
               style={[iconStyle, iconAnimatedStyle]}
             >
               <Icon source={icon} size={iconSize} color={textColor} />
@@ -244,7 +244,7 @@ const SegmentedButtonItem = ({
             selectable={false}
             numberOfLines={1}
             maxFontSizeMultiplier={labelMaxFontSizeMultiplier}
-            testID={`${testID}-label`}
+            testID={testID ? `${testID}-label` : undefined}
           >
             {label}
           </Text>

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -338,7 +338,7 @@ const Snackbar = ({
                 }
                 aria-label={iconAccessibilityLabel}
                 style={styles.icon}
-                testID={`${testID}-icon`}
+                testID={testID ? `${testID}-icon` : undefined}
               />
             ) : null}
           </View>

--- a/src/components/__tests__/Appbar/Appbar.test.tsx
+++ b/src/components/__tests__/Appbar/Appbar.test.tsx
@@ -196,8 +196,8 @@ describe('AppbarAction', () => {
       </Appbar>
     );
     // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-    const appbarActionIcon = screen.getByTestId('cross-fade-icon-current').props
-      .children;
+    const appbarActionIcon = screen.getByTestId('appbar-action-icon-current')
+      .props.children;
     // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
     expect(appbarActionIcon.props.color).toBe(
       getTheme().colors.onSurfaceVariant
@@ -211,8 +211,8 @@ describe('AppbarAction', () => {
       </Appbar>
     );
     // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-    const appbarActionIcon = screen.getByTestId('cross-fade-icon-current').props
-      .children;
+    const appbarActionIcon = screen.getByTestId('appbar-action-icon-current')
+      .props.children;
     // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
     expect(appbarActionIcon.props.color).toBe(getTheme().colors.onSurface);
   });
@@ -224,8 +224,8 @@ describe('AppbarAction', () => {
       </Appbar>
     );
     // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-    const appbarActionIcon = screen.getByTestId('cross-fade-icon-current').props
-      .children;
+    const appbarActionIcon = screen.getByTestId('appbar-action-icon-current')
+      .props.children;
     // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
     expect(appbarActionIcon.props.color).toBe('purple');
   });
@@ -237,8 +237,9 @@ describe('AppbarAction', () => {
       </Appbar>
     );
     // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-    const appbarBackActionIcon = screen.getByTestId('cross-fade-icon-current')
-      .props.children;
+    const appbarBackActionIcon = screen.getByTestId(
+      'appbar-action-icon-current'
+    ).props.children;
     // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
     expect(appbarBackActionIcon.props.color).toBe('purple');
   });
@@ -249,7 +250,7 @@ describe('AppbarContent', () => {
     it(`should render text component with appropriate variant for ${mode} mode`, async () => {
       await render(
         <Appbar mode={mode}>
-          <Appbar.Content title="Title" />
+          <Appbar.Content testID="appbar-content" title="Title" />
         </Appbar>
       );
 

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
@@ -140,7 +140,6 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
         },
       ]
     }
-    testID="search-bar-container"
   >
     <View
       collapsable={false}
@@ -210,7 +209,6 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
           undefined,
         ]
       }
-      testID="search-bar-icon-container"
     >
       <View
         accessibilityLabel="search"
@@ -268,7 +266,6 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
             ],
           ]
         }
-        testID="search-bar-icon"
       >
         <View
           style={
@@ -341,7 +338,6 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
           undefined,
         ]
       }
-      testID="search-bar"
       underlineColorAndroid="transparent"
       value=""
     />
@@ -357,7 +353,6 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
           false,
         ]
       }
-      testID="search-bar-icon-wrapper"
     >
       <View
         collapsable={false}
@@ -380,7 +375,6 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
             undefined,
           ]
         }
-        testID="search-bar-clear-icon-container"
       >
         <View
           accessibilityLabel="clear"
@@ -438,7 +432,6 @@ exports[`Appbar does not pass any additional props to Searchbar 1`] = `
               ],
             ]
           }
-          testID="search-bar-clear-icon"
         >
           <View
             style={
@@ -604,7 +597,6 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
         undefined,
       ]
     }
-    testID="icon-button-container"
   >
     <View
       accessibilityLabel="Back"
@@ -662,7 +654,6 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
           ],
         ]
       }
-      testID="icon-button"
     >
       <View
         style={
@@ -706,7 +697,6 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
                 },
               ]
             }
-            testID="cross-fade-icon-current"
           >
             <View
               style={
@@ -769,7 +759,6 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
         ],
       ]
     }
-    testID="appbar-content"
   >
     <Text
       accessible={true}
@@ -806,7 +795,6 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
           ],
         ]
       }
-      testID="appbar-content-title-text"
     >
       Examples
     </Text>
@@ -832,7 +820,6 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
         undefined,
       ]
     }
-    testID="icon-button-container"
   >
     <View
       accessibilityState={
@@ -889,7 +876,6 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
           ],
         ]
       }
-      testID="icon-button"
     >
       <View
         style={
@@ -933,7 +919,6 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
                 },
               ]
             }
-            testID="cross-fade-icon-current"
           >
             <Text
               accessibilityElementsHidden={true}

--- a/src/components/__tests__/BottomNavigation.test.tsx
+++ b/src/components/__tests__/BottomNavigation.test.tsx
@@ -158,6 +158,7 @@ it('calls onIndexChange', async () => {
   const onIndexChange = jest.fn();
   await render(
     <BottomNavigation
+      testID="bottom-navigation"
       shifting
       navigationState={createState(0, 5)}
       onIndexChange={onIndexChange}
@@ -181,6 +182,7 @@ it('calls onTabPress', async () => {
 
   await render(
     <BottomNavigation
+      testID="bottom-navigation"
       shifting
       onTabPress={onTabPress}
       onIndexChange={onIndexChange}
@@ -211,6 +213,7 @@ it('calls onTabLongPress', async () => {
 
   await render(
     <BottomNavigation
+      testID="bottom-navigation"
       shifting
       onIndexChange={onIndexChange}
       onTabLongPress={onTabLongPress}
@@ -427,13 +430,13 @@ it('should have labelMaxFontSizeMultiplier passed to label', async () => {
 it('renders custom background color passed to barStyle property', async () => {
   await render(
     <BottomNavigation
+      testID="bottom-navigation"
       shifting={false}
       labeled={true}
       navigationState={createState(0, 3)}
       onIndexChange={jest.fn()}
       renderScene={renderScene}
       barStyle={styles.backgroundColor}
-      testID={'bottom-navigation'}
     />
   );
 
@@ -498,11 +501,11 @@ it('uses the rendered bar height when hiding it for the keyboard', async () => {
 it('renders a single tab', async () => {
   await render(
     <BottomNavigation
+      testID="bottom-navigation"
       shifting={false}
       navigationState={createState(0, 1)}
       onIndexChange={jest.fn()}
       renderScene={renderScene}
-      testID={'bottom-navigation'}
     />
   );
 
@@ -527,12 +530,12 @@ it('renders bottom navigation with getLazy', async () => {
 it('applies maxTabBarWidth styling if compact prop is truthy', async () => {
   await render(
     <BottomNavigation
+      testID="bottom-navigation"
       navigationState={createState(0, 5)}
       onIndexChange={jest.fn()}
       renderScene={renderScene}
       getLazy={({ route }) => route.key === 'key-2'}
       shifting={false}
-      testID="bottom-navigation"
       compact
     />
   );
@@ -547,12 +550,12 @@ it('applies maxTabBarWidth styling if compact prop is truthy', async () => {
 it('does not apply maxTabBarWidth styling if compact prop is falsy', async () => {
   await render(
     <BottomNavigation
+      testID="bottom-navigation"
       navigationState={createState(0, 5)}
       onIndexChange={jest.fn()}
       renderScene={renderScene}
       getLazy={({ route }) => route.key === 'key-2'}
       shifting={false}
-      testID="bottom-navigation"
       compact={false}
     />
   );
@@ -567,11 +570,11 @@ it('does not apply maxTabBarWidth styling if compact prop is falsy', async () =>
 it('renders bar content when shifting is enabled', async () => {
   await render(
     <BottomNavigation
+      testID="bottom-navigation"
       navigationState={createState(0, 5)}
       onIndexChange={jest.fn()}
       renderScene={renderScene}
       getLazy={({ route }) => route.key === 'key-2'}
-      testID="bottom-navigation"
       shifting
     />
   );
@@ -582,11 +585,11 @@ it('renders bar content when shifting is enabled', async () => {
 it('does not render legacy ripple overlay when shifting is disabled', async () => {
   await render(
     <BottomNavigation
+      testID="bottom-navigation"
       navigationState={createState(0, 5)}
       onIndexChange={jest.fn()}
       renderScene={renderScene}
       getLazy={({ route }) => route.key === 'key-2'}
-      testID="bottom-navigation"
       shifting={false}
     />
   );

--- a/src/components/__tests__/Card/Card.test.tsx
+++ b/src/components/__tests__/Card/Card.test.tsx
@@ -92,7 +92,7 @@ describe('Card', () => {
 
   it('renders with a content style', async () => {
     await render(
-      <Card contentStyle={styles.contentStyle}>
+      <Card testID="card" contentStyle={styles.contentStyle}>
         <Text>Content</Text>
       </Card>
     );
@@ -101,13 +101,13 @@ describe('Card', () => {
   });
 
   it('does not render a disabled accessibility state', async () => {
-    await render(<Card>{null}</Card>);
+    await render(<Card testID="card">{null}</Card>);
 
     expect(screen.getByTestId('card')).toBeEnabled();
   });
   it('does render a disabled accessibility state', async () => {
     await render(
-      <Card onPress={() => {}} disabled>
+      <Card testID="card" onPress={() => {}} disabled>
         {null}
       </Card>
     );

--- a/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
@@ -41,7 +41,6 @@ exports[`Card renders an outlined card 1`] = `
       },
     ]
   }
-  testID="card-container"
 >
   <View
     collapsable={false}
@@ -109,7 +108,6 @@ exports[`Card renders an outlined card 1`] = `
         },
       ]
     }
-    testID="card-outline"
   />
   <View
     style={
@@ -120,7 +118,6 @@ exports[`Card renders an outlined card 1`] = `
         undefined,
       ]
     }
-    testID="card"
   />
 </View>
 `;

--- a/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.tsx.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.tsx.snap
@@ -269,7 +269,6 @@ exports[`can render leading checkbox control 1`] = `
           ],
         ]
       }
-      testID="undefined-text"
     >
       Default with leading control
     </Text>
@@ -367,7 +366,6 @@ exports[`renders unchecked 1`] = `
           ],
         ]
       }
-      testID="undefined-text"
     >
       Unchecked Button
     </Text>

--- a/src/components/__tests__/Drawer/DrawerCollapsedItem.test.tsx
+++ b/src/components/__tests__/Drawer/DrawerCollapsedItem.test.tsx
@@ -7,6 +7,7 @@ describe('DrawerCollapsedItem', () => {
   it('should have regular outline if label is specified', async () => {
     await render(
       <DrawerCollapsedItem
+        testID="drawer-collapsed-item"
         label="starred"
         focusedIcon="star"
         unfocusedIcon="star-outline"
@@ -20,7 +21,11 @@ describe('DrawerCollapsedItem', () => {
 
   it('should have rounded outline if label is not specified', async () => {
     await render(
-      <DrawerCollapsedItem focusedIcon="star" unfocusedIcon="star-outline" />
+      <DrawerCollapsedItem
+        testID="drawer-collapsed-item"
+        focusedIcon="star"
+        unfocusedIcon="star-outline"
+      />
     );
 
     expect(screen.getByTestId('drawer-collapsed-item-outline')).toHaveStyle({
@@ -30,7 +35,11 @@ describe('DrawerCollapsedItem', () => {
 
   it('should display unfocused icon in inactive state, if unfocused icon is specified', async () => {
     await render(
-      <DrawerCollapsedItem focusedIcon="star" unfocusedIcon="star-outline" />
+      <DrawerCollapsedItem
+        testID="drawer-collapsed-item"
+        focusedIcon="star"
+        unfocusedIcon="star-outline"
+      />
     );
 
     expect(
@@ -41,7 +50,9 @@ describe('DrawerCollapsedItem', () => {
   });
 
   it('should display focused icon in inactive state, if unfocused icon is not specified', async () => {
-    await render(<DrawerCollapsedItem focusedIcon="star" />);
+    await render(
+      <DrawerCollapsedItem testID="drawer-collapsed-item" focusedIcon="star" />
+    );
 
     expect(
       // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
@@ -53,6 +64,7 @@ describe('DrawerCollapsedItem', () => {
   it('should display focused icon in active state', async () => {
     await render(
       <DrawerCollapsedItem
+        testID="drawer-collapsed-item"
         active
         focusedIcon="star"
         unfocusedIcon="star-outline"

--- a/src/components/__tests__/FABMenu.test.tsx
+++ b/src/components/__tests__/FABMenu.test.tsx
@@ -171,11 +171,10 @@ it('calls trigger onPress when menu is closed', async () => {
     <FAB.Menu
       expanded={false}
       onDismiss={jest.fn()}
-      trigger={{ icon: 'plus', onPress: onTriggerPress }}
+      trigger={{ icon: 'plus', onPress: onTriggerPress, testID: 'fab-shell' }}
       items={makeItems()}
     />
   );
-  // Shell's TouchableRipple uses the default testID 'fab-shell'
   await userEvent.press(screen.getByTestId('fab-shell'));
   expect(onTriggerPress).toHaveBeenCalledTimes(1);
 });
@@ -186,7 +185,7 @@ it('calls onDismiss when trigger is pressed while menu is open', async () => {
     <FAB.Menu
       expanded
       onDismiss={onDismiss}
-      trigger={{ icon: 'plus' }}
+      trigger={{ icon: 'plus', testID: 'fab-shell' }}
       items={makeItems()}
     />
   );

--- a/src/components/__tests__/ListItem.test.tsx
+++ b/src/components/__tests__/ListItem.test.tsx
@@ -155,7 +155,9 @@ it('calling onPress on ListItem right component', async () => {
       title="First Item"
       description="Item description"
       testID={testID}
-      right={() => <IconButton icon="pencil" onPress={onPress} />}
+      right={() => (
+        <IconButton icon="pencil" onPress={onPress} testID="icon-button" />
+      )}
     />
   );
 

--- a/src/components/__tests__/MenuItem.test.tsx
+++ b/src/components/__tests__/MenuItem.test.tsx
@@ -40,6 +40,7 @@ describe('Menu Item', () => {
 
     await render(
       <Menu.Item
+        testID="menu-item"
         titleMaxFontSizeMultiplier={labelMaxFontSizeMultiplier}
         leadingIcon="content-cut"
         onPress={() => {}}

--- a/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Banner.test.tsx.snap
@@ -228,7 +228,6 @@ exports[`render visible banner, with custom theme 1`] = `
               },
             ]
           }
-          testID="button-container"
         >
           <View
             collapsable={false}
@@ -318,7 +317,6 @@ exports[`render visible banner, with custom theme 1`] = `
                 },
               ]
             }
-            testID="button"
           >
             <View
               style={
@@ -381,7 +379,6 @@ exports[`render visible banner, with custom theme 1`] = `
                     ],
                   ]
                 }
-                testID="button-text"
               >
                 first
               </Text>
@@ -840,7 +837,6 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
               },
             ]
           }
-          testID="button-container"
         >
           <View
             collapsable={false}
@@ -930,7 +926,6 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                 },
               ]
             }
-            testID="button"
           >
             <View
               style={
@@ -993,7 +988,6 @@ exports[`renders visible banner, with action buttons and with image 1`] = `
                     ],
                   ]
                 }
-                testID="button-text"
               >
                 first
               </Text>
@@ -1234,7 +1228,6 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
               },
             ]
           }
-          testID="button-container"
         >
           <View
             collapsable={false}
@@ -1324,7 +1317,6 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                 },
               ]
             }
-            testID="button"
           >
             <View
               style={
@@ -1387,7 +1379,6 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                     ],
                   ]
                 }
-                testID="button-text"
               >
                 first
               </Text>
@@ -1444,7 +1435,6 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
               },
             ]
           }
-          testID="button-container"
         >
           <View
             collapsable={false}
@@ -1534,7 +1524,6 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                 },
               ]
             }
-            testID="button"
           >
             <View
               style={
@@ -1597,7 +1586,6 @@ exports[`renders visible banner, with action buttons and without image 1`] = `
                     ],
                   ]
                 }
-                testID="button-text"
               >
                 second
               </Text>

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
@@ -11,7 +11,6 @@ exports[`allows customizing Route's type via generics 1`] = `
       undefined,
     ]
   }
-  testID="bottom-navigation"
 >
   <View
     style={
@@ -83,7 +82,6 @@ exports[`allows customizing Route's type via generics 1`] = `
         "right": 0,
       }
     }
-    testID="bottom-navigation-bar"
   >
     <View
       collapsable={false}
@@ -94,7 +92,6 @@ exports[`allows customizing Route's type via generics 1`] = `
           "overflow": "hidden",
         }
       }
-      testID="bottom-navigation-bar-content"
     >
       <View
         role="tablist"
@@ -110,7 +107,6 @@ exports[`allows customizing Route's type via generics 1`] = `
             false,
           ]
         }
-        testID="bottom-navigation-bar-content-wrapper"
       >
         <View
           accessibilityState={
@@ -666,7 +662,6 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
       undefined,
     ]
   }
-  testID="bottom-navigation"
 >
   <View
     style={
@@ -738,7 +733,6 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
         "right": 0,
       }
     }
-    testID="bottom-navigation-bar"
   >
     <View
       collapsable={false}
@@ -749,7 +743,6 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
           "overflow": "hidden",
         }
       }
-      testID="bottom-navigation-bar-content"
     >
       <View
         role="tablist"
@@ -765,7 +758,6 @@ exports[`hides labels in non-shifting bottom navigation 1`] = `
             false,
           ]
         }
-        testID="bottom-navigation-bar-content-wrapper"
       >
         <View
           accessibilityState={
@@ -1401,7 +1393,6 @@ exports[`hides labels in shifting bottom navigation 1`] = `
       undefined,
     ]
   }
-  testID="bottom-navigation"
 >
   <View
     style={
@@ -1473,7 +1464,6 @@ exports[`hides labels in shifting bottom navigation 1`] = `
         "right": 0,
       }
     }
-    testID="bottom-navigation-bar"
   >
     <View
       collapsable={false}
@@ -1484,7 +1474,6 @@ exports[`hides labels in shifting bottom navigation 1`] = `
           "overflow": "hidden",
         }
       }
-      testID="bottom-navigation-bar-content"
     >
       <View
         role="tablist"
@@ -1500,7 +1489,6 @@ exports[`hides labels in shifting bottom navigation 1`] = `
             false,
           ]
         }
-        testID="bottom-navigation-bar-content-wrapper"
       >
         <View
           accessibilityState={
@@ -2136,7 +2124,6 @@ exports[`renders bottom navigation with getLazy 1`] = `
       undefined,
     ]
   }
-  testID="bottom-navigation"
 >
   <View
     style={
@@ -2346,7 +2333,6 @@ exports[`renders bottom navigation with getLazy 1`] = `
         "right": 0,
       }
     }
-    testID="bottom-navigation-bar"
   >
     <View
       collapsable={false}
@@ -2357,7 +2343,6 @@ exports[`renders bottom navigation with getLazy 1`] = `
           "overflow": "hidden",
         }
       }
-      testID="bottom-navigation-bar-content"
     >
       <View
         role="tablist"
@@ -2373,7 +2358,6 @@ exports[`renders bottom navigation with getLazy 1`] = `
             false,
           ]
         }
-        testID="bottom-navigation-bar-content-wrapper"
       >
         <View
           accessibilityState={
@@ -4009,7 +3993,6 @@ exports[`renders bottom navigation with scene animation 1`] = `
       undefined,
     ]
   }
-  testID="bottom-navigation"
 >
   <View
     style={
@@ -4081,7 +4064,6 @@ exports[`renders bottom navigation with scene animation 1`] = `
         "right": 0,
       }
     }
-    testID="bottom-navigation-bar"
   >
     <View
       collapsable={false}
@@ -4092,7 +4074,6 @@ exports[`renders bottom navigation with scene animation 1`] = `
           "overflow": "hidden",
         }
       }
-      testID="bottom-navigation-bar-content"
     >
       <View
         role="tablist"
@@ -4108,7 +4089,6 @@ exports[`renders bottom navigation with scene animation 1`] = `
             false,
           ]
         }
-        testID="bottom-navigation-bar-content-wrapper"
       >
         <View
           accessibilityState={
@@ -5489,7 +5469,6 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
       undefined,
     ]
   }
-  testID="bottom-navigation"
 >
   <View
     style={
@@ -5561,7 +5540,6 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
         "right": 0,
       }
     }
-    testID="bottom-navigation-bar"
   >
     <View
       collapsable={false}
@@ -5572,7 +5550,6 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
           "overflow": "hidden",
         }
       }
-      testID="bottom-navigation-bar-content"
     >
       <View
         role="tablist"
@@ -5588,7 +5565,6 @@ exports[`renders custom icon and label in non-shifting bottom navigation 1`] = `
             false,
           ]
         }
-        testID="bottom-navigation-bar-content-wrapper"
       >
         <View
           accessibilityState={
@@ -6209,7 +6185,6 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
       undefined,
     ]
   }
-  testID="bottom-navigation"
 >
   <View
     style={
@@ -6281,7 +6256,6 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
         "right": 0,
       }
     }
-    testID="bottom-navigation-bar"
   >
     <View
       collapsable={false}
@@ -6292,7 +6266,6 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
           "overflow": "hidden",
         }
       }
-      testID="bottom-navigation-bar-content"
     >
       <View
         role="tablist"
@@ -6308,7 +6281,6 @@ exports[`renders custom icon and label in shifting bottom navigation 1`] = `
             false,
           ]
         }
-        testID="bottom-navigation-bar-content-wrapper"
       >
         <View
           accessibilityState={
@@ -7229,7 +7201,6 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
       undefined,
     ]
   }
-  testID="bottom-navigation"
 >
   <View
     style={
@@ -7301,7 +7272,6 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
         "right": 0,
       }
     }
-    testID="bottom-navigation-bar"
   >
     <View
       collapsable={false}
@@ -7312,7 +7282,6 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
           "overflow": "hidden",
         }
       }
-      testID="bottom-navigation-bar-content"
     >
       <View
         role="tablist"
@@ -7328,7 +7297,6 @@ exports[`renders custom icon and label with custom colors in non-shifting bottom
             false,
           ]
         }
-        testID="bottom-navigation-bar-content-wrapper"
       >
         <View
           accessibilityState={
@@ -8324,7 +8292,6 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
       undefined,
     ]
   }
-  testID="bottom-navigation"
 >
   <View
     style={
@@ -8396,7 +8363,6 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
         "right": 0,
       }
     }
-    testID="bottom-navigation-bar"
   >
     <View
       collapsable={false}
@@ -8407,7 +8373,6 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
           "overflow": "hidden",
         }
       }
-      testID="bottom-navigation-bar-content"
     >
       <View
         role="tablist"
@@ -8423,7 +8388,6 @@ exports[`renders custom icon and label with custom colors in shifting bottom nav
             false,
           ]
         }
-        testID="bottom-navigation-bar-content-wrapper"
       >
         <View
           accessibilityState={
@@ -9266,7 +9230,6 @@ exports[`renders non-shifting bottom navigation 1`] = `
       undefined,
     ]
   }
-  testID="bottom-navigation"
 >
   <View
     style={
@@ -9338,7 +9301,6 @@ exports[`renders non-shifting bottom navigation 1`] = `
         "right": 0,
       }
     }
-    testID="bottom-navigation-bar"
   >
     <View
       collapsable={false}
@@ -9349,7 +9311,6 @@ exports[`renders non-shifting bottom navigation 1`] = `
           "overflow": "hidden",
         }
       }
-      testID="bottom-navigation-bar-content"
     >
       <View
         role="tablist"
@@ -9365,7 +9326,6 @@ exports[`renders non-shifting bottom navigation 1`] = `
             false,
           ]
         }
-        testID="bottom-navigation-bar-content-wrapper"
       >
         <View
           accessibilityState={
@@ -10361,7 +10321,6 @@ exports[`renders shifting bottom navigation 1`] = `
       undefined,
     ]
   }
-  testID="bottom-navigation"
 >
   <View
     style={
@@ -10433,7 +10392,6 @@ exports[`renders shifting bottom navigation 1`] = `
         "right": 0,
       }
     }
-    testID="bottom-navigation-bar"
   >
     <View
       collapsable={false}
@@ -10444,7 +10402,6 @@ exports[`renders shifting bottom navigation 1`] = `
           "overflow": "hidden",
         }
       }
-      testID="bottom-navigation-bar-content"
     >
       <View
         role="tablist"
@@ -10460,7 +10417,6 @@ exports[`renders shifting bottom navigation 1`] = `
             false,
           ]
         }
-        testID="bottom-navigation-bar-content-wrapper"
       >
         <View
           accessibilityState={

--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -47,7 +47,6 @@ exports[`renders button with an accessibility hint 1`] = `
       },
     ]
   }
-  testID="button-container"
 >
   <View
     collapsable={false}
@@ -138,7 +137,6 @@ exports[`renders button with an accessibility hint 1`] = `
         },
       ]
     }
-    testID="button"
   >
     <View
       style={
@@ -199,7 +197,6 @@ exports[`renders button with an accessibility hint 1`] = `
             ],
           ]
         }
-        testID="button-text"
       >
         Button with accessibility hint
       </Text>
@@ -256,7 +253,6 @@ exports[`renders button with an accessibility label 1`] = `
       },
     ]
   }
-  testID="button-container"
 >
   <View
     collapsable={false}
@@ -346,7 +342,6 @@ exports[`renders button with an accessibility label 1`] = `
         },
       ]
     }
-    testID="button"
   >
     <View
       style={
@@ -407,7 +402,6 @@ exports[`renders button with an accessibility label 1`] = `
             ],
           ]
         }
-        testID="button-text"
       >
         Button with accessibility label
       </Text>
@@ -463,7 +457,6 @@ exports[`renders button with button color 1`] = `
       },
     ]
   }
-  testID="button-container"
 >
   <View
     collapsable={false}
@@ -553,7 +546,6 @@ exports[`renders button with button color 1`] = `
         },
       ]
     }
-    testID="button"
   >
     <View
       style={
@@ -614,7 +606,6 @@ exports[`renders button with button color 1`] = `
             ],
           ]
         }
-        testID="button-text"
       >
         Custom Button
       </Text>
@@ -670,7 +661,6 @@ exports[`renders button with color 1`] = `
       },
     ]
   }
-  testID="button-container"
 >
   <View
     collapsable={false}
@@ -760,7 +750,6 @@ exports[`renders button with color 1`] = `
         },
       ]
     }
-    testID="button"
   >
     <View
       style={
@@ -821,7 +810,6 @@ exports[`renders button with color 1`] = `
             ],
           ]
         }
-        testID="button-text"
       >
         Custom Button
       </Text>
@@ -1084,7 +1072,6 @@ exports[`renders button with icon 1`] = `
       },
     ]
   }
-  testID="button-container"
 >
   <View
     collapsable={false}
@@ -1174,7 +1161,6 @@ exports[`renders button with icon 1`] = `
         },
       ]
     }
-    testID="button"
   >
     <View
       style={
@@ -1208,7 +1194,6 @@ exports[`renders button with icon 1`] = `
             },
           ]
         }
-        testID="button-icon-container"
       >
         <Text
           accessibilityElementsHidden={true}
@@ -1284,7 +1269,6 @@ exports[`renders button with icon 1`] = `
             ],
           ]
         }
-        testID="button-text"
       >
         Icon Button
       </Text>
@@ -1340,7 +1324,6 @@ exports[`renders button with icon in reverse order 1`] = `
       },
     ]
   }
-  testID="button-container"
 >
   <View
     collapsable={false}
@@ -1430,7 +1413,6 @@ exports[`renders button with icon in reverse order 1`] = `
         },
       ]
     }
-    testID="button"
   >
     <View
       style={
@@ -1466,7 +1448,6 @@ exports[`renders button with icon in reverse order 1`] = `
             },
           ]
         }
-        testID="button-icon-container"
       >
         <Text
           accessibilityElementsHidden={true}
@@ -1542,7 +1523,6 @@ exports[`renders button with icon in reverse order 1`] = `
             ],
           ]
         }
-        testID="button-text"
       >
         Right Icon
       </Text>
@@ -1598,7 +1578,6 @@ exports[`renders contained contained with mode 1`] = `
       },
     ]
   }
-  testID="button-container"
 >
   <View
     collapsable={false}
@@ -1688,7 +1667,6 @@ exports[`renders contained contained with mode 1`] = `
         },
       ]
     }
-    testID="button"
   >
     <View
       style={
@@ -1750,7 +1728,6 @@ exports[`renders contained contained with mode 1`] = `
             ],
           ]
         }
-        testID="button-text"
       >
         Contained Button
       </Text>
@@ -1806,7 +1783,6 @@ exports[`renders disabled button 1`] = `
       },
     ]
   }
-  testID="button-container"
 >
   <View
     collapsable={false}
@@ -1896,7 +1872,6 @@ exports[`renders disabled button 1`] = `
         },
       ]
     }
-    testID="button"
   >
     <View
       style={
@@ -1957,7 +1932,6 @@ exports[`renders disabled button 1`] = `
             ],
           ]
         }
-        testID="button-text"
       >
         Disabled Button
       </Text>
@@ -2013,7 +1987,6 @@ exports[`renders loading button 1`] = `
       },
     ]
   }
-  testID="button-container"
 >
   <View
     collapsable={false}
@@ -2103,7 +2076,6 @@ exports[`renders loading button 1`] = `
         },
       ]
     }
-    testID="button"
   >
     <View
       style={
@@ -2368,7 +2340,6 @@ exports[`renders loading button 1`] = `
             ],
           ]
         }
-        testID="button-text"
       >
         Loading Button
       </Text>
@@ -2424,7 +2395,6 @@ exports[`renders outlined button with mode 1`] = `
       },
     ]
   }
-  testID="button-container"
 >
   <View
     collapsable={false}
@@ -2514,7 +2484,6 @@ exports[`renders outlined button with mode 1`] = `
         },
       ]
     }
-    testID="button"
   >
     <View
       style={
@@ -2576,7 +2545,6 @@ exports[`renders outlined button with mode 1`] = `
             ],
           ]
         }
-        testID="button-text"
       >
         Outlined Button
       </Text>
@@ -2632,7 +2600,6 @@ exports[`renders text button by default 1`] = `
       },
     ]
   }
-  testID="button-container"
 >
   <View
     collapsable={false}
@@ -2722,7 +2689,6 @@ exports[`renders text button by default 1`] = `
         },
       ]
     }
-    testID="button"
   >
     <View
       style={
@@ -2783,7 +2749,6 @@ exports[`renders text button by default 1`] = `
             ],
           ]
         }
-        testID="button-text"
       >
         Text Button
       </Text>
@@ -2839,7 +2804,6 @@ exports[`renders text button with mode 1`] = `
       },
     ]
   }
-  testID="button-container"
 >
   <View
     collapsable={false}
@@ -2929,7 +2893,6 @@ exports[`renders text button with mode 1`] = `
         },
       ]
     }
-    testID="button"
   >
     <View
       style={
@@ -2990,7 +2953,6 @@ exports[`renders text button with mode 1`] = `
             ],
           ]
         }
-        testID="button-text"
       >
         Text Button
       </Text>

--- a/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -49,7 +49,6 @@ exports[`renders chip with close button 1`] = `
       },
     ]
   }
-  testID="chip-container"
 >
   <View
     collapsable={false}
@@ -144,7 +143,6 @@ exports[`renders chip with close button 1`] = `
         ],
       ]
     }
-    testID="chip"
   >
     <View
       style={
@@ -404,7 +402,6 @@ exports[`renders chip with custom close button 1`] = `
       },
     ]
   }
-  testID="chip-container"
 >
   <View
     collapsable={false}
@@ -499,7 +496,6 @@ exports[`renders chip with custom close button 1`] = `
         ],
       ]
     }
-    testID="chip"
   >
     <View
       style={
@@ -759,7 +755,6 @@ exports[`renders chip with icon 1`] = `
       },
     ]
   }
-  testID="chip-container"
 >
   <View
     collapsable={false}
@@ -854,7 +849,6 @@ exports[`renders chip with icon 1`] = `
         ],
       ]
     }
-    testID="chip"
   >
     <View
       style={
@@ -1021,7 +1015,6 @@ exports[`renders chip with onPress 1`] = `
       },
     ]
   }
-  testID="chip-container"
 >
   <View
     collapsable={false}
@@ -1116,7 +1109,6 @@ exports[`renders chip with onPress 1`] = `
         ],
       ]
     }
-    testID="chip"
   >
     <View
       style={
@@ -1238,7 +1230,6 @@ exports[`renders outlined disabled chip 1`] = `
       },
     ]
   }
-  testID="chip-container"
 >
   <View
     collapsable={false}
@@ -1333,7 +1324,6 @@ exports[`renders outlined disabled chip 1`] = `
         ],
       ]
     }
-    testID="chip"
   >
     <View
       style={
@@ -1455,7 +1445,6 @@ exports[`renders selected chip 1`] = `
       },
     ]
   }
-  testID="chip-container"
 >
   <View
     collapsable={false}
@@ -1550,7 +1539,6 @@ exports[`renders selected chip 1`] = `
         ],
       ]
     }
-    testID="chip"
   >
     <View
       style={

--- a/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -400,7 +400,6 @@ exports[`DataTable.Pagination renders data table pagination 1`] = `
           undefined,
         ]
       }
-      testID="icon-button-container"
     >
       <View
         accessibilityLabel="chevron-left"
@@ -458,7 +457,6 @@ exports[`DataTable.Pagination renders data table pagination 1`] = `
             ],
           ]
         }
-        testID="icon-button"
       >
         <View
           style={
@@ -520,7 +518,6 @@ exports[`DataTable.Pagination renders data table pagination 1`] = `
           undefined,
         ]
       }
-      testID="icon-button-container"
     >
       <View
         accessibilityLabel="chevron-right"
@@ -578,7 +575,6 @@ exports[`DataTable.Pagination renders data table pagination 1`] = `
             ],
           ]
         }
-        testID="icon-button"
       >
         <View
           style={
@@ -698,7 +694,6 @@ exports[`DataTable.Pagination renders data table pagination with fast-forward bu
           undefined,
         ]
       }
-      testID="icon-button-container"
     >
       <View
         accessibilityLabel="page-first"
@@ -756,7 +751,6 @@ exports[`DataTable.Pagination renders data table pagination with fast-forward bu
             ],
           ]
         }
-        testID="icon-button"
       >
         <View
           style={
@@ -818,7 +812,6 @@ exports[`DataTable.Pagination renders data table pagination with fast-forward bu
           undefined,
         ]
       }
-      testID="icon-button-container"
     >
       <View
         accessibilityLabel="chevron-left"
@@ -876,7 +869,6 @@ exports[`DataTable.Pagination renders data table pagination with fast-forward bu
             ],
           ]
         }
-        testID="icon-button"
       >
         <View
           style={
@@ -938,7 +930,6 @@ exports[`DataTable.Pagination renders data table pagination with fast-forward bu
           undefined,
         ]
       }
-      testID="icon-button-container"
     >
       <View
         accessibilityLabel="chevron-right"
@@ -996,7 +987,6 @@ exports[`DataTable.Pagination renders data table pagination with fast-forward bu
             ],
           ]
         }
-        testID="icon-button"
       >
         <View
           style={
@@ -1058,7 +1048,6 @@ exports[`DataTable.Pagination renders data table pagination with fast-forward bu
           undefined,
         ]
       }
-      testID="icon-button-container"
     >
       <View
         accessibilityLabel="page-last"
@@ -1116,7 +1105,6 @@ exports[`DataTable.Pagination renders data table pagination with fast-forward bu
             ],
           ]
         }
-        testID="icon-button"
       >
         <View
           style={
@@ -1236,7 +1224,6 @@ exports[`DataTable.Pagination renders data table pagination with label 1`] = `
           undefined,
         ]
       }
-      testID="icon-button-container"
     >
       <View
         accessibilityLabel="chevron-left"
@@ -1294,7 +1281,6 @@ exports[`DataTable.Pagination renders data table pagination with label 1`] = `
             ],
           ]
         }
-        testID="icon-button"
       >
         <View
           style={
@@ -1356,7 +1342,6 @@ exports[`DataTable.Pagination renders data table pagination with label 1`] = `
           undefined,
         ]
       }
-      testID="icon-button-container"
     >
       <View
         accessibilityLabel="chevron-right"
@@ -1414,7 +1399,6 @@ exports[`DataTable.Pagination renders data table pagination with label 1`] = `
             ],
           ]
         }
-        testID="icon-button"
       >
         <View
           style={
@@ -1570,7 +1554,6 @@ exports[`DataTable.Pagination renders data table pagination with options select 
             },
           ]
         }
-        testID="button-container"
       >
         <View
           collapsable={false}
@@ -1660,7 +1643,6 @@ exports[`DataTable.Pagination renders data table pagination with options select 
               },
             ]
           }
-          testID="button"
         >
           <View
             style={
@@ -1693,7 +1675,6 @@ exports[`DataTable.Pagination renders data table pagination with options select 
                   false,
                 ]
               }
-              testID="button-icon-container"
             >
               <Text
                 accessibilityElementsHidden={true}
@@ -1770,7 +1751,6 @@ exports[`DataTable.Pagination renders data table pagination with options select 
                   ],
                 ]
               }
-              testID="button-text"
             >
               2
             </Text>
@@ -1838,7 +1818,6 @@ exports[`DataTable.Pagination renders data table pagination with options select 
           undefined,
         ]
       }
-      testID="icon-button-container"
     >
       <View
         accessibilityLabel="page-first"
@@ -1896,7 +1875,6 @@ exports[`DataTable.Pagination renders data table pagination with options select 
             ],
           ]
         }
-        testID="icon-button"
       >
         <View
           style={
@@ -1958,7 +1936,6 @@ exports[`DataTable.Pagination renders data table pagination with options select 
           undefined,
         ]
       }
-      testID="icon-button-container"
     >
       <View
         accessibilityLabel="chevron-left"
@@ -2016,7 +1993,6 @@ exports[`DataTable.Pagination renders data table pagination with options select 
             ],
           ]
         }
-        testID="icon-button"
       >
         <View
           style={
@@ -2078,7 +2054,6 @@ exports[`DataTable.Pagination renders data table pagination with options select 
           undefined,
         ]
       }
-      testID="icon-button-container"
     >
       <View
         accessibilityLabel="chevron-right"
@@ -2136,7 +2111,6 @@ exports[`DataTable.Pagination renders data table pagination with options select 
             ],
           ]
         }
-        testID="icon-button"
       >
         <View
           style={
@@ -2198,7 +2172,6 @@ exports[`DataTable.Pagination renders data table pagination with options select 
           undefined,
         ]
       }
-      testID="icon-button-container"
     >
       <View
         accessibilityLabel="page-last"
@@ -2256,7 +2229,6 @@ exports[`DataTable.Pagination renders data table pagination with options select 
             ],
           ]
         }
-        testID="icon-button"
       >
         <View
           style={

--- a/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -65,7 +65,6 @@ exports[`DataTable.Cell renders data table cell 1`] = `
         undefined,
       ]
     }
-    testID="undefined-text-container"
   >
     Cupcake
   </Text>
@@ -139,7 +138,6 @@ exports[`DataTable.Cell renders right aligned data table cell 1`] = `
         undefined,
       ]
     }
-    testID="undefined-text-container"
   >
     356
   </Text>

--- a/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
@@ -54,7 +54,6 @@ exports[`renders FAB large size 1`] = `
       },
     ]
   }
-  testID="floating-action-button-container"
 >
   <View
     collapsable={false}
@@ -161,7 +160,6 @@ exports[`renders FAB large size 1`] = `
           ],
         ]
       }
-      testID="floating-action-button"
     >
       <View
         style={
@@ -295,7 +293,6 @@ exports[`renders FAB medium size 1`] = `
       },
     ]
   }
-  testID="floating-action-button-container"
 >
   <View
     collapsable={false}
@@ -402,7 +399,6 @@ exports[`renders FAB medium size 1`] = `
           ],
         ]
       }
-      testID="floating-action-button"
     >
       <View
         style={
@@ -536,7 +532,6 @@ exports[`renders FAB transitioning to not visible 1`] = `
       },
     ]
   }
-  testID="floating-action-button-container"
 >
   <View
     collapsable={false}
@@ -643,7 +638,6 @@ exports[`renders FAB transitioning to not visible 1`] = `
           ],
         ]
       }
-      testID="floating-action-button"
     >
       <View
         style={
@@ -777,7 +771,6 @@ exports[`renders FAB transitioning to visible 1`] = `
       },
     ]
   }
-  testID="floating-action-button-container"
 >
   <View
     collapsable={false}
@@ -884,7 +877,6 @@ exports[`renders FAB transitioning to visible 1`] = `
           ],
         ]
       }
-      testID="floating-action-button"
     >
       <View
         style={
@@ -1018,7 +1010,6 @@ exports[`renders FAB with aria-label 1`] = `
       },
     ]
   }
-  testID="floating-action-button-container"
 >
   <View
     collapsable={false}
@@ -1126,7 +1117,6 @@ exports[`renders FAB with aria-label 1`] = `
           ],
         ]
       }
-      testID="floating-action-button"
     >
       <View
         style={
@@ -1260,7 +1250,6 @@ exports[`renders FAB with containerColor and contentColor overrides 1`] = `
       },
     ]
   }
-  testID="floating-action-button-container"
 >
   <View
     collapsable={false}
@@ -1367,7 +1356,6 @@ exports[`renders FAB with containerColor and contentColor overrides 1`] = `
           ],
         ]
       }
-      testID="floating-action-button"
     >
       <View
         style={
@@ -1501,7 +1489,6 @@ exports[`renders FAB with containerColor override 1`] = `
       },
     ]
   }
-  testID="floating-action-button-container"
 >
   <View
     collapsable={false}
@@ -1608,7 +1595,6 @@ exports[`renders FAB with containerColor override 1`] = `
           ],
         ]
       }
-      testID="floating-action-button"
     >
       <View
         style={
@@ -1742,7 +1728,6 @@ exports[`renders FAB with default props 1`] = `
       },
     ]
   }
-  testID="floating-action-button-container"
 >
   <View
     collapsable={false}
@@ -1849,7 +1834,6 @@ exports[`renders FAB with default props 1`] = `
           ],
         ]
       }
-      testID="floating-action-button"
     >
       <View
         style={
@@ -1983,7 +1967,6 @@ exports[`renders FAB with primary variant 1`] = `
       },
     ]
   }
-  testID="floating-action-button-container"
 >
   <View
     collapsable={false}
@@ -2090,7 +2073,6 @@ exports[`renders FAB with primary variant 1`] = `
           ],
         ]
       }
-      testID="floating-action-button"
     >
       <View
         style={
@@ -2224,7 +2206,6 @@ exports[`renders FAB with secondary variant 1`] = `
       },
     ]
   }
-  testID="floating-action-button-container"
 >
   <View
     collapsable={false}
@@ -2331,7 +2312,6 @@ exports[`renders FAB with secondary variant 1`] = `
           ],
         ]
       }
-      testID="floating-action-button"
     >
       <View
         style={
@@ -2465,7 +2445,6 @@ exports[`renders FAB with tertiary variant 1`] = `
       },
     ]
   }
-  testID="floating-action-button-container"
 >
   <View
     collapsable={false}
@@ -2572,7 +2551,6 @@ exports[`renders FAB with tertiary variant 1`] = `
           ],
         ]
       }
-      testID="floating-action-button"
     >
       <View
         style={
@@ -2706,7 +2684,6 @@ exports[`renders FAB with tonalSecondary variant 1`] = `
       },
     ]
   }
-  testID="floating-action-button-container"
 >
   <View
     collapsable={false}
@@ -2813,7 +2790,6 @@ exports[`renders FAB with tonalSecondary variant 1`] = `
           ],
         ]
       }
-      testID="floating-action-button"
     >
       <View
         style={
@@ -2947,7 +2923,6 @@ exports[`renders FAB with tonalTertiary variant 1`] = `
       },
     ]
   }
-  testID="floating-action-button-container"
 >
   <View
     collapsable={false}
@@ -3054,7 +3029,6 @@ exports[`renders FAB with tonalTertiary variant 1`] = `
           ],
         ]
       }
-      testID="floating-action-button"
     >
       <View
         style={

--- a/src/components/__tests__/__snapshots__/FABExtended.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FABExtended.test.tsx.snap
@@ -55,7 +55,6 @@ exports[`renders extended FAB collapsed 1`] = `
         },
       ]
     }
-    testID="extended-floating-action-button-container"
   >
     <View
       collapsable={false}
@@ -163,7 +162,6 @@ exports[`renders extended FAB collapsed 1`] = `
             ],
           ]
         }
-        testID="extended-floating-action-button"
       >
         <View
           style={
@@ -252,7 +250,6 @@ exports[`renders extended FAB collapsed 1`] = `
                   },
                 ]
               }
-              testID="extended-floating-action-button-text"
             >
               New message
             </Text>
@@ -384,7 +381,6 @@ exports[`renders extended FAB expanded 1`] = `
         },
       ]
     }
-    testID="extended-floating-action-button-container"
   >
     <View
       collapsable={false}
@@ -492,7 +488,6 @@ exports[`renders extended FAB expanded 1`] = `
             ],
           ]
         }
-        testID="extended-floating-action-button"
       >
         <View
           style={
@@ -581,7 +576,6 @@ exports[`renders extended FAB expanded 1`] = `
                   },
                 ]
               }
-              testID="extended-floating-action-button-text"
             >
               New message
             </Text>
@@ -713,7 +707,6 @@ exports[`renders extended FAB large size 1`] = `
         },
       ]
     }
-    testID="extended-floating-action-button-container"
   >
     <View
       collapsable={false}
@@ -821,7 +814,6 @@ exports[`renders extended FAB large size 1`] = `
             ],
           ]
         }
-        testID="extended-floating-action-button"
       >
         <View
           style={
@@ -910,7 +902,6 @@ exports[`renders extended FAB large size 1`] = `
                   },
                 ]
               }
-              testID="extended-floating-action-button-text"
             >
               New message
             </Text>
@@ -1042,7 +1033,6 @@ exports[`renders extended FAB medium size 1`] = `
         },
       ]
     }
-    testID="extended-floating-action-button-container"
   >
     <View
       collapsable={false}
@@ -1150,7 +1140,6 @@ exports[`renders extended FAB medium size 1`] = `
             ],
           ]
         }
-        testID="extended-floating-action-button"
       >
         <View
           style={
@@ -1239,7 +1228,6 @@ exports[`renders extended FAB medium size 1`] = `
                   },
                 ]
               }
-              testID="extended-floating-action-button-text"
             >
               New message
             </Text>
@@ -1371,7 +1359,6 @@ exports[`renders extended FAB not visible 1`] = `
         },
       ]
     }
-    testID="extended-floating-action-button-container"
   >
     <View
       collapsable={false}
@@ -1479,7 +1466,6 @@ exports[`renders extended FAB not visible 1`] = `
             ],
           ]
         }
-        testID="extended-floating-action-button"
       >
         <View
           style={
@@ -1568,7 +1554,6 @@ exports[`renders extended FAB not visible 1`] = `
                   },
                 ]
               }
-              testID="extended-floating-action-button-text"
             >
               New message
             </Text>
@@ -1700,7 +1685,6 @@ exports[`renders extended FAB transitioning to collapsed 1`] = `
         },
       ]
     }
-    testID="extended-floating-action-button-container"
   >
     <View
       collapsable={false}
@@ -1808,7 +1792,6 @@ exports[`renders extended FAB transitioning to collapsed 1`] = `
             ],
           ]
         }
-        testID="extended-floating-action-button"
       >
         <View
           style={
@@ -1897,7 +1880,6 @@ exports[`renders extended FAB transitioning to collapsed 1`] = `
                   },
                 ]
               }
-              testID="extended-floating-action-button-text"
             >
               New message
             </Text>

--- a/src/components/__tests__/__snapshots__/FABMenu.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FABMenu.test.tsx.snap
@@ -21,7 +21,6 @@ exports[`renders FAB.Menu closed 1`] = `
       },
     ]
   }
-  testID="floating-action-button-menu"
 >
   <View
     style={
@@ -479,7 +478,6 @@ exports[`renders FAB.Menu closed 1`] = `
             },
           ]
         }
-        testID="fab-shell-container"
       >
         <View
           collapsable={false}
@@ -630,7 +628,6 @@ exports[`renders FAB.Menu closed 1`] = `
                 ],
               ]
             }
-            testID="fab-shell"
           >
             <View
               style={
@@ -803,7 +800,6 @@ exports[`renders FAB.Menu not expanded when trigger is not visible 1`] = `
       },
     ]
   }
-  testID="floating-action-button-menu"
 >
   <View
     style={
@@ -1261,7 +1257,6 @@ exports[`renders FAB.Menu not expanded when trigger is not visible 1`] = `
             },
           ]
         }
-        testID="fab-shell-container"
       >
         <View
           collapsable={false}
@@ -1412,7 +1407,6 @@ exports[`renders FAB.Menu not expanded when trigger is not visible 1`] = `
                 ],
               ]
             }
-            testID="fab-shell"
           >
             <View
               style={
@@ -1585,7 +1579,6 @@ exports[`renders FAB.Menu open 1`] = `
       },
     ]
   }
-  testID="floating-action-button-menu"
 >
   <View
     style={
@@ -2043,7 +2036,6 @@ exports[`renders FAB.Menu open 1`] = `
             },
           ]
         }
-        testID="fab-shell-container"
       >
         <View
           collapsable={false}
@@ -2194,7 +2186,6 @@ exports[`renders FAB.Menu open 1`] = `
                 ],
               ]
             }
-            testID="fab-shell"
           >
             <View
               style={
@@ -2367,7 +2358,6 @@ exports[`renders FAB.Menu with 6 items 1`] = `
       },
     ]
   }
-  testID="floating-action-button-menu"
 >
   <View
     style={
@@ -3533,7 +3523,6 @@ exports[`renders FAB.Menu with 6 items 1`] = `
             },
           ]
         }
-        testID="fab-shell-container"
       >
         <View
           collapsable={false}
@@ -3684,7 +3673,6 @@ exports[`renders FAB.Menu with 6 items 1`] = `
                 ],
               ]
             }
-            testID="fab-shell"
           >
             <View
               style={
@@ -3857,7 +3845,6 @@ exports[`renders FAB.Menu with center alignment 1`] = `
       },
     ]
   }
-  testID="floating-action-button-menu"
 >
   <View
     style={
@@ -4316,7 +4303,6 @@ exports[`renders FAB.Menu with center alignment 1`] = `
             },
           ]
         }
-        testID="fab-shell-container"
       >
         <View
           collapsable={false}
@@ -4467,7 +4453,6 @@ exports[`renders FAB.Menu with center alignment 1`] = `
                 ],
               ]
             }
-            testID="fab-shell"
           >
             <View
               style={
@@ -4640,7 +4625,6 @@ exports[`renders FAB.Menu with items having icons 1`] = `
       },
     ]
   }
-  testID="floating-action-button-menu"
 >
   <View
     style={
@@ -5156,7 +5140,6 @@ exports[`renders FAB.Menu with items having icons 1`] = `
             },
           ]
         }
-        testID="fab-shell-container"
       >
         <View
           collapsable={false}
@@ -5307,7 +5290,6 @@ exports[`renders FAB.Menu with items having icons 1`] = `
                 ],
               ]
             }
-            testID="fab-shell"
           >
             <View
               style={
@@ -5480,7 +5462,6 @@ exports[`renders FAB.Menu with start alignment 1`] = `
       },
     ]
   }
-  testID="floating-action-button-menu"
 >
   <View
     style={
@@ -5938,7 +5919,6 @@ exports[`renders FAB.Menu with start alignment 1`] = `
             },
           ]
         }
-        testID="fab-shell-container"
       >
         <View
           collapsable={false}
@@ -6089,7 +6069,6 @@ exports[`renders FAB.Menu with start alignment 1`] = `
                 ],
               ]
             }
-            testID="fab-shell"
           >
             <View
               style={

--- a/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
@@ -22,7 +22,6 @@ exports[`renders disabled icon button 1`] = `
       undefined,
     ]
   }
-  testID="icon-button-container"
 >
   <View
     accessibilityState={
@@ -79,7 +78,6 @@ exports[`renders disabled icon button 1`] = `
         ],
       ]
     }
-    testID="icon-button"
   >
     <View
       style={
@@ -144,7 +142,6 @@ exports[`renders icon button by default 1`] = `
       undefined,
     ]
   }
-  testID="icon-button-container"
 >
   <View
     accessibilityState={
@@ -201,7 +198,6 @@ exports[`renders icon button by default 1`] = `
         ],
       ]
     }
-    testID="icon-button"
   >
     <View
       style={
@@ -266,7 +262,6 @@ exports[`renders icon button with color 1`] = `
       undefined,
     ]
   }
-  testID="icon-button-container"
 >
   <View
     accessibilityState={
@@ -323,7 +318,6 @@ exports[`renders icon button with color 1`] = `
         ],
       ]
     }
-    testID="icon-button"
   >
     <View
       style={
@@ -388,7 +382,6 @@ exports[`renders icon button with size 1`] = `
       undefined,
     ]
   }
-  testID="icon-button-container"
 >
   <View
     accessibilityState={
@@ -445,7 +438,6 @@ exports[`renders icon button with size 1`] = `
         ],
       ]
     }
-    testID="icon-button"
   >
     <View
       style={
@@ -510,7 +502,6 @@ exports[`renders icon change animated 1`] = `
       undefined,
     ]
   }
-  testID="icon-button-container"
 >
   <View
     accessibilityState={
@@ -567,7 +558,6 @@ exports[`renders icon change animated 1`] = `
         ],
       ]
     }
-    testID="icon-button"
   >
     <View
       style={
@@ -611,7 +601,6 @@ exports[`renders icon change animated 1`] = `
               },
             ]
           }
-          testID="cross-fade-icon-current"
         >
           <Text
             accessibilityElementsHidden={true}

--- a/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListAccordion.test.tsx.snap
@@ -226,7 +226,6 @@ exports[`renders expanded accordion 1`] = `
             undefined,
           ]
         }
-        testID="undefined-content"
       >
         <Text
           numberOfLines={1}

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -165,7 +165,6 @@ exports[`renders list item with custom description 1`] = `
                 },
               ]
             }
-            testID="chip-container"
           >
             <View
               collapsable={false}
@@ -260,7 +259,6 @@ exports[`renders list item with custom description 1`] = `
                   ],
                 ]
               }
-              testID="chip"
             >
               <View
                 style={

--- a/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -59,7 +59,6 @@ exports[`renders not visible menu 1`] = `
           },
         ]
       }
-      testID="button-container"
     >
       <View
         collapsable={false}
@@ -149,7 +148,6 @@ exports[`renders not visible menu 1`] = `
             },
           ]
         }
-        testID="button"
       >
         <View
           style={
@@ -211,7 +209,6 @@ exports[`renders not visible menu 1`] = `
                 ],
               ]
             }
-            testID="button-text"
           >
             Open menu
           </Text>
@@ -282,7 +279,6 @@ exports[`renders visible menu 1`] = `
             },
           ]
         }
-        testID="button-container"
       >
         <View
           collapsable={false}
@@ -372,7 +368,6 @@ exports[`renders visible menu 1`] = `
               },
             ]
           }
-          testID="button"
         >
           <View
             style={
@@ -434,7 +429,6 @@ exports[`renders visible menu 1`] = `
                   ],
                 ]
               }
-              testID="button-text"
             >
               Open menu
             </Text>
@@ -517,7 +511,6 @@ exports[`renders visible menu 1`] = `
           undefined,
         ]
       }
-      testID="menu-view"
     >
       <View
         collapsable={false}
@@ -591,7 +584,6 @@ exports[`renders visible menu 1`] = `
               },
             ]
           }
-          testID="menu-surface"
         >
           <View
             collapsable={false}
@@ -701,7 +693,6 @@ exports[`renders visible menu 1`] = `
                   ],
                 ]
               }
-              testID="menu-item"
             >
               <View
                 style={
@@ -769,7 +760,6 @@ exports[`renders visible menu 1`] = `
                         ],
                       ]
                     }
-                    testID="menu-item-title"
                   >
                     Undo
                   </Text>
@@ -825,7 +815,6 @@ exports[`renders visible menu 1`] = `
                   ],
                 ]
               }
-              testID="menu-item"
             >
               <View
                 style={
@@ -893,7 +882,6 @@ exports[`renders visible menu 1`] = `
                         ],
                       ]
                     }
-                    testID="menu-item-title"
                   >
                     Redo
                   </Text>

--- a/src/components/__tests__/__snapshots__/MenuItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/MenuItem.test.tsx.snap
@@ -51,7 +51,6 @@ exports[`Menu Item renders menu item 1`] = `
         ],
       ]
     }
-    testID="menu-item"
   >
     <View
       style={
@@ -159,7 +158,6 @@ exports[`Menu Item renders menu item 1`] = `
               ],
             ]
           }
-          testID="menu-item-title"
         >
           Redo
         </Text>
@@ -215,7 +213,6 @@ exports[`Menu Item renders menu item 1`] = `
         ],
       ]
     }
-    testID="menu-item"
   >
     <View
       style={
@@ -323,7 +320,6 @@ exports[`Menu Item renders menu item 1`] = `
               ],
             ]
           }
-          testID="menu-item-title"
         >
           Undo
         </Text>
@@ -379,7 +375,6 @@ exports[`Menu Item renders menu item 1`] = `
         ],
       ]
     }
-    testID="menu-item"
   >
     <View
       style={
@@ -487,7 +482,6 @@ exports[`Menu Item renders menu item 1`] = `
               ],
             ]
           }
-          testID="menu-item-title"
         >
           Cut
         </Text>
@@ -543,7 +537,6 @@ exports[`Menu Item renders menu item 1`] = `
         ],
       ]
     }
-    testID="menu-item"
   >
     <View
       style={
@@ -651,7 +644,6 @@ exports[`Menu Item renders menu item 1`] = `
               ],
             ]
           }
-          testID="menu-item-title"
         >
           Copy
         </Text>
@@ -707,7 +699,6 @@ exports[`Menu Item renders menu item 1`] = `
         ],
       ]
     }
-    testID="menu-item"
   >
     <View
       style={
@@ -775,7 +766,6 @@ exports[`Menu Item renders menu item 1`] = `
               ],
             ]
           }
-          testID="menu-item-title"
         >
           Paste
         </Text>

--- a/src/components/__tests__/__snapshots__/ProgressBar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ProgressBar.test.tsx.snap
@@ -10,7 +10,6 @@ exports[`renders colored progress bar 1`] = `
   onLayout={[Function]}
   role="progressbar"
   style={false}
-  testID="progress-bar"
 >
   <View
     collapsable={false}
@@ -40,7 +39,6 @@ exports[`renders colored progress bar 1`] = `
           "width": 100,
         }
       }
-      testID="progress-bar-fill"
     />
   </View>
 </View>
@@ -56,7 +54,6 @@ exports[`renders hidden progress bar 1`] = `
   onLayout={[Function]}
   role="progressbar"
   style={false}
-  testID="progress-bar"
 >
   <View
     collapsable={false}
@@ -86,7 +83,6 @@ exports[`renders hidden progress bar 1`] = `
           "width": 100,
         }
       }
-      testID="progress-bar-fill"
     />
   </View>
 </View>
@@ -99,7 +95,6 @@ exports[`renders indeterminate progress bar 1`] = `
   onLayout={[Function]}
   role="progressbar"
   style={false}
-  testID="progress-bar"
 >
   <View
     collapsable={false}
@@ -129,7 +124,6 @@ exports[`renders indeterminate progress bar 1`] = `
           "width": 100,
         }
       }
-      testID="progress-bar-fill"
     />
   </View>
 </View>
@@ -145,7 +139,6 @@ exports[`renders progress bar with specific progress 1`] = `
   onLayout={[Function]}
   role="progressbar"
   style={false}
-  testID="progress-bar"
 >
   <View
     collapsable={false}
@@ -175,7 +168,6 @@ exports[`renders progress bar with specific progress 1`] = `
           "width": 100,
         }
       }
-      testID="progress-bar-fill"
     />
   </View>
 </View>

--- a/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
@@ -42,7 +42,6 @@ exports[`activity indicator snapshot test 1`] = `
       },
     ]
   }
-  testID="search-bar-container"
 >
   <View
     collapsable={false}
@@ -112,7 +111,6 @@ exports[`activity indicator snapshot test 1`] = `
         undefined,
       ]
     }
-    testID="search-bar-icon-container"
   >
     <View
       accessibilityLabel="search"
@@ -170,7 +168,6 @@ exports[`activity indicator snapshot test 1`] = `
           ],
         ]
       }
-      testID="search-bar-icon"
     >
       <View
         style={
@@ -243,7 +240,6 @@ exports[`activity indicator snapshot test 1`] = `
         undefined,
       ]
     }
-    testID="search-bar"
     underlineColorAndroid="transparent"
     value=""
   />
@@ -486,7 +482,6 @@ exports[`renders with placeholder 1`] = `
       },
     ]
   }
-  testID="search-bar-container"
 >
   <View
     collapsable={false}
@@ -556,7 +551,6 @@ exports[`renders with placeholder 1`] = `
         undefined,
       ]
     }
-    testID="search-bar-icon-container"
   >
     <View
       accessibilityLabel="search"
@@ -614,7 +608,6 @@ exports[`renders with placeholder 1`] = `
           ],
         ]
       }
-      testID="search-bar-icon"
     >
       <View
         style={
@@ -687,7 +680,6 @@ exports[`renders with placeholder 1`] = `
         undefined,
       ]
     }
-    testID="search-bar"
     underlineColorAndroid="transparent"
     value=""
   />
@@ -703,7 +695,6 @@ exports[`renders with placeholder 1`] = `
         false,
       ]
     }
-    testID="search-bar-icon-wrapper"
   >
     <View
       collapsable={false}
@@ -726,7 +717,6 @@ exports[`renders with placeholder 1`] = `
           undefined,
         ]
       }
-      testID="search-bar-clear-icon-container"
     >
       <View
         accessibilityLabel="clear"
@@ -784,7 +774,6 @@ exports[`renders with placeholder 1`] = `
             ],
           ]
         }
-        testID="search-bar-clear-icon"
       >
         <View
           style={
@@ -871,7 +860,6 @@ exports[`renders with text 1`] = `
       },
     ]
   }
-  testID="search-bar-container"
 >
   <View
     collapsable={false}
@@ -941,7 +929,6 @@ exports[`renders with text 1`] = `
         undefined,
       ]
     }
-    testID="search-bar-icon-container"
   >
     <View
       accessibilityLabel="search"
@@ -999,7 +986,6 @@ exports[`renders with text 1`] = `
           ],
         ]
       }
-      testID="search-bar-icon"
     >
       <View
         style={
@@ -1072,7 +1058,6 @@ exports[`renders with text 1`] = `
         undefined,
       ]
     }
-    testID="search-bar"
     underlineColorAndroid="transparent"
     value="query"
   />
@@ -1084,7 +1069,6 @@ exports[`renders with text 1`] = `
         false,
       ]
     }
-    testID="search-bar-icon-wrapper"
   >
     <View
       collapsable={false}
@@ -1107,7 +1091,6 @@ exports[`renders with text 1`] = `
           undefined,
         ]
       }
-      testID="search-bar-clear-icon-container"
     >
       <View
         accessibilityLabel="clear"
@@ -1165,7 +1148,6 @@ exports[`renders with text 1`] = `
             ],
           ]
         }
-        testID="search-bar-clear-icon"
       >
         <View
           style={

--- a/src/components/__tests__/__snapshots__/SegmentedButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/SegmentedButton.test.tsx.snap
@@ -134,7 +134,6 @@ exports[`renders segmented button 1`] = `
               ],
             ]
           }
-          testID="undefined-label"
         />
       </View>
     </View>
@@ -260,7 +259,6 @@ exports[`renders segmented button 1`] = `
               ],
             ]
           }
-          testID="undefined-label"
         />
       </View>
     </View>

--- a/src/components/__tests__/__snapshots__/Snackbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Snackbar.test.tsx.snap
@@ -528,7 +528,6 @@ exports[`renders snackbar with action button 1`] = `
             },
           ]
         }
-        testID="button-container"
       >
         <View
           collapsable={false}
@@ -618,7 +617,6 @@ exports[`renders snackbar with action button 1`] = `
               },
             ]
           }
-          testID="button"
         >
           <View
             style={
@@ -679,7 +677,6 @@ exports[`renders snackbar with action button 1`] = `
                   ],
                 ]
               }
-              testID="button-text"
             >
               Undo
             </Text>

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -176,7 +176,6 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
             false,
           ]
         }
-        testID="icon-button-container"
       >
         <View
           accessibilityState={
@@ -234,7 +233,6 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
               ],
             ]
           }
-          testID="icon-button"
         >
           <View
             style={
@@ -367,7 +365,6 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
             false,
           ]
         }
-        testID="icon-button-container"
       >
         <View
           accessibilityState={
@@ -425,7 +422,6 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
               ],
             ]
           }
-          testID="icon-button"
         >
           <View
             style={
@@ -654,7 +650,6 @@ exports[`renders filled TextInput with TextInput.Icon accessories when error is 
             false,
           ]
         }
-        testID="icon-button-container"
       >
         <View
           accessibilityState={
@@ -712,7 +707,6 @@ exports[`renders filled TextInput with TextInput.Icon accessories when error is 
               ],
             ]
           }
-          testID="icon-button"
         >
           <View
             style={
@@ -845,7 +839,6 @@ exports[`renders filled TextInput with TextInput.Icon accessories when error is 
             false,
           ]
         }
-        testID="icon-button-container"
       >
         <View
           accessibilityState={
@@ -903,7 +896,6 @@ exports[`renders filled TextInput with TextInput.Icon accessories when error is 
               ],
             ]
           }
-          testID="icon-button"
         >
           <View
             style={
@@ -1310,7 +1302,6 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
             false,
           ]
         }
-        testID="icon-button-container"
       >
         <View
           accessibilityState={
@@ -1368,7 +1359,6 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
               ],
             ]
           }
-          testID="icon-button"
         >
           <View
             style={
@@ -1501,7 +1491,6 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
             false,
           ]
         }
-        testID="icon-button-container"
       >
         <View
           accessibilityState={
@@ -1559,7 +1548,6 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
               ],
             ]
           }
-          testID="icon-button"
         >
           <View
             style={
@@ -1768,7 +1756,6 @@ exports[`renders outlined TextInput with TextInput.Icon accessories when error i
             false,
           ]
         }
-        testID="icon-button-container"
       >
         <View
           accessibilityState={
@@ -1826,7 +1813,6 @@ exports[`renders outlined TextInput with TextInput.Icon accessories when error i
               ],
             ]
           }
-          testID="icon-button"
         >
           <View
             style={
@@ -1959,7 +1945,6 @@ exports[`renders outlined TextInput with TextInput.Icon accessories when error i
             false,
           ]
         }
-        testID="icon-button-container"
       >
         <View
           accessibilityState={
@@ -2017,7 +2002,6 @@ exports[`renders outlined TextInput with TextInput.Icon accessories when error i
               ],
             ]
           }
-          testID="icon-button"
         >
           <View
             style={

--- a/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ToggleButton.test.tsx.snap
@@ -32,7 +32,6 @@ exports[`renders disabled toggle button 1`] = `
       undefined,
     ]
   }
-  testID="icon-button-container"
 >
   <View
     accessibilityState={
@@ -87,7 +86,6 @@ exports[`renders disabled toggle button 1`] = `
         ],
       ]
     }
-    testID="icon-button"
   >
     <View
       style={
@@ -162,7 +160,6 @@ exports[`renders toggle button 1`] = `
       undefined,
     ]
   }
-  testID="icon-button-container"
 >
   <View
     accessibilityState={
@@ -217,7 +214,6 @@ exports[`renders toggle button 1`] = `
         ],
       ]
     }
-    testID="icon-button"
   >
     <View
       style={
@@ -292,7 +288,6 @@ exports[`renders unchecked toggle button 1`] = `
       undefined,
     ]
   }
-  testID="icon-button-container"
 >
   <View
     accessibilityState={
@@ -347,7 +342,6 @@ exports[`renders unchecked toggle button 1`] = `
         ],
       ]
     }
-    testID="icon-button"
   >
     <View
       style={


### PR DESCRIPTION
### Motivation

Several components fell back to a hardcoded default `testID` (e.g. `testID = 'button'`, `testID = 'card'`, `testID = 'search-bar'`) whenever a consumer didn't pass one explicitly. This meant every instance of a component rendered without an explicit `testID` still emitted a fixed, non-configurable testID into the tree  leading to duplicate/colliding testIDs when multiple instances of the same component render on screen.

This PR removes all hardcoded default `testID` values so that `testID` is `undefined` unless a consumer explicitly provides one. Suffixed child testIDs (e.g. `` `${testID}-container` ``) are now only rendered when a `testID` is explicitly given, instead of always deriving from the removed default.

Along the way this surfaced two latent bugs that the hardcoded defaults had been masking:
- `IconButton` never forwarded its `testID` down into the inner icon, relying on `CrossFadeIcon`'s own default instead. Now it forwards `${testID}-icon` explicitly.
- `FAB.Menu`'s trigger wrapper put `testID` on a non-interactive positioning `View` instead of the actual pressable `Shell`, which only worked before because `Shell` had its own hardcoded default in the right place.

Affected components: `Button`, `Card`, `Chip`, `Surface`, `Modal`, `Menu`, `Menu.Item`, `IconButton`, `Searchbar`, `CrossFadeIcon`, `ProgressBar`, `Appbar.Header`, `Appbar.Content`, `Drawer.CollapsedItem`, `FAB`, `FAB.Extended`, `FAB.Menu`, `BottomNavigation`, `BottomNavigationBar`.

### Test plan

- `yarn typecheck` passes.
- `yarn lint` passes.
- `yarn jest` passes (55 suites, 732 tests, 169 snapshots — snapshots updated to reflect the removed default testID attributes).
- Updated unit tests that relied on the old default testID strings (`Button`, `Card`, `Menu`, `Menu.Item`, `Drawer.CollapsedItem`, `FAB.Menu`, `ListItem`, `Appbar`, `BottomNavigation`) to pass an explicit `testID` where the assertion actually needs one.
- No behavior change for consumers who already pass an explicit `testID`, only the implicit-default fallback is removed.
