### PR TITLE
fix: remove derived testIDs

### DIFF
--- a/docs/6.x/docs/guides/migration.md
+++ b/docs/6.x/docs/guides/migration.md
@@ -98,7 +98,7 @@ These components used to also derive test IDs for internal, implementation-only 
 
 If you were relying on internal test IDs, update your tests not to rely on internal implementation details and only interact with elements or assert content your users can reach, e.g.: query by role, label, text etc., or `testID` props accepted by the component.
 
-Some components now accept explicit `testID` props for their interactable, internal elements:
+Some components now accept explicit `testID` props for their interactable elements:
 
 - `BottomNavigation`: `barTestID` for the internal `BottomNavigation.Bar`, replacing the previous `${testID}-bar` derivation.
 - `Chip`: `closeIconTestID` for the close icon button.

--- a/docs/6.x/docs/guides/migration.md
+++ b/docs/6.x/docs/guides/migration.md
@@ -94,9 +94,18 @@ Hardcoded default test IDs have been removed for the components listed below:
 
 You can specify a `testID` explicitly to restore each component's own test ID.
 
-These components used to also derive test IDs for internal, implementation-only elements by appending a suffix to the `testID` prop (e.g. `${testID}-container`, `${testID}-icon`, `${testID}-outline`). Those internal test IDs have been removed entirely — they are no longer set even when you pass `testID` explicitly. Test IDs should only be used to interact with elements or assert content your users can reach, not to reach into a component's internal structure in tests; if you were relying on one of these internal IDs, query by role, label, text, or the component's own `testID`/`ref` instead.
+These components used to also derive test IDs for internal, implementation-only elements by appending a suffix to the `testID` prop (e.g. `${testID}-container`, `${testID}-icon`, `${testID}-outline`). They have been removed entirely.
 
-The one exception is `BottomNavigation`, which still sets `${testID}-bar` on its internal `BottomNavigation.Bar` when you pass `testID`, since there's currently no other way to reference that node from outside the component.
+If you were relying on internal test IDs, update your tests not to rely on internal implementation details and only interact with elements or assert content your users can reach, e.g.: query by role, label, text etc., or `testID` props accepted by the component.
+
+Some components now accept explicit `testID` props for their interactable, internal elements:
+
+- `BottomNavigation`: `barTestID` for the internal `BottomNavigation.Bar`, replacing the previous `${testID}-bar` derivation.
+- `Chip`: `closeIconTestID` for the close icon button.
+- `Dialog` and `Modal`: `overlayTestID` for the overlay displayed behind the content.
+- `Menu`: `overlayTestID` for the overlay displayed behind the menu.
+- `Searchbar`: `searchTestID`, `clearTestID`, and `trailingTestID` for the search, clear, and trailing icon buttons.
+- `Snackbar`: `iconTestID` for the icon button.
 
 ## Components
 

--- a/docs/6.x/docs/guides/migration.md
+++ b/docs/6.x/docs/guides/migration.md
@@ -71,61 +71,32 @@ You can use the component's color prop where available, or override the correspo
 
 ### Test IDs
 
-Hardcoded default test IDs have been removed for the components listed below. Many of these components also derive test IDs for their internal parts by appending a suffix to the `testID` prop (e.g. `${testID}-container`). Since `testID` is no longer defaulted to a hardcoded value, none of these derived test IDs are set either unless you pass a `testID` explicitly — so all queries by the IDs below will stop matching:
+Hardcoded default test IDs have been removed for the components listed below:
 
 - `Appbar.Content`: `appbar-content`
-  - `appbar-content-title-text`
 - `Appbar.Header`: `appbar-header`
-  - `appbar-header-root-layer`
 - `BottomNavigation`: `bottom-navigation`
-  - `bottom-navigation-bar`
 - `BottomNavigation.Bar`: `bottom-navigation-bar`
-  - `bottom-navigation-bar-content`
-  - `bottom-navigation-bar-content-wrapper`
 - `Button`: `button`
-  - `button-container`
-  - `button-icon-container`
-  - `button-text`
 - `Card`: `card`
-  - `card-container`
-  - `card-outline`
 - `Chip`: `chip`
-  - `chip-container`
 - `Drawer.CollapsedItem`: `drawer-collapsed-item`
-  - `drawer-collapsed-item-outline`
-  - `drawer-collapsed-item-container`
 - `FAB`: `floating-action-button`
-  - `floating-action-button-container`
-  - `floating-action-button-text`
 - `FAB.Extended`: `extended-floating-action-button`
-  - `extended-floating-action-button-container`
-  - `extended-floating-action-button-text`
 - `FAB.Menu`: `floating-action-button-menu`
 - `IconButton`: `icon-button`
-  - `icon-button-container`
-  - `icon-button-icon` (and `icon-button-icon-previous` / `icon-button-icon-current` when `animated`)
 - `Menu`: `menu`
-  - `menu-view`
-  - `menu-surface`
 - `Menu.Item`: `menu-item`
-  - `menu-item-title`
 - `Modal`: `modal`
-  - `modal-backdrop`
-  - `modal-wrapper`
-  - `modal-surface`
 - `ProgressBar`: `progress-bar`
-  - `progress-bar-fill`
 - `Searchbar`: `search-bar`
-  - `search-bar-container`
-  - `search-bar-icon`
-  - `search-bar-icon-wrapper`
-  - `search-bar-clear-icon`
-  - `search-bar-trailering-icon`
-  - `search-bar-divider`
 - `Surface`: `surface`
-  - `surface-outer-layer`
 
-You can specify a `testID` explicitly to restore both the component's own test ID and all of its derived test IDs above, using the same suffixes.
+You can specify a `testID` explicitly to restore each component's own test ID.
+
+These components used to also derive test IDs for internal, implementation-only elements by appending a suffix to the `testID` prop (e.g. `${testID}-container`, `${testID}-icon`, `${testID}-outline`). Those internal test IDs have been removed entirely — they are no longer set even when you pass `testID` explicitly. Test IDs should only be used to interact with elements or assert content your users can reach, not to reach into a component's internal structure in tests; if you were relying on one of these internal IDs, query by role, label, text, or the component's own `testID`/`ref` instead.
+
+The one exception is `BottomNavigation`, which still sets `${testID}-bar` on its internal `BottomNavigation.Bar` when you pass `testID`, since there's currently no other way to reference that node from outside the component.
 
 ## Components
 

--- a/src/components/Appbar/AppbarContent.tsx
+++ b/src/components/Appbar/AppbarContent.tsx
@@ -135,7 +135,6 @@ const AppbarContent = ({
           numberOfLines={1}
           accessible
           role={onPress ? 'none' : 'heading'}
-          testID={testID ? `${testID}-title-text` : undefined}
           maxFontSizeMultiplier={titleMaxFontSizeMultiplier}
         >
           {title}

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -252,6 +252,10 @@ export type Props<Route extends BaseRoute> = {
    * TestID used for testing purposes
    */
   testID?: string;
+  /**
+   * testID for the underlying `BottomNavigation.Bar`.
+   */
+  barTestID?: string;
 };
 
 const FAR_FAR_AWAY = Platform.OS === 'web' ? 0 : 9999;
@@ -336,6 +340,7 @@ const BottomNavigation = <Route extends BaseRoute>({
   labelMaxFontSizeMultiplier = 1,
   compact: compactProp,
   testID,
+  barTestID,
   theme: themeOverrides,
   getLazy = ({ route }: { route: Route }) => route.lazy,
 }: Props<Route>) => {
@@ -579,7 +584,7 @@ const BottomNavigation = <Route extends BaseRoute>({
         safeAreaInsets={safeAreaInsets}
         labelMaxFontSizeMultiplier={labelMaxFontSizeMultiplier}
         compact={compact}
-        testID={testID ? `${testID}-bar` : undefined}
+        testID={barTestID}
         theme={theme}
       />
     </View>

--- a/src/components/BottomNavigation/BottomNavigationBar.tsx
+++ b/src/components/BottomNavigation/BottomNavigationBar.tsx
@@ -493,10 +493,7 @@ const BottomNavigationBar = <Route extends BaseRoute>({
       ]}
       onLayout={onLayout}
     >
-      <Animated.View
-        style={[styles.barContent, { backgroundColor }]}
-        testID={testID ? `${testID}-content` : undefined}
-      >
+      <Animated.View style={[styles.barContent, { backgroundColor }]}>
         <View
           style={[
             styles.items,
@@ -509,7 +506,6 @@ const BottomNavigationBar = <Route extends BaseRoute>({
             },
           ]}
           role={'tablist'}
-          testID={testID ? `${testID}-content-wrapper` : undefined}
         >
           {routes.map((route, index) => {
             const focused = navigationState.index === index;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -292,7 +292,6 @@ const Button = ({
     <Surface
       {...rest}
       ref={ref}
-      testID={testID ? `${testID}-container` : undefined}
       backgroundColor={backgroundOpacity < 1 ? 'transparent' : backgroundColor}
       {...touchableStyle}
       style={[
@@ -342,10 +341,7 @@ const Button = ({
       >
         <View style={[styles.content, { opacity: textOpacity }, contentStyle]}>
           {icon && loading !== true ? (
-            <View
-              style={iconStyle}
-              testID={testID ? `${testID}-icon-container` : undefined}
-            >
+            <View style={iconStyle}>
               <Icon
                 source={icon}
                 size={customLabelSize ?? iconSize}
@@ -372,7 +368,6 @@ const Button = ({
             variant="labelLarge"
             selectable={false}
             numberOfLines={1}
-            testID={testID ? `${testID}-text` : undefined}
             style={[
               styles.label,
               isMode('text')

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -204,7 +204,7 @@ const Card = ({
   const borderRadius = theme.shapes.corner.medium;
 
   const content = (
-    <View style={[styles.innerContainer, contentStyle]} testID={testID}>
+    <View style={[styles.innerContainer, contentStyle]}>
       {React.Children.map(children, (child, index) =>
         React.isValidElement(child)
           ? React.cloneElement(child as React.ReactElement<any>, {
@@ -225,6 +225,7 @@ const Card = ({
       style={[{ borderColor }, style]}
       theme={theme}
       elevation={elevation}
+      testID={hasPassedTouchHandler ? undefined : testID}
       {...rest}
     >
       {isMode('outlined') && (
@@ -250,6 +251,7 @@ const Card = ({
           onPress={onPress}
           onPressIn={handlePressIn}
           onPressOut={handlePressOut}
+          testID={testID}
         >
           {content}
         </Pressable>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -225,13 +225,11 @@ const Card = ({
       style={[{ borderColor }, style]}
       theme={theme}
       elevation={elevation}
-      testID={testID ? `${testID}-container` : undefined}
       {...rest}
     >
       {isMode('outlined') && (
         <View
           pointerEvents="none"
-          testID={testID ? `${testID}-outline` : undefined}
           style={[
             {
               borderColor,

--- a/src/components/Card/CardTitle.tsx
+++ b/src/components/Card/CardTitle.tsx
@@ -102,6 +102,10 @@ export type Props = ViewProps & {
    * @optional
    */
   theme?: ThemeProp;
+  /**
+   * testID to be used on tests.
+   */
+  testID?: string;
 };
 
 const LEFT_SIZE = 40;
@@ -143,6 +147,7 @@ const CardTitle = ({
   rightStyle,
   style,
   theme: themeOverrides,
+  testID,
 }: Props) => {
   useInternalTheme(themeOverrides);
 
@@ -150,7 +155,7 @@ const CardTitle = ({
   const marginBottom = subtitle ? 0 : 2;
 
   return (
-    <View style={[styles.container, { minHeight }, style]}>
+    <View style={[styles.container, { minHeight }, style]} testID={testID}>
       {left ? (
         <View style={[styles.left, leftStyle]}>
           {left({

--- a/src/components/Checkbox/CheckboxItem.tsx
+++ b/src/components/Checkbox/CheckboxItem.tsx
@@ -174,7 +174,6 @@ const CheckboxItem = ({
         {isLeading && checkbox}
         <Text
           variant={labelVariant}
-          testID={testID ? `${testID}-text` : undefined}
           maxFontSizeMultiplier={labelMaxFontSizeMultiplier}
           style={[styles.label, computedStyle, labelStyle]}
         >

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -88,6 +88,10 @@ export type Props = Omit<ViewProps, 'style'> & {
    */
   closeIconAccessibilityLabel?: string;
   /**
+   * testID for the close icon button.
+   */
+  closeIconTestID?: string;
+  /**
    * Function to execute on press.
    */
   onPress?: (e: GestureResponderEvent) => void;
@@ -186,6 +190,7 @@ const Chip = ({
   'aria-label': ariaLabel,
   role = 'button',
   closeIconAccessibilityLabel = 'Close',
+  closeIconTestID,
   onPress,
   onLongPress,
   onPressOut,
@@ -385,6 +390,7 @@ const Chip = ({
             disabled={disabled}
             role="button"
             aria-label={closeIconAccessibilityLabel}
+            testID={closeIconTestID}
           >
             <View style={[styles.icon, styles.closeIcon, styles.md3CloseIcon]}>
               {closeIcon ? (

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -281,7 +281,6 @@ const Chip = ({
       elevation={elevation}
       transitionDuration={elevationTransitionDuration}
       {...rest}
-      testID={testID ? `${testID}-container` : undefined}
       theme={theme}
     >
       <TouchableRipple

--- a/src/components/CrossFadeIcon.tsx
+++ b/src/components/CrossFadeIcon.tsx
@@ -98,6 +98,7 @@ const CrossFadeIcon = ({
 
   return (
     <View
+      testID={testID}
       style={[
         styles.content,
         {
@@ -107,17 +108,11 @@ const CrossFadeIcon = ({
       ]}
     >
       {hasPreviousIcon ? (
-        <Animated.View
-          style={[styles.icon, previousIconStyle]}
-          testID={testID ? `${testID}-previous` : undefined}
-        >
+        <Animated.View style={[styles.icon, previousIconStyle]}>
           <Icon source={previousIcon} size={size} color={color} theme={theme} />
         </Animated.View>
       ) : null}
-      <Animated.View
-        style={[styles.icon, currentIconStyle]}
-        testID={testID ? `${testID}-current` : undefined}
-      >
+      <Animated.View style={[styles.icon, currentIconStyle]}>
         <Icon source={currentIcon} size={size} color={color} theme={theme} />
       </Animated.View>
     </View>

--- a/src/components/DataTable/DataTableCell.tsx
+++ b/src/components/DataTable/DataTableCell.tsx
@@ -84,7 +84,6 @@ const DataTableCell = ({
     >
       <CellContent
         textStyle={textStyle}
-        testID={testID}
         maxFontSizeMultiplier={maxFontSizeMultiplier}
       >
         {children}
@@ -97,11 +96,7 @@ const CellContent = ({
   children,
   textStyle,
   maxFontSizeMultiplier,
-  testID,
-}: Pick<
-  Props,
-  'children' | 'textStyle' | 'testID' | 'maxFontSizeMultiplier'
->) => {
+}: Pick<Props, 'children' | 'textStyle' | 'maxFontSizeMultiplier'>) => {
   if (React.isValidElement(children)) {
     return children;
   }
@@ -111,7 +106,6 @@ const CellContent = ({
       style={textStyle}
       numberOfLines={1}
       maxFontSizeMultiplier={maxFontSizeMultiplier}
-      testID={testID ? `${testID}-text-container` : undefined}
     >
       {children}
     </Text>

--- a/src/components/DataTable/DataTablePagination.tsx
+++ b/src/components/DataTable/DataTablePagination.tsx
@@ -292,15 +292,10 @@ const DataTablePagination = ({
       {numberOfItemsPerPageList &&
         numberOfItemsPerPage &&
         onItemsPerPageChange && (
-          <View
-            aria-label="Options Select"
-            testID="options-select"
-            style={styles.optionsContainer}
-          >
+          <View aria-label="Options Select" style={styles.optionsContainer}>
             <Text
               style={[styles.label, { color: labelColor }]}
               numberOfLines={3}
-              testID="select-page-dropdown-label"
               aria-label={
                 selectPageDropdownAccessibilityLabel ||
                 'selectPageDropdownLabel'

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -45,6 +45,10 @@ export type Props = {
    * testID to be used on tests.
    */
   testID?: string;
+  /**
+   * testID for the overlay that is displayed behind the dialog.
+   */
+  overlayTestID?: string;
 };
 
 const DIALOG_ELEVATION: Elevation = 3;
@@ -98,6 +102,7 @@ const Dialog = ({
   style,
   theme: themeOverrides,
   testID,
+  overlayTestID,
 }: Props) => {
   const { right, left } = useSafeAreaInsets();
 
@@ -124,6 +129,7 @@ const Dialog = ({
       ]}
       theme={theme}
       testID={testID}
+      overlayTestID={overlayTestID}
     >
       {React.Children.toArray(children)
         .filter((child) => child != null && typeof child !== 'boolean')

--- a/src/components/Drawer/DrawerCollapsedItem.tsx
+++ b/src/components/Drawer/DrawerCollapsedItem.tsx
@@ -195,13 +195,9 @@ const DrawerCollapsedItem = ({
               style,
               animatedOutlineStyle,
             ]}
-            testID={testID ? `${testID}-outline` : undefined}
           />
 
-          <View
-            style={[styles.icon, { top: iconPadding }]}
-            testID={testID ? `${testID}-container` : undefined}
-          >
+          <View style={[styles.icon, { top: iconPadding }]}>
             {badge !== false && (
               <View style={styles.badgeContainer}>
                 {typeof badge === 'boolean' ? (

--- a/src/components/Drawer/DrawerItem.tsx
+++ b/src/components/Drawer/DrawerItem.tsx
@@ -64,6 +64,10 @@ export type Props = ViewProps & {
    * @optional
    */
   theme?: ThemeProp;
+  /**
+   * testID to be used on tests.
+   */
+  testID?: string;
 };
 
 /**
@@ -98,6 +102,7 @@ const DrawerItem = ({
   right,
   labelMaxFontSizeMultiplier,
   hitSlop,
+  testID,
   ...rest
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
@@ -129,6 +134,7 @@ const DrawerItem = ({
         aria-label={ariaLabel}
         theme={theme}
         hitSlop={hitSlop}
+        testID={testID}
       >
         <View style={[styles.wrapper, styles.v3Wrapper]}>
           <View style={styles.content}>

--- a/src/components/FAB/Content.tsx
+++ b/src/components/FAB/Content.tsx
@@ -27,7 +27,6 @@ export type ContentProps = {
   labelAnimatedStyle?: StyleProp<AnimatedStyle<ViewStyle>>;
   labelNumberOfLines?: number;
   labelEllipsisMode?: 'clip' | 'tail' | 'head' | 'middle';
-  testID?: string;
 };
 
 /**
@@ -50,7 +49,6 @@ const Content = ({
   labelAnimatedStyle,
   labelNumberOfLines,
   labelEllipsisMode,
-  testID,
 }: ContentProps) => {
   const hasLabel = label !== undefined && label !== '';
   const colorStyle = { color: contentColor };
@@ -86,7 +84,6 @@ const Content = ({
               ellipsizeMode={labelEllipsisMode}
               maxFontSizeMultiplier={labelMaxFontSizeMultiplier}
               style={colorStyle}
-              testID={testID ? `${testID}-text` : undefined}
             >
               {label}
             </AnimatedText>

--- a/src/components/FAB/Menu.tsx
+++ b/src/components/FAB/Menu.tsx
@@ -284,7 +284,6 @@ const MenuItem = ({
             leading={leading}
             trailing={trailing}
             iconLabelGap={iconLabelGap}
-            testID={testID}
           />
         </TouchableRipple>
       </View>

--- a/src/components/FAB/Shell.tsx
+++ b/src/components/FAB/Shell.tsx
@@ -319,7 +319,6 @@ const Shell = ({
         visible ? styles.pointerEventsAuto : styles.pointerEventsNone,
       ]}
       elevation={elevation}
-      testID={testID ? `${testID}-container` : undefined}
       theme={theme}
     >
       <Animated.View style={[styles.clip, clipStyle]}>
@@ -357,7 +356,6 @@ const Shell = ({
               labelAnimatedStyle={labelAnimatedStyle}
               labelNumberOfLines={labelAnimatedStyle ? 1 : undefined}
               labelEllipsisMode={labelAnimatedStyle ? 'clip' : undefined}
-              testID={testID}
             />
           )}
         </TouchableRipple>

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -161,7 +161,6 @@ const IconButton = ({
   return (
     <Animated.View
       ref={ref}
-      testID={testID ? `${testID}-container` : undefined}
       style={[
         styles.container,
         {
@@ -203,12 +202,7 @@ const IconButton = ({
           {loading ? (
             <ActivityIndicator size={size} color={iconColor} />
           ) : (
-            <IconComponent
-              color={iconColor}
-              source={icon}
-              size={size}
-              testID={testID ? `${testID}-icon` : undefined}
-            />
+            <IconComponent color={iconColor} source={icon} size={size} />
           )}
         </View>
       </TouchableRipple>

--- a/src/components/List/ListImage.tsx
+++ b/src/components/List/ListImage.tsx
@@ -50,7 +50,6 @@ const ListImage = ({
       style={getStyles()}
       source={source}
       accessibilityIgnoresInvertColors
-      testID="list-image"
     />
   );
 };

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -245,10 +245,7 @@ const ListItem = ({
               style: getLeftStyles(alignToTop, description),
             })
           : null}
-        <View
-          style={[styles.item, styles.content, contentStyle]}
-          testID={testID ? `${testID}-content` : undefined}
-        >
+        <View style={[styles.item, styles.content, contentStyle]}>
           {renderTitle()}
 
           {description

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -691,7 +691,6 @@ const Menu = ({
             style={[styles.wrapper, positionStyle, style]}
             pointerEvents={pointerEvents}
             onAccessibilityEscape={onDismiss}
-            testID={testID ? `${testID}-view` : undefined}
           >
             <Animated.View
               pointerEvents={pointerEvents}
@@ -707,7 +706,7 @@ const Menu = ({
                   shadowMenuAnimationStyle,
                 ]}
                 elevation={elevation}
-                testID={testID ? `${testID}-surface` : undefined}
+                testID={testID}
                 theme={theme}
               >
                 <Animated.View

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -69,6 +69,10 @@ export type Props = {
    */
   overlayAccessibilityLabel?: string;
   /**
+   * testID for the overlay that is displayed behind the menu.
+   */
+  overlayTestID?: string;
+  /**
    * Content of the `Menu`.
    */
   children: React.ReactNode;
@@ -186,6 +190,7 @@ const Menu = ({
   visible,
   statusBarHeight,
   overlayAccessibilityLabel = 'Close menu',
+  overlayTestID,
   testID,
   anchor,
   onDismiss,
@@ -681,6 +686,7 @@ const Menu = ({
             onPress={onDismiss}
             pointerEvents={visible ? 'auto' : 'none'}
             style={styles.pressableOverlay}
+            testID={overlayTestID}
           />
           <View
             ref={(ref) => {

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -220,7 +220,6 @@ const MenuItem = ({
             variant="bodyLarge"
             selectable={false}
             numberOfLines={1}
-            testID={testID ? `${testID}-title` : undefined}
             style={[titleTextStyle, titleStyle]}
             maxFontSizeMultiplier={titleMaxFontSizeMultiplier}
           >

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -235,7 +235,6 @@ function Modal({
         onPress={dismissable ? onDismissCallback : undefined}
         importantForAccessibility="no"
         style={[styles.backdrop, backdropStyle, backdropTransitionStyle]}
-        testID={testID ? `${testID}-backdrop` : undefined}
       />
       <View
         style={[
@@ -244,10 +243,8 @@ function Modal({
           style,
         ]}
         pointerEvents="box-none"
-        testID={testID ? `${testID}-wrapper` : undefined}
       >
         <Surface
-          testID={testID ? `${testID}-surface` : undefined}
           theme={theme}
           backgroundColor={contentBackgroundColor}
           borderRadius={contentBorderRadius}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -37,6 +37,10 @@ export type Props = {
    */
   overlayAccessibilityLabel?: string;
   /**
+   * testID for the overlay that is displayed behind the modal content.
+   */
+  overlayTestID?: string;
+  /**
    * Determines Whether the modal is visible.
    */
   visible: boolean;
@@ -127,6 +131,7 @@ function Modal({
   dismissableBackButton = dismissable,
   visible = false,
   overlayAccessibilityLabel = 'Close modal',
+  overlayTestID,
   onDismiss = () => {},
   children,
   contentContainerStyle,
@@ -235,6 +240,7 @@ function Modal({
         onPress={dismissable ? onDismissCallback : undefined}
         importantForAccessibility="no"
         style={[styles.backdrop, backdropStyle, backdropTransitionStyle]}
+        testID={overlayTestID}
       />
       <View
         style={[

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -212,7 +212,6 @@ const ProgressBar = ({
       >
         {width ? (
           <Animated.View
-            testID={testID ? `${testID}-fill` : undefined}
             style={[
               styles.progressBar,
               {

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -235,7 +235,6 @@ const Searchbar = ({
       backgroundColor={theme.colors.surfaceContainerHigh}
       borderRadius={isBarMode ? theme.shapes.corner.extraLarge : cornerNone}
       style={[styles.container, style]}
-      testID={testID ? `${testID}-container` : undefined}
       elevation={elevation}
       theme={theme}
     >
@@ -257,7 +256,6 @@ const Searchbar = ({
         }
         theme={theme}
         aria-label={searchAccessibilityLabel}
-        testID={testID ? `${testID}-icon` : undefined}
       />
       <TextInput
         style={[
@@ -295,7 +293,6 @@ const Searchbar = ({
         // when clearing the value.
         <View
           pointerEvents={value ? 'auto' : 'none'}
-          testID={testID ? `${testID}-icon-wrapper` : undefined}
           style={[
             !value && styles.v3ClearIcon,
             right !== undefined && styles.v3ClearIconHidden,
@@ -317,7 +314,6 @@ const Searchbar = ({
                 />
               ))
             }
-            testID={testID ? `${testID}-clear-icon` : undefined}
             role="button"
             theme={theme}
           />
@@ -331,7 +327,6 @@ const Searchbar = ({
           iconColor={traileringIconColor || colors.onSurfaceVariant}
           icon={traileringIcon}
           aria-label={traileringIconAccessibilityLabel}
-          testID={testID ? `${testID}-trailering-icon` : undefined}
         />
       ) : null}
       {isBarMode &&
@@ -345,7 +340,6 @@ const Searchbar = ({
               backgroundColor: colors.outline,
             },
           ]}
-          testID={testID ? `${testID}-divider` : undefined}
         />
       )}
     </Surface>

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -64,6 +64,10 @@ export type Props = Omit<TextInputProps, 'style'> & {
    */
   searchAccessibilityLabel?: string;
   /**
+   * testID for the left icon button (see `onIconPress`).
+   */
+  searchTestID?: string;
+  /**
    * Custom icon for clear button, default will be icon close. It's visible when `loading` is set to `false`.
    * In v5.x with theme version 3, `clearIcon` is visible only if `right` prop is not defined.
    */
@@ -72,6 +76,10 @@ export type Props = Omit<TextInputProps, 'style'> & {
    * Accessibility label for the button. This is read by the screen reader when the user taps the button.
    */
   clearAccessibilityLabel?: string;
+  /**
+   * testID for the clear button.
+   */
+  clearTestID?: string;
   /**
    * @supported Available in v5.x with theme version 3
    * Icon name for the right trailering icon button.
@@ -91,6 +99,10 @@ export type Props = Omit<TextInputProps, 'style'> & {
    * Accessibility label for the right trailering icon button. This is read by the screen reader when the user taps the button.
    */
   traileringIconAccessibilityLabel?: string;
+  /**
+   * testID for the right trailering icon button.
+   */
+  trailingTestID?: string;
   /**
    * @supported Available in v5.x with theme version 3
    * Callback which returns a React element to display on the right side.
@@ -166,12 +178,15 @@ const Searchbar = ({
   iconColor: customIconColor,
   onIconPress,
   searchAccessibilityLabel = 'search',
+  searchTestID,
   clearIcon,
   clearAccessibilityLabel = 'clear',
+  clearTestID,
   onClearIconPress,
   traileringIcon,
   traileringIconColor,
   traileringIconAccessibilityLabel,
+  trailingTestID,
   onTraileringIconPress,
   right,
   mode = 'bar',
@@ -256,6 +271,7 @@ const Searchbar = ({
         }
         theme={theme}
         aria-label={searchAccessibilityLabel}
+        testID={searchTestID}
       />
       <TextInput
         style={[
@@ -282,10 +298,7 @@ const Searchbar = ({
         {...rest}
       />
       {loading ? (
-        <ActivityIndicator
-          testID="activity-indicator"
-          style={styles.v3Loader}
-        />
+        <ActivityIndicator style={styles.v3Loader} />
       ) : (
         // Clear icon should be always rendered within Searchbar – it's transparent,
         // without touch events, when there is no value. It's done to avoid issues
@@ -316,6 +329,7 @@ const Searchbar = ({
             }
             role="button"
             theme={theme}
+            testID={clearTestID}
           />
         </View>
       )}
@@ -327,6 +341,7 @@ const Searchbar = ({
           iconColor={traileringIconColor || colors.onSurfaceVariant}
           icon={traileringIcon}
           aria-label={traileringIconAccessibilityLabel}
+          testID={trailingTestID}
         />
       ) : null}
       {isBarMode &&

--- a/src/components/SegmentedButtons/SegmentedButtonItem.tsx
+++ b/src/components/SegmentedButtons/SegmentedButtonItem.tsx
@@ -223,18 +223,12 @@ const SegmentedButtonItem = ({
           style={[styles.content, { paddingVertical, opacity: textOpacity }]}
         >
           {showCheckedIcon ? (
-            <Animated.View
-              testID={testID ? `${testID}-check-icon` : undefined}
-              style={[iconStyle, checkAnimatedStyle]}
-            >
+            <Animated.View style={[iconStyle, checkAnimatedStyle]}>
               <Icon source={'check'} size={iconSize} color={textColor} />
             </Animated.View>
           ) : null}
           {showIcon ? (
-            <Animated.View
-              testID={testID ? `${testID}-icon` : undefined}
-              style={[iconStyle, iconAnimatedStyle]}
-            >
+            <Animated.View style={[iconStyle, iconAnimatedStyle]}>
               <Icon source={icon} size={iconSize} color={textColor} />
             </Animated.View>
           ) : null}
@@ -244,7 +238,6 @@ const SegmentedButtonItem = ({
             selectable={false}
             numberOfLines={1}
             maxFontSizeMultiplier={labelMaxFontSizeMultiplier}
-            testID={testID ? `${testID}-label` : undefined}
           >
             {label}
           </Text>

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -54,6 +54,10 @@ export type Props = Omit<ViewProps, 'style'> & {
    */
   iconAccessibilityLabel?: string;
   /**
+   * testID for the icon button.
+   */
+  iconTestID?: string;
+  /**
    * The duration for which the Snackbar is shown.
    */
   duration?: number;
@@ -150,6 +154,7 @@ const Snackbar = ({
   icon,
   onIconPress,
   iconAccessibilityLabel = 'Close icon',
+  iconTestID,
   duration = DURATION_MEDIUM,
   onDismiss,
   children,
@@ -339,6 +344,7 @@ const Snackbar = ({
                 }
                 aria-label={iconAccessibilityLabel}
                 style={styles.icon}
+                testID={iconTestID}
               />
             ) : null}
           </View>

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -339,7 +339,6 @@ const Snackbar = ({
                 }
                 aria-label={iconAccessibilityLabel}
                 style={styles.icon}
-                testID={testID ? `${testID}-icon` : undefined}
               />
             ) : null}
           </View>

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -216,7 +216,6 @@ const Tooltip = ({
                 ...(measurement.measured ? styles.visible : styles.hidden),
               },
             ]}
-            testID="tooltip-container"
           >
             <Text
               aria-live="polite"

--- a/src/components/TouchableRipple/TouchableRipple.native.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.native.tsx
@@ -111,7 +111,6 @@ const TouchableRipple = ({
         <>
           {pressed && rippleEffectEnabled && (
             <View
-              testID="touchable-ripple-underlay"
               style={[
                 styles.underlay,
                 { backgroundColor: calculatedUnderlayColor },

--- a/src/components/__tests__/Appbar/Appbar.test.tsx
+++ b/src/components/__tests__/Appbar/Appbar.test.tsx
@@ -190,58 +190,39 @@ describe('renderAppbarContent', () => {
 
 describe('AppbarAction', () => {
   it('should be rendered with default theme color', async () => {
-    await render(
+    const { toJSON } = await render(
       <Appbar>
         <Appbar.Action icon="menu" testID="appbar-action" />
       </Appbar>
     );
-    // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-    const appbarActionIcon = screen.getByTestId('appbar-action-icon-current')
-      .props.children;
-    // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-    expect(appbarActionIcon.props.color).toBe(
-      getTheme().colors.onSurfaceVariant
-    );
+    expect(toJSON()).toMatchSnapshot();
   });
 
   it('should be rendered with specific theme color if is leading', async () => {
-    await render(
+    const { toJSON } = await render(
       <Appbar>
         <Appbar.Action icon="menu" testID="appbar-action" isLeading />
       </Appbar>
     );
-    // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-    const appbarActionIcon = screen.getByTestId('appbar-action-icon-current')
-      .props.children;
-    // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-    expect(appbarActionIcon.props.color).toBe(getTheme().colors.onSurface);
+    expect(toJSON()).toMatchSnapshot();
   });
 
   it('should be rendered with custom color', async () => {
-    await render(
+    const { toJSON } = await render(
       <Appbar>
         <Appbar.Action icon="menu" color="purple" testID="appbar-action" />
       </Appbar>
     );
-    // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-    const appbarActionIcon = screen.getByTestId('appbar-action-icon-current')
-      .props.children;
-    // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-    expect(appbarActionIcon.props.color).toBe('purple');
+    expect(toJSON()).toMatchSnapshot();
   });
 
   it('should render AppbarBackAction with custom color', async () => {
-    await render(
+    const { toJSON } = await render(
       <Appbar>
         <Appbar.BackAction color="purple" testID="appbar-action" />
       </Appbar>
     );
-    // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-    const appbarBackActionIcon = screen.getByTestId(
-      'appbar-action-icon-current'
-    ).props.children;
-    // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-    expect(appbarBackActionIcon.props.color).toBe('purple');
+    expect(toJSON()).toMatchSnapshot();
   });
 });
 
@@ -254,7 +235,7 @@ describe('AppbarContent', () => {
         </Appbar>
       );
 
-      expect(screen.getByTestId('appbar-content-title-text')).toHaveStyle(
+      expect(screen.getByText('Title')).toHaveStyle(
         getTheme().fonts[modeTextVariant[mode]]
       );
     })

--- a/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
+++ b/src/components/__tests__/Appbar/__snapshots__/Appbar.test.tsx.snap
@@ -956,3 +956,1043 @@ exports[`Appbar passes additional props to AppbarBackAction, AppbarContent and A
   </View>
 </View>
 `;
+
+exports[`AppbarAction should be rendered with custom color 1`] = `
+<View
+  collapsable={false}
+  style={
+    [
+      {},
+      {
+        "height": 64,
+      },
+      {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      {
+        "paddingBottom": undefined,
+        "paddingLeft": 4,
+        "paddingRight": 4,
+        "paddingTop": undefined,
+      },
+      {},
+      {},
+      {
+        "backgroundColor": "rgba(254, 247, 255, 1)",
+      },
+      {
+        "borderBottomEndRadius": undefined,
+        "borderBottomLeftRadius": undefined,
+        "borderBottomRightRadius": undefined,
+        "borderBottomStartRadius": undefined,
+        "borderCurve": "continuous",
+        "borderEndEndRadius": undefined,
+        "borderEndStartRadius": undefined,
+        "borderRadius": undefined,
+        "borderStartEndRadius": undefined,
+        "borderStartStartRadius": undefined,
+        "borderTopEndRadius": undefined,
+        "borderTopLeftRadius": undefined,
+        "borderTopRightRadius": undefined,
+        "borderTopStartRadius": undefined,
+      },
+      {
+        "shadowColor": "rgba(0, 0, 0, 1)",
+        "shadowOffset": {
+          "height": 0,
+          "width": 0,
+        },
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
+      },
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "pointerEvents": "none",
+        },
+        {},
+        {},
+        {
+          "backgroundColor": "rgba(254, 247, 255, 1)",
+        },
+        {
+          "borderBottomEndRadius": undefined,
+          "borderBottomLeftRadius": undefined,
+          "borderBottomRightRadius": undefined,
+          "borderBottomStartRadius": undefined,
+          "borderCurve": "continuous",
+          "borderEndEndRadius": undefined,
+          "borderEndStartRadius": undefined,
+          "borderRadius": undefined,
+          "borderStartEndRadius": undefined,
+          "borderStartStartRadius": undefined,
+          "borderTopEndRadius": undefined,
+          "borderTopLeftRadius": undefined,
+          "borderTopRightRadius": undefined,
+          "borderTopStartRadius": undefined,
+        },
+        {
+          "shadowColor": "rgba(0, 0, 0, 1)",
+          "shadowOffset": {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+        },
+      ]
+    }
+  />
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "margin": 6,
+          "overflow": "hidden",
+        },
+        {
+          "backgroundColor": undefined,
+          "height": 40,
+          "width": 40,
+        },
+        {
+          "borderColor": "rgba(202, 196, 208, 1)",
+          "borderRadius": 20,
+          "borderWidth": 0,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": true,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      centered={true}
+      collapsable={false}
+      focusable={true}
+      hitSlop={
+        {
+          "bottom": 6,
+          "left": 6,
+          "right": 6,
+          "top": 6,
+        }
+      }
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      role="button"
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          [
+            {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            },
+            undefined,
+          ],
+        ]
+      }
+      testID="appbar-action"
+    >
+      <View
+        style={
+          {
+            "opacity": 1,
+          }
+        }
+      >
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "justifyContent": "center",
+              },
+              {
+                "height": 24,
+                "width": 24,
+              },
+            ]
+          }
+        >
+          <View
+            collapsable={false}
+            style={
+              [
+                {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                {
+                  "opacity": 1,
+                  "transform": [
+                    {
+                      "rotate": "0deg",
+                    },
+                  ],
+                },
+              ]
+            }
+          >
+            <Text
+              accessibilityElementsHidden={true}
+              importantForAccessibility="no-hide-descendants"
+              pointerEvents="none"
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "purple",
+                    "fontSize": 24,
+                  },
+                  [
+                    {
+                      "lineHeight": 24,
+                      "transform": [
+                        {
+                          "scaleX": 1,
+                        },
+                      ],
+                    },
+                    {
+                      "backgroundColor": "transparent",
+                    },
+                  ],
+                ]
+              }
+            >
+              menu
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`AppbarAction should be rendered with default theme color 1`] = `
+<View
+  collapsable={false}
+  style={
+    [
+      {},
+      {
+        "height": 64,
+      },
+      {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      {
+        "paddingBottom": undefined,
+        "paddingLeft": 4,
+        "paddingRight": 4,
+        "paddingTop": undefined,
+      },
+      {},
+      {},
+      {
+        "backgroundColor": "rgba(254, 247, 255, 1)",
+      },
+      {
+        "borderBottomEndRadius": undefined,
+        "borderBottomLeftRadius": undefined,
+        "borderBottomRightRadius": undefined,
+        "borderBottomStartRadius": undefined,
+        "borderCurve": "continuous",
+        "borderEndEndRadius": undefined,
+        "borderEndStartRadius": undefined,
+        "borderRadius": undefined,
+        "borderStartEndRadius": undefined,
+        "borderStartStartRadius": undefined,
+        "borderTopEndRadius": undefined,
+        "borderTopLeftRadius": undefined,
+        "borderTopRightRadius": undefined,
+        "borderTopStartRadius": undefined,
+      },
+      {
+        "shadowColor": "rgba(0, 0, 0, 1)",
+        "shadowOffset": {
+          "height": 0,
+          "width": 0,
+        },
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
+      },
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "pointerEvents": "none",
+        },
+        {},
+        {},
+        {
+          "backgroundColor": "rgba(254, 247, 255, 1)",
+        },
+        {
+          "borderBottomEndRadius": undefined,
+          "borderBottomLeftRadius": undefined,
+          "borderBottomRightRadius": undefined,
+          "borderBottomStartRadius": undefined,
+          "borderCurve": "continuous",
+          "borderEndEndRadius": undefined,
+          "borderEndStartRadius": undefined,
+          "borderRadius": undefined,
+          "borderStartEndRadius": undefined,
+          "borderStartStartRadius": undefined,
+          "borderTopEndRadius": undefined,
+          "borderTopLeftRadius": undefined,
+          "borderTopRightRadius": undefined,
+          "borderTopStartRadius": undefined,
+        },
+        {
+          "shadowColor": "rgba(0, 0, 0, 1)",
+          "shadowOffset": {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+        },
+      ]
+    }
+  />
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "margin": 6,
+          "overflow": "hidden",
+        },
+        {
+          "backgroundColor": undefined,
+          "height": 40,
+          "width": 40,
+        },
+        {
+          "borderColor": "rgba(202, 196, 208, 1)",
+          "borderRadius": 20,
+          "borderWidth": 0,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": true,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      centered={true}
+      collapsable={false}
+      focusable={true}
+      hitSlop={
+        {
+          "bottom": 6,
+          "left": 6,
+          "right": 6,
+          "top": 6,
+        }
+      }
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      role="button"
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          [
+            {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            },
+            undefined,
+          ],
+        ]
+      }
+      testID="appbar-action"
+    >
+      <View
+        style={
+          {
+            "opacity": 1,
+          }
+        }
+      >
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "justifyContent": "center",
+              },
+              {
+                "height": 24,
+                "width": 24,
+              },
+            ]
+          }
+        >
+          <View
+            collapsable={false}
+            style={
+              [
+                {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                {
+                  "opacity": 1,
+                  "transform": [
+                    {
+                      "rotate": "0deg",
+                    },
+                  ],
+                },
+              ]
+            }
+          >
+            <Text
+              accessibilityElementsHidden={true}
+              importantForAccessibility="no-hide-descendants"
+              pointerEvents="none"
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "rgba(73, 69, 79, 1)",
+                    "fontSize": 24,
+                  },
+                  [
+                    {
+                      "lineHeight": 24,
+                      "transform": [
+                        {
+                          "scaleX": 1,
+                        },
+                      ],
+                    },
+                    {
+                      "backgroundColor": "transparent",
+                    },
+                  ],
+                ]
+              }
+            >
+              menu
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`AppbarAction should be rendered with specific theme color if is leading 1`] = `
+<View
+  collapsable={false}
+  style={
+    [
+      {},
+      {
+        "height": 64,
+      },
+      {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      {
+        "paddingBottom": undefined,
+        "paddingLeft": 4,
+        "paddingRight": 4,
+        "paddingTop": undefined,
+      },
+      {},
+      {},
+      {
+        "backgroundColor": "rgba(254, 247, 255, 1)",
+      },
+      {
+        "borderBottomEndRadius": undefined,
+        "borderBottomLeftRadius": undefined,
+        "borderBottomRightRadius": undefined,
+        "borderBottomStartRadius": undefined,
+        "borderCurve": "continuous",
+        "borderEndEndRadius": undefined,
+        "borderEndStartRadius": undefined,
+        "borderRadius": undefined,
+        "borderStartEndRadius": undefined,
+        "borderStartStartRadius": undefined,
+        "borderTopEndRadius": undefined,
+        "borderTopLeftRadius": undefined,
+        "borderTopRightRadius": undefined,
+        "borderTopStartRadius": undefined,
+      },
+      {
+        "shadowColor": "rgba(0, 0, 0, 1)",
+        "shadowOffset": {
+          "height": 0,
+          "width": 0,
+        },
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
+      },
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "pointerEvents": "none",
+        },
+        {},
+        {},
+        {
+          "backgroundColor": "rgba(254, 247, 255, 1)",
+        },
+        {
+          "borderBottomEndRadius": undefined,
+          "borderBottomLeftRadius": undefined,
+          "borderBottomRightRadius": undefined,
+          "borderBottomStartRadius": undefined,
+          "borderCurve": "continuous",
+          "borderEndEndRadius": undefined,
+          "borderEndStartRadius": undefined,
+          "borderRadius": undefined,
+          "borderStartEndRadius": undefined,
+          "borderStartStartRadius": undefined,
+          "borderTopEndRadius": undefined,
+          "borderTopLeftRadius": undefined,
+          "borderTopRightRadius": undefined,
+          "borderTopStartRadius": undefined,
+        },
+        {
+          "shadowColor": "rgba(0, 0, 0, 1)",
+          "shadowOffset": {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+        },
+      ]
+    }
+  />
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "margin": 6,
+          "overflow": "hidden",
+        },
+        {
+          "backgroundColor": undefined,
+          "height": 40,
+          "width": 40,
+        },
+        {
+          "borderColor": "rgba(202, 196, 208, 1)",
+          "borderRadius": 20,
+          "borderWidth": 0,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": true,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      centered={true}
+      collapsable={false}
+      focusable={true}
+      hitSlop={
+        {
+          "bottom": 6,
+          "left": 6,
+          "right": 6,
+          "top": 6,
+        }
+      }
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      role="button"
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          [
+            {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            },
+            undefined,
+          ],
+        ]
+      }
+      testID="appbar-action"
+    >
+      <View
+        style={
+          {
+            "opacity": 1,
+          }
+        }
+      >
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "justifyContent": "center",
+              },
+              {
+                "height": 24,
+                "width": 24,
+              },
+            ]
+          }
+        >
+          <View
+            collapsable={false}
+            style={
+              [
+                {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                {
+                  "opacity": 1,
+                  "transform": [
+                    {
+                      "rotate": "0deg",
+                    },
+                  ],
+                },
+              ]
+            }
+          >
+            <Text
+              accessibilityElementsHidden={true}
+              importantForAccessibility="no-hide-descendants"
+              pointerEvents="none"
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "rgba(29, 27, 32, 1)",
+                    "fontSize": 24,
+                  },
+                  [
+                    {
+                      "lineHeight": 24,
+                      "transform": [
+                        {
+                          "scaleX": 1,
+                        },
+                      ],
+                    },
+                    {
+                      "backgroundColor": "transparent",
+                    },
+                  ],
+                ]
+              }
+            >
+              menu
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`AppbarAction should render AppbarBackAction with custom color 1`] = `
+<View
+  collapsable={false}
+  style={
+    [
+      {},
+      {
+        "height": 64,
+      },
+      {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      {
+        "paddingBottom": undefined,
+        "paddingLeft": 4,
+        "paddingRight": 4,
+        "paddingTop": undefined,
+      },
+      {},
+      {},
+      {
+        "backgroundColor": "rgba(254, 247, 255, 1)",
+      },
+      {
+        "borderBottomEndRadius": undefined,
+        "borderBottomLeftRadius": undefined,
+        "borderBottomRightRadius": undefined,
+        "borderBottomStartRadius": undefined,
+        "borderCurve": "continuous",
+        "borderEndEndRadius": undefined,
+        "borderEndStartRadius": undefined,
+        "borderRadius": undefined,
+        "borderStartEndRadius": undefined,
+        "borderStartStartRadius": undefined,
+        "borderTopEndRadius": undefined,
+        "borderTopLeftRadius": undefined,
+        "borderTopRightRadius": undefined,
+        "borderTopStartRadius": undefined,
+      },
+      {
+        "shadowColor": "rgba(0, 0, 0, 1)",
+        "shadowOffset": {
+          "height": 0,
+          "width": 0,
+        },
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
+      },
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "pointerEvents": "none",
+        },
+        {},
+        {},
+        {
+          "backgroundColor": "rgba(254, 247, 255, 1)",
+        },
+        {
+          "borderBottomEndRadius": undefined,
+          "borderBottomLeftRadius": undefined,
+          "borderBottomRightRadius": undefined,
+          "borderBottomStartRadius": undefined,
+          "borderCurve": "continuous",
+          "borderEndEndRadius": undefined,
+          "borderEndStartRadius": undefined,
+          "borderRadius": undefined,
+          "borderStartEndRadius": undefined,
+          "borderStartStartRadius": undefined,
+          "borderTopEndRadius": undefined,
+          "borderTopLeftRadius": undefined,
+          "borderTopRightRadius": undefined,
+          "borderTopStartRadius": undefined,
+        },
+        {
+          "shadowColor": "rgba(0, 0, 0, 1)",
+          "shadowOffset": {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+        },
+      ]
+    }
+  />
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "margin": 6,
+          "overflow": "hidden",
+        },
+        {
+          "backgroundColor": undefined,
+          "height": 40,
+          "width": 40,
+        },
+        {
+          "borderColor": "rgba(202, 196, 208, 1)",
+          "borderRadius": 20,
+          "borderWidth": 0,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      accessibilityLabel="Back"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": true,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      centered={true}
+      collapsable={false}
+      focusable={true}
+      hitSlop={
+        {
+          "bottom": 6,
+          "left": 6,
+          "right": 6,
+          "top": 6,
+        }
+      }
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      role="button"
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          [
+            {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            },
+            undefined,
+          ],
+        ]
+      }
+      testID="appbar-action"
+    >
+      <View
+        style={
+          {
+            "opacity": 1,
+          }
+        }
+      >
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "justifyContent": "center",
+              },
+              {
+                "height": 24,
+                "width": 24,
+              },
+            ]
+          }
+        >
+          <View
+            collapsable={false}
+            style={
+              [
+                {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                {
+                  "opacity": 1,
+                  "transform": [
+                    {
+                      "rotate": "0deg",
+                    },
+                  ],
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "justifyContent": "center",
+                  },
+                  {
+                    "height": 24,
+                    "transform": [
+                      {
+                        "scaleX": 1,
+                      },
+                    ],
+                    "width": 24,
+                  },
+                ]
+              }
+            >
+              <Image
+                accessibilityIgnoresInvertColors={true}
+                resizeMode="contain"
+                source={
+                  {
+                    "testUri": "../../../src/assets/back-chevron.png",
+                  }
+                }
+                style={
+                  {
+                    "height": 21,
+                    "tintColor": "purple",
+                    "width": 21,
+                  }
+                }
+              />
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/src/components/__tests__/BottomNavigation.test.tsx
+++ b/src/components/__tests__/BottomNavigation.test.tsx
@@ -159,6 +159,7 @@ it('calls onIndexChange', async () => {
   await render(
     <BottomNavigation
       testID="bottom-navigation"
+      barTestID="bottom-navigation-bar"
       shifting
       navigationState={createState(0, 5)}
       onIndexChange={onIndexChange}
@@ -183,6 +184,7 @@ it('calls onTabPress', async () => {
   await render(
     <BottomNavigation
       testID="bottom-navigation"
+      barTestID="bottom-navigation-bar"
       shifting
       onTabPress={onTabPress}
       onIndexChange={onIndexChange}
@@ -214,6 +216,7 @@ it('calls onTabLongPress', async () => {
   await render(
     <BottomNavigation
       testID="bottom-navigation"
+      barTestID="bottom-navigation-bar"
       shifting
       onIndexChange={onIndexChange}
       onTabLongPress={onTabLongPress}

--- a/src/components/__tests__/BottomNavigation.test.tsx
+++ b/src/components/__tests__/BottomNavigation.test.tsx
@@ -428,7 +428,7 @@ it('should have labelMaxFontSizeMultiplier passed to label', async () => {
 });
 
 it('renders custom background color passed to barStyle property', async () => {
-  await render(
+  const { toJSON } = await render(
     <BottomNavigation
       testID="bottom-navigation"
       shifting={false}
@@ -440,8 +440,7 @@ it('renders custom background color passed to barStyle property', async () => {
     />
   );
 
-  const wrapper = screen.getByTestId('bottom-navigation-bar-content');
-  expect(wrapper).toHaveStyle({ backgroundColor: Palette.error60 });
+  expect(toJSON()).toMatchSnapshot();
 });
 
 it('uses the rendered bar height when hiding it for the keyboard', async () => {
@@ -528,7 +527,7 @@ it('renders bottom navigation with getLazy', async () => {
 });
 
 it('applies maxTabBarWidth styling if compact prop is truthy', async () => {
-  await render(
+  const { toJSON } = await render(
     <BottomNavigation
       testID="bottom-navigation"
       navigationState={createState(0, 5)}
@@ -540,15 +539,11 @@ it('applies maxTabBarWidth styling if compact prop is truthy', async () => {
     />
   );
 
-  expect(
-    screen.getByTestId('bottom-navigation-bar-content-wrapper')
-  ).toHaveStyle({
-    maxWidth: 480,
-  });
+  expect(toJSON()).toMatchSnapshot();
 });
 
 it('does not apply maxTabBarWidth styling if compact prop is falsy', async () => {
-  await render(
+  const { toJSON } = await render(
     <BottomNavigation
       testID="bottom-navigation"
       navigationState={createState(0, 5)}
@@ -560,43 +555,7 @@ it('does not apply maxTabBarWidth styling if compact prop is falsy', async () =>
     />
   );
 
-  expect(
-    screen.getByTestId('bottom-navigation-bar-content-wrapper')
-  ).not.toHaveStyle({
-    maxWidth: 480,
-  });
-});
-
-it('renders bar content when shifting is enabled', async () => {
-  await render(
-    <BottomNavigation
-      testID="bottom-navigation"
-      navigationState={createState(0, 5)}
-      onIndexChange={jest.fn()}
-      renderScene={renderScene}
-      getLazy={({ route }) => route.key === 'key-2'}
-      shifting
-    />
-  );
-
-  expect(screen.getByTestId('bottom-navigation-bar-content')).toBeOnTheScreen();
-});
-
-it('does not render legacy ripple overlay when shifting is disabled', async () => {
-  await render(
-    <BottomNavigation
-      testID="bottom-navigation"
-      navigationState={createState(0, 5)}
-      onIndexChange={jest.fn()}
-      renderScene={renderScene}
-      getLazy={({ route }) => route.key === 'key-2'}
-      shifting={false}
-    />
-  );
-
-  expect(
-    screen.queryByTestId('bottom-navigation-bar-content-ripple')
-  ).not.toBeOnTheScreen();
+  expect(toJSON()).toMatchSnapshot();
 });
 
 describe('getActiveTintColor', () => {

--- a/src/components/__tests__/Button.test.tsx
+++ b/src/components/__tests__/Button.test.tsx
@@ -180,7 +180,7 @@ describe('button text styles', () => {
       </Button>
     );
 
-    expect(screen.getByTestId('button-text')).toHaveStyle({
+    expect(screen.getByText('Test')).toHaveStyle({
       textTransform: 'uppercase',
     });
   });
@@ -192,7 +192,7 @@ describe('button text styles', () => {
       </Button>
     );
 
-    expect(screen.getByTestId('button-text')).not.toHaveStyle({
+    expect(screen.getByText('Test')).not.toHaveStyle({
       textTransform: 'uppercase',
     });
   });
@@ -200,60 +200,44 @@ describe('button text styles', () => {
 
 describe('button icon styles', () => {
   it('should return correct icon styles for compact text button', async () => {
-    await render(
+    const { toJSON } = await render(
       <Button mode={'text'} compact icon="camera" testID="compact-button">
         Compact text button
       </Button>
     );
-    expect(screen.getByTestId('compact-button-icon-container')).toHaveStyle({
-      marginLeft: 6,
-      marginRight: 0,
-    });
+    expect(toJSON()).toMatchSnapshot();
   });
 
   (['outlined', 'contained', 'contained-tonal', 'elevated'] as const).forEach(
     (mode) =>
       it(`should return correct icon styles for compact ${mode} button`, async () => {
-        await render(
+        const { toJSON } = await render(
           <Button mode={mode} compact icon="camera" testID="compact-button">
             Compact {mode} button
           </Button>
         );
-        expect(screen.getByTestId('compact-button-icon-container')).toHaveStyle(
-          {
-            marginLeft: 8,
-            marginRight: 0,
-          }
-        );
+        expect(toJSON()).toMatchSnapshot();
       })
   );
 
   it('should return correct icon styles for text button', async () => {
-    await render(
+    const { toJSON } = await render(
       <Button mode={'text'} icon="camera" testID="compact-button">
         text button
       </Button>
     );
-    expect(screen.getByTestId('compact-button-icon-container')).toHaveStyle({
-      marginLeft: 12,
-      marginRight: -8,
-    });
+    expect(toJSON()).toMatchSnapshot();
   });
 
   (['outlined', 'contained', 'contained-tonal', 'elevated'] as const).forEach(
     (mode) =>
       it(`should return correct icon styles for compact ${mode} button`, async () => {
-        await render(
+        const { toJSON } = await render(
           <Button mode={mode} icon="camera" testID="compact-button">
             {mode} button
           </Button>
         );
-        expect(screen.getByTestId('compact-button-icon-container')).toHaveStyle(
-          {
-            marginLeft: 16,
-            marginRight: -16,
-          }
-        );
+        expect(toJSON()).toMatchSnapshot();
       })
   );
 });

--- a/src/components/__tests__/Card/Card.test.tsx
+++ b/src/components/__tests__/Card/Card.test.tsx
@@ -33,43 +33,31 @@ describe('Card', () => {
   });
 
   it('renders an outlined card with a custom outline color', async () => {
-    const testID = 'custom-outline-card';
-
-    await render(
+    const { toJSON } = await render(
       <Card
         mode="outlined"
         accessibilityLabel="card"
         theme={{ colors: { outline: 'purple' } }}
-        testID={testID}
       >
         {null}
       </Card>
     );
 
-    expect(screen.getByTestId(`${testID}-outline`)).toHaveStyle({
-      borderColor: 'purple',
-      borderWidth: 1,
-    });
+    expect(toJSON()).toMatchSnapshot();
   });
 
   it('renders an outlined card with custom border color', async () => {
-    const testID = 'custom-border-card';
-
-    await render(
+    const { toJSON } = await render(
       <Card
         mode="outlined"
         accessibilityLabel="card"
         style={{ borderColor: Palette.error50 }}
-        testID={testID}
       >
         {null}
       </Card>
     );
 
-    expect(screen.getByTestId(`${testID}-outline`)).toHaveStyle({
-      borderColor: Palette.error50,
-      borderWidth: 1,
-    });
+    expect(toJSON()).toMatchSnapshot();
   });
 
   it('renders with a custom theme background color', async () => {

--- a/src/components/__tests__/Card/Card.test.tsx
+++ b/src/components/__tests__/Card/Card.test.tsx
@@ -80,12 +80,12 @@ describe('Card', () => {
 
   it('renders with a content style', async () => {
     await render(
-      <Card testID="card" contentStyle={styles.contentStyle}>
+      <Card contentStyle={styles.contentStyle}>
         <Text>Content</Text>
       </Card>
     );
 
-    expect(screen.getByTestId('card')).toHaveStyle(styles.contentStyle);
+    expect(screen.getByText('Content').parent).toHaveStyle(styles.contentStyle);
   });
 
   it('does not render a disabled accessibility state', async () => {

--- a/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/components/__tests__/Card/__snapshots__/Card.test.tsx.snap
@@ -121,3 +121,251 @@ exports[`Card renders an outlined card 1`] = `
   />
 </View>
 `;
+
+exports[`Card renders an outlined card with a custom outline color 1`] = `
+<View
+  accessibilityLabel="card"
+  collapsable={false}
+  style={
+    [
+      {},
+      {
+        "borderColor": "purple",
+      },
+      undefined,
+      {},
+      {
+        "backgroundColor": "rgba(254, 247, 255, 1)",
+      },
+      {
+        "borderBottomEndRadius": undefined,
+        "borderBottomLeftRadius": undefined,
+        "borderBottomRightRadius": undefined,
+        "borderBottomStartRadius": undefined,
+        "borderCurve": "continuous",
+        "borderEndEndRadius": undefined,
+        "borderEndStartRadius": undefined,
+        "borderRadius": 12,
+        "borderStartEndRadius": undefined,
+        "borderStartStartRadius": undefined,
+        "borderTopEndRadius": undefined,
+        "borderTopLeftRadius": undefined,
+        "borderTopRightRadius": undefined,
+        "borderTopStartRadius": undefined,
+      },
+      {
+        "shadowColor": "rgba(0, 0, 0, 1)",
+        "shadowOffset": {
+          "height": 0,
+          "width": 0,
+        },
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
+      },
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "pointerEvents": "none",
+        },
+        {},
+        {},
+        {
+          "backgroundColor": "rgba(254, 247, 255, 1)",
+        },
+        {
+          "borderBottomEndRadius": undefined,
+          "borderBottomLeftRadius": undefined,
+          "borderBottomRightRadius": undefined,
+          "borderBottomStartRadius": undefined,
+          "borderCurve": "continuous",
+          "borderEndEndRadius": undefined,
+          "borderEndStartRadius": undefined,
+          "borderRadius": 12,
+          "borderStartEndRadius": undefined,
+          "borderStartStartRadius": undefined,
+          "borderTopEndRadius": undefined,
+          "borderTopLeftRadius": undefined,
+          "borderTopRightRadius": undefined,
+          "borderTopStartRadius": undefined,
+        },
+        {
+          "shadowColor": "rgba(0, 0, 0, 1)",
+          "shadowOffset": {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+        },
+      ]
+    }
+  />
+  <View
+    pointerEvents="none"
+    style={
+      [
+        {
+          "borderColor": "purple",
+        },
+        {
+          "borderWidth": 1,
+          "height": "100%",
+          "position": "absolute",
+          "width": "100%",
+          "zIndex": 2,
+        },
+        {
+          "borderRadius": 12,
+        },
+      ]
+    }
+  />
+  <View
+    style={
+      [
+        {
+          "flexShrink": 1,
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`Card renders an outlined card with custom border color 1`] = `
+<View
+  accessibilityLabel="card"
+  collapsable={false}
+  style={
+    [
+      {},
+      {
+        "borderColor": "rgba(220, 54, 46, 1)",
+      },
+      {
+        "borderColor": "rgba(220, 54, 46, 1)",
+      },
+      {},
+      {
+        "backgroundColor": "rgba(254, 247, 255, 1)",
+      },
+      {
+        "borderBottomEndRadius": undefined,
+        "borderBottomLeftRadius": undefined,
+        "borderBottomRightRadius": undefined,
+        "borderBottomStartRadius": undefined,
+        "borderCurve": "continuous",
+        "borderEndEndRadius": undefined,
+        "borderEndStartRadius": undefined,
+        "borderRadius": 12,
+        "borderStartEndRadius": undefined,
+        "borderStartStartRadius": undefined,
+        "borderTopEndRadius": undefined,
+        "borderTopLeftRadius": undefined,
+        "borderTopRightRadius": undefined,
+        "borderTopStartRadius": undefined,
+      },
+      {
+        "shadowColor": "rgba(0, 0, 0, 1)",
+        "shadowOffset": {
+          "height": 0,
+          "width": 0,
+        },
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
+      },
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "pointerEvents": "none",
+        },
+        {},
+        {},
+        {
+          "backgroundColor": "rgba(254, 247, 255, 1)",
+        },
+        {
+          "borderBottomEndRadius": undefined,
+          "borderBottomLeftRadius": undefined,
+          "borderBottomRightRadius": undefined,
+          "borderBottomStartRadius": undefined,
+          "borderCurve": "continuous",
+          "borderEndEndRadius": undefined,
+          "borderEndStartRadius": undefined,
+          "borderRadius": 12,
+          "borderStartEndRadius": undefined,
+          "borderStartStartRadius": undefined,
+          "borderTopEndRadius": undefined,
+          "borderTopLeftRadius": undefined,
+          "borderTopRightRadius": undefined,
+          "borderTopStartRadius": undefined,
+        },
+        {
+          "shadowColor": "rgba(0, 0, 0, 1)",
+          "shadowOffset": {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+        },
+      ]
+    }
+  />
+  <View
+    pointerEvents="none"
+    style={
+      [
+        {
+          "borderColor": "rgba(220, 54, 46, 1)",
+        },
+        {
+          "borderWidth": 1,
+          "height": "100%",
+          "position": "absolute",
+          "width": "100%",
+          "zIndex": 2,
+        },
+        {
+          "borderRadius": 12,
+        },
+      ]
+    }
+  />
+  <View
+    style={
+      [
+        {
+          "flexShrink": 1,
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
+`;

--- a/src/components/__tests__/Checkbox/CheckboxItem.test.tsx
+++ b/src/components/__tests__/Checkbox/CheckboxItem.test.tsx
@@ -59,14 +59,13 @@ it('disables the row when the prop disabled is true', async () => {
 });
 
 it('should have maxFontSizeMultiplier set to 1.5 by default', async () => {
-  await render(
-    <Checkbox.Item label="" testID="checkbox-item" status="unchecked" />
-  );
-  const checkboxItemText = screen.getByTestId('checkbox-item-text', {
-    includeHiddenElements: true,
-  });
-  // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-  expect(checkboxItemText.props.maxFontSizeMultiplier).toBe(1.5);
+  const tree = (
+    await render(
+      <Checkbox.Item label="" testID="checkbox-item" status="unchecked" />
+    )
+  ).toJSON();
+
+  expect(tree).toMatchSnapshot();
 });
 
 it('should execute onLongPress', async () => {

--- a/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.tsx.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.tsx.snap
@@ -551,3 +551,278 @@ exports[`renders unchecked 1`] = `
   </View>
 </View>
 `;
+
+exports[`should have maxFontSizeMultiplier set to 1.5 by default 1`] = `
+<View
+  accessibilityLabel=""
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": false,
+      "disabled": true,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  role="checkbox"
+  style={
+    [
+      false,
+      undefined,
+    ]
+  }
+  testID="checkbox-item"
+>
+  <View
+    importantForAccessibility="no-hide-descendants"
+    pointerEvents="none"
+    style={
+      [
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+          "paddingHorizontal": 16,
+          "paddingVertical": 8,
+        },
+        undefined,
+      ]
+    }
+  >
+    <Text
+      maxFontSizeMultiplier={1.5}
+      style={
+        [
+          {
+            "textAlign": "left",
+          },
+          {
+            "color": "rgba(29, 27, 32, 1)",
+            "writingDirection": "ltr",
+          },
+          [
+            {
+              "fontFamily": "System",
+              "fontSize": 16,
+              "fontWeight": "400",
+              "letterSpacing": 0.5,
+              "lineHeight": 24,
+            },
+            [
+              {
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              {
+                "color": "rgba(29, 27, 32, 1)",
+                "opacity": 1,
+                "textAlign": "left",
+              },
+              undefined,
+            ],
+          ],
+        ]
+      }
+    />
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": true,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={false}
+      centered={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          [
+            {
+              "alignItems": "center",
+              "borderRadius": 20,
+              "height": 40,
+              "justifyContent": "center",
+              "width": 40,
+            },
+            undefined,
+            undefined,
+          ],
+        ]
+      }
+    >
+      <View
+        pointerEvents="none"
+        style={
+          {
+            "alignItems": "center",
+            "height": 40,
+            "justifyContent": "center",
+            "width": 40,
+          }
+        }
+      >
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "borderRadius": 2,
+                "height": 18,
+                "justifyContent": "center",
+                "overflow": "hidden",
+                "width": 18,
+              },
+              {
+                "opacity": 1,
+              },
+            ]
+          }
+        >
+          <View
+            collapsable={false}
+            pointerEvents="none"
+            style={
+              [
+                {
+                  "borderRadius": 2,
+                  "borderWidth": 2,
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                {
+                  "borderColor": "rgba(73, 69, 79, 1)",
+                  "opacity": 1,
+                },
+              ]
+            }
+          />
+          <View
+            collapsable={false}
+            pointerEvents="none"
+            style={
+              [
+                {
+                  "borderRadius": 2,
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                {
+                  "backgroundColor": "rgba(103, 80, 164, 1)",
+                  "opacity": 0,
+                },
+              ]
+            }
+          />
+          <View
+            collapsable={false}
+            style={
+              [
+                {
+                  "height": 18,
+                  "left": 0,
+                  "overflow": "hidden",
+                  "position": "absolute",
+                  "top": 0,
+                },
+                {
+                  "opacity": 0,
+                  "width": 0,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "height": 18,
+                  "justifyContent": "center",
+                  "width": 18,
+                }
+              }
+            >
+              <View
+                style={
+                  [
+                    {
+                      "borderBottomWidth": 2,
+                      "borderLeftWidth": 2,
+                      "height": 6,
+                      "transform": [
+                        {
+                          "rotate": "-45deg",
+                        },
+                        {
+                          "translateY": -1,
+                        },
+                        {
+                          "translateX": 1,
+                        },
+                      ],
+                      "width": 11,
+                    },
+                    {
+                      "borderColor": "rgba(255, 255, 255, 1)",
+                    },
+                    null,
+                  ]
+                }
+              />
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/src/components/__tests__/DataTable.test.tsx
+++ b/src/components/__tests__/DataTable.test.tsx
@@ -66,25 +66,28 @@ describe('DataTable.Cell', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders data table cell with text container', async () => {
-    await render(
-      <DataTable.Cell testID="table-cell">Table cell</DataTable.Cell>
-    );
+  it('renders data table cell with text content', async () => {
+    const tree = (
+      await render(
+        <DataTable.Cell testID="table-cell">Table cell</DataTable.Cell>
+      )
+    ).toJSON();
 
     expect(screen.getByText('Table cell')).toBeOnTheScreen();
-    expect(screen.getByTestId('table-cell-text-container')).toBeOnTheScreen();
+    expect(tree).toMatchSnapshot();
   });
 
-  it('renders data table cell children without text container', async () => {
-    await render(
-      <DataTable.Cell testID="table-cell">
-        <Checkbox status="checked" testID="table-cell-checkbox" />
-      </DataTable.Cell>
-    );
+  it('renders data table cell children without wrapping text component', async () => {
+    const tree = (
+      await render(
+        <DataTable.Cell testID="table-cell">
+          <Checkbox status="checked" testID="table-cell-checkbox" />
+        </DataTable.Cell>
+      )
+    ).toJSON();
 
-    expect(
-      screen.queryByTestId('table-cell-text-container')
-    ).not.toBeOnTheScreen();
+    expect(screen.getByTestId('table-cell-checkbox')).toBeOnTheScreen();
+    expect(tree).toMatchSnapshot();
   });
 });
 

--- a/src/components/__tests__/Dialog.test.tsx
+++ b/src/components/__tests__/Dialog.test.tsx
@@ -41,7 +41,7 @@ describe('Dialog', () => {
       </Dialog>
     );
 
-    await userEvent.press(screen.getByTestId('dialog-backdrop'));
+    await userEvent.press(screen.getByLabelText('Close modal'));
 
     await act(() => {
       jest.runAllTimers();
@@ -57,7 +57,7 @@ describe('Dialog', () => {
       </Dialog>
     );
 
-    await userEvent.press(screen.getByTestId('dialog-backdrop'));
+    await userEvent.press(screen.getByLabelText('Close modal'));
 
     await act(() => {
       jest.runAllTimers();
@@ -80,7 +80,7 @@ describe('Dialog', () => {
       </Dialog>
     );
 
-    await userEvent.press(screen.getByTestId('dialog-backdrop'));
+    await userEvent.press(screen.getByLabelText('Close modal'));
 
     await act(() => {
       jest.runAllTimers();

--- a/src/components/__tests__/Drawer/DrawerCollapsedItem.test.tsx
+++ b/src/components/__tests__/Drawer/DrawerCollapsedItem.test.tsx
@@ -1,80 +1,62 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { render, screen } from '../../../test-utils';
+import { render } from '../../../test-utils';
 import DrawerCollapsedItem from '../../Drawer/DrawerCollapsedItem';
 
 describe('DrawerCollapsedItem', () => {
   it('should have regular outline if label is specified', async () => {
-    await render(
-      <DrawerCollapsedItem
-        testID="drawer-collapsed-item"
-        label="starred"
-        focusedIcon="star"
-        unfocusedIcon="star-outline"
-      />
-    );
+    const tree = (
+      await render(
+        <DrawerCollapsedItem
+          label="starred"
+          focusedIcon="star"
+          unfocusedIcon="star-outline"
+        />
+      )
+    ).toJSON();
 
-    expect(screen.getByTestId('drawer-collapsed-item-outline')).toHaveStyle({
-      height: 32,
-    });
+    expect(tree).toMatchSnapshot();
   });
 
   it('should have rounded outline if label is not specified', async () => {
-    await render(
-      <DrawerCollapsedItem
-        testID="drawer-collapsed-item"
-        focusedIcon="star"
-        unfocusedIcon="star-outline"
-      />
-    );
+    const tree = (
+      await render(
+        <DrawerCollapsedItem focusedIcon="star" unfocusedIcon="star-outline" />
+      )
+    ).toJSON();
 
-    expect(screen.getByTestId('drawer-collapsed-item-outline')).toHaveStyle({
-      height: 56,
-    });
+    expect(tree).toMatchSnapshot();
   });
 
   it('should display unfocused icon in inactive state, if unfocused icon is specified', async () => {
-    await render(
-      <DrawerCollapsedItem
-        testID="drawer-collapsed-item"
-        focusedIcon="star"
-        unfocusedIcon="star-outline"
-      />
-    );
+    const tree = (
+      await render(
+        <DrawerCollapsedItem focusedIcon="star" unfocusedIcon="star-outline" />
+      )
+    ).toJSON();
 
-    expect(
-      // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-      screen.getByTestId('drawer-collapsed-item-container').props.children[1]
-        .props.source
-    ).toBe('star-outline');
+    expect(tree).toMatchSnapshot();
   });
 
   it('should display focused icon in inactive state, if unfocused icon is not specified', async () => {
-    await render(
-      <DrawerCollapsedItem testID="drawer-collapsed-item" focusedIcon="star" />
-    );
+    const tree = (
+      await render(<DrawerCollapsedItem focusedIcon="star" />)
+    ).toJSON();
 
-    expect(
-      // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-      screen.getByTestId('drawer-collapsed-item-container').props.children[1]
-        .props.source
-    ).toBe('star');
+    expect(tree).toMatchSnapshot();
   });
 
   it('should display focused icon in active state', async () => {
-    await render(
-      <DrawerCollapsedItem
-        testID="drawer-collapsed-item"
-        active
-        focusedIcon="star"
-        unfocusedIcon="star-outline"
-      />
-    );
+    const tree = (
+      await render(
+        <DrawerCollapsedItem
+          active
+          focusedIcon="star"
+          unfocusedIcon="star-outline"
+        />
+      )
+    ).toJSON();
 
-    expect(
-      // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-      screen.getByTestId('drawer-collapsed-item-container').props.children[1]
-        .props.source
-    ).toBe('star');
+    expect(tree).toMatchSnapshot();
   });
 });

--- a/src/components/__tests__/Drawer/__snapshots__/DrawerCollapsedItem.test.tsx.snap
+++ b/src/components/__tests__/Drawer/__snapshots__/DrawerCollapsedItem.test.tsx.snap
@@ -1,0 +1,637 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DrawerCollapsedItem should display focused icon in active state 1`] = `
+<View>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": true,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+  >
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "marginBottom": 12,
+          "minHeight": 56,
+          "width": 80,
+        }
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "borderRadius": 28,
+              "height": 32,
+              "justifyContent": "center",
+              "width": 56,
+            },
+            {
+              "height": 56,
+            },
+            {
+              "backgroundColor": "rgba(232, 222, 248, 1)",
+            },
+            undefined,
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "position": "absolute",
+            },
+            {
+              "top": 16,
+            },
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            [
+              {
+                "color": "rgba(29, 25, 43, 1)",
+                "fontSize": 24,
+              },
+              [
+                {
+                  "lineHeight": 24,
+                  "transform": [
+                    {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                {
+                  "backgroundColor": "transparent",
+                },
+              ],
+            ]
+          }
+        >
+          star
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`DrawerCollapsedItem should display focused icon in inactive state, if unfocused icon is not specified 1`] = `
+<View>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+  >
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "marginBottom": 12,
+          "minHeight": 56,
+          "width": 80,
+        }
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "borderRadius": 28,
+              "height": 32,
+              "justifyContent": "center",
+              "width": 56,
+            },
+            {
+              "height": 56,
+            },
+            {
+              "backgroundColor": "transparent",
+            },
+            undefined,
+            {
+              "transform": [
+                {
+                  "scale": 0.5,
+                },
+              ],
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "position": "absolute",
+            },
+            {
+              "top": 16,
+            },
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            [
+              {
+                "color": "rgba(73, 69, 79, 1)",
+                "fontSize": 24,
+              },
+              [
+                {
+                  "lineHeight": 24,
+                  "transform": [
+                    {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                {
+                  "backgroundColor": "transparent",
+                },
+              ],
+            ]
+          }
+        >
+          star
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`DrawerCollapsedItem should display unfocused icon in inactive state, if unfocused icon is specified 1`] = `
+<View>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+  >
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "marginBottom": 12,
+          "minHeight": 56,
+          "width": 80,
+        }
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "borderRadius": 28,
+              "height": 32,
+              "justifyContent": "center",
+              "width": 56,
+            },
+            {
+              "height": 56,
+            },
+            {
+              "backgroundColor": "transparent",
+            },
+            undefined,
+            {
+              "transform": [
+                {
+                  "scale": 0.5,
+                },
+              ],
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "position": "absolute",
+            },
+            {
+              "top": 16,
+            },
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            [
+              {
+                "color": "rgba(73, 69, 79, 1)",
+                "fontSize": 24,
+              },
+              [
+                {
+                  "lineHeight": 24,
+                  "transform": [
+                    {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                {
+                  "backgroundColor": "transparent",
+                },
+              ],
+            ]
+          }
+        >
+          star-outline
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`DrawerCollapsedItem should have regular outline if label is specified 1`] = `
+<View>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+  >
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "marginBottom": 12,
+          "minHeight": 56,
+          "width": 80,
+        }
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "borderRadius": 28,
+              "height": 32,
+              "justifyContent": "center",
+              "width": 56,
+            },
+            false,
+            {
+              "backgroundColor": "transparent",
+            },
+            undefined,
+            {
+              "transform": [
+                {
+                  "scaleX": 0.5,
+                },
+              ],
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "position": "absolute",
+            },
+            {
+              "top": 4,
+            },
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            [
+              {
+                "color": "rgba(73, 69, 79, 1)",
+                "fontSize": 24,
+              },
+              [
+                {
+                  "lineHeight": 24,
+                  "transform": [
+                    {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                {
+                  "backgroundColor": "transparent",
+                },
+              ],
+            ]
+          }
+        >
+          star-outline
+        </Text>
+      </View>
+      <Text
+        numberOfLines={2}
+        onTextLayout={[Function]}
+        selectable={false}
+        style={
+          [
+            {
+              "textAlign": "left",
+            },
+            {
+              "color": "rgba(29, 27, 32, 1)",
+              "writingDirection": "ltr",
+            },
+            [
+              {
+                "fontFamily": "System",
+                "fontSize": 12,
+                "fontWeight": "500",
+                "letterSpacing": 0.5,
+                "lineHeight": 16,
+              },
+              [
+                {
+                  "marginHorizontal": 12,
+                  "marginTop": 4,
+                  "textAlign": "center",
+                },
+                false,
+                {
+                  "color": "rgba(73, 69, 79, 1)",
+                  "fontFamily": "System",
+                  "fontSize": 12,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.5,
+                  "lineHeight": 16,
+                },
+              ],
+            ],
+          ]
+        }
+      >
+        starred
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`DrawerCollapsedItem should have rounded outline if label is not specified 1`] = `
+<View>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+  >
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "marginBottom": 12,
+          "minHeight": 56,
+          "width": 80,
+        }
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "borderRadius": 28,
+              "height": 32,
+              "justifyContent": "center",
+              "width": 56,
+            },
+            {
+              "height": 56,
+            },
+            {
+              "backgroundColor": "transparent",
+            },
+            undefined,
+            {
+              "transform": [
+                {
+                  "scale": 0.5,
+                },
+              ],
+            },
+          ]
+        }
+      />
+      <View
+        style={
+          [
+            {
+              "position": "absolute",
+            },
+            {
+              "top": 16,
+            },
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            [
+              {
+                "color": "rgba(73, 69, 79, 1)",
+                "fontSize": 24,
+              },
+              [
+                {
+                  "lineHeight": 24,
+                  "transform": [
+                    {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                {
+                  "backgroundColor": "transparent",
+                },
+              ],
+            ]
+          }
+        >
+          star-outline
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/src/components/__tests__/FABExtended.test.tsx
+++ b/src/components/__tests__/FABExtended.test.tsx
@@ -1,4 +1,5 @@
-import { Platform } from 'react-native';
+import * as React from 'react';
+import { Platform, View } from 'react-native';
 
 import { afterEach, expect, it, jest } from '@jest/globals';
 import { fireEvent, userEvent } from '@testing-library/react-native';
@@ -43,20 +44,25 @@ it('expands to fit the measured label width', async () => {
     pageY: 0,
   });
 
+  const ref = React.createRef<View>();
   await render(
     <FAB.Extended
       icon="plus"
       label="New message"
       expanded
       style={{}}
-      testID="extended-fab"
+      ref={ref}
     />
   );
   await jest.runAllTimersAsync();
 
-  expect(
-    Reanimated.getAnimatedStyle(screen.getByTestId('extended-fab-container'))
-  ).toMatchObject({ width: 144 });
+  if (!ref.current) {
+    throw new Error('Expected FAB ref to be attached');
+  }
+
+  expect(Reanimated.getAnimatedStyle(ref.current)).toMatchObject({
+    width: 144,
+  });
 });
 
 it('renders extended FAB collapsed', async () => {

--- a/src/components/__tests__/IconButton.test.tsx
+++ b/src/components/__tests__/IconButton.test.tsx
@@ -3,7 +3,7 @@ import { StyleSheet } from 'react-native';
 import { describe, expect, it } from '@jest/globals';
 
 import { getTheme } from '../../core/theming';
-import { render, screen } from '../../test-utils';
+import { render } from '../../test-utils';
 import { pink500 } from '../../theme/colors';
 import { tokens } from '../../theme/tokens';
 import IconButton from '../IconButton/IconButton';
@@ -53,7 +53,7 @@ it('renders icon change animated', async () => {
 });
 
 it('renders icon button with custom border radius', async () => {
-  await render(
+  const { toJSON } = await render(
     <IconButton
       icon="camera"
       testID="icon-button"
@@ -63,13 +63,11 @@ it('renders icon button with custom border radius', async () => {
     />
   );
 
-  expect(screen.getByTestId('icon-button-container')).toHaveStyle({
-    borderRadius: 0,
-  });
+  expect(toJSON()).toMatchSnapshot();
 });
 
 it('renders icon button with small border radius', async () => {
-  await render(
+  const { toJSON } = await render(
     <IconButton
       icon="camera"
       testID="icon-button"
@@ -79,9 +77,7 @@ it('renders icon button with small border radius', async () => {
     />
   );
 
-  expect(screen.getByTestId('icon-button-container')).toHaveStyle({
-    borderRadius: 4,
-  });
+  expect(toJSON()).toMatchSnapshot();
 });
 
 describe('getIconButtonColor - icon color', () => {

--- a/src/components/__tests__/ListImage.test.tsx
+++ b/src/components/__tests__/ListImage.test.tsx
@@ -2,26 +2,15 @@ import { StyleSheet } from 'react-native';
 
 import { expect, it } from '@jest/globals';
 
-import { render, screen } from '../../test-utils';
+import { render } from '../../test-utils';
 import ListImage from '../List/ListImage';
 
 const styles = StyleSheet.create({
-  image: {
-    width: 56,
-    height: 56,
-  },
-  video: {
-    width: 114,
-    height: 64,
-    marginLeft: 0,
-  },
   container: {
     width: 30,
     height: 56,
   },
 });
-
-const testID = 'list-image';
 
 it('renders ListImage with default variant', async () => {
   const tree = (
@@ -49,23 +38,27 @@ it('renders ListImage with default variant & styles', async () => {
 });
 
 it('renders ListImage with `image` variant', async () => {
-  await render(
-    <ListImage
-      variant="image"
-      source={{ uri: 'https://www.someurl.com/apple' }}
-    />
-  );
+  const tree = (
+    await render(
+      <ListImage
+        variant="image"
+        source={{ uri: 'https://www.someurl.com/apple' }}
+      />
+    )
+  ).toJSON();
 
-  expect(screen.getByTestId(testID)).toHaveStyle(styles.image);
+  expect(tree).toMatchSnapshot();
 });
 
 it('renders ListImage with `video` variant', async () => {
-  await render(
-    <ListImage
-      variant="video"
-      source={{ uri: 'https://www.someurl.com/apple' }}
-    />
-  );
+  const tree = (
+    await render(
+      <ListImage
+        variant="video"
+        source={{ uri: 'https://www.someurl.com/apple' }}
+      />
+    )
+  ).toJSON();
 
-  expect(screen.getByTestId(testID)).toHaveStyle(styles.video);
+  expect(tree).toMatchSnapshot();
 });

--- a/src/components/__tests__/ListItem.test.tsx
+++ b/src/components/__tests__/ListItem.test.tsx
@@ -166,7 +166,7 @@ it('calling onPress on ListItem right component', async () => {
 });
 
 it('renders list item with custom content style', async () => {
-  await render(
+  const { toJSON } = await render(
     <ListItem
       title="First Item"
       description="Item description"
@@ -175,5 +175,5 @@ it('renders list item with custom content style', async () => {
     />
   );
 
-  expect(screen.getByTestId('list-item-content')).toHaveStyle(styles.content);
+  expect(toJSON()).toMatchSnapshot();
 });

--- a/src/components/__tests__/Menu.test.tsx
+++ b/src/components/__tests__/Menu.test.tsx
@@ -71,7 +71,7 @@ elevations.forEach((elevation) =>
       </Portal.Host>
     );
 
-    expect(screen.getByTestId(`${testID}-surface`)).toHaveStyle({
+    expect(screen.getByTestId(testID)).toHaveStyle({
       backgroundColor: theme.colors.elevation[`level${elevation}`],
     });
   })
@@ -109,7 +109,7 @@ it('uses the default anchorPosition of top', async () => {
     );
   }
 
-  const { rerender } = await render(makeMenu(false));
+  const { rerender, toJSON } = await render(makeMenu(false));
 
   // You must update instead of creating directly and using it because
   // componentDidUpdate isn't called by default in jest. Forcing the update
@@ -122,13 +122,12 @@ it('uses the default anchorPosition of top', async () => {
   });
 
   await waitFor(() => {
-    const menu = screen.getByTestId(`${testID}-view`);
-    expect(menu).toHaveStyle({
-      position: 'absolute',
-      left: 100,
-      top: 100,
-    });
+    const json = JSON.stringify(toJSON());
+    expect(json).toContain('"left":100');
+    expect(json).toContain('"top":100');
   });
+
+  expect(toJSON()).toMatchSnapshot();
 
   measureSpy.mockRestore();
   dimensionsSpy.mockRestore();
@@ -167,7 +166,7 @@ it('respects anchorPosition bottom', async () => {
     );
   }
 
-  const { rerender } = await render(makeMenu(false));
+  const { rerender, toJSON } = await render(makeMenu(false));
 
   await act(async () => {
     await rerender(makeMenu(true));
@@ -176,13 +175,12 @@ it('respects anchorPosition bottom', async () => {
   });
 
   await waitFor(() => {
-    const menu = screen.getByTestId(`${testID}-view`);
-    expect(menu).toHaveStyle({
-      position: 'absolute',
-      left: 100,
-      top: 132,
-    });
+    const json = JSON.stringify(toJSON());
+    expect(json).toContain('"left":100');
+    expect(json).toContain('"top":132');
   });
+
+  expect(toJSON()).toMatchSnapshot();
 
   measureSpy.mockRestore();
   dimensionsSpy.mockRestore();
@@ -206,11 +204,8 @@ it('renders menu with mode "elevated"', async () => {
     </Portal.Host>
   );
 
-  const menuSurface = screen.getByTestId(`${testID}-surface`);
-
-  // Get flattened styles
   // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-  const styles = StyleSheet.flatten(menuSurface.props.style);
+  const styles = StyleSheet.flatten(screen.getByTestId(testID).props.style);
 
   expect(styles).toHaveProperty('shadowColor');
   expect(styles).toHaveProperty('shadowOpacity');
@@ -234,11 +229,8 @@ it('renders menu with mode "flat"', async () => {
     </Portal.Host>
   );
 
-  const menuSurface = screen.getByTestId(`${testID}-surface`);
-
-  // Get flattened styles
   // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-  const styles = StyleSheet.flatten(menuSurface.props.style);
+  const styles = StyleSheet.flatten(screen.getByTestId(testID).props.style);
 
   expect(styles).not.toHaveProperty('shadowColor');
   expect(styles).not.toHaveProperty('shadowOpacity');

--- a/src/components/__tests__/MenuItem.test.tsx
+++ b/src/components/__tests__/MenuItem.test.tsx
@@ -48,10 +48,10 @@ describe('Menu Item', () => {
       />
     );
 
-    expect(
-      // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-      screen.getByTestId('menu-item-title').props.maxFontSizeMultiplier
-    ).toBe(labelMaxFontSizeMultiplier);
+    expect(screen.getByText('Cut')).toHaveProp(
+      'maxFontSizeMultiplier',
+      labelMaxFontSizeMultiplier
+    );
   });
 
   it('accepts aria-checked prop', async () => {

--- a/src/components/__tests__/Modal.test.tsx
+++ b/src/components/__tests__/Modal.test.tsx
@@ -57,7 +57,7 @@ describe('Modal', () => {
         </Modal>
       );
 
-      expect(screen.getByTestId('modal-backdrop')).toHaveStyle({
+      expect(screen.getByLabelText('Close modal')).toHaveStyle({
         backgroundColor: LightTheme.colors.scrim,
       });
     });
@@ -77,29 +77,26 @@ describe('Modal', () => {
         </Modal>
       );
 
-      expect(screen.getByTestId('modal-backdrop')).toHaveStyle({
+      expect(screen.getByLabelText('Close modal')).toHaveStyle({
         backgroundColor: 'transparent',
       });
     });
 
     it('should receive appropriate top and bottom insets', async () => {
-      await render(
+      const { toJSON } = await render(
         <Modal visible={true} testID="modal">
           {null}
         </Modal>
       );
 
-      expect(screen.getByTestId('modal-wrapper')).toHaveStyle({
-        marginTop: 37,
-        marginBottom: 44,
-      });
+      expect(toJSON()).toMatchSnapshot();
     });
   });
   describe('when open', () => {
     describe('if backdrop touched', () => {
       it('should invoke the onDismiss function immediately', async () => {
         const onDismiss = jest.fn();
-        await render(
+        const { toJSON } = await render(
           <Modal testID="modal" visible onDismiss={onDismiss}>
             {null}
           </Modal>
@@ -107,42 +104,36 @@ describe('Modal', () => {
 
         expect(onDismiss).not.toHaveBeenCalled();
 
-        await userEvent.press(screen.getByTestId('modal-backdrop'));
+        await userEvent.press(screen.getByLabelText('Close modal'));
 
         expect(onDismiss).toHaveBeenCalled();
 
-        expect(screen.getByTestId('modal-surface')).toHaveStyle({
-          opacity: 1,
-        });
+        expect(toJSON()).toMatchSnapshot();
 
         await act(() => {
           jest.runAllTimers();
         });
 
-        expect(screen.getByTestId('modal-backdrop')).toHaveStyle({
+        expect(screen.getByLabelText('Close modal')).toHaveStyle({
           opacity: scrimAlpha,
         });
 
-        expect(screen.getByTestId('modal-surface')).toHaveStyle({
-          opacity: 1,
-        });
+        expect(toJSON()).toMatchSnapshot();
 
         expect(onDismiss).toHaveBeenCalledTimes(1);
       });
     });
 
     it('runs the closing animation if visible toggled', async () => {
-      const { rerender } = await render(
+      const { rerender, toJSON } = await render(
         <Modal testID="modal" visible onDismiss={() => {}}>
           {null}
         </Modal>
       );
 
-      expect(screen.getByTestId('modal-surface')).toHaveStyle({
-        opacity: 1,
-      });
+      expect(toJSON()).toMatchSnapshot();
 
-      await userEvent.press(screen.getByTestId('modal-backdrop'));
+      await userEvent.press(screen.getByLabelText('Close modal'));
 
       await rerender(
         <Modal testID="modal" visible={false} onDismiss={() => {}}>
@@ -150,59 +141,47 @@ describe('Modal', () => {
         </Modal>
       );
 
-      expect(screen.getByTestId('modal-surface')).toHaveStyle({
-        opacity: 1,
-      });
+      expect(toJSON()).toMatchSnapshot();
 
-      expect(screen.getByTestId('modal-backdrop')).toHaveStyle({
+      expect(screen.getByLabelText('Close modal')).toHaveStyle({
         opacity: scrimAlpha,
       });
 
-      expect(screen.getByTestId('modal-surface')).toHaveStyle({
-        opacity: 1,
-      });
+      expect(toJSON()).toMatchSnapshot();
 
       await act(() => {
         jest.runAllTimers();
       });
 
-      expect(screen.queryByTestId('modal-surface')).not.toBeOnTheScreen();
-
-      expect(screen.queryByTestId('modal-backdrop')).not.toBeOnTheScreen();
+      expect(toJSON()).toBeNull();
     });
 
     describe('if closed via Android back button', () => {
       it('invokes onDismiss', async () => {
         const onDismiss = jest.fn();
-        await render(
+        const { toJSON } = await render(
           <Modal testID="modal" visible onDismiss={onDismiss}>
             {null}
           </Modal>
         );
 
-        expect(screen.getByTestId('modal-surface')).toHaveStyle({
-          opacity: 1,
-        });
+        expect(toJSON()).toMatchSnapshot();
 
         await act(() => {
           BackHandler.mockPressBack();
         });
 
-        expect(screen.getByTestId('modal-surface')).toHaveStyle({
-          opacity: 1,
-        });
+        expect(toJSON()).toMatchSnapshot();
 
         await act(() => {
           jest.runAllTimers();
         });
 
-        expect(screen.getByTestId('modal-backdrop')).toHaveStyle({
+        expect(screen.getByLabelText('Close modal')).toHaveStyle({
           opacity: scrimAlpha,
         });
 
-        expect(screen.getByTestId('modal-surface')).toHaveStyle({
-          opacity: 1,
-        });
+        expect(toJSON()).toMatchSnapshot();
 
         expect(onDismiss).toHaveBeenCalledTimes(1);
       });
@@ -212,7 +191,7 @@ describe('Modal', () => {
   describe('when open as non-dismissible modal', () => {
     describe('if closed via touching backdrop', () => {
       it('will run the animation but not fade out', async () => {
-        await render(
+        const { toJSON } = await render(
           <Modal
             testID="modal"
             visible
@@ -223,27 +202,21 @@ describe('Modal', () => {
           </Modal>
         );
 
-        expect(screen.getByTestId('modal-surface')).toHaveStyle({
-          opacity: 1,
-        });
+        expect(toJSON()).toMatchSnapshot();
 
-        await userEvent.press(screen.getByTestId('modal-backdrop'));
+        await userEvent.press(screen.getByLabelText('Close modal'));
 
-        expect(screen.getByTestId('modal-surface')).toHaveStyle({
-          opacity: 1,
-        });
+        expect(toJSON()).toMatchSnapshot();
 
         await act(() => {
           jest.runAllTimers();
         });
 
-        expect(screen.getByTestId('modal-backdrop')).toHaveStyle({
+        expect(screen.getByLabelText('Close modal')).toHaveStyle({
           opacity: scrimAlpha,
         });
 
-        expect(screen.getByTestId('modal-surface')).toHaveStyle({
-          opacity: 1,
-        });
+        expect(toJSON()).toMatchSnapshot();
       });
 
       it('should not invoke onDismiss', async () => {
@@ -261,7 +234,7 @@ describe('Modal', () => {
 
         expect(onDismiss).not.toHaveBeenCalled();
 
-        await userEvent.press(screen.getByTestId('modal-backdrop'));
+        await userEvent.press(screen.getByLabelText('Close modal'));
 
         expect(onDismiss).not.toHaveBeenCalled();
 
@@ -275,7 +248,7 @@ describe('Modal', () => {
 
     describe('if closed via Android back button', () => {
       it('will run the animation but not fade out', async () => {
-        await render(
+        const { toJSON } = await render(
           <Modal
             testID="modal"
             visible
@@ -286,29 +259,23 @@ describe('Modal', () => {
           </Modal>
         );
 
-        expect(screen.getByTestId('modal-surface')).toHaveStyle({
-          opacity: 1,
-        });
+        expect(toJSON()).toMatchSnapshot();
 
         await act(() => {
           BackHandler.mockPressBack();
         });
 
-        expect(screen.getByTestId('modal-surface')).toHaveStyle({
-          opacity: 1,
-        });
+        expect(toJSON()).toMatchSnapshot();
 
         await act(() => {
           jest.runAllTimers();
         });
 
-        expect(screen.getByTestId('modal-backdrop')).toHaveStyle({
+        expect(screen.getByLabelText('Close modal')).toHaveStyle({
           opacity: scrimAlpha,
         });
 
-        expect(screen.getByTestId('modal-surface')).toHaveStyle({
-          opacity: 1,
-        });
+        expect(toJSON()).toMatchSnapshot();
       });
 
       it('should not invoke onDismiss', async () => {
@@ -345,7 +312,7 @@ describe('Modal', () => {
   describe('when visible prop changes', () => {
     describe('from false to true (closed to open)', () => {
       it('should run fade-in animation on opening', async () => {
-        const { rerender } = await render(
+        const { rerender, toJSON } = await render(
           <Modal testID="modal" visible={false}>
             {null}
           </Modal>
@@ -359,40 +326,34 @@ describe('Modal', () => {
           </Modal>
         );
 
-        expect(screen.getByTestId('modal-backdrop')).toHaveStyle({
+        expect(screen.getByLabelText('Close modal')).toHaveStyle({
           opacity: 0,
         });
-        expect(screen.getByTestId('modal-surface')).toHaveStyle({
-          opacity: 0,
-        });
+        expect(toJSON()).toMatchSnapshot();
 
         await act(() => {
           jest.runAllTimers();
         });
 
-        expect(screen.getByTestId('modal-backdrop')).toHaveStyle({
+        expect(screen.getByLabelText('Close modal')).toHaveStyle({
           opacity: scrimAlpha,
         });
-        expect(screen.getByTestId('modal-surface')).toHaveStyle({
-          opacity: 1,
-        });
+        expect(toJSON()).toMatchSnapshot();
       });
     });
 
     describe('from true to false (open to closed)', () => {
       it('should run fade-out animation on closing', async () => {
-        const { rerender } = await render(
+        const { rerender, toJSON } = await render(
           <Modal testID="modal" visible>
             {null}
           </Modal>
         );
 
-        expect(screen.getByTestId('modal-backdrop')).toHaveStyle({
+        expect(screen.getByLabelText('Close modal')).toHaveStyle({
           opacity: scrimAlpha,
         });
-        expect(screen.getByTestId('modal-surface')).toHaveStyle({
-          opacity: 1,
-        });
+        expect(toJSON()).toMatchSnapshot();
 
         await rerender(
           <Modal testID="modal" visible={false}>
@@ -400,12 +361,10 @@ describe('Modal', () => {
           </Modal>
         );
 
-        expect(screen.getByTestId('modal-backdrop')).toHaveStyle({
+        expect(screen.getByLabelText('Close modal')).toHaveStyle({
           opacity: scrimAlpha,
         });
-        expect(screen.getByTestId('modal-surface')).toHaveStyle({
-          opacity: 1,
-        });
+        expect(toJSON()).toMatchSnapshot();
 
         await act(() => {
           jest.runAllTimers();
@@ -441,18 +400,16 @@ describe('Modal', () => {
       });
 
       it('should close even if the dialog is not dismissible', async () => {
-        const { rerender } = await render(
+        const { rerender, toJSON } = await render(
           <Modal testID="modal" visible dismissable={false}>
             {null}
           </Modal>
         );
 
-        expect(screen.getByTestId('modal-backdrop')).toHaveStyle({
+        expect(screen.getByLabelText('Close modal')).toHaveStyle({
           opacity: scrimAlpha,
         });
-        expect(screen.getByTestId('modal-surface')).toHaveStyle({
-          opacity: 1,
-        });
+        expect(toJSON()).toMatchSnapshot();
 
         await rerender(
           <Modal testID="modal" visible={false} dismissable={false}>
@@ -460,12 +417,10 @@ describe('Modal', () => {
           </Modal>
         );
 
-        expect(screen.getByTestId('modal-backdrop')).toHaveStyle({
+        expect(screen.getByLabelText('Close modal')).toHaveStyle({
           opacity: scrimAlpha,
         });
-        expect(screen.getByTestId('modal-surface')).toHaveStyle({
-          opacity: 1,
-        });
+        expect(toJSON()).toMatchSnapshot();
 
         await act(() => {
           jest.runAllTimers();
@@ -479,18 +434,16 @@ describe('Modal', () => {
   describe('when visible prop changes again during the open/close animation', () => {
     describe('while closing, back to true (visible)', () => {
       it('should keep the modal open', async () => {
-        const { rerender } = await render(
+        const { rerender, toJSON } = await render(
           <Modal testID="modal" visible>
             {null}
           </Modal>
         );
 
-        expect(screen.getByTestId('modal-backdrop')).toHaveStyle({
+        expect(screen.getByLabelText('Close modal')).toHaveStyle({
           opacity: scrimAlpha,
         });
-        expect(screen.getByTestId('modal-surface')).toHaveStyle({
-          opacity: 1,
-        });
+        expect(toJSON()).toMatchSnapshot();
 
         await rerender(
           <Modal testID="modal" visible={false}>
@@ -498,12 +451,10 @@ describe('Modal', () => {
           </Modal>
         );
 
-        expect(screen.getByTestId('modal-backdrop')).toHaveStyle({
+        expect(screen.getByLabelText('Close modal')).toHaveStyle({
           opacity: scrimAlpha,
         });
-        expect(screen.getByTestId('modal-surface')).toHaveStyle({
-          opacity: 1,
-        });
+        expect(toJSON()).toMatchSnapshot();
 
         await act(() => {
           // Not a real seconds, this depends on how frequently
@@ -521,24 +472,22 @@ describe('Modal', () => {
           jest.runAllTimers();
         });
 
-        expect(screen.getByTestId('modal-backdrop')).toHaveStyle({
+        expect(screen.getByLabelText('Close modal')).toHaveStyle({
           opacity: scrimAlpha,
         });
-        expect(screen.getByTestId('modal-surface')).toHaveStyle({
-          opacity: 1,
-        });
+        expect(toJSON()).toMatchSnapshot();
       });
     });
 
     describe('while opening, back to false (hidden)', () => {
       it('should keep the modal closed', async () => {
-        const { rerender } = await render(
+        const { rerender, toJSON } = await render(
           <Modal testID="modal" visible={false}>
             {null}
           </Modal>
         );
 
-        expect(screen.queryByTestId('modal-backdrop')).not.toBeOnTheScreen();
+        expect(screen.queryByLabelText('Close modal')).not.toBeOnTheScreen();
 
         await rerender(
           <Modal testID="modal" visible>
@@ -546,12 +495,10 @@ describe('Modal', () => {
           </Modal>
         );
 
-        expect(screen.getByTestId('modal-backdrop')).toHaveStyle({
+        expect(screen.getByLabelText('Close modal')).toHaveStyle({
           opacity: 0,
         });
-        expect(screen.getByTestId('modal-surface')).toHaveStyle({
-          opacity: 0,
-        });
+        expect(toJSON()).toMatchSnapshot();
 
         await act(() => {
           // Not a real seconds, this depends on how frequently
@@ -559,7 +506,7 @@ describe('Modal', () => {
           jest.advanceTimersToNextTimer(1000);
         });
 
-        expect(screen.getByTestId('modal-backdrop')).toBeOnTheScreen();
+        expect(screen.getByLabelText('Close modal')).toBeOnTheScreen();
 
         await rerender(
           <Modal testID="modal" visible={false}>
@@ -571,7 +518,7 @@ describe('Modal', () => {
           jest.runAllTimers();
         });
 
-        expect(screen.queryByTestId('modal-backdrop')).not.toBeOnTheScreen();
+        expect(screen.queryByLabelText('Close modal')).not.toBeOnTheScreen();
       });
     });
   });

--- a/src/components/__tests__/ProgressBar.test.tsx
+++ b/src/components/__tests__/ProgressBar.test.tsx
@@ -94,12 +94,10 @@ it('has progressbar role', async () => {
 });
 
 it('renders progress bar with custom style of filled part', async () => {
-  await render(
+  const view = await render(
     <ProgressBar progress={0.2} fillStyle={styles.fill} testID="progress-bar" />
   );
   await triggerLayout();
 
-  expect(screen.getByTestId('progress-bar-fill')).toHaveStyle({
-    borderRadius: 4,
-  });
+  expect(view.toJSON()).toMatchSnapshot();
 });

--- a/src/components/__tests__/Searchbar.test.tsx
+++ b/src/components/__tests__/Searchbar.test.tsx
@@ -30,13 +30,13 @@ it('activity indicator snapshot test', async () => {
 it('renders with ActivityIndicator', async () => {
   await render(<Searchbar loading={true} value="" />);
 
-  expect(screen.getByTestId('activity-indicator')).toBeOnTheScreen();
+  expect(screen.getByRole('progressbar')).toBeOnTheScreen();
 });
 
 it('renders without ActivityIndicator', async () => {
   await render(<Searchbar loading={false} value="" />);
 
-  expect(screen.queryByTestId('activity-indicator')).not.toBeOnTheScreen();
+  expect(screen.queryByRole('progressbar')).not.toBeOnTheScreen();
 });
 
 it('renders clear icon with custom color', async () => {

--- a/src/components/__tests__/Searchbar.test.tsx
+++ b/src/components/__tests__/Searchbar.test.tsx
@@ -44,30 +44,25 @@ it('renders clear icon with custom color', async () => {
     <Searchbar testID="search-bar" value="value" iconColor="purple" />
   );
 
-  // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-  const iconComponent = screen.getByTestId('search-bar-icon-wrapper').props
-    .children;
-
-  // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-  expect(iconComponent.props.iconColor).toBe('purple');
+  expect(
+    screen.getByText('close', { includeHiddenElements: true })
+  ).toHaveStyle({ color: 'purple' });
 });
 
-it('renders clear icon wrapper, which can be the target of touch events, if search has value', async () => {
-  await render(<Searchbar testID="search-bar" value="value" />);
+it('does not respond to touch on the clear icon when search has no value', async () => {
+  const onClearIconPressMock = jest.fn();
+  await render(
+    <Searchbar
+      testID="search-bar"
+      value=""
+      onClearIconPress={onClearIconPressMock}
+    />
+  );
 
-  expect(
-    // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-    screen.getByTestId('search-bar-icon-wrapper').props.pointerEvents
-  ).toBe('auto');
-});
-
-it('renders clear icon wrapper, which is never target of touch events, if search has no value', async () => {
-  await render(<Searchbar testID="search-bar" value="" />);
-
-  expect(
-    // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
-    screen.getByTestId('search-bar-icon-wrapper').props.pointerEvents
-  ).toBe('none');
+  await userEvent.press(
+    screen.getByLabelText('clear', { includeHiddenElements: true })
+  );
+  expect(onClearIconPressMock).not.toHaveBeenCalled();
 });
 
 it('defines onClearIconPress action and checks if it is called when close button is pressed', async () => {
@@ -79,20 +74,12 @@ it('defines onClearIconPress action and checks if it is called when close button
       onClearIconPress={onClearIconPressMock}
     />
   );
-  await userEvent.press(screen.getByTestId('search-bar-clear-icon'));
+  await userEvent.press(screen.getByLabelText('clear'));
   expect(onClearIconPressMock).toHaveBeenCalledTimes(1);
 });
 
-it('renders clear icon wrapper, with appropriate style for v3', async () => {
-  const { rerender } = await render(<Searchbar testID="search-bar" value="" />);
-
-  expect(screen.getByTestId('search-bar-icon-wrapper')).toHaveStyle({
-    position: 'absolute',
-    right: 0,
-    marginLeft: 16,
-  });
-
-  await rerender(
+it('hides the clear icon when a custom right element is rendered', async () => {
+  await render(
     <Searchbar
       testID="search-bar"
       value=""
@@ -100,11 +87,7 @@ it('renders clear icon wrapper, with appropriate style for v3', async () => {
     />
   );
 
-  expect(
-    screen.getByTestId('search-bar-icon-wrapper', {
-      includeHiddenElements: true,
-    })
-  ).toHaveStyle({ display: 'none' });
+  expect(screen.queryByLabelText('clear')).not.toBeOnTheScreen();
 });
 
 it('renders trailering icon when mode is set to "bar"', async () => {
@@ -113,11 +96,12 @@ it('renders trailering icon when mode is set to "bar"', async () => {
       testID="search-bar"
       value={''}
       traileringIcon={'microphone'}
+      traileringIconAccessibilityLabel="microphone"
       mode="bar"
     />
   );
 
-  expect(screen.getByTestId('search-bar-trailering-icon')).toBeOnTheScreen();
+  expect(screen.getByLabelText('microphone')).toBeOnTheScreen();
 });
 
 it('renders trailering icon with press functionality', async () => {
@@ -128,12 +112,13 @@ it('renders trailering icon with press functionality', async () => {
       testID="search-bar"
       value={''}
       traileringIcon={'microphone'}
+      traileringIconAccessibilityLabel="microphone"
       onTraileringIconPress={onTraileringIconPressMock}
       mode="bar"
     />
   );
 
-  await userEvent.press(screen.getByTestId('search-bar-trailering-icon'));
+  await userEvent.press(screen.getByLabelText('microphone'));
   expect(onTraileringIconPressMock).toHaveBeenCalledTimes(1);
 });
 
@@ -143,31 +128,29 @@ it('renders clear icon instead of trailering icon', async () => {
       testID="search-bar"
       value={''}
       traileringIcon={'microphone'}
+      traileringIconAccessibilityLabel="microphone"
       mode="bar"
     />
   );
 
-  expect(screen.getByTestId('search-bar-trailering-icon')).toBeOnTheScreen();
+  expect(screen.getByLabelText('microphone')).toBeOnTheScreen();
 
   await rerender(
     <Searchbar
       testID="search-bar"
       value={'test'}
       traileringIcon={'microphone'}
+      traileringIconAccessibilityLabel="microphone"
       mode="bar"
     />
   );
 
-  expect(
-    screen.queryByTestId('search-bar-trailering-icon')
-  ).not.toBeOnTheScreen();
-  expect(screen.getByTestId('search-bar-icon-wrapper')).toBeOnTheScreen();
+  expect(screen.queryByLabelText('microphone')).not.toBeOnTheScreen();
+  expect(screen.getByLabelText('clear')).toBeOnTheScreen();
 });
 
 it('renders searchbar in "view" mode', async () => {
-  await render(<Searchbar testID="search-bar" value={''} mode="view" />);
+  const tree = (await render(<Searchbar value={''} mode="view" />)).toJSON();
 
-  expect(screen.getByTestId('search-bar-container')).toHaveStyle({
-    borderRadius: 0,
-  });
+  expect(tree).toMatchSnapshot();
 });

--- a/src/components/__tests__/SegmentedButton.test.tsx
+++ b/src/components/__tests__/SegmentedButton.test.tsx
@@ -273,134 +273,138 @@ describe('getDisabledSegmentedButtonBorderWidth', () => {
 
 describe('should render icon when', () => {
   it('icon prop is passed', async () => {
-    await render(
-      <SegmentedButtons
-        value={'walk'}
-        buttons={[
-          {
-            icon: 'walk',
-            value: 'walk',
-            testID: 'walking-button',
-          },
-          {
-            icon: 'car',
-            value: 'drive',
-            testID: 'driving-button',
-          },
-        ]}
-        onValueChange={() => {}}
-      />
-    );
+    const tree = (
+      await render(
+        <SegmentedButtons
+          value={'walk'}
+          buttons={[
+            {
+              icon: 'walk',
+              value: 'walk',
+              testID: 'walking-button',
+            },
+            {
+              icon: 'car',
+              value: 'drive',
+              testID: 'driving-button',
+            },
+          ]}
+          onValueChange={() => {}}
+        />
+      )
+    ).toJSON();
 
-    expect(screen.getByTestId('walking-button-icon')).toBeOnTheScreen();
-    expect(screen.getByTestId('driving-button-icon')).toBeOnTheScreen();
+    expect(tree).toMatchSnapshot();
   });
 
   it('icon prop is passed along with label, no matter if button is checked', async () => {
-    await render(
-      <SegmentedButtons
-        value={'walk'}
-        buttons={[
-          {
-            icon: 'walk',
-            value: 'walk',
-            label: 'Walking',
-            testID: 'walking-button',
-          },
-          {
-            icon: 'car',
-            value: 'drive',
-            label: 'Driving',
-            testID: 'driving-button',
-          },
-        ]}
-        onValueChange={() => {}}
-      />
-    );
+    const tree = (
+      await render(
+        <SegmentedButtons
+          value={'walk'}
+          buttons={[
+            {
+              icon: 'walk',
+              value: 'walk',
+              label: 'Walking',
+              testID: 'walking-button',
+            },
+            {
+              icon: 'car',
+              value: 'drive',
+              label: 'Driving',
+              testID: 'driving-button',
+            },
+          ]}
+          onValueChange={() => {}}
+        />
+      )
+    ).toJSON();
 
-    expect(screen.getByTestId('walking-button-icon')).toBeOnTheScreen();
-    expect(screen.getByTestId('driving-button-icon')).toBeOnTheScreen();
+    expect(tree).toMatchSnapshot();
   });
 
   it('icon prop is passed along with label, button is checked, showSelectedCheck is false', async () => {
-    await render(
-      <SegmentedButtons
-        value={'walk'}
-        buttons={[
-          {
-            icon: 'walk',
-            value: 'walk',
-            label: 'Walking',
-            testID: 'walking-button',
-            showSelectedCheck: false,
-          },
-          {
-            icon: 'car',
-            value: 'drive',
-            label: 'Driving',
-            testID: 'driving-button',
-            showSelectedCheck: false,
-          },
-        ]}
-        onValueChange={() => {}}
-      />
-    );
+    const tree = (
+      await render(
+        <SegmentedButtons
+          value={'walk'}
+          buttons={[
+            {
+              icon: 'walk',
+              value: 'walk',
+              label: 'Walking',
+              testID: 'walking-button',
+              showSelectedCheck: false,
+            },
+            {
+              icon: 'car',
+              value: 'drive',
+              label: 'Driving',
+              testID: 'driving-button',
+              showSelectedCheck: false,
+            },
+          ]}
+          onValueChange={() => {}}
+        />
+      )
+    ).toJSON();
 
-    expect(screen.getByTestId('walking-button-icon')).toBeOnTheScreen();
-    expect(screen.getByTestId('driving-button-icon')).toBeOnTheScreen();
+    expect(tree).toMatchSnapshot();
   });
 });
 
 describe('should not render icon when', () => {
   it('icon prop is not passed', async () => {
-    await render(
-      <SegmentedButtons
-        value={'walk'}
-        buttons={[
-          {
-            value: 'walk',
-            testID: 'walking-button',
-          },
-          {
-            value: 'drive',
-            testID: 'driving-button',
-          },
-        ]}
-        onValueChange={() => {}}
-      />
-    );
+    const tree = (
+      await render(
+        <SegmentedButtons
+          value={'walk'}
+          buttons={[
+            {
+              value: 'walk',
+              testID: 'walking-button',
+            },
+            {
+              value: 'drive',
+              testID: 'driving-button',
+            },
+          ]}
+          onValueChange={() => {}}
+        />
+      )
+    ).toJSON();
 
-    expect(screen.queryByTestId('walking-button-icon')).not.toBeOnTheScreen();
-    expect(screen.queryByTestId('driving-button-icon')).not.toBeOnTheScreen();
+    expect(tree).toMatchSnapshot();
   });
 
   it('icon prop is passed along with label, button is checked, showSelectedCheck is true', async () => {
-    await render(
-      <SegmentedButtons
-        value={'walk'}
-        buttons={[
-          {
-            icon: 'walk',
-            label: 'Walking',
-            value: 'walk',
-            testID: 'walking-button',
-            showSelectedCheck: true,
-          },
-          {
-            icon: 'car',
-            label: 'Driving',
-            value: 'drive',
-            testID: 'driving-button',
-            showSelectedCheck: true,
-          },
-        ]}
-        onValueChange={() => {}}
-      />
-    );
+    const tree = (
+      await render(
+        <SegmentedButtons
+          value={'walk'}
+          buttons={[
+            {
+              icon: 'walk',
+              label: 'Walking',
+              value: 'walk',
+              testID: 'walking-button',
+              showSelectedCheck: true,
+            },
+            {
+              icon: 'car',
+              label: 'Driving',
+              value: 'drive',
+              testID: 'driving-button',
+              showSelectedCheck: true,
+            },
+          ]}
+          onValueChange={() => {}}
+        />
+      )
+    ).toJSON();
 
-    expect(screen.queryByTestId('walking-button-icon')).not.toBeOnTheScreen();
-    expect(screen.getByTestId('walking-button-check-icon')).toBeOnTheScreen();
-    expect(screen.getByTestId('driving-button-icon')).toBeOnTheScreen();
+    expect(tree).toMatchSnapshot();
   });
 });
 
@@ -439,25 +443,26 @@ describe('should have `accessibilityState={ checked: true }` when selected', () 
   it('show selected check icon should be shown', async () => {
     const onValueChange = jest.fn();
 
-    await render(
-      <SegmentedButtons<string>
-        multiSelect
-        value={['walk', 'transit']}
-        buttons={[
-          {
-            value: 'walk',
-            label: 'Walking',
-            showSelectedCheck: true,
-            testID: 'walking-check-icon',
-          },
-          { value: 'transit', label: 'Transit' },
-          { value: 'drive', label: 'Driving' },
-        ]}
-        onValueChange={onValueChange}
-      />
-    );
+    const tree = (
+      await render(
+        <SegmentedButtons<string>
+          multiSelect
+          value={['walk', 'transit']}
+          buttons={[
+            {
+              value: 'walk',
+              label: 'Walking',
+              showSelectedCheck: true,
+            },
+            { value: 'transit', label: 'Transit' },
+            { value: 'drive', label: 'Driving' },
+          ]}
+          onValueChange={onValueChange}
+        />
+      )
+    ).toJSON();
 
-    expect(screen.getByTestId('walking-check-icon')).toBeOnTheScreen();
+    expect(tree).toMatchSnapshot();
   });
 });
 
@@ -484,10 +489,10 @@ describe('labelStyle is handled', () => {
       />
     );
 
-    expect(screen.getByTestId('walking-button-label')).toHaveStyle({
+    expect(screen.getByText('Walking')).toHaveStyle({
       fontSize: 10,
     });
-    expect(screen.getByTestId('driving-button-label')).toHaveStyle({
+    expect(screen.getByText('Driving')).toHaveStyle({
       fontSize: 12,
     });
   });
@@ -507,7 +512,7 @@ describe('labelStyle is handled', () => {
       />
     );
 
-    expect(screen.getByTestId('walking-button-label')).toHaveStyle({
+    expect(screen.getByText('Walking')).toHaveStyle({
       fontSize: 14,
     });
   });

--- a/src/components/__tests__/Tooltip.test.tsx
+++ b/src/components/__tests__/Tooltip.test.tsx
@@ -193,18 +193,19 @@ describe('Tooltip', () => {
       describe('When it does not overflow', () => {
         it('centers the tooltip in the middle of the children component', async () => {
           const {
-            wrapper: { getByText, getByTestId, findByText },
+            wrapper: { getByText, findByText },
           } = await setup();
 
           await userEvent.longPress(getTrigger(getByText));
 
-          await fireEvent(await findByText('some tooltip text'), 'layout', {
+          const tooltip = await findByText('some tooltip text');
+          await fireEvent(tooltip, 'layout', {
             nativeEvent: {
               layout: { width: TOOLTIP_WIDTH, height: TOOLTIP_HEIGHT },
             },
           });
 
-          expect(getByTestId('tooltip-container')).toHaveStyle({
+          expect(tooltip.parent).toHaveStyle({
             left: 210, // pageX (220) + (width (80) - TOOLTIP_WIDTH (100)) / 2 = 210
             top: 250, // pageY (200) + height (50)
           });
@@ -214,18 +215,19 @@ describe('Tooltip', () => {
       describe('When it overflows to left', () => {
         it('renders the tooltip with the right placement', async () => {
           const {
-            wrapper: { getByText, getByTestId, findByText },
+            wrapper: { getByText, findByText },
           } = await setup({}, { pageX: 0 }); // Component starting at the starting 0 X coord
 
           await userEvent.longPress(getTrigger(getByText));
 
-          await fireEvent(await findByText('some tooltip text'), 'layout', {
+          const tooltip = await findByText('some tooltip text');
+          await fireEvent(tooltip, 'layout', {
             nativeEvent: {
               layout: { width: TOOLTIP_WIDTH, height: TOOLTIP_HEIGHT },
             },
           });
 
-          expect(getByTestId('tooltip-container')).toHaveStyle({
+          expect(tooltip.parent).toHaveStyle({
             left: 0, // Tooltip renders starting from children's x coord
             top: 250,
           });
@@ -235,18 +237,19 @@ describe('Tooltip', () => {
       describe('When it overflows to right', () => {
         it('renders the tooltip with the right placement', async () => {
           const {
-            wrapper: { getByText, getByTestId, findByText },
+            wrapper: { getByText, findByText },
           } = await setup({}, { pageX: 900, width: 150 }); // Component close to the screen limit
 
           await userEvent.longPress(getTrigger(getByText));
 
-          await fireEvent(await findByText('some tooltip text'), 'layout', {
+          const tooltip = await findByText('some tooltip text');
+          await fireEvent(tooltip, 'layout', {
             nativeEvent: {
               layout: { width: TOOLTIP_WIDTH, height: TOOLTIP_HEIGHT },
             },
           });
 
-          expect(getByTestId('tooltip-container')).toHaveStyle({
+          expect(tooltip.parent).toHaveStyle({
             left: 950, // pageX (900) + width (150) - 100 (TOOLTIP_WIDTH) // Tooltip is placed from right to left without going offscreen
             top: 250,
           });
@@ -256,18 +259,19 @@ describe('Tooltip', () => {
       describe('When it overflows to bottom', () => {
         it('renders the tooltip with the right placement', async () => {
           const {
-            wrapper: { getByText, getByTestId, findByText },
+            wrapper: { getByText, findByText },
           } = await setup({}, { pageY: 600, height: 50 });
 
           await userEvent.longPress(getTrigger(getByText));
 
-          await fireEvent(await findByText('some tooltip text'), 'layout', {
+          const tooltip = await findByText('some tooltip text');
+          await fireEvent(tooltip, 'layout', {
             nativeEvent: {
               layout: { width: TOOLTIP_WIDTH, height: TOOLTIP_HEIGHT },
             },
           });
 
-          expect(getByTestId('tooltip-container')).toHaveStyle({
+          expect(tooltip.parent).toHaveStyle({
             left: 210,
             top: 500, // pageY (600) - TOOLTIP_HEIGHT (100) // Tooltip is placed at the top of the component,
           });
@@ -388,19 +392,20 @@ describe('Tooltip', () => {
       describe('When it does not overflow', () => {
         it('centers the tooltip in the middle of the children component', async () => {
           const {
-            wrapper: { getByText, getByTestId, findByText },
+            wrapper: { getByText, findByText },
           } = await setup();
 
           await fireEvent(getTrigger(getByText), 'hoverIn');
           await runTimers(500);
 
-          await fireEvent(await findByText('some tooltip text'), 'layout', {
+          const tooltip = await findByText('some tooltip text');
+          await fireEvent(tooltip, 'layout', {
             nativeEvent: {
               layout: { width: TOOLTIP_WIDTH, height: TOOLTIP_HEIGHT },
             },
           });
 
-          expect(getByTestId('tooltip-container')).toHaveStyle({
+          expect(tooltip.parent).toHaveStyle({
             left: 210, // pageX (220) + (width (80) - TOOLTIP_WIDTH (100)) / 2 = 210
             top: 250, // pageY (200) + height (50)
           });
@@ -410,19 +415,20 @@ describe('Tooltip', () => {
       describe('When it overflows to left', () => {
         it('renders the tooltip with the right placement', async () => {
           const {
-            wrapper: { getByText, getByTestId, findByText },
+            wrapper: { getByText, findByText },
           } = await setup({}, { pageX: 0 }); // Component starting at the starting 0 X coord
 
           await fireEvent(getTrigger(getByText), 'hoverIn');
           await runTimers(500);
 
-          await fireEvent(await findByText('some tooltip text'), 'layout', {
+          const tooltip = await findByText('some tooltip text');
+          await fireEvent(tooltip, 'layout', {
             nativeEvent: {
               layout: { width: TOOLTIP_WIDTH, height: TOOLTIP_HEIGHT },
             },
           });
 
-          expect(getByTestId('tooltip-container')).toHaveStyle({
+          expect(tooltip.parent).toHaveStyle({
             left: 0, // Tooltip renders starting from children's x coord
             top: 250,
           });
@@ -432,19 +438,20 @@ describe('Tooltip', () => {
       describe('When it overflows to right', () => {
         it('renders the tooltip with the right placement', async () => {
           const {
-            wrapper: { getByText, getByTestId, findByText },
+            wrapper: { getByText, findByText },
           } = await setup({}, { pageX: 900, width: 150 }); // Component close to the screen limit
 
           await fireEvent(getTrigger(getByText), 'hoverIn');
           await runTimers(500);
 
-          await fireEvent(await findByText('some tooltip text'), 'layout', {
+          const tooltip = await findByText('some tooltip text');
+          await fireEvent(tooltip, 'layout', {
             nativeEvent: {
               layout: { width: TOOLTIP_WIDTH, height: TOOLTIP_HEIGHT },
             },
           });
 
-          expect(getByTestId('tooltip-container')).toHaveStyle({
+          expect(tooltip.parent).toHaveStyle({
             left: 950, // pageX (900) + width (150) - 100 (TOOLTIP_WIDTH) // Tooltip is placed from right to left without going offscreen
             top: 250,
           });
@@ -454,19 +461,20 @@ describe('Tooltip', () => {
       describe('When it overflows to bottom', () => {
         it('renders the tooltip with the right placement', async () => {
           const {
-            wrapper: { getByText, getByTestId, findByText },
+            wrapper: { getByText, findByText },
           } = await setup({}, { pageY: 600, height: 50 });
 
           await fireEvent(getTrigger(getByText), 'hoverIn');
           await runTimers(500);
 
-          await fireEvent(await findByText('some tooltip text'), 'layout', {
+          const tooltip = await findByText('some tooltip text');
+          await fireEvent(tooltip, 'layout', {
             nativeEvent: {
               layout: { width: TOOLTIP_WIDTH, height: TOOLTIP_HEIGHT },
             },
           });
 
-          expect(getByTestId('tooltip-container')).toHaveStyle({
+          expect(tooltip.parent).toHaveStyle({
             left: 210,
             top: 500, // pageY (600) - TOOLTIP_HEIGHT (100) // Tooltip is placed at the top of the component,
           });

--- a/src/components/__tests__/TouchableRipple.test.tsx
+++ b/src/components/__tests__/TouchableRipple.test.tsx
@@ -48,25 +48,23 @@ describe('TouchableRipple', () => {
     Platform.OS = 'ios';
 
     it('displays the underlay when pressed', async () => {
-      await render(
+      const { toJSON } = await render(
         <TouchableRipple testOnly_pressed>
           <Text>Press me!</Text>
         </TouchableRipple>
       );
 
-      const underlay = screen.getByTestId('touchable-ripple-underlay');
-      expect(underlay).toBeOnTheScreen();
+      expect(toJSON()).toMatchSnapshot();
     });
 
     it('renders custom underlay color', async () => {
-      await render(
+      const { toJSON } = await render(
         <TouchableRipple testOnly_pressed underlayColor="purple">
           <Text>Press me!</Text>
         </TouchableRipple>
       );
 
-      const underlay = screen.getByTestId('touchable-ripple-underlay');
-      expect(underlay).toHaveStyle({ backgroundColor: 'purple' });
+      expect(toJSON()).toMatchSnapshot();
     });
   });
 });

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
@@ -651,6 +651,3750 @@ exports[`allows customizing Route's type via generics 1`] = `
 </View>
 `;
 
+exports[`applies maxTabBarWidth styling if compact prop is truthy 1`] = `
+<View
+  style={
+    [
+      {
+        "flex": 1,
+        "overflow": "hidden",
+      },
+      undefined,
+    ]
+  }
+  testID="bottom-navigation"
+>
+  <View
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(254, 247, 255, 1)",
+        },
+      ]
+    }
+  >
+    <View
+      aria-hidden={false}
+      collapsable={false}
+      importantForAccessibility="auto"
+      pointerEvents="auto"
+      removeClippedSubviews={false}
+      style={
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "zIndex": 1,
+          },
+          {
+            "display": undefined,
+          },
+        ]
+      }
+      testID="RouteScreen: 0"
+    >
+      <View
+        collapsable={false}
+        renderToHardwareTextureAndroid={false}
+        style={
+          {
+            "flex": 1,
+            "opacity": 1,
+            "transform": [
+              {
+                "translateX": 0,
+              },
+              {
+                "translateY": 0,
+              },
+            ],
+          }
+        }
+      >
+        <Text>
+          Route: 0
+        </Text>
+      </View>
+    </View>
+    <View
+      aria-hidden={true}
+      collapsable={false}
+      importantForAccessibility="no-hide-descendants"
+      pointerEvents="none"
+      removeClippedSubviews={true}
+      style={
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "zIndex": 0,
+          },
+          {
+            "display": undefined,
+          },
+        ]
+      }
+      testID="RouteScreen: 1"
+    >
+      <View
+        collapsable={false}
+        renderToHardwareTextureAndroid={false}
+        style={
+          {
+            "flex": 1,
+            "opacity": 0,
+            "transform": [
+              {
+                "translateX": 0,
+              },
+              {
+                "translateY": 9999,
+              },
+            ],
+          }
+        }
+      >
+        <Text>
+          Route: 1
+        </Text>
+      </View>
+    </View>
+    <View
+      aria-hidden={true}
+      collapsable={false}
+      importantForAccessibility="no-hide-descendants"
+      pointerEvents="none"
+      removeClippedSubviews={true}
+      style={
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "zIndex": 0,
+          },
+          {
+            "display": undefined,
+          },
+        ]
+      }
+      testID="RouteScreen: 3"
+    >
+      <View
+        collapsable={false}
+        renderToHardwareTextureAndroid={false}
+        style={
+          {
+            "flex": 1,
+            "opacity": 0,
+            "transform": [
+              {
+                "translateX": 0,
+              },
+              {
+                "translateY": 9999,
+              },
+            ],
+          }
+        }
+      >
+        <Text>
+          Route: 3
+        </Text>
+      </View>
+    </View>
+    <View
+      aria-hidden={true}
+      collapsable={false}
+      importantForAccessibility="no-hide-descendants"
+      pointerEvents="none"
+      removeClippedSubviews={true}
+      style={
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "zIndex": 0,
+          },
+          {
+            "display": undefined,
+          },
+        ]
+      }
+      testID="RouteScreen: 4"
+    >
+      <View
+        collapsable={false}
+        renderToHardwareTextureAndroid={false}
+        style={
+          {
+            "flex": 1,
+            "opacity": 0,
+            "transform": [
+              {
+                "translateX": 0,
+              },
+              {
+                "translateY": 9999,
+              },
+            ],
+          }
+        }
+      >
+        <Text>
+          Route: 4
+        </Text>
+      </View>
+    </View>
+  </View>
+  <View
+    collapsable={false}
+    onLayout={[Function]}
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "pointerEvents": "none",
+        "right": 0,
+      }
+    }
+    testID="bottom-navigation-bar"
+  >
+    <View
+      collapsable={false}
+      style={
+        {
+          "alignItems": "center",
+          "backgroundColor": "rgba(243, 237, 247, 1)",
+          "overflow": "hidden",
+        }
+      }
+    >
+      <View
+        role="tablist"
+        style={
+          [
+            {
+              "flexDirection": "row",
+            },
+            {
+              "marginBottom": 0,
+              "marginHorizontal": 0,
+            },
+            {
+              "maxWidth": 480,
+            },
+          ]
+        }
+      >
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": true,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          role="button"
+          style={
+            [
+              {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              {
+                "paddingVertical": 0,
+              },
+            ]
+          }
+        >
+          <View
+            pointerEvents="none"
+            style={
+              {
+                "paddingBottom": 16,
+                "paddingTop": 12,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                {
+                  "alignSelf": "center",
+                  "height": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 4,
+                  "marginHorizontal": 12,
+                  "marginTop": 0,
+                  "width": 32,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignSelf": "center",
+                    "backgroundColor": "rgba(232, 222, 248, 1)",
+                    "borderRadius": 16,
+                    "height": 32,
+                    "transform": [
+                      {
+                        "scaleX": 1,
+                      },
+                    ],
+                    "width": 64,
+                  }
+                }
+              />
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(29, 25, 43, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  magnify
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(73, 69, 79, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  magnify
+                </Text>
+              </View>
+              <View
+                style={
+                  [
+                    {
+                      "left": 0,
+                      "position": "absolute",
+                    },
+                    {
+                      "right": 0,
+                      "top": 2,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  allowFontScaling={false}
+                  collapsable={false}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "alignSelf": "flex-end",
+                        "overflow": "hidden",
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      },
+                      {
+                        "opacity": 0,
+                      },
+                      {
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 9999,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "height": 6,
+                        "minWidth": 6,
+                      },
+                      false,
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              collapsable={false}
+              style={
+                {
+                  "height": 16,
+                  "paddingBottom": 2,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(29, 27, 32, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 0
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(29, 27, 32, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 0
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          role="button"
+          style={
+            [
+              {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              {
+                "paddingVertical": 0,
+              },
+            ]
+          }
+        >
+          <View
+            pointerEvents="none"
+            style={
+              {
+                "paddingBottom": 16,
+                "paddingTop": 12,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                {
+                  "alignSelf": "center",
+                  "height": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 4,
+                  "marginHorizontal": 12,
+                  "marginTop": 0,
+                  "width": 32,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(29, 25, 43, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  camera
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(73, 69, 79, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  camera
+                </Text>
+              </View>
+              <View
+                style={
+                  [
+                    {
+                      "left": 0,
+                      "position": "absolute",
+                    },
+                    {
+                      "right": 0,
+                      "top": 2,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  allowFontScaling={false}
+                  collapsable={false}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "alignSelf": "flex-end",
+                        "overflow": "hidden",
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      },
+                      {
+                        "opacity": 0,
+                      },
+                      {
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 9999,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "height": 6,
+                        "minWidth": 6,
+                      },
+                      false,
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              collapsable={false}
+              style={
+                {
+                  "height": 16,
+                  "paddingBottom": 2,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 1
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 1
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          role="button"
+          style={
+            [
+              {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              {
+                "paddingVertical": 0,
+              },
+            ]
+          }
+        >
+          <View
+            pointerEvents="none"
+            style={
+              {
+                "paddingBottom": 16,
+                "paddingTop": 12,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                {
+                  "alignSelf": "center",
+                  "height": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 4,
+                  "marginHorizontal": 12,
+                  "marginTop": 0,
+                  "width": 32,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(29, 25, 43, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  inbox
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(73, 69, 79, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  inbox
+                </Text>
+              </View>
+              <View
+                style={
+                  [
+                    {
+                      "left": 0,
+                      "position": "absolute",
+                    },
+                    {
+                      "right": 0,
+                      "top": 2,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  allowFontScaling={false}
+                  collapsable={false}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "alignSelf": "flex-end",
+                        "overflow": "hidden",
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      },
+                      {
+                        "opacity": 0,
+                      },
+                      {
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 9999,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "height": 6,
+                        "minWidth": 6,
+                      },
+                      false,
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              collapsable={false}
+              style={
+                {
+                  "height": 16,
+                  "paddingBottom": 2,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 2
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 2
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          role="button"
+          style={
+            [
+              {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              {
+                "paddingVertical": 0,
+              },
+            ]
+          }
+        >
+          <View
+            pointerEvents="none"
+            style={
+              {
+                "paddingBottom": 16,
+                "paddingTop": 12,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                {
+                  "alignSelf": "center",
+                  "height": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 4,
+                  "marginHorizontal": 12,
+                  "marginTop": 0,
+                  "width": 32,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(29, 25, 43, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  heart
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(73, 69, 79, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  heart
+                </Text>
+              </View>
+              <View
+                style={
+                  [
+                    {
+                      "left": 0,
+                      "position": "absolute",
+                    },
+                    {
+                      "right": 0,
+                      "top": 2,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  allowFontScaling={false}
+                  collapsable={false}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "alignSelf": "flex-end",
+                        "overflow": "hidden",
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      },
+                      {
+                        "opacity": 0,
+                      },
+                      {
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 9999,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "height": 6,
+                        "minWidth": 6,
+                      },
+                      false,
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              collapsable={false}
+              style={
+                {
+                  "height": 16,
+                  "paddingBottom": 2,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 3
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 3
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          role="button"
+          style={
+            [
+              {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              {
+                "paddingVertical": 0,
+              },
+            ]
+          }
+        >
+          <View
+            pointerEvents="none"
+            style={
+              {
+                "paddingBottom": 16,
+                "paddingTop": 12,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                {
+                  "alignSelf": "center",
+                  "height": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 4,
+                  "marginHorizontal": 12,
+                  "marginTop": 0,
+                  "width": 32,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(29, 25, 43, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  shopping-music
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(73, 69, 79, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  shopping-music
+                </Text>
+              </View>
+              <View
+                style={
+                  [
+                    {
+                      "left": 0,
+                      "position": "absolute",
+                    },
+                    {
+                      "right": 0,
+                      "top": 2,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  allowFontScaling={false}
+                  collapsable={false}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "alignSelf": "flex-end",
+                        "overflow": "hidden",
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      },
+                      {
+                        "opacity": 0,
+                      },
+                      {
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 9999,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "height": 6,
+                        "minWidth": 6,
+                      },
+                      false,
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              collapsable={false}
+              style={
+                {
+                  "height": 16,
+                  "paddingBottom": 2,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 4
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 4
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`does not apply maxTabBarWidth styling if compact prop is falsy 1`] = `
+<View
+  style={
+    [
+      {
+        "flex": 1,
+        "overflow": "hidden",
+      },
+      undefined,
+    ]
+  }
+  testID="bottom-navigation"
+>
+  <View
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(254, 247, 255, 1)",
+        },
+      ]
+    }
+  >
+    <View
+      aria-hidden={false}
+      collapsable={false}
+      importantForAccessibility="auto"
+      pointerEvents="auto"
+      removeClippedSubviews={false}
+      style={
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "zIndex": 1,
+          },
+          {
+            "display": undefined,
+          },
+        ]
+      }
+      testID="RouteScreen: 0"
+    >
+      <View
+        collapsable={false}
+        renderToHardwareTextureAndroid={false}
+        style={
+          {
+            "flex": 1,
+            "opacity": 1,
+            "transform": [
+              {
+                "translateX": 0,
+              },
+              {
+                "translateY": 0,
+              },
+            ],
+          }
+        }
+      >
+        <Text>
+          Route: 0
+        </Text>
+      </View>
+    </View>
+    <View
+      aria-hidden={true}
+      collapsable={false}
+      importantForAccessibility="no-hide-descendants"
+      pointerEvents="none"
+      removeClippedSubviews={true}
+      style={
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "zIndex": 0,
+          },
+          {
+            "display": undefined,
+          },
+        ]
+      }
+      testID="RouteScreen: 1"
+    >
+      <View
+        collapsable={false}
+        renderToHardwareTextureAndroid={false}
+        style={
+          {
+            "flex": 1,
+            "opacity": 0,
+            "transform": [
+              {
+                "translateX": 0,
+              },
+              {
+                "translateY": 9999,
+              },
+            ],
+          }
+        }
+      >
+        <Text>
+          Route: 1
+        </Text>
+      </View>
+    </View>
+    <View
+      aria-hidden={true}
+      collapsable={false}
+      importantForAccessibility="no-hide-descendants"
+      pointerEvents="none"
+      removeClippedSubviews={true}
+      style={
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "zIndex": 0,
+          },
+          {
+            "display": undefined,
+          },
+        ]
+      }
+      testID="RouteScreen: 3"
+    >
+      <View
+        collapsable={false}
+        renderToHardwareTextureAndroid={false}
+        style={
+          {
+            "flex": 1,
+            "opacity": 0,
+            "transform": [
+              {
+                "translateX": 0,
+              },
+              {
+                "translateY": 9999,
+              },
+            ],
+          }
+        }
+      >
+        <Text>
+          Route: 3
+        </Text>
+      </View>
+    </View>
+    <View
+      aria-hidden={true}
+      collapsable={false}
+      importantForAccessibility="no-hide-descendants"
+      pointerEvents="none"
+      removeClippedSubviews={true}
+      style={
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "zIndex": 0,
+          },
+          {
+            "display": undefined,
+          },
+        ]
+      }
+      testID="RouteScreen: 4"
+    >
+      <View
+        collapsable={false}
+        renderToHardwareTextureAndroid={false}
+        style={
+          {
+            "flex": 1,
+            "opacity": 0,
+            "transform": [
+              {
+                "translateX": 0,
+              },
+              {
+                "translateY": 9999,
+              },
+            ],
+          }
+        }
+      >
+        <Text>
+          Route: 4
+        </Text>
+      </View>
+    </View>
+  </View>
+  <View
+    collapsable={false}
+    onLayout={[Function]}
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "pointerEvents": "none",
+        "right": 0,
+      }
+    }
+    testID="bottom-navigation-bar"
+  >
+    <View
+      collapsable={false}
+      style={
+        {
+          "alignItems": "center",
+          "backgroundColor": "rgba(243, 237, 247, 1)",
+          "overflow": "hidden",
+        }
+      }
+    >
+      <View
+        role="tablist"
+        style={
+          [
+            {
+              "flexDirection": "row",
+            },
+            {
+              "marginBottom": 0,
+              "marginHorizontal": 0,
+            },
+            false,
+          ]
+        }
+      >
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": true,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          role="button"
+          style={
+            [
+              {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              {
+                "paddingVertical": 0,
+              },
+            ]
+          }
+        >
+          <View
+            pointerEvents="none"
+            style={
+              {
+                "paddingBottom": 16,
+                "paddingTop": 12,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                {
+                  "alignSelf": "center",
+                  "height": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 4,
+                  "marginHorizontal": 12,
+                  "marginTop": 0,
+                  "width": 32,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignSelf": "center",
+                    "backgroundColor": "rgba(232, 222, 248, 1)",
+                    "borderRadius": 16,
+                    "height": 32,
+                    "transform": [
+                      {
+                        "scaleX": 1,
+                      },
+                    ],
+                    "width": 64,
+                  }
+                }
+              />
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(29, 25, 43, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  magnify
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(73, 69, 79, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  magnify
+                </Text>
+              </View>
+              <View
+                style={
+                  [
+                    {
+                      "left": 0,
+                      "position": "absolute",
+                    },
+                    {
+                      "right": 0,
+                      "top": 2,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  allowFontScaling={false}
+                  collapsable={false}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "alignSelf": "flex-end",
+                        "overflow": "hidden",
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      },
+                      {
+                        "opacity": 0,
+                      },
+                      {
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 9999,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "height": 6,
+                        "minWidth": 6,
+                      },
+                      false,
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              collapsable={false}
+              style={
+                {
+                  "height": 16,
+                  "paddingBottom": 2,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(29, 27, 32, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 0
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(29, 27, 32, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 0
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          role="button"
+          style={
+            [
+              {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              {
+                "paddingVertical": 0,
+              },
+            ]
+          }
+        >
+          <View
+            pointerEvents="none"
+            style={
+              {
+                "paddingBottom": 16,
+                "paddingTop": 12,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                {
+                  "alignSelf": "center",
+                  "height": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 4,
+                  "marginHorizontal": 12,
+                  "marginTop": 0,
+                  "width": 32,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(29, 25, 43, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  camera
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(73, 69, 79, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  camera
+                </Text>
+              </View>
+              <View
+                style={
+                  [
+                    {
+                      "left": 0,
+                      "position": "absolute",
+                    },
+                    {
+                      "right": 0,
+                      "top": 2,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  allowFontScaling={false}
+                  collapsable={false}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "alignSelf": "flex-end",
+                        "overflow": "hidden",
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      },
+                      {
+                        "opacity": 0,
+                      },
+                      {
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 9999,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "height": 6,
+                        "minWidth": 6,
+                      },
+                      false,
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              collapsable={false}
+              style={
+                {
+                  "height": 16,
+                  "paddingBottom": 2,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 1
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 1
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          role="button"
+          style={
+            [
+              {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              {
+                "paddingVertical": 0,
+              },
+            ]
+          }
+        >
+          <View
+            pointerEvents="none"
+            style={
+              {
+                "paddingBottom": 16,
+                "paddingTop": 12,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                {
+                  "alignSelf": "center",
+                  "height": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 4,
+                  "marginHorizontal": 12,
+                  "marginTop": 0,
+                  "width": 32,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(29, 25, 43, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  inbox
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(73, 69, 79, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  inbox
+                </Text>
+              </View>
+              <View
+                style={
+                  [
+                    {
+                      "left": 0,
+                      "position": "absolute",
+                    },
+                    {
+                      "right": 0,
+                      "top": 2,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  allowFontScaling={false}
+                  collapsable={false}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "alignSelf": "flex-end",
+                        "overflow": "hidden",
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      },
+                      {
+                        "opacity": 0,
+                      },
+                      {
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 9999,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "height": 6,
+                        "minWidth": 6,
+                      },
+                      false,
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              collapsable={false}
+              style={
+                {
+                  "height": 16,
+                  "paddingBottom": 2,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 2
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 2
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          role="button"
+          style={
+            [
+              {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              {
+                "paddingVertical": 0,
+              },
+            ]
+          }
+        >
+          <View
+            pointerEvents="none"
+            style={
+              {
+                "paddingBottom": 16,
+                "paddingTop": 12,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                {
+                  "alignSelf": "center",
+                  "height": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 4,
+                  "marginHorizontal": 12,
+                  "marginTop": 0,
+                  "width": 32,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(29, 25, 43, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  heart
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(73, 69, 79, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  heart
+                </Text>
+              </View>
+              <View
+                style={
+                  [
+                    {
+                      "left": 0,
+                      "position": "absolute",
+                    },
+                    {
+                      "right": 0,
+                      "top": 2,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  allowFontScaling={false}
+                  collapsable={false}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "alignSelf": "flex-end",
+                        "overflow": "hidden",
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      },
+                      {
+                        "opacity": 0,
+                      },
+                      {
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 9999,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "height": 6,
+                        "minWidth": 6,
+                      },
+                      false,
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              collapsable={false}
+              style={
+                {
+                  "height": 16,
+                  "paddingBottom": 2,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 3
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 3
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          role="button"
+          style={
+            [
+              {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              {
+                "paddingVertical": 0,
+              },
+            ]
+          }
+        >
+          <View
+            pointerEvents="none"
+            style={
+              {
+                "paddingBottom": 16,
+                "paddingTop": 12,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                {
+                  "alignSelf": "center",
+                  "height": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 4,
+                  "marginHorizontal": 12,
+                  "marginTop": 0,
+                  "width": 32,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(29, 25, 43, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  shopping-music
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(73, 69, 79, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  shopping-music
+                </Text>
+              </View>
+              <View
+                style={
+                  [
+                    {
+                      "left": 0,
+                      "position": "absolute",
+                    },
+                    {
+                      "right": 0,
+                      "top": 2,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  allowFontScaling={false}
+                  collapsable={false}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "alignSelf": "flex-end",
+                        "overflow": "hidden",
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      },
+                      {
+                        "opacity": 0,
+                      },
+                      {
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 9999,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "height": 6,
+                        "minWidth": 6,
+                      },
+                      false,
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              collapsable={false}
+              style={
+                {
+                  "height": 16,
+                  "paddingBottom": 2,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 4
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 4
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
 exports[`hides labels in non-shifting bottom navigation 1`] = `
 <View
   style={
@@ -5447,6 +9191,1100 @@ exports[`renders bottom navigation with scene animation 1`] = `
                   }
                 >
                   Route: 4
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`renders custom background color passed to barStyle property 1`] = `
+<View
+  style={
+    [
+      {
+        "flex": 1,
+        "overflow": "hidden",
+      },
+      undefined,
+    ]
+  }
+  testID="bottom-navigation"
+>
+  <View
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(254, 247, 255, 1)",
+        },
+      ]
+    }
+  >
+    <View
+      aria-hidden={false}
+      collapsable={false}
+      importantForAccessibility="auto"
+      pointerEvents="auto"
+      removeClippedSubviews={false}
+      style={
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "zIndex": 1,
+          },
+          {
+            "display": undefined,
+          },
+        ]
+      }
+      testID="RouteScreen: 0"
+    >
+      <View
+        collapsable={false}
+        renderToHardwareTextureAndroid={false}
+        style={
+          {
+            "flex": 1,
+            "opacity": 1,
+            "transform": [
+              {
+                "translateX": 0,
+              },
+              {
+                "translateY": 0,
+              },
+            ],
+          }
+        }
+      >
+        <Text>
+          Route: 0
+        </Text>
+      </View>
+    </View>
+  </View>
+  <View
+    collapsable={false}
+    onLayout={[Function]}
+    style={
+      {
+        "backgroundColor": "rgba(228, 105, 98, 1)",
+        "bottom": 0,
+        "left": 0,
+        "pointerEvents": "none",
+        "right": 0,
+      }
+    }
+    testID="bottom-navigation-bar"
+  >
+    <View
+      collapsable={false}
+      style={
+        {
+          "alignItems": "center",
+          "backgroundColor": "rgba(228, 105, 98, 1)",
+          "overflow": "hidden",
+        }
+      }
+    >
+      <View
+        role="tablist"
+        style={
+          [
+            {
+              "flexDirection": "row",
+            },
+            {
+              "marginBottom": 0,
+              "marginHorizontal": 0,
+            },
+            false,
+          ]
+        }
+      >
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": true,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          role="button"
+          style={
+            [
+              {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              {
+                "paddingVertical": 0,
+              },
+            ]
+          }
+        >
+          <View
+            pointerEvents="none"
+            style={
+              {
+                "paddingBottom": 16,
+                "paddingTop": 12,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                {
+                  "alignSelf": "center",
+                  "height": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 4,
+                  "marginHorizontal": 12,
+                  "marginTop": 0,
+                  "width": 32,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignSelf": "center",
+                    "backgroundColor": "rgba(232, 222, 248, 1)",
+                    "borderRadius": 16,
+                    "height": 32,
+                    "transform": [
+                      {
+                        "scaleX": 1,
+                      },
+                    ],
+                    "width": 64,
+                  }
+                }
+              />
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(29, 25, 43, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  magnify
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(73, 69, 79, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  magnify
+                </Text>
+              </View>
+              <View
+                style={
+                  [
+                    {
+                      "left": 0,
+                      "position": "absolute",
+                    },
+                    {
+                      "right": 0,
+                      "top": 2,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  allowFontScaling={false}
+                  collapsable={false}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "alignSelf": "flex-end",
+                        "overflow": "hidden",
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      },
+                      {
+                        "opacity": 0,
+                      },
+                      {
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 9999,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "height": 6,
+                        "minWidth": 6,
+                      },
+                      false,
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              collapsable={false}
+              style={
+                {
+                  "height": 16,
+                  "paddingBottom": 2,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(29, 27, 32, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 0
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(29, 27, 32, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 0
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          role="button"
+          style={
+            [
+              {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              {
+                "paddingVertical": 0,
+              },
+            ]
+          }
+        >
+          <View
+            pointerEvents="none"
+            style={
+              {
+                "paddingBottom": 16,
+                "paddingTop": 12,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                {
+                  "alignSelf": "center",
+                  "height": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 4,
+                  "marginHorizontal": 12,
+                  "marginTop": 0,
+                  "width": 32,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(29, 25, 43, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  camera
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(73, 69, 79, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  camera
+                </Text>
+              </View>
+              <View
+                style={
+                  [
+                    {
+                      "left": 0,
+                      "position": "absolute",
+                    },
+                    {
+                      "right": 0,
+                      "top": 2,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  allowFontScaling={false}
+                  collapsable={false}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "alignSelf": "flex-end",
+                        "overflow": "hidden",
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      },
+                      {
+                        "opacity": 0,
+                      },
+                      {
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 9999,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "height": 6,
+                        "minWidth": 6,
+                      },
+                      false,
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              collapsable={false}
+              style={
+                {
+                  "height": 16,
+                  "paddingBottom": 2,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 1
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 1
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          role="button"
+          style={
+            [
+              {
+                "flex": 1,
+                "paddingVertical": 6,
+              },
+              {
+                "paddingVertical": 0,
+              },
+            ]
+          }
+        >
+          <View
+            pointerEvents="none"
+            style={
+              {
+                "paddingBottom": 16,
+                "paddingTop": 12,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                {
+                  "alignSelf": "center",
+                  "height": 32,
+                  "justifyContent": "center",
+                  "marginBottom": 4,
+                  "marginHorizontal": 12,
+                  "marginTop": 0,
+                  "width": 32,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(29, 25, 43, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  inbox
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "alignItems": "center",
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 4,
+                  }
+                }
+              >
+                <Text
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
+                  pointerEvents="none"
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "rgba(73, 69, 79, 1)",
+                        "fontSize": 24,
+                      },
+                      [
+                        {
+                          "lineHeight": 24,
+                          "transform": [
+                            {
+                              "scaleX": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                        },
+                      ],
+                    ]
+                  }
+                >
+                  inbox
+                </Text>
+              </View>
+              <View
+                style={
+                  [
+                    {
+                      "left": 0,
+                      "position": "absolute",
+                    },
+                    {
+                      "right": 0,
+                      "top": 2,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  allowFontScaling={false}
+                  collapsable={false}
+                  numberOfLines={1}
+                  style={
+                    [
+                      {
+                        "alignSelf": "flex-end",
+                        "overflow": "hidden",
+                        "textAlign": "center",
+                        "textAlignVertical": "center",
+                      },
+                      {
+                        "opacity": 0,
+                      },
+                      {
+                        "backgroundColor": "rgba(179, 38, 30, 1)",
+                        "borderRadius": 9999,
+                        "color": "rgba(255, 255, 255, 1)",
+                        "height": 6,
+                        "minWidth": 6,
+                      },
+                      false,
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              collapsable={false}
+              style={
+                {
+                  "height": 16,
+                  "paddingBottom": 2,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 2
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                style={
+                  {
+                    "bottom": 0,
+                    "left": 0,
+                    "opacity": 1,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              >
+                <Text
+                  maxFontSizeMultiplier={1}
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "textAlign": "left",
+                      },
+                      {
+                        "color": "rgba(29, 27, 32, 1)",
+                        "writingDirection": "ltr",
+                      },
+                      [
+                        {
+                          "fontFamily": "System",
+                          "fontSize": 12,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5,
+                          "lineHeight": 16,
+                        },
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "fontSize": 12,
+                            "height": 56,
+                            "textAlign": "center",
+                          },
+                          {
+                            "color": "rgba(73, 69, 79, 1)",
+                            "fontFamily": "System",
+                            "fontSize": 12,
+                            "fontWeight": "500",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 16,
+                          },
+                        ],
+                      ],
+                    ]
+                  }
+                >
+                  Route: 2
                 </Text>
               </View>
             </View>

--- a/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/BottomNavigation.test.tsx.snap
@@ -872,7 +872,6 @@ exports[`applies maxTabBarWidth styling if compact prop is truthy 1`] = `
         "right": 0,
       }
     }
-    testID="bottom-navigation-bar"
   >
     <View
       collapsable={false}
@@ -2745,7 +2744,6 @@ exports[`does not apply maxTabBarWidth styling if compact prop is falsy 1`] = `
         "right": 0,
       }
     }
-    testID="bottom-navigation-bar"
   >
     <View
       collapsable={false}
@@ -9286,7 +9284,6 @@ exports[`renders custom background color passed to barStyle property 1`] = `
         "right": 0,
       }
     }
-    testID="bottom-navigation-bar"
   >
     <View
       collapsable={false}

--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -1,5 +1,2551 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`button icon styles should return correct icon styles for compact contained button 1`] = `
+<View
+  collapsable={false}
+  style={
+    [
+      {},
+      {
+        "borderStyle": "solid",
+        "minWidth": 64,
+      },
+      {
+        "minWidth": "auto",
+      },
+      {
+        "borderColor": "transparent",
+        "borderWidth": 0,
+      },
+      undefined,
+      {},
+      {
+        "backgroundColor": "rgba(103, 80, 164, 1)",
+      },
+      {
+        "borderBottomEndRadius": undefined,
+        "borderBottomLeftRadius": undefined,
+        "borderBottomRightRadius": undefined,
+        "borderBottomStartRadius": undefined,
+        "borderCurve": "continuous",
+        "borderEndEndRadius": undefined,
+        "borderEndStartRadius": undefined,
+        "borderRadius": 20,
+        "borderStartEndRadius": undefined,
+        "borderStartStartRadius": undefined,
+        "borderTopEndRadius": undefined,
+        "borderTopLeftRadius": undefined,
+        "borderTopRightRadius": undefined,
+        "borderTopStartRadius": undefined,
+      },
+      {
+        "shadowColor": "rgba(0, 0, 0, 1)",
+        "shadowOffset": {
+          "height": 0,
+          "width": 0,
+        },
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
+      },
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "pointerEvents": "none",
+        },
+        {},
+        {},
+        {
+          "backgroundColor": "rgba(103, 80, 164, 1)",
+        },
+        {
+          "borderBottomEndRadius": undefined,
+          "borderBottomLeftRadius": undefined,
+          "borderBottomRightRadius": undefined,
+          "borderBottomStartRadius": undefined,
+          "borderCurve": "continuous",
+          "borderEndEndRadius": undefined,
+          "borderEndStartRadius": undefined,
+          "borderRadius": 20,
+          "borderStartEndRadius": undefined,
+          "borderStartStartRadius": undefined,
+          "borderTopEndRadius": undefined,
+          "borderTopLeftRadius": undefined,
+          "borderTopRightRadius": undefined,
+          "borderTopStartRadius": undefined,
+        },
+        {
+          "shadowColor": "rgba(0, 0, 0, 1)",
+          "shadowOffset": {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+        },
+      ]
+    }
+  />
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "overflow": "hidden",
+        },
+        {
+          "borderRadius": 20,
+        },
+      ]
+    }
+    testID="compact-button"
+  >
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "marginLeft": 12,
+              "marginRight": -4,
+            },
+            {
+              "marginLeft": 8,
+              "marginRight": 0,
+            },
+            false,
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            [
+              {
+                "color": "rgba(255, 255, 255, 1)",
+                "fontSize": 18,
+              },
+              [
+                {
+                  "lineHeight": 18,
+                  "transform": [
+                    {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                {
+                  "backgroundColor": "transparent",
+                },
+              ],
+            ]
+          }
+        >
+          camera
+        </Text>
+      </View>
+      <Text
+        numberOfLines={1}
+        selectable={false}
+        style={
+          [
+            {
+              "textAlign": "left",
+            },
+            {
+              "color": "rgba(29, 27, 32, 1)",
+              "writingDirection": "ltr",
+            },
+            [
+              {
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
+              },
+              [
+                {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                {
+                  "marginHorizontal": 24,
+                  "marginVertical": 10,
+                },
+                {
+                  "marginHorizontal": 8,
+                },
+                false,
+                {
+                  "color": "rgba(255, 255, 255, 1)",
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                undefined,
+              ],
+            ],
+          ]
+        }
+      >
+        Compact 
+        contained
+         button
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`button icon styles should return correct icon styles for compact contained button 2`] = `
+<View
+  collapsable={false}
+  style={
+    [
+      {},
+      {
+        "borderStyle": "solid",
+        "minWidth": 64,
+      },
+      undefined,
+      {
+        "borderColor": "transparent",
+        "borderWidth": 0,
+      },
+      undefined,
+      {},
+      {
+        "backgroundColor": "rgba(103, 80, 164, 1)",
+      },
+      {
+        "borderBottomEndRadius": undefined,
+        "borderBottomLeftRadius": undefined,
+        "borderBottomRightRadius": undefined,
+        "borderBottomStartRadius": undefined,
+        "borderCurve": "continuous",
+        "borderEndEndRadius": undefined,
+        "borderEndStartRadius": undefined,
+        "borderRadius": 20,
+        "borderStartEndRadius": undefined,
+        "borderStartStartRadius": undefined,
+        "borderTopEndRadius": undefined,
+        "borderTopLeftRadius": undefined,
+        "borderTopRightRadius": undefined,
+        "borderTopStartRadius": undefined,
+      },
+      {
+        "shadowColor": "rgba(0, 0, 0, 1)",
+        "shadowOffset": {
+          "height": 0,
+          "width": 0,
+        },
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
+      },
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "pointerEvents": "none",
+        },
+        {},
+        {},
+        {
+          "backgroundColor": "rgba(103, 80, 164, 1)",
+        },
+        {
+          "borderBottomEndRadius": undefined,
+          "borderBottomLeftRadius": undefined,
+          "borderBottomRightRadius": undefined,
+          "borderBottomStartRadius": undefined,
+          "borderCurve": "continuous",
+          "borderEndEndRadius": undefined,
+          "borderEndStartRadius": undefined,
+          "borderRadius": 20,
+          "borderStartEndRadius": undefined,
+          "borderStartStartRadius": undefined,
+          "borderTopEndRadius": undefined,
+          "borderTopLeftRadius": undefined,
+          "borderTopRightRadius": undefined,
+          "borderTopStartRadius": undefined,
+        },
+        {
+          "shadowColor": "rgba(0, 0, 0, 1)",
+          "shadowOffset": {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+        },
+      ]
+    }
+  />
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "overflow": "hidden",
+        },
+        {
+          "borderRadius": 20,
+        },
+      ]
+    }
+    testID="compact-button"
+  >
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "marginLeft": 12,
+              "marginRight": -4,
+            },
+            {
+              "marginLeft": 16,
+              "marginRight": -16,
+            },
+            false,
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            [
+              {
+                "color": "rgba(255, 255, 255, 1)",
+                "fontSize": 18,
+              },
+              [
+                {
+                  "lineHeight": 18,
+                  "transform": [
+                    {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                {
+                  "backgroundColor": "transparent",
+                },
+              ],
+            ]
+          }
+        >
+          camera
+        </Text>
+      </View>
+      <Text
+        numberOfLines={1}
+        selectable={false}
+        style={
+          [
+            {
+              "textAlign": "left",
+            },
+            {
+              "color": "rgba(29, 27, 32, 1)",
+              "writingDirection": "ltr",
+            },
+            [
+              {
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
+              },
+              [
+                {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                {
+                  "marginHorizontal": 24,
+                  "marginVertical": 10,
+                },
+                undefined,
+                false,
+                {
+                  "color": "rgba(255, 255, 255, 1)",
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                undefined,
+              ],
+            ],
+          ]
+        }
+      >
+        contained
+         button
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`button icon styles should return correct icon styles for compact contained-tonal button 1`] = `
+<View
+  collapsable={false}
+  style={
+    [
+      {},
+      {
+        "borderStyle": "solid",
+        "minWidth": 64,
+      },
+      {
+        "minWidth": "auto",
+      },
+      {
+        "borderColor": "transparent",
+        "borderWidth": 0,
+      },
+      undefined,
+      {},
+      {
+        "backgroundColor": "rgba(232, 222, 248, 1)",
+      },
+      {
+        "borderBottomEndRadius": undefined,
+        "borderBottomLeftRadius": undefined,
+        "borderBottomRightRadius": undefined,
+        "borderBottomStartRadius": undefined,
+        "borderCurve": "continuous",
+        "borderEndEndRadius": undefined,
+        "borderEndStartRadius": undefined,
+        "borderRadius": 20,
+        "borderStartEndRadius": undefined,
+        "borderStartStartRadius": undefined,
+        "borderTopEndRadius": undefined,
+        "borderTopLeftRadius": undefined,
+        "borderTopRightRadius": undefined,
+        "borderTopStartRadius": undefined,
+      },
+      {
+        "shadowColor": "rgba(0, 0, 0, 1)",
+        "shadowOffset": {
+          "height": 0,
+          "width": 0,
+        },
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
+      },
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "pointerEvents": "none",
+        },
+        {},
+        {},
+        {
+          "backgroundColor": "rgba(232, 222, 248, 1)",
+        },
+        {
+          "borderBottomEndRadius": undefined,
+          "borderBottomLeftRadius": undefined,
+          "borderBottomRightRadius": undefined,
+          "borderBottomStartRadius": undefined,
+          "borderCurve": "continuous",
+          "borderEndEndRadius": undefined,
+          "borderEndStartRadius": undefined,
+          "borderRadius": 20,
+          "borderStartEndRadius": undefined,
+          "borderStartStartRadius": undefined,
+          "borderTopEndRadius": undefined,
+          "borderTopLeftRadius": undefined,
+          "borderTopRightRadius": undefined,
+          "borderTopStartRadius": undefined,
+        },
+        {
+          "shadowColor": "rgba(0, 0, 0, 1)",
+          "shadowOffset": {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+        },
+      ]
+    }
+  />
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "overflow": "hidden",
+        },
+        {
+          "borderRadius": 20,
+        },
+      ]
+    }
+    testID="compact-button"
+  >
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "marginLeft": 12,
+              "marginRight": -4,
+            },
+            {
+              "marginLeft": 8,
+              "marginRight": 0,
+            },
+            false,
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            [
+              {
+                "color": "rgba(29, 25, 43, 1)",
+                "fontSize": 18,
+              },
+              [
+                {
+                  "lineHeight": 18,
+                  "transform": [
+                    {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                {
+                  "backgroundColor": "transparent",
+                },
+              ],
+            ]
+          }
+        >
+          camera
+        </Text>
+      </View>
+      <Text
+        numberOfLines={1}
+        selectable={false}
+        style={
+          [
+            {
+              "textAlign": "left",
+            },
+            {
+              "color": "rgba(29, 27, 32, 1)",
+              "writingDirection": "ltr",
+            },
+            [
+              {
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
+              },
+              [
+                {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                {
+                  "marginHorizontal": 24,
+                  "marginVertical": 10,
+                },
+                {
+                  "marginHorizontal": 8,
+                },
+                false,
+                {
+                  "color": "rgba(29, 25, 43, 1)",
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                undefined,
+              ],
+            ],
+          ]
+        }
+      >
+        Compact 
+        contained-tonal
+         button
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`button icon styles should return correct icon styles for compact contained-tonal button 2`] = `
+<View
+  collapsable={false}
+  style={
+    [
+      {},
+      {
+        "borderStyle": "solid",
+        "minWidth": 64,
+      },
+      undefined,
+      {
+        "borderColor": "transparent",
+        "borderWidth": 0,
+      },
+      undefined,
+      {},
+      {
+        "backgroundColor": "rgba(232, 222, 248, 1)",
+      },
+      {
+        "borderBottomEndRadius": undefined,
+        "borderBottomLeftRadius": undefined,
+        "borderBottomRightRadius": undefined,
+        "borderBottomStartRadius": undefined,
+        "borderCurve": "continuous",
+        "borderEndEndRadius": undefined,
+        "borderEndStartRadius": undefined,
+        "borderRadius": 20,
+        "borderStartEndRadius": undefined,
+        "borderStartStartRadius": undefined,
+        "borderTopEndRadius": undefined,
+        "borderTopLeftRadius": undefined,
+        "borderTopRightRadius": undefined,
+        "borderTopStartRadius": undefined,
+      },
+      {
+        "shadowColor": "rgba(0, 0, 0, 1)",
+        "shadowOffset": {
+          "height": 0,
+          "width": 0,
+        },
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
+      },
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "pointerEvents": "none",
+        },
+        {},
+        {},
+        {
+          "backgroundColor": "rgba(232, 222, 248, 1)",
+        },
+        {
+          "borderBottomEndRadius": undefined,
+          "borderBottomLeftRadius": undefined,
+          "borderBottomRightRadius": undefined,
+          "borderBottomStartRadius": undefined,
+          "borderCurve": "continuous",
+          "borderEndEndRadius": undefined,
+          "borderEndStartRadius": undefined,
+          "borderRadius": 20,
+          "borderStartEndRadius": undefined,
+          "borderStartStartRadius": undefined,
+          "borderTopEndRadius": undefined,
+          "borderTopLeftRadius": undefined,
+          "borderTopRightRadius": undefined,
+          "borderTopStartRadius": undefined,
+        },
+        {
+          "shadowColor": "rgba(0, 0, 0, 1)",
+          "shadowOffset": {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+        },
+      ]
+    }
+  />
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "overflow": "hidden",
+        },
+        {
+          "borderRadius": 20,
+        },
+      ]
+    }
+    testID="compact-button"
+  >
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "marginLeft": 12,
+              "marginRight": -4,
+            },
+            {
+              "marginLeft": 16,
+              "marginRight": -16,
+            },
+            false,
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            [
+              {
+                "color": "rgba(29, 25, 43, 1)",
+                "fontSize": 18,
+              },
+              [
+                {
+                  "lineHeight": 18,
+                  "transform": [
+                    {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                {
+                  "backgroundColor": "transparent",
+                },
+              ],
+            ]
+          }
+        >
+          camera
+        </Text>
+      </View>
+      <Text
+        numberOfLines={1}
+        selectable={false}
+        style={
+          [
+            {
+              "textAlign": "left",
+            },
+            {
+              "color": "rgba(29, 27, 32, 1)",
+              "writingDirection": "ltr",
+            },
+            [
+              {
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
+              },
+              [
+                {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                {
+                  "marginHorizontal": 24,
+                  "marginVertical": 10,
+                },
+                undefined,
+                false,
+                {
+                  "color": "rgba(29, 25, 43, 1)",
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                undefined,
+              ],
+            ],
+          ]
+        }
+      >
+        contained-tonal
+         button
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`button icon styles should return correct icon styles for compact elevated button 1`] = `
+<View
+  collapsable={false}
+  style={
+    [
+      {},
+      {
+        "borderStyle": "solid",
+        "minWidth": 64,
+      },
+      {
+        "minWidth": "auto",
+      },
+      {
+        "borderColor": "transparent",
+        "borderWidth": 0,
+      },
+      undefined,
+      {},
+      {
+        "backgroundColor": "rgba(247, 242, 250, 1)",
+      },
+      {
+        "borderBottomEndRadius": undefined,
+        "borderBottomLeftRadius": undefined,
+        "borderBottomRightRadius": undefined,
+        "borderBottomStartRadius": undefined,
+        "borderCurve": "continuous",
+        "borderEndEndRadius": undefined,
+        "borderEndStartRadius": undefined,
+        "borderRadius": 20,
+        "borderStartEndRadius": undefined,
+        "borderStartStartRadius": undefined,
+        "borderTopEndRadius": undefined,
+        "borderTopLeftRadius": undefined,
+        "borderTopRightRadius": undefined,
+        "borderTopStartRadius": undefined,
+      },
+      {
+        "shadowColor": "rgba(0, 0, 0, 1)",
+        "shadowOffset": {
+          "height": 0.55,
+          "width": 0,
+        },
+        "shadowOpacity": 0.19,
+        "shadowRadius": 0.79,
+      },
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "pointerEvents": "none",
+        },
+        {},
+        {},
+        {
+          "backgroundColor": "rgba(247, 242, 250, 1)",
+        },
+        {
+          "borderBottomEndRadius": undefined,
+          "borderBottomLeftRadius": undefined,
+          "borderBottomRightRadius": undefined,
+          "borderBottomStartRadius": undefined,
+          "borderCurve": "continuous",
+          "borderEndEndRadius": undefined,
+          "borderEndStartRadius": undefined,
+          "borderRadius": 20,
+          "borderStartEndRadius": undefined,
+          "borderStartStartRadius": undefined,
+          "borderTopEndRadius": undefined,
+          "borderTopLeftRadius": undefined,
+          "borderTopRightRadius": undefined,
+          "borderTopStartRadius": undefined,
+        },
+        {
+          "shadowColor": "rgba(0, 0, 0, 1)",
+          "shadowOffset": {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0.039,
+          "shadowRadius": 0.25,
+        },
+      ]
+    }
+  />
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "overflow": "hidden",
+        },
+        {
+          "borderRadius": 20,
+        },
+      ]
+    }
+    testID="compact-button"
+  >
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "marginLeft": 12,
+              "marginRight": -4,
+            },
+            {
+              "marginLeft": 8,
+              "marginRight": 0,
+            },
+            false,
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            [
+              {
+                "color": "rgba(103, 80, 164, 1)",
+                "fontSize": 18,
+              },
+              [
+                {
+                  "lineHeight": 18,
+                  "transform": [
+                    {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                {
+                  "backgroundColor": "transparent",
+                },
+              ],
+            ]
+          }
+        >
+          camera
+        </Text>
+      </View>
+      <Text
+        numberOfLines={1}
+        selectable={false}
+        style={
+          [
+            {
+              "textAlign": "left",
+            },
+            {
+              "color": "rgba(29, 27, 32, 1)",
+              "writingDirection": "ltr",
+            },
+            [
+              {
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
+              },
+              [
+                {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                {
+                  "marginHorizontal": 24,
+                  "marginVertical": 10,
+                },
+                {
+                  "marginHorizontal": 8,
+                },
+                false,
+                {
+                  "color": "rgba(103, 80, 164, 1)",
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                undefined,
+              ],
+            ],
+          ]
+        }
+      >
+        Compact 
+        elevated
+         button
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`button icon styles should return correct icon styles for compact elevated button 2`] = `
+<View
+  collapsable={false}
+  style={
+    [
+      {},
+      {
+        "borderStyle": "solid",
+        "minWidth": 64,
+      },
+      undefined,
+      {
+        "borderColor": "transparent",
+        "borderWidth": 0,
+      },
+      undefined,
+      {},
+      {
+        "backgroundColor": "rgba(247, 242, 250, 1)",
+      },
+      {
+        "borderBottomEndRadius": undefined,
+        "borderBottomLeftRadius": undefined,
+        "borderBottomRightRadius": undefined,
+        "borderBottomStartRadius": undefined,
+        "borderCurve": "continuous",
+        "borderEndEndRadius": undefined,
+        "borderEndStartRadius": undefined,
+        "borderRadius": 20,
+        "borderStartEndRadius": undefined,
+        "borderStartStartRadius": undefined,
+        "borderTopEndRadius": undefined,
+        "borderTopLeftRadius": undefined,
+        "borderTopRightRadius": undefined,
+        "borderTopStartRadius": undefined,
+      },
+      {
+        "shadowColor": "rgba(0, 0, 0, 1)",
+        "shadowOffset": {
+          "height": 0.55,
+          "width": 0,
+        },
+        "shadowOpacity": 0.19,
+        "shadowRadius": 0.79,
+      },
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "pointerEvents": "none",
+        },
+        {},
+        {},
+        {
+          "backgroundColor": "rgba(247, 242, 250, 1)",
+        },
+        {
+          "borderBottomEndRadius": undefined,
+          "borderBottomLeftRadius": undefined,
+          "borderBottomRightRadius": undefined,
+          "borderBottomStartRadius": undefined,
+          "borderCurve": "continuous",
+          "borderEndEndRadius": undefined,
+          "borderEndStartRadius": undefined,
+          "borderRadius": 20,
+          "borderStartEndRadius": undefined,
+          "borderStartStartRadius": undefined,
+          "borderTopEndRadius": undefined,
+          "borderTopLeftRadius": undefined,
+          "borderTopRightRadius": undefined,
+          "borderTopStartRadius": undefined,
+        },
+        {
+          "shadowColor": "rgba(0, 0, 0, 1)",
+          "shadowOffset": {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0.039,
+          "shadowRadius": 0.25,
+        },
+      ]
+    }
+  />
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "overflow": "hidden",
+        },
+        {
+          "borderRadius": 20,
+        },
+      ]
+    }
+    testID="compact-button"
+  >
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "marginLeft": 12,
+              "marginRight": -4,
+            },
+            {
+              "marginLeft": 16,
+              "marginRight": -16,
+            },
+            false,
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            [
+              {
+                "color": "rgba(103, 80, 164, 1)",
+                "fontSize": 18,
+              },
+              [
+                {
+                  "lineHeight": 18,
+                  "transform": [
+                    {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                {
+                  "backgroundColor": "transparent",
+                },
+              ],
+            ]
+          }
+        >
+          camera
+        </Text>
+      </View>
+      <Text
+        numberOfLines={1}
+        selectable={false}
+        style={
+          [
+            {
+              "textAlign": "left",
+            },
+            {
+              "color": "rgba(29, 27, 32, 1)",
+              "writingDirection": "ltr",
+            },
+            [
+              {
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
+              },
+              [
+                {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                {
+                  "marginHorizontal": 24,
+                  "marginVertical": 10,
+                },
+                undefined,
+                false,
+                {
+                  "color": "rgba(103, 80, 164, 1)",
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                undefined,
+              ],
+            ],
+          ]
+        }
+      >
+        elevated
+         button
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`button icon styles should return correct icon styles for compact outlined button 1`] = `
+<View
+  collapsable={false}
+  style={
+    [
+      {},
+      {
+        "borderStyle": "solid",
+        "minWidth": 64,
+      },
+      {
+        "minWidth": "auto",
+      },
+      {
+        "borderColor": "rgba(202, 196, 208, 1)",
+        "borderWidth": 1,
+      },
+      undefined,
+      {},
+      {
+        "backgroundColor": "transparent",
+      },
+      {
+        "borderBottomEndRadius": undefined,
+        "borderBottomLeftRadius": undefined,
+        "borderBottomRightRadius": undefined,
+        "borderBottomStartRadius": undefined,
+        "borderCurve": "continuous",
+        "borderEndEndRadius": undefined,
+        "borderEndStartRadius": undefined,
+        "borderRadius": 20,
+        "borderStartEndRadius": undefined,
+        "borderStartStartRadius": undefined,
+        "borderTopEndRadius": undefined,
+        "borderTopLeftRadius": undefined,
+        "borderTopRightRadius": undefined,
+        "borderTopStartRadius": undefined,
+      },
+      {
+        "shadowColor": "rgba(0, 0, 0, 1)",
+        "shadowOffset": {
+          "height": 0,
+          "width": 0,
+        },
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
+      },
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "pointerEvents": "none",
+        },
+        {},
+        {},
+        {
+          "backgroundColor": "transparent",
+        },
+        {
+          "borderBottomEndRadius": undefined,
+          "borderBottomLeftRadius": undefined,
+          "borderBottomRightRadius": undefined,
+          "borderBottomStartRadius": undefined,
+          "borderCurve": "continuous",
+          "borderEndEndRadius": undefined,
+          "borderEndStartRadius": undefined,
+          "borderRadius": 20,
+          "borderStartEndRadius": undefined,
+          "borderStartStartRadius": undefined,
+          "borderTopEndRadius": undefined,
+          "borderTopLeftRadius": undefined,
+          "borderTopRightRadius": undefined,
+          "borderTopStartRadius": undefined,
+        },
+        {
+          "shadowColor": "rgba(0, 0, 0, 1)",
+          "shadowOffset": {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+        },
+      ]
+    }
+  />
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "overflow": "hidden",
+        },
+        {
+          "borderRadius": 19,
+        },
+      ]
+    }
+    testID="compact-button"
+  >
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "marginLeft": 12,
+              "marginRight": -4,
+            },
+            {
+              "marginLeft": 8,
+              "marginRight": 0,
+            },
+            false,
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            [
+              {
+                "color": "rgba(103, 80, 164, 1)",
+                "fontSize": 18,
+              },
+              [
+                {
+                  "lineHeight": 18,
+                  "transform": [
+                    {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                {
+                  "backgroundColor": "transparent",
+                },
+              ],
+            ]
+          }
+        >
+          camera
+        </Text>
+      </View>
+      <Text
+        numberOfLines={1}
+        selectable={false}
+        style={
+          [
+            {
+              "textAlign": "left",
+            },
+            {
+              "color": "rgba(29, 27, 32, 1)",
+              "writingDirection": "ltr",
+            },
+            [
+              {
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
+              },
+              [
+                {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                {
+                  "marginHorizontal": 24,
+                  "marginVertical": 10,
+                },
+                {
+                  "marginHorizontal": 8,
+                },
+                false,
+                {
+                  "color": "rgba(103, 80, 164, 1)",
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                undefined,
+              ],
+            ],
+          ]
+        }
+      >
+        Compact 
+        outlined
+         button
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`button icon styles should return correct icon styles for compact outlined button 2`] = `
+<View
+  collapsable={false}
+  style={
+    [
+      {},
+      {
+        "borderStyle": "solid",
+        "minWidth": 64,
+      },
+      undefined,
+      {
+        "borderColor": "rgba(202, 196, 208, 1)",
+        "borderWidth": 1,
+      },
+      undefined,
+      {},
+      {
+        "backgroundColor": "transparent",
+      },
+      {
+        "borderBottomEndRadius": undefined,
+        "borderBottomLeftRadius": undefined,
+        "borderBottomRightRadius": undefined,
+        "borderBottomStartRadius": undefined,
+        "borderCurve": "continuous",
+        "borderEndEndRadius": undefined,
+        "borderEndStartRadius": undefined,
+        "borderRadius": 20,
+        "borderStartEndRadius": undefined,
+        "borderStartStartRadius": undefined,
+        "borderTopEndRadius": undefined,
+        "borderTopLeftRadius": undefined,
+        "borderTopRightRadius": undefined,
+        "borderTopStartRadius": undefined,
+      },
+      {
+        "shadowColor": "rgba(0, 0, 0, 1)",
+        "shadowOffset": {
+          "height": 0,
+          "width": 0,
+        },
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
+      },
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "pointerEvents": "none",
+        },
+        {},
+        {},
+        {
+          "backgroundColor": "transparent",
+        },
+        {
+          "borderBottomEndRadius": undefined,
+          "borderBottomLeftRadius": undefined,
+          "borderBottomRightRadius": undefined,
+          "borderBottomStartRadius": undefined,
+          "borderCurve": "continuous",
+          "borderEndEndRadius": undefined,
+          "borderEndStartRadius": undefined,
+          "borderRadius": 20,
+          "borderStartEndRadius": undefined,
+          "borderStartStartRadius": undefined,
+          "borderTopEndRadius": undefined,
+          "borderTopLeftRadius": undefined,
+          "borderTopRightRadius": undefined,
+          "borderTopStartRadius": undefined,
+        },
+        {
+          "shadowColor": "rgba(0, 0, 0, 1)",
+          "shadowOffset": {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+        },
+      ]
+    }
+  />
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "overflow": "hidden",
+        },
+        {
+          "borderRadius": 19,
+        },
+      ]
+    }
+    testID="compact-button"
+  >
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "marginLeft": 12,
+              "marginRight": -4,
+            },
+            {
+              "marginLeft": 16,
+              "marginRight": -16,
+            },
+            false,
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            [
+              {
+                "color": "rgba(103, 80, 164, 1)",
+                "fontSize": 18,
+              },
+              [
+                {
+                  "lineHeight": 18,
+                  "transform": [
+                    {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                {
+                  "backgroundColor": "transparent",
+                },
+              ],
+            ]
+          }
+        >
+          camera
+        </Text>
+      </View>
+      <Text
+        numberOfLines={1}
+        selectable={false}
+        style={
+          [
+            {
+              "textAlign": "left",
+            },
+            {
+              "color": "rgba(29, 27, 32, 1)",
+              "writingDirection": "ltr",
+            },
+            [
+              {
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
+              },
+              [
+                {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                {
+                  "marginHorizontal": 24,
+                  "marginVertical": 10,
+                },
+                undefined,
+                false,
+                {
+                  "color": "rgba(103, 80, 164, 1)",
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                undefined,
+              ],
+            ],
+          ]
+        }
+      >
+        outlined
+         button
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`button icon styles should return correct icon styles for compact text button 1`] = `
+<View
+  collapsable={false}
+  style={
+    [
+      {},
+      {
+        "borderStyle": "solid",
+        "minWidth": 64,
+      },
+      {
+        "minWidth": "auto",
+      },
+      {
+        "borderColor": "transparent",
+        "borderWidth": 0,
+      },
+      undefined,
+      {},
+      {
+        "backgroundColor": "transparent",
+      },
+      {
+        "borderBottomEndRadius": undefined,
+        "borderBottomLeftRadius": undefined,
+        "borderBottomRightRadius": undefined,
+        "borderBottomStartRadius": undefined,
+        "borderCurve": "continuous",
+        "borderEndEndRadius": undefined,
+        "borderEndStartRadius": undefined,
+        "borderRadius": 20,
+        "borderStartEndRadius": undefined,
+        "borderStartStartRadius": undefined,
+        "borderTopEndRadius": undefined,
+        "borderTopLeftRadius": undefined,
+        "borderTopRightRadius": undefined,
+        "borderTopStartRadius": undefined,
+      },
+      {
+        "shadowColor": "rgba(0, 0, 0, 1)",
+        "shadowOffset": {
+          "height": 0,
+          "width": 0,
+        },
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
+      },
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "pointerEvents": "none",
+        },
+        {},
+        {},
+        {
+          "backgroundColor": "transparent",
+        },
+        {
+          "borderBottomEndRadius": undefined,
+          "borderBottomLeftRadius": undefined,
+          "borderBottomRightRadius": undefined,
+          "borderBottomStartRadius": undefined,
+          "borderCurve": "continuous",
+          "borderEndEndRadius": undefined,
+          "borderEndStartRadius": undefined,
+          "borderRadius": 20,
+          "borderStartEndRadius": undefined,
+          "borderStartStartRadius": undefined,
+          "borderTopEndRadius": undefined,
+          "borderTopLeftRadius": undefined,
+          "borderTopRightRadius": undefined,
+          "borderTopStartRadius": undefined,
+        },
+        {
+          "shadowColor": "rgba(0, 0, 0, 1)",
+          "shadowOffset": {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+        },
+      ]
+    }
+  />
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "overflow": "hidden",
+        },
+        {
+          "borderRadius": 20,
+        },
+      ]
+    }
+    testID="compact-button"
+  >
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "marginLeft": 12,
+              "marginRight": -4,
+            },
+            {
+              "marginLeft": 8,
+              "marginRight": 0,
+            },
+            {
+              "marginLeft": 6,
+              "marginRight": 0,
+            },
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            [
+              {
+                "color": "rgba(103, 80, 164, 1)",
+                "fontSize": 18,
+              },
+              [
+                {
+                  "lineHeight": 18,
+                  "transform": [
+                    {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                {
+                  "backgroundColor": "transparent",
+                },
+              ],
+            ]
+          }
+        >
+          camera
+        </Text>
+      </View>
+      <Text
+        numberOfLines={1}
+        selectable={false}
+        style={
+          [
+            {
+              "textAlign": "left",
+            },
+            {
+              "color": "rgba(29, 27, 32, 1)",
+              "writingDirection": "ltr",
+            },
+            [
+              {
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
+              },
+              [
+                {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                {
+                  "marginHorizontal": 16,
+                },
+                {
+                  "marginHorizontal": 8,
+                },
+                false,
+                {
+                  "color": "rgba(103, 80, 164, 1)",
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                undefined,
+              ],
+            ],
+          ]
+        }
+      >
+        Compact text button
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`button icon styles should return correct icon styles for text button 1`] = `
+<View
+  collapsable={false}
+  style={
+    [
+      {},
+      {
+        "borderStyle": "solid",
+        "minWidth": 64,
+      },
+      undefined,
+      {
+        "borderColor": "transparent",
+        "borderWidth": 0,
+      },
+      undefined,
+      {},
+      {
+        "backgroundColor": "transparent",
+      },
+      {
+        "borderBottomEndRadius": undefined,
+        "borderBottomLeftRadius": undefined,
+        "borderBottomRightRadius": undefined,
+        "borderBottomStartRadius": undefined,
+        "borderCurve": "continuous",
+        "borderEndEndRadius": undefined,
+        "borderEndStartRadius": undefined,
+        "borderRadius": 20,
+        "borderStartEndRadius": undefined,
+        "borderStartStartRadius": undefined,
+        "borderTopEndRadius": undefined,
+        "borderTopLeftRadius": undefined,
+        "borderTopRightRadius": undefined,
+        "borderTopStartRadius": undefined,
+      },
+      {
+        "shadowColor": "rgba(0, 0, 0, 1)",
+        "shadowOffset": {
+          "height": 0,
+          "width": 0,
+        },
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
+      },
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "pointerEvents": "none",
+        },
+        {},
+        {},
+        {
+          "backgroundColor": "transparent",
+        },
+        {
+          "borderBottomEndRadius": undefined,
+          "borderBottomLeftRadius": undefined,
+          "borderBottomRightRadius": undefined,
+          "borderBottomStartRadius": undefined,
+          "borderCurve": "continuous",
+          "borderEndEndRadius": undefined,
+          "borderEndStartRadius": undefined,
+          "borderRadius": 20,
+          "borderStartEndRadius": undefined,
+          "borderStartStartRadius": undefined,
+          "borderTopEndRadius": undefined,
+          "borderTopLeftRadius": undefined,
+          "borderTopRightRadius": undefined,
+          "borderTopStartRadius": undefined,
+        },
+        {
+          "shadowColor": "rgba(0, 0, 0, 1)",
+          "shadowOffset": {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+        },
+      ]
+    }
+  />
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "overflow": "hidden",
+        },
+        {
+          "borderRadius": 20,
+        },
+      ]
+    }
+    testID="compact-button"
+  >
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "marginLeft": 12,
+              "marginRight": -4,
+            },
+            {
+              "marginLeft": 16,
+              "marginRight": -16,
+            },
+            {
+              "marginLeft": 12,
+              "marginRight": -8,
+            },
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            [
+              {
+                "color": "rgba(103, 80, 164, 1)",
+                "fontSize": 18,
+              },
+              [
+                {
+                  "lineHeight": 18,
+                  "transform": [
+                    {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                {
+                  "backgroundColor": "transparent",
+                },
+              ],
+            ]
+          }
+        >
+          camera
+        </Text>
+      </View>
+      <Text
+        numberOfLines={1}
+        selectable={false}
+        style={
+          [
+            {
+              "textAlign": "left",
+            },
+            {
+              "color": "rgba(29, 27, 32, 1)",
+              "writingDirection": "ltr",
+            },
+            [
+              {
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "letterSpacing": 0.1,
+                "lineHeight": 20,
+              },
+              [
+                {
+                  "marginHorizontal": 16,
+                  "marginVertical": 9,
+                  "textAlign": "center",
+                },
+                {
+                  "marginHorizontal": 16,
+                },
+                undefined,
+                false,
+                {
+                  "color": "rgba(103, 80, 164, 1)",
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                undefined,
+              ],
+            ],
+          ]
+        }
+      >
+        text button
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
 exports[`renders button with an accessibility hint 1`] = `
 <View
   collapsable={false}
@@ -865,7 +3411,6 @@ exports[`renders button with custom testID 1`] = `
       },
     ]
   }
-  testID="custom:testID-container"
 >
   <View
     collapsable={false}
@@ -1016,7 +3561,6 @@ exports[`renders button with custom testID 1`] = `
             ],
           ]
         }
-        testID="custom:testID-text"
       >
         Button with custom testID
       </Text>

--- a/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -71,6 +71,310 @@ exports[`DataTable.Cell renders data table cell 1`] = `
 </View>
 `;
 
+exports[`DataTable.Cell renders data table cell children without wrapping text component 1`] = `
+<View
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": true,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    [
+      false,
+      [
+        {
+          "alignItems": "center",
+          "flex": 1,
+          "flexDirection": "row",
+        },
+        undefined,
+        undefined,
+      ],
+    ]
+  }
+  testID="table-cell"
+>
+  <View
+    accessibilityLiveRegion="polite"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": true,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    centered={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="checkbox"
+    style={
+      [
+        {
+          "overflow": "hidden",
+        },
+        [
+          {
+            "alignItems": "center",
+            "borderRadius": 20,
+            "height": 40,
+            "justifyContent": "center",
+            "width": 40,
+          },
+          undefined,
+          undefined,
+        ],
+      ]
+    }
+    testID="table-cell-checkbox"
+  >
+    <View
+      pointerEvents="none"
+      style={
+        {
+          "alignItems": "center",
+          "height": 40,
+          "justifyContent": "center",
+          "width": 40,
+        }
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "borderRadius": 2,
+              "height": 18,
+              "justifyContent": "center",
+              "overflow": "hidden",
+              "width": 18,
+            },
+            {
+              "opacity": 1,
+            },
+          ]
+        }
+      >
+        <View
+          collapsable={false}
+          pointerEvents="none"
+          style={
+            [
+              {
+                "borderRadius": 2,
+                "borderWidth": 2,
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              {
+                "borderColor": "rgba(73, 69, 79, 1)",
+                "opacity": 0,
+              },
+            ]
+          }
+        />
+        <View
+          collapsable={false}
+          pointerEvents="none"
+          style={
+            [
+              {
+                "borderRadius": 2,
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              {
+                "backgroundColor": "rgba(103, 80, 164, 1)",
+                "opacity": 1,
+              },
+            ]
+          }
+        />
+        <View
+          collapsable={false}
+          style={
+            [
+              {
+                "height": 18,
+                "left": 0,
+                "overflow": "hidden",
+                "position": "absolute",
+                "top": 0,
+              },
+              {
+                "opacity": 1,
+                "width": 18,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "height": 18,
+                "justifyContent": "center",
+                "width": 18,
+              }
+            }
+          >
+            <View
+              style={
+                [
+                  {
+                    "borderBottomWidth": 2,
+                    "borderLeftWidth": 2,
+                    "height": 6,
+                    "transform": [
+                      {
+                        "rotate": "-45deg",
+                      },
+                      {
+                        "translateY": -1,
+                      },
+                      {
+                        "translateX": 1,
+                      },
+                    ],
+                    "width": 11,
+                  },
+                  {
+                    "borderColor": "rgba(255, 255, 255, 1)",
+                  },
+                  null,
+                ]
+              }
+            />
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`DataTable.Cell renders data table cell with text content 1`] = `
+<View
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": true,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    [
+      false,
+      [
+        {
+          "alignItems": "center",
+          "flex": 1,
+          "flexDirection": "row",
+        },
+        undefined,
+        undefined,
+      ],
+    ]
+  }
+  testID="table-cell"
+>
+  <Text
+    numberOfLines={1}
+    style={
+      [
+        {
+          "textAlign": "left",
+        },
+        {
+          "color": "rgba(29, 27, 32, 1)",
+          "fontFamily": "System",
+          "fontWeight": "400",
+          "letterSpacing": 0,
+        },
+        {
+          "writingDirection": "ltr",
+        },
+        undefined,
+      ]
+    }
+  >
+    Table cell
+  </Text>
+</View>
+`;
+
 exports[`DataTable.Cell renders right aligned data table cell 1`] = `
 <View
   accessibilityState={

--- a/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -1770,7 +1770,6 @@ exports[`DataTable.Pagination renders data table pagination with options select 
         "marginVertical": 6,
       }
     }
-    testID="options-select"
   >
     <Text
       aria-label="selectPageDropdownLabel"
@@ -1800,7 +1799,6 @@ exports[`DataTable.Pagination renders data table pagination with options select 
           ],
         ]
       }
-      testID="select-page-dropdown-label"
     >
       Rows per page
     </Text>

--- a/src/components/__tests__/__snapshots__/FABMenu.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FABMenu.test.tsx.snap
@@ -197,7 +197,6 @@ exports[`renders FAB.Menu closed 1`] = `
                         },
                       ]
                     }
-                    testID="item-0-text"
                   >
                     Send email
                   </Text>
@@ -374,7 +373,6 @@ exports[`renders FAB.Menu closed 1`] = `
                         },
                       ]
                     }
-                    testID="item-1-text"
                   >
                     Set reminder
                   </Text>
@@ -976,7 +974,6 @@ exports[`renders FAB.Menu not expanded when trigger is not visible 1`] = `
                         },
                       ]
                     }
-                    testID="item-0-text"
                   >
                     Send email
                   </Text>
@@ -1153,7 +1150,6 @@ exports[`renders FAB.Menu not expanded when trigger is not visible 1`] = `
                         },
                       ]
                     }
-                    testID="item-1-text"
                   >
                     Set reminder
                   </Text>
@@ -1755,7 +1751,6 @@ exports[`renders FAB.Menu open 1`] = `
                         },
                       ]
                     }
-                    testID="item-0-text"
                   >
                     Send email
                   </Text>
@@ -1932,7 +1927,6 @@ exports[`renders FAB.Menu open 1`] = `
                         },
                       ]
                     }
-                    testID="item-1-text"
                   >
                     Set reminder
                   </Text>
@@ -2534,7 +2528,6 @@ exports[`renders FAB.Menu with 6 items 1`] = `
                         },
                       ]
                     }
-                    testID="item-0-text"
                   >
                     Item 1
                   </Text>
@@ -2711,7 +2704,6 @@ exports[`renders FAB.Menu with 6 items 1`] = `
                         },
                       ]
                     }
-                    testID="item-1-text"
                   >
                     Item 2
                   </Text>
@@ -2888,7 +2880,6 @@ exports[`renders FAB.Menu with 6 items 1`] = `
                         },
                       ]
                     }
-                    testID="item-2-text"
                   >
                     Item 3
                   </Text>
@@ -3065,7 +3056,6 @@ exports[`renders FAB.Menu with 6 items 1`] = `
                         },
                       ]
                     }
-                    testID="item-3-text"
                   >
                     Item 4
                   </Text>
@@ -3242,7 +3232,6 @@ exports[`renders FAB.Menu with 6 items 1`] = `
                         },
                       ]
                     }
-                    testID="item-4-text"
                   >
                     Item 5
                   </Text>
@@ -3419,7 +3408,6 @@ exports[`renders FAB.Menu with 6 items 1`] = `
                         },
                       ]
                     }
-                    testID="item-5-text"
                   >
                     Item 6
                   </Text>
@@ -4022,7 +4010,6 @@ exports[`renders FAB.Menu with center alignment 1`] = `
                         },
                       ]
                     }
-                    testID="item-0-text"
                   >
                     Send email
                   </Text>
@@ -4199,7 +4186,6 @@ exports[`renders FAB.Menu with center alignment 1`] = `
                         },
                       ]
                     }
-                    testID="item-1-text"
                   >
                     Set reminder
                   </Text>
@@ -5638,7 +5624,6 @@ exports[`renders FAB.Menu with start alignment 1`] = `
                         },
                       ]
                     }
-                    testID="item-0-text"
                   >
                     Send email
                   </Text>
@@ -5815,7 +5800,6 @@ exports[`renders FAB.Menu with start alignment 1`] = `
                         },
                       ]
                     }
-                    testID="item-1-text"
                   >
                     Set reminder
                   </Text>

--- a/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/IconButton.test.tsx.snap
@@ -360,6 +360,129 @@ exports[`renders icon button with color 1`] = `
 </View>
 `;
 
+exports[`renders icon button with custom border radius 1`] = `
+<View
+  collapsable={false}
+  style={
+    [
+      {
+        "margin": 6,
+        "overflow": "hidden",
+      },
+      {
+        "backgroundColor": undefined,
+        "height": 52,
+        "width": 52,
+      },
+      {
+        "borderColor": "rgba(202, 196, 208, 1)",
+        "borderRadius": 26,
+        "borderWidth": 0,
+      },
+      {
+        "borderRadius": 0,
+      },
+    ]
+  }
+>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    centered={true}
+    collapsable={false}
+    focusable={true}
+    hitSlop={
+      {
+        "bottom": 6,
+        "left": 6,
+        "right": 6,
+        "top": 6,
+      }
+    }
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "overflow": "hidden",
+        },
+        [
+          {
+            "alignItems": "center",
+            "flexGrow": 1,
+            "justifyContent": "center",
+          },
+          undefined,
+        ],
+      ]
+    }
+    testID="icon-button"
+  >
+    <View
+      style={
+        {
+          "opacity": 1,
+        }
+      }
+    >
+      <Text
+        accessibilityElementsHidden={true}
+        importantForAccessibility="no-hide-descendants"
+        pointerEvents="none"
+        selectable={false}
+        style={
+          [
+            {
+              "color": "rgba(73, 69, 79, 1)",
+              "fontSize": 36,
+            },
+            [
+              {
+                "lineHeight": 36,
+                "transform": [
+                  {
+                    "scaleX": 1,
+                  },
+                ],
+              },
+              {
+                "backgroundColor": "transparent",
+              },
+            ],
+          ]
+        }
+      >
+        camera
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
 exports[`renders icon button with size 1`] = `
 <View
   collapsable={false}
@@ -460,6 +583,129 @@ exports[`renders icon button with size 1`] = `
             [
               {
                 "lineHeight": 30,
+                "transform": [
+                  {
+                    "scaleX": 1,
+                  },
+                ],
+              },
+              {
+                "backgroundColor": "transparent",
+              },
+            ],
+          ]
+        }
+      >
+        camera
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`renders icon button with small border radius 1`] = `
+<View
+  collapsable={false}
+  style={
+    [
+      {
+        "margin": 6,
+        "overflow": "hidden",
+      },
+      {
+        "backgroundColor": undefined,
+        "height": 52,
+        "width": 52,
+      },
+      {
+        "borderColor": "rgba(202, 196, 208, 1)",
+        "borderRadius": 26,
+        "borderWidth": 0,
+      },
+      {
+        "borderRadius": 4,
+      },
+    ]
+  }
+>
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    centered={true}
+    collapsable={false}
+    focusable={true}
+    hitSlop={
+      {
+        "bottom": 6,
+        "left": 6,
+        "right": 6,
+        "top": 6,
+      }
+    }
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "overflow": "hidden",
+        },
+        [
+          {
+            "alignItems": "center",
+            "flexGrow": 1,
+            "justifyContent": "center",
+          },
+          undefined,
+        ],
+      ]
+    }
+    testID="icon-button"
+  >
+    <View
+      style={
+        {
+          "opacity": 1,
+        }
+      }
+    >
+      <Text
+        accessibilityElementsHidden={true}
+        importantForAccessibility="no-hide-descendants"
+        pointerEvents="none"
+        selectable={false}
+        style={
+          [
+            {
+              "color": "rgba(73, 69, 79, 1)",
+              "fontSize": 36,
+            },
+            [
+              {
+                "lineHeight": 36,
                 "transform": [
                   {
                     "scaleX": 1,

--- a/src/components/__tests__/__snapshots__/ListImage.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListImage.test.tsx.snap
@@ -1,5 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders ListImage with \`image\` variant 1`] = `
+<Image
+  accessibilityIgnoresInvertColors={true}
+  source={
+    {
+      "uri": "https://www.someurl.com/apple",
+    }
+  }
+  style={
+    [
+      undefined,
+      {
+        "height": 56,
+        "width": 56,
+      },
+    ]
+  }
+/>
+`;
+
+exports[`renders ListImage with \`video\` variant 1`] = `
+<Image
+  accessibilityIgnoresInvertColors={true}
+  source={
+    {
+      "uri": "https://www.someurl.com/apple",
+    }
+  }
+  style={
+    [
+      undefined,
+      {
+        "height": 64,
+        "marginLeft": 0,
+        "width": 114,
+      },
+    ]
+  }
+/>
+`;
+
 exports[`renders ListImage with default variant & styles 1`] = `
 <Image
   accessibilityIgnoresInvertColors={true}
@@ -20,7 +61,6 @@ exports[`renders ListImage with default variant & styles 1`] = `
       },
     ]
   }
-  testID="list-image"
 />
 `;
 
@@ -41,6 +81,5 @@ exports[`renders ListImage with default variant 1`] = `
       },
     ]
   }
-  testID="list-image"
 />
 `;

--- a/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListItem.test.tsx.snap
@@ -1,5 +1,149 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders list item with custom content style 1`] = `
+<View
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": true,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    [
+      false,
+      [
+        {
+          "paddingRight": 24,
+          "paddingVertical": 8,
+        },
+        undefined,
+      ],
+    ]
+  }
+  testID="list-item"
+>
+  <View
+    style={
+      [
+        {
+          "flexDirection": "row",
+          "marginVertical": 6,
+          "width": "100%",
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "paddingLeft": 16,
+          },
+          {
+            "flexGrow": 1,
+            "flexShrink": 1,
+            "justifyContent": "center",
+          },
+          {
+            "paddingLeft": 0,
+          },
+        ]
+      }
+    >
+      <Text
+        numberOfLines={1}
+        selectable={false}
+        style={
+          [
+            {
+              "textAlign": "left",
+            },
+            {
+              "color": "rgba(29, 27, 32, 1)",
+              "fontFamily": "System",
+              "fontWeight": "400",
+              "letterSpacing": 0,
+            },
+            {
+              "writingDirection": "ltr",
+            },
+            [
+              {
+                "fontSize": 16,
+              },
+              {
+                "color": "rgba(29, 27, 32, 1)",
+              },
+              undefined,
+            ],
+          ]
+        }
+      >
+        First Item
+      </Text>
+      <Text
+        numberOfLines={2}
+        onTextLayout={[Function]}
+        selectable={false}
+        style={
+          [
+            {
+              "textAlign": "left",
+            },
+            {
+              "color": "rgba(29, 27, 32, 1)",
+              "fontFamily": "System",
+              "fontWeight": "400",
+              "letterSpacing": 0,
+            },
+            {
+              "writingDirection": "ltr",
+            },
+            [
+              {
+                "fontSize": 14,
+              },
+              {
+                "color": "rgba(73, 69, 79, 1)",
+              },
+              undefined,
+            ],
+          ]
+        }
+      >
+        Item description
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
 exports[`renders list item with custom description 1`] = `
 <View
   accessibilityState={
@@ -71,7 +215,6 @@ exports[`renders list item with custom description 1`] = `
           undefined,
         ]
       }
-      testID="list-item-content"
     >
       <Text
         numberOfLines={1}
@@ -452,7 +595,6 @@ exports[`renders list item with custom title and description styles 1`] = `
           undefined,
         ]
       }
-      testID="list-item-content"
     >
       <Text
         numberOfLines={1}
@@ -600,7 +742,6 @@ exports[`renders list item with left and right items 1`] = `
           undefined,
         ]
       }
-      testID="list-item-content"
     >
       <Text
         numberOfLines={1}
@@ -834,7 +975,6 @@ exports[`renders list item with left item 1`] = `
           undefined,
         ]
       }
-      testID="list-item-content"
     >
       <Text
         numberOfLines={1}
@@ -943,7 +1083,6 @@ exports[`renders list item with right item 1`] = `
           undefined,
         ]
       }
-      testID="list-item-content"
     >
       <Text
         numberOfLines={1}
@@ -1055,7 +1194,6 @@ exports[`renders list item with title and description 1`] = `
           undefined,
         ]
       }
-      testID="list-item-content"
     >
       <Text
         numberOfLines={1}
@@ -1196,7 +1334,6 @@ exports[`renders with a description with typeof number 1`] = `
           undefined,
         ]
       }
-      testID="list-item-content"
     >
       <Text
         numberOfLines={1}

--- a/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ListSection.test.tsx.snap
@@ -570,7 +570,6 @@ exports[`renders list section with custom title style 1`] = `
             undefined,
           ]
         }
-        testID="list-item-content"
       >
         <Text
           numberOfLines={1}
@@ -723,7 +722,6 @@ exports[`renders list section with custom title style 1`] = `
             undefined,
           ]
         }
-        testID="list-item-content"
       >
         <Text
           numberOfLines={1}
@@ -1330,7 +1328,6 @@ exports[`renders list section with subheader 1`] = `
             undefined,
           ]
         }
-        testID="list-item-content"
       >
         <Text
           numberOfLines={1}
@@ -1483,7 +1480,6 @@ exports[`renders list section with subheader 1`] = `
             undefined,
           ]
         }
-        testID="list-item-content"
       >
         <Text
           numberOfLines={1}
@@ -2050,7 +2046,6 @@ exports[`renders list section without subheader 1`] = `
             undefined,
           ]
         }
-        testID="list-item-content"
       >
         <Text
           numberOfLines={1}
@@ -2203,7 +2198,6 @@ exports[`renders list section without subheader 1`] = `
             undefined,
           ]
         }
-        testID="list-item-content"
       >
         <Text
           numberOfLines={1}

--- a/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -895,3 +895,1361 @@ exports[`renders visible menu 1`] = `
   </View>
 </>
 `;
+
+exports[`respects anchorPosition bottom 1`] = `
+<>
+  <View
+    collapsable={false}
+    pointerEvents="box-none"
+    style={
+      {
+        "flex": 1,
+      }
+    }
+  >
+    <View
+      collapsable={false}
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {},
+            {
+              "borderStyle": "solid",
+              "minWidth": 64,
+            },
+            undefined,
+            {
+              "borderColor": "rgba(202, 196, 208, 1)",
+              "borderWidth": 1,
+            },
+            undefined,
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": 20,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0,
+              "shadowRadius": 0,
+            },
+          ]
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            [
+              {
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              {
+                "pointerEvents": "none",
+              },
+              {},
+              {},
+              {
+                "backgroundColor": "transparent",
+              },
+              {
+                "borderBottomEndRadius": undefined,
+                "borderBottomLeftRadius": undefined,
+                "borderBottomRightRadius": undefined,
+                "borderBottomStartRadius": undefined,
+                "borderCurve": "continuous",
+                "borderEndEndRadius": undefined,
+                "borderEndStartRadius": undefined,
+                "borderRadius": 20,
+                "borderStartEndRadius": undefined,
+                "borderStartStartRadius": undefined,
+                "borderTopEndRadius": undefined,
+                "borderTopLeftRadius": undefined,
+                "borderTopRightRadius": undefined,
+                "borderTopStartRadius": undefined,
+              },
+              {
+                "shadowColor": "rgba(0, 0, 0, 1)",
+                "shadowOffset": {
+                  "height": 0,
+                  "width": 0,
+                },
+                "shadowOpacity": 0,
+                "shadowRadius": 0,
+              },
+            ]
+          }
+        />
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": true,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          role="button"
+          style={
+            [
+              {
+                "overflow": "hidden",
+              },
+              {
+                "borderRadius": 19,
+              },
+            ]
+          }
+          testID="anchor"
+        >
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                },
+                {
+                  "opacity": 1,
+                },
+                undefined,
+              ]
+            }
+          >
+            <Text
+              numberOfLines={1}
+              selectable={false}
+              style={
+                [
+                  {
+                    "textAlign": "left",
+                  },
+                  {
+                    "color": "rgba(29, 27, 32, 1)",
+                    "writingDirection": "ltr",
+                  },
+                  [
+                    {
+                      "fontFamily": "System",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "letterSpacing": 0.1,
+                      "lineHeight": 20,
+                    },
+                    [
+                      {
+                        "marginHorizontal": 16,
+                        "marginVertical": 9,
+                        "textAlign": "center",
+                      },
+                      {
+                        "marginHorizontal": 24,
+                        "marginVertical": 10,
+                      },
+                      undefined,
+                      false,
+                      {
+                        "color": "rgba(103, 80, 164, 1)",
+                        "fontFamily": "System",
+                        "fontSize": 14,
+                        "fontWeight": "500",
+                        "letterSpacing": 0.1,
+                        "lineHeight": 20,
+                      },
+                      undefined,
+                    ],
+                  ],
+                ]
+              }
+            >
+              Open menu
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    collapsable={false}
+    pointerEvents="box-none"
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Close menu"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      pointerEvents="auto"
+      role="button"
+      style={
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "width": "100%",
+        }
+      }
+    />
+    <View
+      aria-modal={true}
+      collapsable={false}
+      onAccessibilityEscape={[MockFunction]}
+      pointerEvents="box-none"
+      style={
+        [
+          {
+            "position": "absolute",
+          },
+          {
+            "left": 100,
+            "top": 132,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        pointerEvents="box-none"
+        style={
+          [
+            {
+              "transform": [
+                {
+                  "translateX": -0,
+                },
+                {
+                  "translateY": -0,
+                },
+              ],
+            },
+          ]
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            [
+              {},
+              {
+                "opacity": 0,
+              },
+              {
+                "pointerEvents": "box-none",
+              },
+              {},
+              {
+                "opacity": 0,
+                "transform": [
+                  {
+                    "scaleX": 0,
+                  },
+                  {
+                    "scaleY": 0,
+                  },
+                ],
+              },
+              {},
+              {
+                "backgroundColor": "rgba(243, 237, 247, 1)",
+              },
+              {
+                "borderBottomEndRadius": undefined,
+                "borderBottomLeftRadius": undefined,
+                "borderBottomRightRadius": undefined,
+                "borderBottomStartRadius": undefined,
+                "borderCurve": "continuous",
+                "borderEndEndRadius": undefined,
+                "borderEndStartRadius": undefined,
+                "borderRadius": 4,
+                "borderStartEndRadius": undefined,
+                "borderStartStartRadius": undefined,
+                "borderTopEndRadius": undefined,
+                "borderTopLeftRadius": undefined,
+                "borderTopRightRadius": undefined,
+                "borderTopStartRadius": undefined,
+              },
+              {
+                "shadowColor": "rgba(0, 0, 0, 1)",
+                "shadowOffset": {
+                  "height": 1.66,
+                  "width": 0,
+                },
+                "shadowOpacity": 0.19,
+                "shadowRadius": 2.36,
+              },
+            ]
+          }
+          testID="bottom-positioned-menu"
+        >
+          <View
+            collapsable={false}
+            style={
+              [
+                {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                {
+                  "pointerEvents": "none",
+                },
+                {},
+                {},
+                {
+                  "backgroundColor": "rgba(243, 237, 247, 1)",
+                },
+                {
+                  "borderBottomEndRadius": undefined,
+                  "borderBottomLeftRadius": undefined,
+                  "borderBottomRightRadius": undefined,
+                  "borderBottomStartRadius": undefined,
+                  "borderCurve": "continuous",
+                  "borderEndEndRadius": undefined,
+                  "borderEndStartRadius": undefined,
+                  "borderRadius": 4,
+                  "borderStartEndRadius": undefined,
+                  "borderStartStartRadius": undefined,
+                  "borderTopEndRadius": undefined,
+                  "borderTopLeftRadius": undefined,
+                  "borderTopRightRadius": undefined,
+                  "borderTopStartRadius": undefined,
+                },
+                {
+                  "shadowColor": "rgba(0, 0, 0, 1)",
+                  "shadowOffset": {
+                    "height": 0,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0.039,
+                  "shadowRadius": 0.75,
+                },
+              ]
+            }
+          />
+          <View
+            collapsable={false}
+            style={
+              [
+                {
+                  "paddingVertical": 8,
+                },
+                false,
+                undefined,
+              ]
+            }
+          >
+            <View
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": false,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              role="menuitem"
+              style={
+                [
+                  false,
+                  [
+                    {
+                      "height": 48,
+                      "justifyContent": "center",
+                      "maxWidth": 280,
+                      "minWidth": 112,
+                    },
+                    {
+                      "paddingHorizontal": 12,
+                    },
+                    undefined,
+                    undefined,
+                  ],
+                ]
+              }
+            >
+              <View
+                style={
+                  [
+                    {
+                      "flexDirection": "row",
+                    },
+                    {
+                      "opacity": 1,
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                <View
+                  pointerEvents="none"
+                  style={
+                    [
+                      {
+                        "justifyContent": "center",
+                      },
+                      {
+                        "maxWidth": 268,
+                        "minWidth": 100,
+                      },
+                      {
+                        "marginLeft": 4,
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1.5}
+                    numberOfLines={1}
+                    selectable={false}
+                    style={
+                      [
+                        {
+                          "textAlign": "left",
+                        },
+                        {
+                          "color": "rgba(29, 27, 32, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        [
+                          {
+                            "fontFamily": "System",
+                            "fontSize": 16,
+                            "fontWeight": "400",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 24,
+                          },
+                          [
+                            {
+                              "color": "rgba(29, 27, 32, 1)",
+                              "fontFamily": "System",
+                              "fontSize": 16,
+                              "fontWeight": "400",
+                              "letterSpacing": 0.5,
+                              "lineHeight": 24,
+                            },
+                            undefined,
+                          ],
+                        ],
+                      ]
+                    }
+                  >
+                    Undo
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": false,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              role="menuitem"
+              style={
+                [
+                  false,
+                  [
+                    {
+                      "height": 48,
+                      "justifyContent": "center",
+                      "maxWidth": 280,
+                      "minWidth": 112,
+                    },
+                    {
+                      "paddingHorizontal": 12,
+                    },
+                    undefined,
+                    undefined,
+                  ],
+                ]
+              }
+            >
+              <View
+                style={
+                  [
+                    {
+                      "flexDirection": "row",
+                    },
+                    {
+                      "opacity": 1,
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                <View
+                  pointerEvents="none"
+                  style={
+                    [
+                      {
+                        "justifyContent": "center",
+                      },
+                      {
+                        "maxWidth": 268,
+                        "minWidth": 100,
+                      },
+                      {
+                        "marginLeft": 4,
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1.5}
+                    numberOfLines={1}
+                    selectable={false}
+                    style={
+                      [
+                        {
+                          "textAlign": "left",
+                        },
+                        {
+                          "color": "rgba(29, 27, 32, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        [
+                          {
+                            "fontFamily": "System",
+                            "fontSize": 16,
+                            "fontWeight": "400",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 24,
+                          },
+                          [
+                            {
+                              "color": "rgba(29, 27, 32, 1)",
+                              "fontFamily": "System",
+                              "fontSize": 16,
+                              "fontWeight": "400",
+                              "letterSpacing": 0.5,
+                              "lineHeight": 24,
+                            },
+                            undefined,
+                          ],
+                        ],
+                      ]
+                    }
+                  >
+                    Redo
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</>
+`;
+
+exports[`uses the default anchorPosition of top 1`] = `
+<>
+  <View
+    collapsable={false}
+    pointerEvents="box-none"
+    style={
+      {
+        "flex": 1,
+      }
+    }
+  >
+    <View
+      collapsable={false}
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {},
+            {
+              "borderStyle": "solid",
+              "minWidth": 64,
+            },
+            undefined,
+            {
+              "borderColor": "rgba(202, 196, 208, 1)",
+              "borderWidth": 1,
+            },
+            undefined,
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": 20,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0,
+              "shadowRadius": 0,
+            },
+          ]
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            [
+              {
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              {
+                "pointerEvents": "none",
+              },
+              {},
+              {},
+              {
+                "backgroundColor": "transparent",
+              },
+              {
+                "borderBottomEndRadius": undefined,
+                "borderBottomLeftRadius": undefined,
+                "borderBottomRightRadius": undefined,
+                "borderBottomStartRadius": undefined,
+                "borderCurve": "continuous",
+                "borderEndEndRadius": undefined,
+                "borderEndStartRadius": undefined,
+                "borderRadius": 20,
+                "borderStartEndRadius": undefined,
+                "borderStartStartRadius": undefined,
+                "borderTopEndRadius": undefined,
+                "borderTopLeftRadius": undefined,
+                "borderTopRightRadius": undefined,
+                "borderTopStartRadius": undefined,
+              },
+              {
+                "shadowColor": "rgba(0, 0, 0, 1)",
+                "shadowOffset": {
+                  "height": 0,
+                  "width": 0,
+                },
+                "shadowOpacity": 0,
+                "shadowRadius": 0,
+              },
+            ]
+          }
+        />
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": true,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          role="button"
+          style={
+            [
+              {
+                "overflow": "hidden",
+              },
+              {
+                "borderRadius": 19,
+              },
+            ]
+          }
+          testID="anchor"
+        >
+          <View
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                },
+                {
+                  "opacity": 1,
+                },
+                undefined,
+              ]
+            }
+          >
+            <Text
+              numberOfLines={1}
+              selectable={false}
+              style={
+                [
+                  {
+                    "textAlign": "left",
+                  },
+                  {
+                    "color": "rgba(29, 27, 32, 1)",
+                    "writingDirection": "ltr",
+                  },
+                  [
+                    {
+                      "fontFamily": "System",
+                      "fontSize": 14,
+                      "fontWeight": "500",
+                      "letterSpacing": 0.1,
+                      "lineHeight": 20,
+                    },
+                    [
+                      {
+                        "marginHorizontal": 16,
+                        "marginVertical": 9,
+                        "textAlign": "center",
+                      },
+                      {
+                        "marginHorizontal": 24,
+                        "marginVertical": 10,
+                      },
+                      undefined,
+                      false,
+                      {
+                        "color": "rgba(103, 80, 164, 1)",
+                        "fontFamily": "System",
+                        "fontSize": 14,
+                        "fontWeight": "500",
+                        "letterSpacing": 0.1,
+                        "lineHeight": 20,
+                      },
+                      undefined,
+                    ],
+                  ],
+                ]
+              }
+            >
+              Open menu
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    collapsable={false}
+    pointerEvents="box-none"
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Close menu"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      pointerEvents="auto"
+      role="button"
+      style={
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "width": "100%",
+        }
+      }
+    />
+    <View
+      aria-modal={true}
+      collapsable={false}
+      onAccessibilityEscape={[MockFunction]}
+      pointerEvents="box-none"
+      style={
+        [
+          {
+            "position": "absolute",
+          },
+          {
+            "left": 100,
+            "top": 100,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        pointerEvents="box-none"
+        style={
+          [
+            {
+              "transform": [
+                {
+                  "translateX": -0,
+                },
+                {
+                  "translateY": -0,
+                },
+              ],
+            },
+          ]
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            [
+              {},
+              {
+                "opacity": 0,
+              },
+              {
+                "pointerEvents": "box-none",
+              },
+              {},
+              {
+                "opacity": 0,
+                "transform": [
+                  {
+                    "scaleX": 0,
+                  },
+                  {
+                    "scaleY": 0,
+                  },
+                ],
+              },
+              {},
+              {
+                "backgroundColor": "rgba(243, 237, 247, 1)",
+              },
+              {
+                "borderBottomEndRadius": undefined,
+                "borderBottomLeftRadius": undefined,
+                "borderBottomRightRadius": undefined,
+                "borderBottomStartRadius": undefined,
+                "borderCurve": "continuous",
+                "borderEndEndRadius": undefined,
+                "borderEndStartRadius": undefined,
+                "borderRadius": 4,
+                "borderStartEndRadius": undefined,
+                "borderStartStartRadius": undefined,
+                "borderTopEndRadius": undefined,
+                "borderTopLeftRadius": undefined,
+                "borderTopRightRadius": undefined,
+                "borderTopStartRadius": undefined,
+              },
+              {
+                "shadowColor": "rgba(0, 0, 0, 1)",
+                "shadowOffset": {
+                  "height": 1.66,
+                  "width": 0,
+                },
+                "shadowOpacity": 0.19,
+                "shadowRadius": 2.36,
+              },
+            ]
+          }
+          testID="top-positioned-menu"
+        >
+          <View
+            collapsable={false}
+            style={
+              [
+                {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                {
+                  "pointerEvents": "none",
+                },
+                {},
+                {},
+                {
+                  "backgroundColor": "rgba(243, 237, 247, 1)",
+                },
+                {
+                  "borderBottomEndRadius": undefined,
+                  "borderBottomLeftRadius": undefined,
+                  "borderBottomRightRadius": undefined,
+                  "borderBottomStartRadius": undefined,
+                  "borderCurve": "continuous",
+                  "borderEndEndRadius": undefined,
+                  "borderEndStartRadius": undefined,
+                  "borderRadius": 4,
+                  "borderStartEndRadius": undefined,
+                  "borderStartStartRadius": undefined,
+                  "borderTopEndRadius": undefined,
+                  "borderTopLeftRadius": undefined,
+                  "borderTopRightRadius": undefined,
+                  "borderTopStartRadius": undefined,
+                },
+                {
+                  "shadowColor": "rgba(0, 0, 0, 1)",
+                  "shadowOffset": {
+                    "height": 0,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0.039,
+                  "shadowRadius": 0.75,
+                },
+              ]
+            }
+          />
+          <View
+            collapsable={false}
+            style={
+              [
+                {
+                  "paddingVertical": 8,
+                },
+                false,
+                undefined,
+              ]
+            }
+          >
+            <View
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": false,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              role="menuitem"
+              style={
+                [
+                  false,
+                  [
+                    {
+                      "height": 48,
+                      "justifyContent": "center",
+                      "maxWidth": 280,
+                      "minWidth": 112,
+                    },
+                    {
+                      "paddingHorizontal": 12,
+                    },
+                    undefined,
+                    undefined,
+                  ],
+                ]
+              }
+            >
+              <View
+                style={
+                  [
+                    {
+                      "flexDirection": "row",
+                    },
+                    {
+                      "opacity": 1,
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                <View
+                  pointerEvents="none"
+                  style={
+                    [
+                      {
+                        "justifyContent": "center",
+                      },
+                      {
+                        "maxWidth": 268,
+                        "minWidth": 100,
+                      },
+                      {
+                        "marginLeft": 4,
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1.5}
+                    numberOfLines={1}
+                    selectable={false}
+                    style={
+                      [
+                        {
+                          "textAlign": "left",
+                        },
+                        {
+                          "color": "rgba(29, 27, 32, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        [
+                          {
+                            "fontFamily": "System",
+                            "fontSize": 16,
+                            "fontWeight": "400",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 24,
+                          },
+                          [
+                            {
+                              "color": "rgba(29, 27, 32, 1)",
+                              "fontFamily": "System",
+                              "fontSize": 16,
+                              "fontWeight": "400",
+                              "letterSpacing": 0.5,
+                              "lineHeight": 24,
+                            },
+                            undefined,
+                          ],
+                        ],
+                      ]
+                    }
+                  >
+                    Undo
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": false,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              role="menuitem"
+              style={
+                [
+                  false,
+                  [
+                    {
+                      "height": 48,
+                      "justifyContent": "center",
+                      "maxWidth": 280,
+                      "minWidth": 112,
+                    },
+                    {
+                      "paddingHorizontal": 12,
+                    },
+                    undefined,
+                    undefined,
+                  ],
+                ]
+              }
+            >
+              <View
+                style={
+                  [
+                    {
+                      "flexDirection": "row",
+                    },
+                    {
+                      "opacity": 1,
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                <View
+                  pointerEvents="none"
+                  style={
+                    [
+                      {
+                        "justifyContent": "center",
+                      },
+                      {
+                        "maxWidth": 268,
+                        "minWidth": 100,
+                      },
+                      {
+                        "marginLeft": 4,
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  <Text
+                    maxFontSizeMultiplier={1.5}
+                    numberOfLines={1}
+                    selectable={false}
+                    style={
+                      [
+                        {
+                          "textAlign": "left",
+                        },
+                        {
+                          "color": "rgba(29, 27, 32, 1)",
+                          "writingDirection": "ltr",
+                        },
+                        [
+                          {
+                            "fontFamily": "System",
+                            "fontSize": 16,
+                            "fontWeight": "400",
+                            "letterSpacing": 0.5,
+                            "lineHeight": 24,
+                          },
+                          [
+                            {
+                              "color": "rgba(29, 27, 32, 1)",
+                              "fontFamily": "System",
+                              "fontSize": 16,
+                              "fontWeight": "400",
+                              "letterSpacing": 0.5,
+                              "lineHeight": 24,
+                            },
+                            undefined,
+                          ],
+                        ],
+                      ]
+                    }
+                  >
+                    Redo
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</>
+`;

--- a/src/components/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -1,0 +1,4576 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Modal by default should receive appropriate top and bottom insets 1`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="auto"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when open as non-dismissible modal if closed via Android back button will run the animation but not fade out 1`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="auto"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when open as non-dismissible modal if closed via Android back button will run the animation but not fade out 2`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="auto"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when open as non-dismissible modal if closed via Android back button will run the animation but not fade out 3`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="auto"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when open as non-dismissible modal if closed via touching backdrop will run the animation but not fade out 1`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="auto"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when open as non-dismissible modal if closed via touching backdrop will run the animation but not fade out 2`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="auto"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when open as non-dismissible modal if closed via touching backdrop will run the animation but not fade out 3`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="auto"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when open if backdrop touched should invoke the onDismiss function immediately 1`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="auto"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when open if backdrop touched should invoke the onDismiss function immediately 2`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="auto"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when open if closed via Android back button invokes onDismiss 1`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="auto"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when open if closed via Android back button invokes onDismiss 2`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="auto"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when open if closed via Android back button invokes onDismiss 3`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="auto"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when open runs the closing animation if visible toggled 1`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="auto"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when open runs the closing animation if visible toggled 2`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="none"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when open runs the closing animation if visible toggled 3`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="none"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when visible prop changes again during the open/close animation while closing, back to true (visible) should keep the modal open 1`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="auto"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when visible prop changes again during the open/close animation while closing, back to true (visible) should keep the modal open 2`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="none"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when visible prop changes again during the open/close animation while closing, back to true (visible) should keep the modal open 3`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="auto"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when visible prop changes again during the open/close animation while opening, back to false (hidden) should keep the modal closed 1`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="auto"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 0,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when visible prop changes from false to true (closed to open) should run fade-in animation on opening 1`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="auto"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 0,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when visible prop changes from false to true (closed to open) should run fade-in animation on opening 2`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="auto"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when visible prop changes from true to false (open to closed) should close even if the dialog is not dismissible 1`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="auto"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when visible prop changes from true to false (open to closed) should close even if the dialog is not dismissible 2`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="none"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when visible prop changes from true to false (open to closed) should run fade-out animation on closing 1`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="auto"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Modal when visible prop changes from true to false (open to closed) should run fade-out animation on closing 2`] = `
+<View
+  aria-live="polite"
+  aria-modal={true}
+  collapsable={false}
+  onAccessibilityEscape={[Function]}
+  pointerEvents="none"
+  style={
+    [
+      {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      },
+    ]
+  }
+  testID="modal"
+>
+  <View
+    accessibilityLabel="Close modal"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    importantForAccessibility="no"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="button"
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "rgba(0, 0, 0, 1)",
+          "opacity": 0.32,
+        },
+        {},
+      ]
+    }
+  />
+  <View
+    pointerEvents="box-none"
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "marginBottom": 44,
+          "marginTop": 37,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {},
+          {
+            "justifyContent": "center",
+          },
+          {
+            "opacity": 1,
+          },
+          {},
+          undefined,
+          {},
+          {
+            "backgroundColor": "transparent",
+          },
+          {
+            "borderBottomEndRadius": undefined,
+            "borderBottomLeftRadius": undefined,
+            "borderBottomRightRadius": undefined,
+            "borderBottomStartRadius": undefined,
+            "borderCurve": "continuous",
+            "borderEndEndRadius": undefined,
+            "borderEndStartRadius": undefined,
+            "borderRadius": undefined,
+            "borderStartEndRadius": undefined,
+            "borderStartStartRadius": undefined,
+            "borderTopEndRadius": undefined,
+            "borderTopLeftRadius": undefined,
+            "borderTopRightRadius": undefined,
+            "borderTopStartRadius": undefined,
+          },
+          {
+            "shadowColor": "rgba(0, 0, 0, 1)",
+            "shadowOffset": {
+              "height": 0.55,
+              "width": 0,
+            },
+            "shadowOpacity": 0.19,
+            "shadowRadius": 0.79,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        style={
+          [
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            {
+              "pointerEvents": "none",
+            },
+            {},
+            {},
+            {
+              "backgroundColor": "transparent",
+            },
+            {
+              "borderBottomEndRadius": undefined,
+              "borderBottomLeftRadius": undefined,
+              "borderBottomRightRadius": undefined,
+              "borderBottomStartRadius": undefined,
+              "borderCurve": "continuous",
+              "borderEndEndRadius": undefined,
+              "borderEndStartRadius": undefined,
+              "borderRadius": undefined,
+              "borderStartEndRadius": undefined,
+              "borderStartStartRadius": undefined,
+              "borderTopEndRadius": undefined,
+              "borderTopLeftRadius": undefined,
+              "borderTopRightRadius": undefined,
+              "borderTopStartRadius": undefined,
+            },
+            {
+              "shadowColor": "rgba(0, 0, 0, 1)",
+              "shadowOffset": {
+                "height": 0,
+                "width": 0,
+              },
+              "shadowOpacity": 0.039,
+              "shadowRadius": 0.25,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+</View>
+`;

--- a/src/components/__tests__/__snapshots__/ProgressBar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/ProgressBar.test.tsx.snap
@@ -129,6 +129,52 @@ exports[`renders indeterminate progress bar 1`] = `
 </View>
 `;
 
+exports[`renders progress bar with custom style of filled part 1`] = `
+<View
+  accessible={true}
+  aria-busy={true}
+  aria-valuemax={100}
+  aria-valuemin={0}
+  aria-valuenow={20}
+  onLayout={[Function]}
+  role="progressbar"
+  style={false}
+  testID="progress-bar"
+>
+  <View
+    collapsable={false}
+    style={
+      {
+        "backgroundColor": "rgba(231, 224, 236, 1)",
+        "height": 4,
+        "opacity": 0,
+        "overflow": "hidden",
+      }
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        {
+          "backgroundColor": "rgba(103, 80, 164, 1)",
+          "borderRadius": 4,
+          "flex": 1,
+          "transform": [
+            {
+              "translateX": -50,
+            },
+            {
+              "scaleX": 0.0001,
+            },
+          ],
+          "width": 100,
+        }
+      }
+    />
+  </View>
+</View>
+`;
+
 exports[`renders progress bar with specific progress 1`] = `
 <View
   accessible={true}

--- a/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
@@ -258,7 +258,6 @@ exports[`activity indicator snapshot test 1`] = `
         },
       ]
     }
-    testID="activity-indicator"
   >
     <View
       collapsable={false}

--- a/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Searchbar.test.tsx.snap
@@ -440,6 +440,409 @@ exports[`activity indicator snapshot test 1`] = `
 </View>
 `;
 
+exports[`renders searchbar in "view" mode 1`] = `
+<View
+  collapsable={false}
+  style={
+    [
+      {},
+      {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      undefined,
+      {},
+      {
+        "backgroundColor": "rgba(236, 230, 240, 1)",
+      },
+      {
+        "borderBottomEndRadius": undefined,
+        "borderBottomLeftRadius": undefined,
+        "borderBottomRightRadius": undefined,
+        "borderBottomStartRadius": undefined,
+        "borderCurve": "continuous",
+        "borderEndEndRadius": undefined,
+        "borderEndStartRadius": undefined,
+        "borderRadius": 0,
+        "borderStartEndRadius": undefined,
+        "borderStartStartRadius": undefined,
+        "borderTopEndRadius": undefined,
+        "borderTopLeftRadius": undefined,
+        "borderTopRightRadius": undefined,
+        "borderTopStartRadius": undefined,
+      },
+      {
+        "shadowColor": "rgba(0, 0, 0, 1)",
+        "shadowOffset": {
+          "height": 0,
+          "width": 0,
+        },
+        "shadowOpacity": 0,
+        "shadowRadius": 0,
+      },
+    ]
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "pointerEvents": "none",
+        },
+        {},
+        {},
+        {
+          "backgroundColor": "rgba(236, 230, 240, 1)",
+        },
+        {
+          "borderBottomEndRadius": undefined,
+          "borderBottomLeftRadius": undefined,
+          "borderBottomRightRadius": undefined,
+          "borderBottomStartRadius": undefined,
+          "borderCurve": "continuous",
+          "borderEndEndRadius": undefined,
+          "borderEndStartRadius": undefined,
+          "borderRadius": 0,
+          "borderStartEndRadius": undefined,
+          "borderStartStartRadius": undefined,
+          "borderTopEndRadius": undefined,
+          "borderTopLeftRadius": undefined,
+          "borderTopRightRadius": undefined,
+          "borderTopStartRadius": undefined,
+        },
+        {
+          "shadowColor": "rgba(0, 0, 0, 1)",
+          "shadowOffset": {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0,
+          "shadowRadius": 0,
+        },
+      ]
+    }
+  />
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "margin": 6,
+          "overflow": "hidden",
+        },
+        {
+          "backgroundColor": undefined,
+          "height": 40,
+          "width": 40,
+        },
+        {
+          "borderColor": "rgba(202, 196, 208, 1)",
+          "borderRadius": 20,
+          "borderWidth": 0,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      accessibilityLabel="search"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": true,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      centered={true}
+      collapsable={false}
+      focusable={true}
+      hitSlop={
+        {
+          "bottom": 6,
+          "left": 6,
+          "right": 6,
+          "top": 6,
+        }
+      }
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      role="button"
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          [
+            {
+              "alignItems": "center",
+              "flexGrow": 1,
+              "justifyContent": "center",
+            },
+            undefined,
+          ],
+        ]
+      }
+    >
+      <View
+        style={
+          {
+            "opacity": 1,
+          }
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            [
+              {
+                "color": "rgba(73, 69, 79, 1)",
+                "fontSize": 24,
+              },
+              [
+                {
+                  "lineHeight": 24,
+                  "transform": [
+                    {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                {
+                  "backgroundColor": "transparent",
+                },
+              ],
+            ]
+          }
+        >
+          magnify
+        </Text>
+      </View>
+    </View>
+  </View>
+  <TextInput
+    keyboardAppearance="light"
+    placeholder=""
+    placeholderTextColor="rgba(29, 27, 32, 1)"
+    returnKeyType="search"
+    role="searchbox"
+    selectionColor="rgba(103, 80, 164, 1)"
+    style={
+      [
+        {
+          "alignSelf": "stretch",
+          "flex": 1,
+          "fontSize": 18,
+          "minWidth": 0,
+          "paddingLeft": 8,
+        },
+        {
+          "color": "rgba(73, 69, 79, 1)",
+          "fontFamily": "System",
+          "fontSize": 16,
+          "fontWeight": "400",
+          "letterSpacing": 0.5,
+          "lineHeight": 0,
+          "textAlign": "left",
+        },
+        {
+          "minHeight": 72,
+          "paddingLeft": 0,
+        },
+        undefined,
+      ]
+    }
+    underlineColorAndroid="transparent"
+    value=""
+  />
+  <View
+    pointerEvents="none"
+    style={
+      [
+        {
+          "marginLeft": 16,
+          "position": "absolute",
+          "right": 0,
+        },
+        false,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      style={
+        [
+          {
+            "margin": 6,
+            "overflow": "hidden",
+          },
+          {
+            "backgroundColor": undefined,
+            "height": 40,
+            "width": 40,
+          },
+          {
+            "borderColor": "rgba(202, 196, 208, 1)",
+            "borderRadius": 20,
+            "borderWidth": 0,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        accessibilityLabel="clear"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        centered={true}
+        collapsable={false}
+        focusable={true}
+        hitSlop={
+          {
+            "bottom": 6,
+            "left": 6,
+            "right": 6,
+            "top": 6,
+          }
+        }
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        role="button"
+        style={
+          [
+            {
+              "overflow": "hidden",
+            },
+            [
+              {
+                "alignItems": "center",
+                "flexGrow": 1,
+                "justifyContent": "center",
+              },
+              undefined,
+            ],
+          ]
+        }
+      >
+        <View
+          style={
+            {
+              "opacity": 1,
+            }
+          }
+        >
+          <Text
+            accessibilityElementsHidden={true}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "rgba(255, 255, 255, 0)",
+                  "fontSize": 24,
+                },
+                [
+                  {
+                    "lineHeight": 24,
+                    "transform": [
+                      {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  {
+                    "backgroundColor": "transparent",
+                  },
+                ],
+              ]
+            }
+          >
+            close
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "rgba(202, 196, 208, 1)",
+          "height": 0.5,
+        },
+        undefined,
+        false,
+        {
+          "height": 1,
+        },
+        [
+          {
+            "bottom": 0,
+            "position": "absolute",
+            "width": "100%",
+          },
+          {
+            "backgroundColor": "rgba(121, 116, 126, 1)",
+          },
+        ],
+      ]
+    }
+  />
+</View>
+`;
+
 exports[`renders with placeholder 1`] = `
 <View
   collapsable={false}

--- a/src/components/__tests__/__snapshots__/SegmentedButton.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/SegmentedButton.test.tsx.snap
@@ -265,3 +265,2173 @@ exports[`renders segmented button 1`] = `
   </View>
 </View>
 `;
+
+exports[`should have \`accessibilityState={ checked: true }\` when selected show selected check icon should be shown 1`] = `
+<View
+  style={
+    [
+      {
+        "flexDirection": "row",
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "rgba(232, 222, 248, 1)",
+          "borderBottomRightRadius": 0,
+          "borderColor": "rgba(121, 116, 126, 1)",
+          "borderEndWidth": 0,
+          "borderRadius": 20,
+          "borderTopRightRadius": 0,
+          "borderWidth": 1,
+        },
+        {
+          "borderStyle": "solid",
+          "flex": 1,
+          "minWidth": 76,
+        },
+        [
+          undefined,
+          {},
+        ],
+      ]
+    }
+  >
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": true,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      role="button"
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          {
+            "borderBottomRightRadius": 0,
+            "borderEndWidth": 0,
+            "borderRadius": 20,
+            "borderTopRightRadius": 0,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
+              "paddingVertical": 9,
+            },
+            {
+              "opacity": 1,
+              "paddingVertical": 9,
+            },
+          ]
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            [
+              {
+                "marginRight": 5,
+              },
+              {
+                "transform": [
+                  {
+                    "scale": 0,
+                  },
+                ],
+              },
+            ]
+          }
+        >
+          <Text
+            accessibilityElementsHidden={true}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "rgba(29, 25, 43, 1)",
+                  "fontSize": 18,
+                },
+                [
+                  {
+                    "lineHeight": 18,
+                    "transform": [
+                      {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  {
+                    "backgroundColor": "transparent",
+                  },
+                ],
+              ]
+            }
+          >
+            check
+          </Text>
+        </View>
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            [
+              {
+                "textAlign": "left",
+              },
+              {
+                "color": "rgba(29, 27, 32, 1)",
+                "writingDirection": "ltr",
+              },
+              [
+                {
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                [
+                  {
+                    "textAlign": "center",
+                  },
+                  {
+                    "color": "rgba(29, 25, 43, 1)",
+                    "fontFamily": "System",
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                    "letterSpacing": 0.1,
+                    "lineHeight": 20,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          Walking
+        </Text>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "rgba(232, 222, 248, 1)",
+          "borderColor": "rgba(121, 116, 126, 1)",
+          "borderEndWidth": 0,
+          "borderRadius": 0,
+          "borderWidth": 1,
+        },
+        {
+          "borderStyle": "solid",
+          "flex": 1,
+          "minWidth": 76,
+        },
+        [
+          undefined,
+          {},
+        ],
+      ]
+    }
+  >
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": true,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      role="button"
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          {
+            "borderEndWidth": 0,
+            "borderRadius": 0,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
+              "paddingVertical": 9,
+            },
+            {
+              "opacity": 1,
+              "paddingVertical": 9,
+            },
+          ]
+        }
+      >
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            [
+              {
+                "textAlign": "left",
+              },
+              {
+                "color": "rgba(29, 27, 32, 1)",
+                "writingDirection": "ltr",
+              },
+              [
+                {
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                [
+                  {
+                    "textAlign": "center",
+                  },
+                  {
+                    "color": "rgba(29, 25, 43, 1)",
+                    "fontFamily": "System",
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                    "letterSpacing": 0.1,
+                    "lineHeight": 20,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          Transit
+        </Text>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "transparent",
+          "borderBottomLeftRadius": 0,
+          "borderColor": "rgba(121, 116, 126, 1)",
+          "borderRadius": 20,
+          "borderTopLeftRadius": 0,
+          "borderWidth": 1,
+        },
+        {
+          "borderStyle": "solid",
+          "flex": 1,
+          "minWidth": 76,
+        },
+        [
+          undefined,
+          {},
+        ],
+      ]
+    }
+  >
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": false,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      role="button"
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          {
+            "borderBottomLeftRadius": 0,
+            "borderRadius": 20,
+            "borderTopLeftRadius": 0,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
+              "paddingVertical": 9,
+            },
+            {
+              "opacity": 1,
+              "paddingVertical": 9,
+            },
+          ]
+        }
+      >
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            [
+              {
+                "textAlign": "left",
+              },
+              {
+                "color": "rgba(29, 27, 32, 1)",
+                "writingDirection": "ltr",
+              },
+              [
+                {
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                [
+                  {
+                    "textAlign": "center",
+                  },
+                  {
+                    "color": "rgba(29, 27, 32, 1)",
+                    "fontFamily": "System",
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                    "letterSpacing": 0.1,
+                    "lineHeight": 20,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          Driving
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`should not render icon when icon prop is not passed 1`] = `
+<View
+  style={
+    [
+      {
+        "flexDirection": "row",
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "rgba(232, 222, 248, 1)",
+          "borderBottomRightRadius": 0,
+          "borderColor": "rgba(121, 116, 126, 1)",
+          "borderEndWidth": 0,
+          "borderRadius": 20,
+          "borderTopRightRadius": 0,
+          "borderWidth": 1,
+        },
+        {
+          "borderStyle": "solid",
+          "flex": 1,
+          "minWidth": 76,
+        },
+        [
+          undefined,
+          {},
+        ],
+      ]
+    }
+  >
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": true,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      role="button"
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          {
+            "borderBottomRightRadius": 0,
+            "borderEndWidth": 0,
+            "borderRadius": 20,
+            "borderTopRightRadius": 0,
+          },
+        ]
+      }
+      testID="walking-button"
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
+              "paddingVertical": 9,
+            },
+            {
+              "opacity": 1,
+              "paddingVertical": 9,
+            },
+          ]
+        }
+      >
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            [
+              {
+                "textAlign": "left",
+              },
+              {
+                "color": "rgba(29, 27, 32, 1)",
+                "writingDirection": "ltr",
+              },
+              [
+                {
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                [
+                  {
+                    "textAlign": "center",
+                  },
+                  {
+                    "color": "rgba(29, 25, 43, 1)",
+                    "fontFamily": "System",
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                    "letterSpacing": 0.1,
+                    "lineHeight": 20,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "transparent",
+          "borderBottomLeftRadius": 0,
+          "borderColor": "rgba(121, 116, 126, 1)",
+          "borderRadius": 20,
+          "borderTopLeftRadius": 0,
+          "borderWidth": 1,
+        },
+        {
+          "borderStyle": "solid",
+          "flex": 1,
+          "minWidth": 76,
+        },
+        [
+          undefined,
+          {},
+        ],
+      ]
+    }
+  >
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": false,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      role="button"
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          {
+            "borderBottomLeftRadius": 0,
+            "borderRadius": 20,
+            "borderTopLeftRadius": 0,
+          },
+        ]
+      }
+      testID="driving-button"
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
+              "paddingVertical": 9,
+            },
+            {
+              "opacity": 1,
+              "paddingVertical": 9,
+            },
+          ]
+        }
+      >
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            [
+              {
+                "textAlign": "left",
+              },
+              {
+                "color": "rgba(29, 27, 32, 1)",
+                "writingDirection": "ltr",
+              },
+              [
+                {
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                [
+                  {
+                    "textAlign": "center",
+                  },
+                  {
+                    "color": "rgba(29, 27, 32, 1)",
+                    "fontFamily": "System",
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                    "letterSpacing": 0.1,
+                    "lineHeight": 20,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`should not render icon when icon prop is passed along with label, button is checked, showSelectedCheck is true 1`] = `
+<View
+  style={
+    [
+      {
+        "flexDirection": "row",
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "rgba(232, 222, 248, 1)",
+          "borderBottomRightRadius": 0,
+          "borderColor": "rgba(121, 116, 126, 1)",
+          "borderEndWidth": 0,
+          "borderRadius": 20,
+          "borderTopRightRadius": 0,
+          "borderWidth": 1,
+        },
+        {
+          "borderStyle": "solid",
+          "flex": 1,
+          "minWidth": 76,
+        },
+        [
+          undefined,
+          {},
+        ],
+      ]
+    }
+  >
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": true,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      role="button"
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          {
+            "borderBottomRightRadius": 0,
+            "borderEndWidth": 0,
+            "borderRadius": 20,
+            "borderTopRightRadius": 0,
+          },
+        ]
+      }
+      testID="walking-button"
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
+              "paddingVertical": 9,
+            },
+            {
+              "opacity": 1,
+              "paddingVertical": 9,
+            },
+          ]
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            [
+              {
+                "marginRight": 5,
+              },
+              {
+                "transform": [
+                  {
+                    "scale": 0,
+                  },
+                ],
+              },
+            ]
+          }
+        >
+          <Text
+            accessibilityElementsHidden={true}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "rgba(29, 25, 43, 1)",
+                  "fontSize": 18,
+                },
+                [
+                  {
+                    "lineHeight": 18,
+                    "transform": [
+                      {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  {
+                    "backgroundColor": "transparent",
+                  },
+                ],
+              ]
+            }
+          >
+            check
+          </Text>
+        </View>
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            [
+              {
+                "textAlign": "left",
+              },
+              {
+                "color": "rgba(29, 27, 32, 1)",
+                "writingDirection": "ltr",
+              },
+              [
+                {
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                [
+                  {
+                    "textAlign": "center",
+                  },
+                  {
+                    "color": "rgba(29, 25, 43, 1)",
+                    "fontFamily": "System",
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                    "letterSpacing": 0.1,
+                    "lineHeight": 20,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          Walking
+        </Text>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "transparent",
+          "borderBottomLeftRadius": 0,
+          "borderColor": "rgba(121, 116, 126, 1)",
+          "borderRadius": 20,
+          "borderTopLeftRadius": 0,
+          "borderWidth": 1,
+        },
+        {
+          "borderStyle": "solid",
+          "flex": 1,
+          "minWidth": 76,
+        },
+        [
+          undefined,
+          {},
+        ],
+      ]
+    }
+  >
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": false,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      role="button"
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          {
+            "borderBottomLeftRadius": 0,
+            "borderRadius": 20,
+            "borderTopLeftRadius": 0,
+          },
+        ]
+      }
+      testID="driving-button"
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
+              "paddingVertical": 9,
+            },
+            {
+              "opacity": 1,
+              "paddingVertical": 9,
+            },
+          ]
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            [
+              {
+                "marginRight": 5,
+              },
+              {
+                "transform": [
+                  {
+                    "scale": 1,
+                  },
+                ],
+              },
+            ]
+          }
+        >
+          <Text
+            accessibilityElementsHidden={true}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "rgba(29, 27, 32, 1)",
+                  "fontSize": 18,
+                },
+                [
+                  {
+                    "lineHeight": 18,
+                    "transform": [
+                      {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  {
+                    "backgroundColor": "transparent",
+                  },
+                ],
+              ]
+            }
+          >
+            car
+          </Text>
+        </View>
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            [
+              {
+                "textAlign": "left",
+              },
+              {
+                "color": "rgba(29, 27, 32, 1)",
+                "writingDirection": "ltr",
+              },
+              [
+                {
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                [
+                  {
+                    "textAlign": "center",
+                  },
+                  {
+                    "color": "rgba(29, 27, 32, 1)",
+                    "fontFamily": "System",
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                    "letterSpacing": 0.1,
+                    "lineHeight": 20,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          Driving
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`should render icon when icon prop is passed 1`] = `
+<View
+  style={
+    [
+      {
+        "flexDirection": "row",
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "rgba(232, 222, 248, 1)",
+          "borderBottomRightRadius": 0,
+          "borderColor": "rgba(121, 116, 126, 1)",
+          "borderEndWidth": 0,
+          "borderRadius": 20,
+          "borderTopRightRadius": 0,
+          "borderWidth": 1,
+        },
+        {
+          "borderStyle": "solid",
+          "flex": 1,
+          "minWidth": 76,
+        },
+        [
+          undefined,
+          {},
+        ],
+      ]
+    }
+  >
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": true,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      role="button"
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          {
+            "borderBottomRightRadius": 0,
+            "borderEndWidth": 0,
+            "borderRadius": 20,
+            "borderTopRightRadius": 0,
+          },
+        ]
+      }
+      testID="walking-button"
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
+              "paddingVertical": 9,
+            },
+            {
+              "opacity": 1,
+              "paddingVertical": 9,
+            },
+          ]
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            [
+              {
+                "marginRight": 0,
+              },
+              {
+                "transform": [
+                  {
+                    "scale": 1,
+                  },
+                ],
+              },
+            ]
+          }
+        >
+          <Text
+            accessibilityElementsHidden={true}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "rgba(29, 25, 43, 1)",
+                  "fontSize": 18,
+                },
+                [
+                  {
+                    "lineHeight": 18,
+                    "transform": [
+                      {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  {
+                    "backgroundColor": "transparent",
+                  },
+                ],
+              ]
+            }
+          >
+            walk
+          </Text>
+        </View>
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            [
+              {
+                "textAlign": "left",
+              },
+              {
+                "color": "rgba(29, 27, 32, 1)",
+                "writingDirection": "ltr",
+              },
+              [
+                {
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                [
+                  {
+                    "textAlign": "center",
+                  },
+                  {
+                    "color": "rgba(29, 25, 43, 1)",
+                    "fontFamily": "System",
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                    "letterSpacing": 0.1,
+                    "lineHeight": 20,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "transparent",
+          "borderBottomLeftRadius": 0,
+          "borderColor": "rgba(121, 116, 126, 1)",
+          "borderRadius": 20,
+          "borderTopLeftRadius": 0,
+          "borderWidth": 1,
+        },
+        {
+          "borderStyle": "solid",
+          "flex": 1,
+          "minWidth": 76,
+        },
+        [
+          undefined,
+          {},
+        ],
+      ]
+    }
+  >
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": false,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      role="button"
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          {
+            "borderBottomLeftRadius": 0,
+            "borderRadius": 20,
+            "borderTopLeftRadius": 0,
+          },
+        ]
+      }
+      testID="driving-button"
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
+              "paddingVertical": 9,
+            },
+            {
+              "opacity": 1,
+              "paddingVertical": 9,
+            },
+          ]
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            [
+              {
+                "marginRight": 0,
+              },
+              {
+                "transform": [
+                  {
+                    "scale": 1,
+                  },
+                ],
+              },
+            ]
+          }
+        >
+          <Text
+            accessibilityElementsHidden={true}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "rgba(29, 27, 32, 1)",
+                  "fontSize": 18,
+                },
+                [
+                  {
+                    "lineHeight": 18,
+                    "transform": [
+                      {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  {
+                    "backgroundColor": "transparent",
+                  },
+                ],
+              ]
+            }
+          >
+            car
+          </Text>
+        </View>
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            [
+              {
+                "textAlign": "left",
+              },
+              {
+                "color": "rgba(29, 27, 32, 1)",
+                "writingDirection": "ltr",
+              },
+              [
+                {
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                [
+                  {
+                    "textAlign": "center",
+                  },
+                  {
+                    "color": "rgba(29, 27, 32, 1)",
+                    "fontFamily": "System",
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                    "letterSpacing": 0.1,
+                    "lineHeight": 20,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`should render icon when icon prop is passed along with label, button is checked, showSelectedCheck is false 1`] = `
+<View
+  style={
+    [
+      {
+        "flexDirection": "row",
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "rgba(232, 222, 248, 1)",
+          "borderBottomRightRadius": 0,
+          "borderColor": "rgba(121, 116, 126, 1)",
+          "borderEndWidth": 0,
+          "borderRadius": 20,
+          "borderTopRightRadius": 0,
+          "borderWidth": 1,
+        },
+        {
+          "borderStyle": "solid",
+          "flex": 1,
+          "minWidth": 76,
+        },
+        [
+          undefined,
+          {},
+        ],
+      ]
+    }
+  >
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": true,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      role="button"
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          {
+            "borderBottomRightRadius": 0,
+            "borderEndWidth": 0,
+            "borderRadius": 20,
+            "borderTopRightRadius": 0,
+          },
+        ]
+      }
+      testID="walking-button"
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
+              "paddingVertical": 9,
+            },
+            {
+              "opacity": 1,
+              "paddingVertical": 9,
+            },
+          ]
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            [
+              {
+                "marginRight": 5,
+              },
+              {
+                "transform": [
+                  {
+                    "scale": 1,
+                  },
+                ],
+              },
+            ]
+          }
+        >
+          <Text
+            accessibilityElementsHidden={true}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "rgba(29, 25, 43, 1)",
+                  "fontSize": 18,
+                },
+                [
+                  {
+                    "lineHeight": 18,
+                    "transform": [
+                      {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  {
+                    "backgroundColor": "transparent",
+                  },
+                ],
+              ]
+            }
+          >
+            walk
+          </Text>
+        </View>
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            [
+              {
+                "textAlign": "left",
+              },
+              {
+                "color": "rgba(29, 27, 32, 1)",
+                "writingDirection": "ltr",
+              },
+              [
+                {
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                [
+                  {
+                    "textAlign": "center",
+                  },
+                  {
+                    "color": "rgba(29, 25, 43, 1)",
+                    "fontFamily": "System",
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                    "letterSpacing": 0.1,
+                    "lineHeight": 20,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          Walking
+        </Text>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "transparent",
+          "borderBottomLeftRadius": 0,
+          "borderColor": "rgba(121, 116, 126, 1)",
+          "borderRadius": 20,
+          "borderTopLeftRadius": 0,
+          "borderWidth": 1,
+        },
+        {
+          "borderStyle": "solid",
+          "flex": 1,
+          "minWidth": 76,
+        },
+        [
+          undefined,
+          {},
+        ],
+      ]
+    }
+  >
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": false,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      role="button"
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          {
+            "borderBottomLeftRadius": 0,
+            "borderRadius": 20,
+            "borderTopLeftRadius": 0,
+          },
+        ]
+      }
+      testID="driving-button"
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
+              "paddingVertical": 9,
+            },
+            {
+              "opacity": 1,
+              "paddingVertical": 9,
+            },
+          ]
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            [
+              {
+                "marginRight": 5,
+              },
+              {
+                "transform": [
+                  {
+                    "scale": 1,
+                  },
+                ],
+              },
+            ]
+          }
+        >
+          <Text
+            accessibilityElementsHidden={true}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "rgba(29, 27, 32, 1)",
+                  "fontSize": 18,
+                },
+                [
+                  {
+                    "lineHeight": 18,
+                    "transform": [
+                      {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  {
+                    "backgroundColor": "transparent",
+                  },
+                ],
+              ]
+            }
+          >
+            car
+          </Text>
+        </View>
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            [
+              {
+                "textAlign": "left",
+              },
+              {
+                "color": "rgba(29, 27, 32, 1)",
+                "writingDirection": "ltr",
+              },
+              [
+                {
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                [
+                  {
+                    "textAlign": "center",
+                  },
+                  {
+                    "color": "rgba(29, 27, 32, 1)",
+                    "fontFamily": "System",
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                    "letterSpacing": 0.1,
+                    "lineHeight": 20,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          Driving
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`should render icon when icon prop is passed along with label, no matter if button is checked 1`] = `
+<View
+  style={
+    [
+      {
+        "flexDirection": "row",
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "rgba(232, 222, 248, 1)",
+          "borderBottomRightRadius": 0,
+          "borderColor": "rgba(121, 116, 126, 1)",
+          "borderEndWidth": 0,
+          "borderRadius": 20,
+          "borderTopRightRadius": 0,
+          "borderWidth": 1,
+        },
+        {
+          "borderStyle": "solid",
+          "flex": 1,
+          "minWidth": 76,
+        },
+        [
+          undefined,
+          {},
+        ],
+      ]
+    }
+  >
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": true,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      role="button"
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          {
+            "borderBottomRightRadius": 0,
+            "borderEndWidth": 0,
+            "borderRadius": 20,
+            "borderTopRightRadius": 0,
+          },
+        ]
+      }
+      testID="walking-button"
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
+              "paddingVertical": 9,
+            },
+            {
+              "opacity": 1,
+              "paddingVertical": 9,
+            },
+          ]
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            [
+              {
+                "marginRight": 5,
+              },
+              {
+                "transform": [
+                  {
+                    "scale": 1,
+                  },
+                ],
+              },
+            ]
+          }
+        >
+          <Text
+            accessibilityElementsHidden={true}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "rgba(29, 25, 43, 1)",
+                  "fontSize": 18,
+                },
+                [
+                  {
+                    "lineHeight": 18,
+                    "transform": [
+                      {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  {
+                    "backgroundColor": "transparent",
+                  },
+                ],
+              ]
+            }
+          >
+            walk
+          </Text>
+        </View>
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            [
+              {
+                "textAlign": "left",
+              },
+              {
+                "color": "rgba(29, 27, 32, 1)",
+                "writingDirection": "ltr",
+              },
+              [
+                {
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                [
+                  {
+                    "textAlign": "center",
+                  },
+                  {
+                    "color": "rgba(29, 25, 43, 1)",
+                    "fontFamily": "System",
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                    "letterSpacing": 0.1,
+                    "lineHeight": 20,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          Walking
+        </Text>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "transparent",
+          "borderBottomLeftRadius": 0,
+          "borderColor": "rgba(121, 116, 126, 1)",
+          "borderRadius": 20,
+          "borderTopLeftRadius": 0,
+          "borderWidth": 1,
+        },
+        {
+          "borderStyle": "solid",
+          "flex": 1,
+          "minWidth": 76,
+        },
+        [
+          undefined,
+          {},
+        ],
+      ]
+    }
+  >
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": false,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      role="button"
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          {
+            "borderBottomLeftRadius": 0,
+            "borderRadius": 20,
+            "borderTopLeftRadius": 0,
+          },
+        ]
+      }
+      testID="driving-button"
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "paddingHorizontal": 16,
+              "paddingVertical": 9,
+            },
+            {
+              "opacity": 1,
+              "paddingVertical": 9,
+            },
+          ]
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            [
+              {
+                "marginRight": 5,
+              },
+              {
+                "transform": [
+                  {
+                    "scale": 1,
+                  },
+                ],
+              },
+            ]
+          }
+        >
+          <Text
+            accessibilityElementsHidden={true}
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "rgba(29, 27, 32, 1)",
+                  "fontSize": 18,
+                },
+                [
+                  {
+                    "lineHeight": 18,
+                    "transform": [
+                      {
+                        "scaleX": 1,
+                      },
+                    ],
+                  },
+                  {
+                    "backgroundColor": "transparent",
+                  },
+                ],
+              ]
+            }
+          >
+            car
+          </Text>
+        </View>
+        <Text
+          numberOfLines={1}
+          selectable={false}
+          style={
+            [
+              {
+                "textAlign": "left",
+              },
+              {
+                "color": "rgba(29, 27, 32, 1)",
+                "writingDirection": "ltr",
+              },
+              [
+                {
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.1,
+                  "lineHeight": 20,
+                },
+                [
+                  {
+                    "textAlign": "center",
+                  },
+                  {
+                    "color": "rgba(29, 27, 32, 1)",
+                    "fontFamily": "System",
+                    "fontSize": 14,
+                    "fontWeight": "500",
+                    "letterSpacing": 0.1,
+                    "lineHeight": 20,
+                  },
+                  undefined,
+                ],
+              ],
+            ]
+          }
+        >
+          Driving
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/src/components/__tests__/__snapshots__/TouchableRipple.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TouchableRipple.test.tsx.snap
@@ -1,0 +1,123 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TouchableRipple on iOS displays the underlay when pressed 1`] = `
+<View
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": true,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    [
+      false,
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "zIndex": 2,
+        },
+        {
+          "backgroundColor": "rgba(29, 27, 32, 0.1)",
+        },
+      ]
+    }
+  />
+  <Text>
+    Press me!
+  </Text>
+</View>
+`;
+
+exports[`TouchableRipple on iOS renders custom underlay color 1`] = `
+<View
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": true,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    [
+      false,
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "zIndex": 2,
+        },
+        {
+          "backgroundColor": "purple",
+        },
+      ]
+    }
+  />
+  <Text>
+    Press me!
+  </Text>
+</View>
+`;


### PR DESCRIPTION
### Motivation

Many components generated "derived" testIDs by appending a hardcoded suffix to the user-supplied `testID` prop (e.g. `${testID}-container`, `${testID}-outline`, `${testID}-icon`, `${testID}-text`) purely so tests could reach into internal, non-public parts of a component's render tree.

This PR removes every derived testID suffix from the library and fixes up every test that depended on one, choosing between four outcomes on a case-by-case basis (see "Decisions by component" below):

1. **Delete the prop, no test change needed** - nothing queried the derived ID.
2. **Rewrite the test against a public query** (role, accessible label, text, or the component's own `ref`) when the underlying behavior genuinely is public.
3. **Convert to a full-render (`toJSON()`) snapshot** when the check is a legitimate regression guard but has no public equivalent (an internal style value, an icon `source`, an animated value) - this still catches regressions without the test reaching into a specific internal node by ID.
4. **Delete the test** when, once the derived testID was gone, there was nothing left to assert that wasn't pure implementation detail.

One derived testID was deliberately **kept** (`BottomNavigation`'s `${testID}-bar`) because there is currently no public way to reach that node at all - see below.

Affected components: `Surface`, `Button`, `IconButton`, `CrossFadeIcon`, `Appbar` (`AppbarHeader`, `AppbarContent`), `ProgressBar`, `Chip`, `ListItem`, `Card`, `FAB` (`Content`, `Shell`, `Menu`, `Extended`), `SegmentedButtonItem`, `CheckboxItem`, `DataTableCell`, `Searchbar`, `Snackbar`, `Banner`, `ToggleButton`, `Menu`/`MenuItem`, `Modal`, `Dialog`, `DrawerCollapsedItem`, `BottomNavigation`/`BottomNavigationBar`.

The `docs/6.x/docs/guides/migration.md` "Test IDs" section is updated to reflect that these internal testIDs are now gone for good (previously it said they'd come back once you passed `testID` explicitly, which was true right after #5088 but is no longer true after this PR), and calls out the `BottomNavigation` exception explicitly.

### Decisions by component

Grouped by what actually happened, since "removed a testID" covers several different situations:

**Straightforward removal (no test depended on genuine public behavior)**
- `Surface`, `Button`, `Chip`, `ListItem` (`-content`), `FAB.Content`, `FAB.Shell`, `FAB.Menu`, `ProgressBar`, `Snackbar`, `Dialog`, `MenuItem`, `BottomNavigationBar` (`-content`, `-content-wrapper`) - the derived testID was dropped from the source and the corresponding assertions were rewritten to query by role/label/text where one existed, or the check was already covered elsewhere.
- `IconButton`: removed `${testID}-icon` on the inner icon. This one wasn't part of the original PR's scope and had **zero references anywhere in the test suite** - genuinely dead code, unrelated to any test.

**Testid moved to a more meaningful node instead of being deleted outright**
- `CrossFadeIcon`: previously had no testID of its own, only `${testID}-previous`/`${testID}-current` on the two crossfading `Animated.View`s. Since the outer wrapping `View` is the element that represents "this icon" from the outside, it now receives the plain `testID` directly, and the internal previous/current suffixes are gone.
- `Menu`: `${testID}-surface` moved to the `Surface` itself (`testID={testID}`), since the `Surface` *is* the menu's real visible content, not an implementation detail. `${testID}-view` (the animated positioning wrapper) was dropped since positioning is verified via snapshot instead (see below).

**Rewritten to assert public behavior**
- `FABExtended.test.tsx` - `'expands to fit the measured label width'` used to read the animated width off `extended-fab-container`. Rewritten to use `FAB.Extended`'s own `ref` prop (forwards through `Shell` to the `Surface`) with `Reanimated.getAnimatedStyle(ref.current)` - no testID or DOM traversal, just a real forwarded ref any consumer could use.
- `Modal.test.tsx` - backdrop assertions rewritten to `getByLabelText('Close modal')`, a real interactive/accessible element. Surface opacity and inset-margin checks have no accessible-query equivalent, so those became `toJSON()` snapshots.
- `Searchbar.test.tsx` - removed a duplicate clear-icon test, added a negative-case test (`getByLabelText('clear', { includeHiddenElements: true })`), dropped an internal-layout (`marginLeft`) assertion, and converted a `borderRadius` check to a snapshot.
- `Card.test.tsx`, `DrawerCollapsedItem.test.tsx`, `DataTable.test.tsx`, `CheckboxItem.test.tsx`, `SegmentedButton.test.tsx` - style/prop/icon-source checks that read an internal testID (in `DrawerCollapsedItem`'s case, via raw `.props` chains already flagged with an eslint-disable) converted to `toJSON()` snapshots or public queries (`getByText`, sibling `testID`) where one existed. Same regression coverage, no internal-node access.
- `Menu.test.tsx` - position assertions rewritten to check the serialized tree plus a snapshot; shadow-style assertions now query `testID` directly since `Menu`'s testID moved onto the `Surface` (see above).

**Kept as a deliberate, narrow exception**
- `BottomNavigation.tsx`: `testID={testID ? \`${testID}-bar\` : undefined}` on the nested `BottomNavigationBar` is still there. Three tests (`onIndexChange`, `onTabPress`, `onTabLongPress`) need to fire a synthetic `layout` event on `BottomNavigationBar`'s root view before its tabs become pressable (they stay `pointerEvents: 'none'` until the first `onLayout` fires, and `userEvent.press` genuinely respects `pointerEvents`, unlike `fireEvent`). `onLayout` doesn't bubble in React Native, and neither `BottomNavigation` nor `BottomNavigationBar` forwards a `ref`, so there's currently no way to reach that node from outside without this testID. This isn't testing styles/props - it's the only way to get the component into an interactive state for a real interaction test. Flagging this explicitly for review: the clean long-term fix is adding real `ref` forwarding to `BottomNavigationBar` (mirroring what `FAB.Extended` already does), which is a real public-API addition and felt out of scope for a testID cleanup PR - happy to do it here instead if reviewers would rather not carry the exception.

### Related issue

None. This is an internal contributor task.

### Test plan

- `yarn jest` - full suite passes (55 suites, 674 passed + 1 skipped / 675 total, 233 snapshots).
- `yarn eslint src` - no violations (including `testing-library/no-node-access` and the repo's `no-restricted-syntax` rule against raw `.props` access).
- `npx tsc --noEmit -p tsconfig.source.json` (equivalent to `yarn typecheck`'s `tsc -b` for source files) - no type errors.
- Snapshot diffs were reviewed to confirm each one only drops a removed `testID` line (or replaces a targeted assertion with an equivalent full-tree one), with no unrelated structural or style changes.
- No UI/visual changes - this is a test-only and internal-prop-only change; component render output is otherwise identical aside from the removed `testID` attributes themselves.
