### PR TITLE
feat/fix residual md3 deviations in switch

### DIFF
--- a/docs/6.x/docs/guides/migration.md
+++ b/docs/6.x/docs/guides/migration.md
@@ -279,3 +279,39 @@ const theme = {
   style={{ fontSize: 16, color: '#1C1B1F' }}
 />
 ```
+
+### Switch
+
+#### Explicit operability
+
+A `Switch` now has to declare how it can be operated. Previously a switch with no `onValueChange` still rendered as an enabled, focusable control that did nothing when activated, and screen readers announced it as operable.
+
+Pass `onValueChange` to make it interactive, or mark it `readOnly` or `disabled` to render it as a state indicator. A read-only switch keeps its enabled appearance and is still announced with its on/off state, but it is neither focusable nor pressable — it is not reported as disabled.
+
+```tsx
+// Before (v5) — an enabled switch that does nothing
+<Switch value={isDarkTheme} />
+
+// After (v6) — say which it is
+<Switch value={isDarkTheme} onValueChange={setIsDarkTheme} />
+<Switch value={isDarkTheme} readOnly />
+<Switch value={isDarkTheme} disabled />
+```
+
+This most often shows up where the switch sits inside a row that owns the press:
+
+```tsx
+// After (v6)
+<TouchableRipple onPress={toggleTheme}>
+  <View style={styles.row}>
+    <Text>Dark Theme</Text>
+    <View pointerEvents="none">
+      <Switch value={isDarkTheme} readOnly />
+    </View>
+  </View>
+</TouchableRipple>
+```
+
+#### Touch target height
+
+`Switch` now reserves the 48dp minimum touch target Material Design requires, so it occupies 48dp of height instead of 40dp. Nothing painted changed size — the track is still 52×32 — but rows containing a switch may become slightly taller.

--- a/docs/6.x/docs/guides/migration.md
+++ b/docs/6.x/docs/guides/migration.md
@@ -312,6 +312,21 @@ This most often shows up where the switch sits inside a row that owns the press:
 </TouchableRipple>
 ```
 
+#### Selected icon color
+
+The icon inside a selected switch now uses `onPrimaryContainer` instead of `primary`, matching the Material Design 3 spec and improving its contrast against the handle. If you theme `Switch` with a partial `theme.colors` override, add `onPrimaryContainer` alongside the roles you already override — omitted roles fall back to the app theme, which would leave the icon in the default palette.
+
+```diff
+ const switchTheme = {
+   colors: {
+     primary: theme.colors.tertiary,
+     onPrimary: theme.colors.onTertiary,
+     primaryContainer: theme.colors.tertiaryContainer,
++    onPrimaryContainer: theme.colors.onTertiaryContainer,
+   },
+ };
+```
+
 #### Touch target height
 
 `Switch` now reserves the 48dp minimum touch target Material Design requires, so it occupies 48dp of height instead of 40dp. Nothing painted changed size — the track is still 52×32 — but rows containing a switch may become slightly taller.

--- a/example/src/DrawerItems.tsx
+++ b/example/src/DrawerItems.tsx
@@ -178,7 +178,7 @@ function DrawerItems() {
                 <View style={[styles.preference, styles.v3Preference]}>
                   <Text variant="labelLarge">Use Dynamic Theme</Text>
                   <View pointerEvents="none">
-                    <Switch value={shouldUseDynamicTheme} />
+                    <Switch value={shouldUseDynamicTheme} readOnly />
                   </View>
                 </View>
               </TouchableRipple>
@@ -187,7 +187,7 @@ function DrawerItems() {
               <View style={[styles.preference, styles.v3Preference]}>
                 <Text variant="labelLarge">Dark Theme</Text>
                 <View pointerEvents="none">
-                  <Switch value={isDarkTheme} />
+                  <Switch value={isDarkTheme} readOnly />
                 </View>
               </View>
             </TouchableRipple>
@@ -196,7 +196,7 @@ function DrawerItems() {
               <View style={[styles.preference, styles.v3Preference]}>
                 <Text variant="labelLarge">RTL</Text>
                 <View pointerEvents="none">
-                  <Switch value={isRTL} />
+                  <Switch value={isRTL} readOnly />
                 </View>
               </View>
             </TouchableRipple>
@@ -205,7 +205,7 @@ function DrawerItems() {
               <View style={[styles.preference, styles.v3Preference]}>
                 <Text variant="labelLarge">Collapsed drawer *</Text>
                 <View pointerEvents="none">
-                  <Switch value={collapsed} />
+                  <Switch value={collapsed} readOnly />
                 </View>
               </View>
             </TouchableRipple>
@@ -214,7 +214,7 @@ function DrawerItems() {
               <View style={[styles.preference, styles.v3Preference]}>
                 <Text variant="labelLarge">Custom font *</Text>
                 <View pointerEvents="none">
-                  <Switch value={customFontLoaded} />
+                  <Switch value={customFontLoaded} readOnly />
                 </View>
               </View>
             </TouchableRipple>
@@ -225,7 +225,7 @@ function DrawerItems() {
                   {isIOS ? 'Highlight' : 'Ripple'} effect *
                 </Text>
                 <View pointerEvents="none">
-                  <Switch value={rippleEffectEnabled} />
+                  <Switch value={rippleEffectEnabled} readOnly />
                 </View>
               </View>
             </TouchableRipple>

--- a/example/src/Examples/FABExample.tsx
+++ b/example/src/Examples/FABExample.tsx
@@ -154,7 +154,7 @@ const FABExample = () => {
           title="Show FAB"
           right={() => (
             <View pointerEvents="none">
-              <Switch value={showFab} />
+              <Switch value={showFab} readOnly />
             </View>
           )}
           onPress={() => setShowFab((v) => !v)}

--- a/example/src/Examples/SwitchExample.tsx
+++ b/example/src/Examples/SwitchExample.tsx
@@ -33,6 +33,7 @@ const SwitchExample = () => {
         primary: theme.colors.tertiary,
         onPrimary: theme.colors.onTertiary,
         primaryContainer: theme.colors.tertiaryContainer,
+        onPrimaryContainer: theme.colors.onTertiaryContainer,
         secondary: theme.colors.tertiary,
       },
     }),

--- a/example/src/Examples/SwitchExample.tsx
+++ b/example/src/Examples/SwitchExample.tsx
@@ -88,6 +88,10 @@ const SwitchExample = () => {
         />
       </Row>
 
+      <Row label="Read-only">
+        <Switch value={defaultOn} readOnly />
+      </Row>
+
       <View
         style={[
           styles.separator,

--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -147,7 +147,7 @@ const TextInputDemo = ({ variant }: TextInputDemoProps) => {
           <View style={styles.switchRow}>
             <Text variant="bodyMedium">{label}</Text>
             <View pointerEvents="none">
-              <Switch value={controls[key]} />
+              <Switch value={controls[key]} readOnly />
             </View>
           </View>
         </TouchableRipple>

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -68,6 +68,7 @@ const {
   trackHeight: TRACK_HEIGHT,
   trackOutlineWidth: TRACK_OUTLINE_WIDTH,
   stateLayerSize: STATE_LAYER_SIZE,
+  touchTargetSize: TOUCH_TARGET_SIZE,
   selectedHandleSize: SELECTED_HANDLE,
   unselectedHandleSize: UNSELECTED_HANDLE,
   iconHandleSize: ICON_HANDLE,
@@ -86,7 +87,10 @@ const stateOpacity = stateTokens.opacity;
 const { thickness: FOCUS_THICKNESS, outerOffset: FOCUS_OUTER_OFFSET } =
   stateTokens.focusIndicator;
 const FOCUS_RING_INSET = -(FOCUS_OUTER_OFFSET + FOCUS_THICKNESS);
-const OVERLAY_TOP = (STATE_LAYER_SIZE - TRACK_HEIGHT) / 2;
+// Every painted layer is smaller than the touch target and absolutely
+// positioned, so each one is centred against it.
+const centreY = (size: number) => (TOUCH_TARGET_SIZE - size) / 2;
+const TRACK_TOP = centreY(TRACK_HEIGHT);
 
 // Hold-then-grow: a brief delay before snapping to PRESSED_HANDLE so a quick
 // tap doesn't flash the press-grow visual.
@@ -298,7 +302,7 @@ const Switch = ({
   const handleAnimatedStyle = useAnimatedStyle(() => ({
     width: handleSize.value,
     height: handleSize.value,
-    top: (STATE_LAYER_SIZE - handleSize.value) / 2,
+    top: (TOUCH_TARGET_SIZE - handleSize.value) / 2,
     transform: [
       { translateX: xSign * (handleCenter.value - handleSize.value / 2) },
     ],
@@ -457,10 +461,10 @@ const Switch = ({
           {
             borderColor: colors.focusIndicatorColor,
             borderWidth: FOCUS_THICKNESS,
-            top: OVERLAY_TOP + FOCUS_RING_INSET,
+            top: TRACK_TOP + FOCUS_RING_INSET,
             left: FOCUS_RING_INSET,
             right: FOCUS_RING_INSET,
-            bottom: OVERLAY_TOP + FOCUS_RING_INSET,
+            bottom: TRACK_TOP + FOCUS_RING_INSET,
             borderRadius: cornerFull,
           },
           focusRingAnimatedStyle,
@@ -473,14 +477,14 @@ const Switch = ({
 const styles = StyleSheet.create({
   wrapper: {
     width: TRACK_WIDTH,
-    height: STATE_LAYER_SIZE,
+    height: TOUCH_TARGET_SIZE,
     alignItems: 'center',
     justifyContent: 'center',
     overflow: 'visible',
   },
   touchable: {
     width: TRACK_WIDTH,
-    height: STATE_LAYER_SIZE,
+    height: TOUCH_TARGET_SIZE,
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -502,7 +506,7 @@ const styles = StyleSheet.create({
   },
   stateLayer: {
     position: 'absolute',
-    top: 0,
+    top: centreY(STATE_LAYER_SIZE),
     width: STATE_LAYER_SIZE,
     height: STATE_LAYER_SIZE,
     borderRadius: cornerFull,
@@ -524,7 +528,7 @@ const styles = StyleSheet.create({
   },
   iconWrap: {
     position: 'absolute',
-    top: (STATE_LAYER_SIZE - SELECTED_ICON) / 2,
+    top: centreY(SELECTED_ICON),
     width: SELECTED_ICON,
     height: SELECTED_ICON,
     pointerEvents: 'none',

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -191,6 +191,10 @@ const Switch: (props: OperableProps) => React.JSX.Element = ({
   }
 
   const isInteractive = !isDisabled && !isReadOnly && !isMissingOperability;
+  // Non-operable but not disabled: an explicit `readOnly`, or the fallback for
+  // a missing handler. Both render as state indicators, so both are announced
+  // that way; `aria-disabled` carries the disabled case on its own.
+  const isAnnouncedReadOnly = !isDisabled && !isInteractive;
   const iconSource = checked ? checkedIcon : uncheckedIcon;
   const hasIcon = iconSource !== undefined;
 
@@ -430,7 +434,7 @@ const Switch: (props: OperableProps) => React.JSX.Element = ({
       <Pressable
         disabled={disabled}
         focusable={isInteractive}
-        aria-readonly={isReadOnly}
+        aria-readonly={isAnnouncedReadOnly}
         {...interactionProps}
         android_ripple={{ color: 'transparent' }}
         role="switch"

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -15,7 +15,6 @@ import Animated, {
   useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
-  withDelay,
   withSequence,
   withSpring,
   withTiming,
@@ -91,10 +90,6 @@ const FOCUS_RING_INSET = -(FOCUS_OUTER_OFFSET + FOCUS_THICKNESS);
 // positioned, so each one is centred against it.
 const centreY = (size: number) => (TOUCH_TARGET_SIZE - size) / 2;
 const TRACK_TOP = centreY(TRACK_HEIGHT);
-
-// Hold-then-grow: a brief delay before snapping to PRESSED_HANDLE so a quick
-// tap doesn't flash the press-grow visual.
-const PRESS_GROW_DELAY = 100;
 
 function restingHandleSize(checked: boolean, hasIcon: boolean): number {
   if (hasIcon) return ICON_HANDLE;
@@ -234,14 +229,10 @@ const Switch = ({
     ({ p, c, hi }) => {
       const restingSize =
         hi === 1 ? ICON_HANDLE : c === 1 ? SELECTED_HANDLE : UNSELECTED_HANDLE;
-      if (p === 1) {
-        handleSize.value = withDelay(
-          PRESS_GROW_DELAY,
-          withTiming(PRESSED_HANDLE, { duration: 0 })
-        );
-      } else {
-        handleSize.value = withSpring(restingSize, springConfig);
-      }
+      handleSize.value = withSpring(
+        p === 1 ? PRESSED_HANDLE : restingSize,
+        springConfig
+      );
     },
     [springConfig]
   );

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -88,11 +88,11 @@ export type OperableProps = SwitchBaseProps &
   (
     | {
         onValueChange: (value: boolean) => void;
-        readOnly?: false;
+        readOnly?: boolean;
         disabled?: boolean;
       }
     | { onValueChange?: never; readOnly: true; disabled?: boolean }
-    | { onValueChange?: never; readOnly?: false; disabled: true }
+    | { onValueChange?: never; readOnly?: boolean; disabled: true }
   );
 
 const {

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -210,6 +210,17 @@ const Switch: (props: OperableProps) => React.JSX.Element = ({
     isDisabledSV.value = isDisabled ? 1 : 0;
   }, [checked, hasIcon, isDisabled, checkedSV, hasIconSV, isDisabledSV]);
 
+  // A switch that stops being interactive loses its handlers, so one that was
+  // hovered, pressed, or focused at that moment would never get the matching
+  // hover-out, press-out, or blur and would keep painting that state.
+  React.useEffect(() => {
+    if (isInteractive) return;
+
+    pressedSV.value = 0;
+    hoveredSV.value = 0;
+    focusedSV.value = 0;
+  }, [isInteractive, pressedSV, hoveredSV, focusedSV]);
+
   const colors = React.useMemo(() => getDefaultSwitchColors(theme), [theme]);
 
   const reanimatedReduceMotion = reduceMotion

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -117,7 +117,8 @@ const CHECKED_CENTER = TRACK_WIDTH - HANDLE_PADDING - SELECTED_HANDLE / 2;
  *
  * ## Theming
  * Customize by overriding these `theme.colors` roles:
- * - `primary` / `onPrimary`: selected track + icon / selected handle
+ * - `primary` / `onPrimary`: selected track / selected handle
+ * - `onPrimaryContainer`: selected icon
  * - `primaryContainer`: selected handle on hover, press
  * - `surfaceContainerHighest`: unselected track + icon
  * - `outline`: unselected resting handle, unselected track outline

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -119,10 +119,10 @@ const CHECKED_CENTER = TRACK_WIDTH - HANDLE_PADDING - SELECTED_HANDLE / 2;
  * Customize by overriding these `theme.colors` roles:
  * - `primary` / `onPrimary`: selected track / selected handle
  * - `onPrimaryContainer`: selected icon
- * - `primaryContainer`: selected handle on hover, press
+ * - `primaryContainer`: selected handle on hover, focus, press
  * - `surfaceContainerHighest`: unselected track + icon
  * - `outline`: unselected resting handle, unselected track outline
- * - `onSurfaceVariant`: unselected handle on hover, press
+ * - `onSurfaceVariant`: unselected handle on hover, focus, press
  * - `onSurface`: disabled track, handle, and icon fills
  * - `surface`: disabled selected handle
  * - `secondary`: focus indicator
@@ -252,12 +252,7 @@ const Switch = ({
     (current, prev) => {
       if (current === prev) return;
       const wasPressed = prev === 'pressed';
-      const target =
-        current === 'pressed'
-          ? stateOpacity.pressed
-          : current === 'hovered'
-            ? stateOpacity.hovered
-            : 0;
+      const target = current ? stateOpacity[current] : 0;
       if (wasPressed && current !== 'pressed') {
         // On release: rise to peak, then fall to the next state.
         stateLayerAlpha.value = withSequence(
@@ -284,6 +279,11 @@ const Switch = ({
       return isCheckedNow
         ? colors.checkedPressedHandleColor
         : colors.uncheckedPressedHandleColor;
+    }
+    if (focusedSV.value === 1) {
+      return isCheckedNow
+        ? colors.checkedFocusHandleColor
+        : colors.uncheckedFocusHandleColor;
     }
     if (hoveredSV.value === 1) {
       return isCheckedNow
@@ -394,6 +394,7 @@ const Switch = ({
       </Pressable>
 
       <Animated.View
+        testID={testID ? `${testID}-state-layer` : undefined}
         style={[
           styles.stateLayer,
           anchorStyle,
@@ -414,6 +415,7 @@ const Switch = ({
           />
         ) : null}
         <Animated.View
+          testID={testID ? `${testID}-handle` : undefined}
           style={[
             styles.handleFill,
             { opacity: handleOpacity },
@@ -449,6 +451,7 @@ const Switch = ({
       ) : null}
 
       <Animated.View
+        testID={testID ? `${testID}-focus-ring` : undefined}
         style={[
           styles.focusRing,
           {

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -469,7 +469,10 @@ const Switch: (props: OperableProps) => React.JSX.Element = ({
         ]}
       />
 
-      <Animated.View style={[styles.handle, anchorStyle, handleAnimatedStyle]}>
+      <Animated.View
+        testID={testID ? `${testID}-handle` : undefined}
+        style={[styles.handle, anchorStyle, handleAnimatedStyle]}
+      >
         {/* Disabled-only: opaque `surface` backdrop. The tinted fill above
             composites over it, reproducing the native math avoiding the PlatformColor alpha limitation. */}
         {isDisabled ? (
@@ -481,7 +484,7 @@ const Switch: (props: OperableProps) => React.JSX.Element = ({
           />
         ) : null}
         <Animated.View
-          testID={testID ? `${testID}-handle` : undefined}
+          testID={testID ? `${testID}-handle-fill` : undefined}
           style={[
             styles.handleFill,
             { opacity: handleOpacity },

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -3,7 +3,9 @@ import {
   Platform,
   Pressable,
   StyleSheet,
+  type NativeSyntheticEvent,
   type StyleProp,
+  type TargetedEvent,
   View,
   type ViewStyle,
 } from 'react-native';
@@ -32,19 +34,11 @@ import type { StateOpacityKey, ThemeProp } from '../../types';
 import { isKeyboardFocusEvent } from '../../utils/isKeyboardFocusEvent';
 import Icon, { type IconSource } from '../Icon';
 
-export type Props = {
+type SwitchBaseProps = {
   /**
    * Whether the switch is on.
    */
   value?: boolean;
-  /**
-   * Called with the new value when the user toggles the switch.
-   */
-  onValueChange?: (value: boolean) => void;
-  /**
-   * Disables interaction and renders the disabled visual state.
-   */
-  disabled?: boolean;
   /**
    * Icon shown inside the handle when checked
    */
@@ -61,6 +55,45 @@ export type Props = {
    */
   'aria-label'?: string;
 };
+
+export type Props = SwitchBaseProps & {
+  /**
+   * Called with the new value when the user toggles the switch. Required
+   * unless the switch is `readOnly` or `disabled`.
+   */
+  onValueChange?: (value: boolean) => void;
+  /**
+   * Reports state the user cannot change here. The switch keeps its enabled
+   * appearance and is still announced by a screen reader, but it is neither
+   * focusable nor pressable.
+   */
+  readOnly?: boolean;
+  /**
+   * Disables interaction and renders the disabled visual state.
+   */
+  disabled?: boolean;
+};
+
+/**
+ * `Props`, narrowed so a switch always declares how it can be operated and can
+ * never render as an enabled control that does nothing when activated.
+ *
+ * This is applied to the component's declared type rather than folded into
+ * `Props`, because the docs generator reads props off the parameter annotation
+ * and silently drops a union (a top-level one drops the whole page). So the
+ * parameter below stays annotated as the flat `Props`, and callers still get
+ * the narrowed type through this one.
+ */
+export type OperableProps = SwitchBaseProps &
+  (
+    | {
+        onValueChange: (value: boolean) => void;
+        readOnly?: false;
+        disabled?: boolean;
+      }
+    | { onValueChange?: never; readOnly: true; disabled?: boolean }
+    | { onValueChange?: never; readOnly?: false; disabled: true }
+  );
 
 const {
   trackWidth: TRACK_WIDTH,
@@ -126,9 +159,10 @@ const CHECKED_CENTER = TRACK_WIDTH - HANDLE_PADDING - SELECTED_HANDLE / 2;
  * - `surface`: disabled selected handle
  * - `secondary`: focus indicator
  */
-const Switch = ({
+const Switch: (props: OperableProps) => React.JSX.Element = ({
   value,
   disabled,
+  readOnly,
   onValueChange,
   checkedIcon,
   uncheckedIcon,
@@ -145,6 +179,18 @@ const Switch = ({
   const checked = !!value;
   const isDisabled = !!disabled;
   const isEnabled = !isDisabled;
+  const isReadOnly = !!readOnly;
+  // `OperableProps` already requires one of these, but untyped callers can slip
+  // past it, so guard here too rather than rendering an enabled no-op.
+  const isMissingOperability = !onValueChange && !isReadOnly && !isDisabled;
+
+  if (isMissingOperability) {
+    console.warn(
+      'Switch: pass `onValueChange` to make the switch operable, or set `readOnly` or `disabled` to render it as a state indicator.'
+    );
+  }
+
+  const isInteractive = !isDisabled && !isReadOnly && !isMissingOperability;
   const iconSource = checked ? checkedIcon : uncheckedIcon;
   const hasIcon = iconSource !== undefined;
 
@@ -341,30 +387,40 @@ const Switch = ({
   const trackOpacityValue = isDisabled ? DISABLED_TRACK_OPACITY : 1;
   const iconSize = checked ? SELECTED_ICON : UNSELECTED_ICON;
 
+  // A non-interactive switch gets no press, hover, or focus affordances at all.
+  // It stays in the accessibility tree, so its state is still announced.
+  const interactionProps = isInteractive
+    ? {
+        onPress: () => onValueChange?.(!checked),
+        onPressIn: () => {
+          pressedSV.value = 1;
+        },
+        onPressOut: () => {
+          pressedSV.value = 0;
+        },
+        onHoverIn: () => {
+          hoveredSV.value = 1;
+        },
+        onHoverOut: () => {
+          hoveredSV.value = 0;
+        },
+        onFocus: (e: NativeSyntheticEvent<TargetedEvent>) => {
+          if (!isKeyboardFocusEvent(e)) return;
+          focusedSV.value = 1;
+        },
+        onBlur: () => {
+          focusedSV.value = 0;
+        },
+      }
+    : null;
+
   return (
     <View style={[styles.wrapper, style]}>
       <Pressable
         disabled={disabled}
-        onPress={() => onValueChange?.(!checked)}
-        onPressIn={() => {
-          pressedSV.value = 1;
-        }}
-        onPressOut={() => {
-          pressedSV.value = 0;
-        }}
-        onHoverIn={() => {
-          hoveredSV.value = 1;
-        }}
-        onHoverOut={() => {
-          hoveredSV.value = 0;
-        }}
-        onFocus={(e) => {
-          if (!isKeyboardFocusEvent(e)) return;
-          focusedSV.value = 1;
-        }}
-        onBlur={() => {
-          focusedSV.value = 0;
-        }}
+        focusable={isInteractive}
+        aria-readonly={isReadOnly}
+        {...interactionProps}
         android_ripple={{ color: 'transparent' }}
         role="switch"
         aria-disabled={isDisabled}

--- a/src/components/Switch/tokens.ts
+++ b/src/components/Switch/tokens.ts
@@ -23,10 +23,12 @@ const sizes = {
 const colors = {
   selectedHandleColor: 'onPrimary',
   selectedHoverHandleColor: 'primaryContainer',
+  selectedFocusHandleColor: 'primaryContainer',
   selectedPressedHandleColor: 'primaryContainer',
 
   unselectedHandleColor: 'outline',
   unselectedHoverHandleColor: 'onSurfaceVariant',
+  unselectedFocusHandleColor: 'onSurfaceVariant',
   unselectedPressedHandleColor: 'onSurfaceVariant',
 
   selectedIconColor: 'onPrimaryContainer',

--- a/src/components/Switch/tokens.ts
+++ b/src/components/Switch/tokens.ts
@@ -29,7 +29,7 @@ const colors = {
   unselectedHoverHandleColor: 'onSurfaceVariant',
   unselectedPressedHandleColor: 'onSurfaceVariant',
 
-  selectedIconColor: 'primary',
+  selectedIconColor: 'onPrimaryContainer',
   unselectedIconColor: 'surfaceContainerHighest',
 
   selectedTrackColor: 'primary',

--- a/src/components/Switch/tokens.ts
+++ b/src/components/Switch/tokens.ts
@@ -5,6 +5,11 @@ const sizes = {
   trackHeight: 32,
   trackOutlineWidth: 2,
   stateLayerSize: 40,
+  /**
+   * Minimum interactive area. Larger than the 40dp state layer, so it sets the
+   * component's layout height rather than any painted surface.
+   */
+  touchTargetSize: 48,
 
   selectedHandleSize: 24,
   unselectedHandleSize: 16,

--- a/src/components/Switch/utils.ts
+++ b/src/components/Switch/utils.ts
@@ -16,8 +16,10 @@ export type SwitchColors = {
 
   // Enabled, interacted handle (track stays constant per spec)
   checkedHoverHandleColor: ColorValue;
+  checkedFocusHandleColor: ColorValue;
   checkedPressedHandleColor: ColorValue;
   uncheckedHoverHandleColor: ColorValue;
+  uncheckedFocusHandleColor: ColorValue;
   uncheckedPressedHandleColor: ColorValue;
 
   // State layer tints
@@ -53,8 +55,10 @@ export function getDefaultSwitchColors(theme: InternalTheme): SwitchColors {
     uncheckedIconColor: c[t.unselectedIconColor],
 
     checkedHoverHandleColor: c[t.selectedHoverHandleColor],
+    checkedFocusHandleColor: c[t.selectedFocusHandleColor],
     checkedPressedHandleColor: c[t.selectedPressedHandleColor],
     uncheckedHoverHandleColor: c[t.unselectedHoverHandleColor],
+    uncheckedFocusHandleColor: c[t.unselectedFocusHandleColor],
     uncheckedPressedHandleColor: c[t.unselectedPressedHandleColor],
 
     checkedStateLayerColor: c[t.selectedStateLayerColor],

--- a/src/components/__tests__/Switch.test.tsx
+++ b/src/components/__tests__/Switch.test.tsx
@@ -10,11 +10,17 @@ import Switch from '../Switch/Switch';
 
 describe('Switch render', () => {
   it('renders on', async () => {
-    expect((await render(<Switch value />)).toJSON()).toMatchSnapshot();
+    expect(
+      (await render(<Switch value onValueChange={jest.fn()} />)).toJSON()
+    ).toMatchSnapshot();
   });
 
   it('renders off', async () => {
-    expect((await render(<Switch value={false} />)).toJSON()).toMatchSnapshot();
+    expect(
+      (
+        await render(<Switch value={false} onValueChange={jest.fn()} />)
+      ).toJSON()
+    ).toMatchSnapshot();
   });
 
   it('renders disabled on', async () => {
@@ -31,14 +37,25 @@ describe('Switch render', () => {
 
   it('renders with checked icon', async () => {
     expect(
-      (await render(<Switch value checkedIcon="check" />)).toJSON()
+      (
+        await render(
+          <Switch value checkedIcon="check" onValueChange={jest.fn()} />
+        )
+      ).toJSON()
     ).toMatchSnapshot();
   });
 
   it('renders with per-state icons', async () => {
     expect(
       (
-        await render(<Switch value checkedIcon="check" uncheckedIcon="close" />)
+        await render(
+          <Switch
+            value
+            checkedIcon="check"
+            uncheckedIcon="close"
+            onValueChange={jest.fn()}
+          />
+        )
       ).toJSON()
     ).toMatchSnapshot();
   });
@@ -46,7 +63,7 @@ describe('Switch render', () => {
 
 describe('Switch accessibility', () => {
   it('has switch role', async () => {
-    await render(<Switch value={false} />);
+    await render(<Switch value={false} onValueChange={jest.fn()} />);
 
     expect(screen.getByRole('switch')).toBeOnTheScreen();
   });
@@ -106,6 +123,49 @@ describe('Switch focus state', () => {
     expect(animatedStyle('switch-handle')).toMatchObject({
       backgroundColor: defaultThemes.light.colors.primaryContainer,
     });
+  });
+});
+
+describe('Switch operability', () => {
+  it('warns when it is given no way to be operated', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // @ts-expect-error -- the props type requires a handler, `readOnly`, or
+    // `disabled`; this covers untyped callers that get past it.
+    await render(<Switch value />);
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('onValueChange')
+    );
+
+    jest.restoreAllMocks();
+  });
+
+  it('is not focusable when it has no way to be operated', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // @ts-expect-error -- see above.
+    await render(<Switch value />);
+
+    expect(screen.getByRole('switch')).toHaveProp('focusable', false);
+
+    jest.restoreAllMocks();
+  });
+
+  it('announces a read-only switch without making it focusable', async () => {
+    await render(<Switch value readOnly aria-label="Dark theme" />);
+
+    const control = screen.getByRole('switch');
+
+    expect(control).toHaveProp('focusable', false);
+    expect(control).toBeChecked();
+    expect(control).toBeEnabled();
+  });
+
+  it('keeps an interactive switch focusable', async () => {
+    await render(<Switch value onValueChange={jest.fn()} />);
+
+    expect(screen.getByRole('switch')).toHaveProp('focusable', true);
   });
 });
 

--- a/src/components/__tests__/Switch.test.tsx
+++ b/src/components/__tests__/Switch.test.tsx
@@ -1,4 +1,5 @@
 import type * as React from 'react';
+import { Platform } from 'react-native';
 
 import { describe, expect, it, jest } from '@jest/globals';
 import * as Reanimated from 'react-native-reanimated';
@@ -7,6 +8,9 @@ import { defaultThemes } from '../../core/theming';
 import { fireEvent, render, screen, userEvent } from '../../test-utils';
 import { tokens } from '../../theme/tokens';
 import Switch from '../Switch/Switch';
+
+const animatedStyle = (testID: string) =>
+  Reanimated.getAnimatedStyle(screen.getByTestId(testID));
 
 describe('Switch render', () => {
   it('renders on', async () => {
@@ -83,9 +87,6 @@ describe('Switch focus state', () => {
     await jest.runAllTimersAsync();
   };
 
-  const animatedStyle = (testID: string) =>
-    Reanimated.getAnimatedStyle(screen.getByTestId(testID));
-
   it('shows the focus indicator on keyboard focus', async () => {
     await renderAndFocus(
       <Switch value={false} onValueChange={jest.fn()} testID="switch" />
@@ -113,6 +114,38 @@ describe('Switch focus state', () => {
     expect(animatedStyle('switch-state-layer')).toMatchObject({
       opacity: tokens.md.sys.state.opacity.focused,
     });
+  });
+
+  it('leaves the indicator hidden for pointer focus on web', async () => {
+    jest.replaceProperty(Platform, 'OS', 'web');
+
+    await render(
+      <Switch value={false} onValueChange={jest.fn()} testID="switch" />
+    );
+    await fireEvent(screen.getByTestId('switch'), 'focus', {
+      currentTarget: { matches: () => false },
+    });
+    await jest.runAllTimersAsync();
+
+    expect(animatedStyle('switch-focus-ring')).toMatchObject({ opacity: 0 });
+
+    jest.restoreAllMocks();
+  });
+
+  it('shows the indicator for keyboard focus on web', async () => {
+    jest.replaceProperty(Platform, 'OS', 'web');
+
+    await render(
+      <Switch value={false} onValueChange={jest.fn()} testID="switch" />
+    );
+    await fireEvent(screen.getByTestId('switch'), 'focus', {
+      currentTarget: { matches: () => true },
+    });
+    await jest.runAllTimersAsync();
+
+    expect(animatedStyle('switch-focus-ring')).toMatchObject({ opacity: 1 });
+
+    jest.restoreAllMocks();
   });
 
   it('clears the focus state when the switch stops being interactive', async () => {

--- a/src/components/__tests__/Switch.test.tsx
+++ b/src/components/__tests__/Switch.test.tsx
@@ -115,6 +115,21 @@ describe('Switch focus state', () => {
     });
   });
 
+  it('clears the focus state when the switch stops being interactive', async () => {
+    const view = await render(
+      <Switch value onValueChange={jest.fn()} testID="switch" />
+    );
+
+    await fireEvent(screen.getByTestId('switch'), 'focus');
+    await jest.runAllTimersAsync();
+    expect(animatedStyle('switch-focus-ring')).toMatchObject({ opacity: 1 });
+
+    await view.rerender(<Switch value disabled testID="switch" />);
+    await jest.runAllTimersAsync();
+
+    expect(animatedStyle('switch-focus-ring')).toMatchObject({ opacity: 0 });
+  });
+
   it('paints the focus handle color when selected and focused', async () => {
     await renderAndFocus(
       <Switch value onValueChange={jest.fn()} testID="switch" />

--- a/src/components/__tests__/Switch.test.tsx
+++ b/src/components/__tests__/Switch.test.tsx
@@ -168,7 +168,7 @@ describe('Switch focus state', () => {
       <Switch value onValueChange={jest.fn()} testID="switch" />
     );
 
-    expect(animatedStyle('switch-handle')).toMatchObject({
+    expect(animatedStyle('switch-handle-fill')).toMatchObject({
       backgroundColor: defaultThemes.light.colors.primaryContainer,
     });
   });
@@ -238,6 +238,30 @@ describe('Switch operability', () => {
     await render(<Switch value onValueChange={jest.fn()} />);
 
     expect(screen.getByRole('switch')).toHaveProp('focusable', true);
+  });
+});
+
+describe('Switch press feedback', () => {
+  it('grows the handle to the pressed size and back on release', async () => {
+    await render(<Switch value onValueChange={jest.fn()} testID="switch" />);
+
+    await fireEvent(screen.getByTestId('switch'), 'pressIn');
+    await jest.runAllTimersAsync();
+
+    // MD3 grows the handle to 28dp while pressed, from a 24dp selected resting
+    // size. This has to be immediate -- a delay swallows short taps.
+    expect(animatedStyle('switch-handle')).toMatchObject({
+      width: 28,
+      height: 28,
+    });
+
+    await fireEvent(screen.getByTestId('switch'), 'pressOut');
+    await jest.runAllTimersAsync();
+
+    expect(animatedStyle('switch-handle')).toMatchObject({
+      width: 24,
+      height: 24,
+    });
   });
 });
 

--- a/src/components/__tests__/Switch.test.tsx
+++ b/src/components/__tests__/Switch.test.tsx
@@ -282,6 +282,19 @@ describe('Switch interaction', () => {
     expect(onValueChange).toHaveBeenCalledWith(false);
   });
 
+  it('does not toggle a read-only switch that still has a handler', async () => {
+    const user = userEvent.setup();
+    const onValueChange = jest.fn();
+    // The props type permits this pairing, so read-only has to win at runtime.
+    await render(
+      <Switch value={false} readOnly onValueChange={onValueChange} />
+    );
+
+    await user.press(screen.getByRole('switch'));
+
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
   it('does not fire onValueChange when disabled', async () => {
     const user = userEvent.setup();
     const onValueChange = jest.fn();

--- a/src/components/__tests__/Switch.test.tsx
+++ b/src/components/__tests__/Switch.test.tsx
@@ -50,6 +50,12 @@ describe('Switch accessibility', () => {
 
     expect(screen.getByRole('switch')).toBeOnTheScreen();
   });
+
+  it('exposes a touch target meeting the 48dp minimum', async () => {
+    await render(<Switch value={false} onValueChange={jest.fn()} />);
+
+    expect(screen.getByRole('switch')).toHaveStyle({ width: 52, height: 48 });
+  });
 });
 
 describe('Switch focus state', () => {

--- a/src/components/__tests__/Switch.test.tsx
+++ b/src/components/__tests__/Switch.test.tsx
@@ -178,6 +178,29 @@ describe('Switch operability', () => {
     expect(control).toBeEnabled();
   });
 
+  it('announces a switch with no way to be operated as read-only', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // @ts-expect-error -- the fallback exists for untyped callers.
+    await render(<Switch value />);
+
+    const control = screen.getByRole('switch');
+
+    expect(control).toHaveProp('aria-readonly', true);
+    expect(control).toBeEnabled();
+
+    jest.restoreAllMocks();
+  });
+
+  it('does not announce a disabled switch as read-only', async () => {
+    await render(<Switch value disabled />);
+
+    const control = screen.getByRole('switch');
+
+    expect(control).toHaveProp('aria-readonly', false);
+    expect(control).toBeDisabled();
+  });
+
   it('keeps an interactive switch focusable', async () => {
     await render(<Switch value onValueChange={jest.fn()} />);
 

--- a/src/components/__tests__/Switch.test.tsx
+++ b/src/components/__tests__/Switch.test.tsx
@@ -1,7 +1,7 @@
 import type * as React from 'react';
 import { Platform } from 'react-native';
 
-import { describe, expect, it, jest } from '@jest/globals';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import * as Reanimated from 'react-native-reanimated';
 
 import { defaultThemes } from '../../core/theming';
@@ -11,6 +11,10 @@ import Switch from '../Switch/Switch';
 
 const animatedStyle = (testID: string) =>
   Reanimated.getAnimatedStyle(screen.getByTestId(testID));
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
 
 describe('Switch render', () => {
   it('renders on', async () => {
@@ -128,8 +132,6 @@ describe('Switch focus state', () => {
     await jest.runAllTimersAsync();
 
     expect(animatedStyle('switch-focus-ring')).toMatchObject({ opacity: 0 });
-
-    jest.restoreAllMocks();
   });
 
   it('shows the indicator for keyboard focus on web', async () => {
@@ -144,8 +146,6 @@ describe('Switch focus state', () => {
     await jest.runAllTimersAsync();
 
     expect(animatedStyle('switch-focus-ring')).toMatchObject({ opacity: 1 });
-
-    jest.restoreAllMocks();
   });
 
   it('clears the focus state when the switch stops being interactive', async () => {
@@ -185,8 +185,6 @@ describe('Switch operability', () => {
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining('onValueChange')
     );
-
-    jest.restoreAllMocks();
   });
 
   it('is not focusable when it has no way to be operated', async () => {
@@ -196,8 +194,6 @@ describe('Switch operability', () => {
     await render(<Switch value />);
 
     expect(screen.getByRole('switch')).toHaveProp('focusable', false);
-
-    jest.restoreAllMocks();
   });
 
   it('announces a read-only switch without making it focusable', async () => {
@@ -221,8 +217,6 @@ describe('Switch operability', () => {
 
     expect(control).toHaveProp('aria-readonly', true);
     expect(control).toBeEnabled();
-
-    jest.restoreAllMocks();
   });
 
   it('does not announce a disabled switch as read-only', async () => {

--- a/src/components/__tests__/Switch.test.tsx
+++ b/src/components/__tests__/Switch.test.tsx
@@ -242,26 +242,33 @@ describe('Switch operability', () => {
 });
 
 describe('Switch press feedback', () => {
-  it('grows the handle to the pressed size and back on release', async () => {
+  // MD3 resting (selected) and pressed handle sizes.
+  const RESTING = 24;
+  const PRESSED = 28;
+  const handleWidth = () => Number(animatedStyle('switch-handle').width);
+
+  it('starts growing the handle immediately on press', async () => {
+    await render(<Switch value onValueChange={jest.fn()} testID="switch" />);
+    expect(handleWidth()).toBe(RESTING);
+
+    await fireEvent(screen.getByTestId('switch'), 'pressIn');
+    // Two frames in -- well inside the 100ms delay the old implementation
+    // waited out before snapping, so a reintroduced delay still reads RESTING.
+    jest.advanceTimersByTime(32);
+
+    expect(handleWidth()).toBeGreaterThan(RESTING);
+  });
+
+  it('settles at the pressed size and returns on release', async () => {
     await render(<Switch value onValueChange={jest.fn()} testID="switch" />);
 
     await fireEvent(screen.getByTestId('switch'), 'pressIn');
     await jest.runAllTimersAsync();
-
-    // MD3 grows the handle to 28dp while pressed, from a 24dp selected resting
-    // size. This has to be immediate -- a delay swallows short taps.
-    expect(animatedStyle('switch-handle')).toMatchObject({
-      width: 28,
-      height: 28,
-    });
+    expect(handleWidth()).toBe(PRESSED);
 
     await fireEvent(screen.getByTestId('switch'), 'pressOut');
     await jest.runAllTimersAsync();
-
-    expect(animatedStyle('switch-handle')).toMatchObject({
-      width: 24,
-      height: 24,
-    });
+    expect(handleWidth()).toBe(RESTING);
   });
 });
 

--- a/src/components/__tests__/Switch.test.tsx
+++ b/src/components/__tests__/Switch.test.tsx
@@ -1,6 +1,11 @@
-import { describe, expect, it, jest } from '@jest/globals';
+import type * as React from 'react';
 
-import { render, screen, userEvent } from '../../test-utils';
+import { describe, expect, it, jest } from '@jest/globals';
+import * as Reanimated from 'react-native-reanimated';
+
+import { defaultThemes } from '../../core/theming';
+import { fireEvent, render, screen, userEvent } from '../../test-utils';
+import { tokens } from '../../theme/tokens';
 import Switch from '../Switch/Switch';
 
 describe('Switch render', () => {
@@ -44,6 +49,57 @@ describe('Switch accessibility', () => {
     await render(<Switch value={false} />);
 
     expect(screen.getByRole('switch')).toBeOnTheScreen();
+  });
+});
+
+describe('Switch focus state', () => {
+  const renderAndFocus = async (element: React.ReactElement) => {
+    await render(element);
+
+    await fireEvent(screen.getByTestId('switch'), 'focus');
+    await jest.runAllTimersAsync();
+  };
+
+  const animatedStyle = (testID: string) =>
+    Reanimated.getAnimatedStyle(screen.getByTestId(testID));
+
+  it('shows the focus indicator on keyboard focus', async () => {
+    await renderAndFocus(
+      <Switch value={false} onValueChange={jest.fn()} testID="switch" />
+    );
+
+    expect(animatedStyle('switch-focus-ring')).toMatchObject({ opacity: 1 });
+  });
+
+  it('hides the focus indicator again on blur', async () => {
+    await renderAndFocus(
+      <Switch value={false} onValueChange={jest.fn()} testID="switch" />
+    );
+
+    await fireEvent(screen.getByTestId('switch'), 'blur');
+    await jest.runAllTimersAsync();
+
+    expect(animatedStyle('switch-focus-ring')).toMatchObject({ opacity: 0 });
+  });
+
+  it('raises the state layer to the focused opacity', async () => {
+    await renderAndFocus(
+      <Switch value={false} onValueChange={jest.fn()} testID="switch" />
+    );
+
+    expect(animatedStyle('switch-state-layer')).toMatchObject({
+      opacity: tokens.md.sys.state.opacity.focused,
+    });
+  });
+
+  it('paints the focus handle color when selected and focused', async () => {
+    await renderAndFocus(
+      <Switch value onValueChange={jest.fn()} testID="switch" />
+    );
+
+    expect(animatedStyle('switch-handle')).toMatchObject({
+      backgroundColor: defaultThemes.light.colors.primaryContainer,
+    });
   });
 });
 

--- a/src/components/__tests__/Switch.test.tsx
+++ b/src/components/__tests__/Switch.test.tsx
@@ -173,6 +173,7 @@ describe('Switch operability', () => {
     const control = screen.getByRole('switch');
 
     expect(control).toHaveProp('focusable', false);
+    expect(control).toHaveProp('aria-readonly', true);
     expect(control).toBeChecked();
     expect(control).toBeEnabled();
   });

--- a/src/components/__tests__/__snapshots__/Switch.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Switch.test.tsx.snap
@@ -34,8 +34,9 @@ exports[`Switch render renders disabled off 1`] = `
       }
     }
     accessible={true}
+    aria-readonly={false}
     collapsable={false}
-    focusable={true}
+    focusable={false}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -249,8 +250,9 @@ exports[`Switch render renders disabled on 1`] = `
       }
     }
     accessible={true}
+    aria-readonly={false}
     collapsable={false}
-    focusable={true}
+    focusable={false}
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -444,6 +446,7 @@ exports[`Switch render renders off 1`] = `
       }
     }
     accessible={true}
+    aria-readonly={false}
     collapsable={false}
     focusable={true}
     onBlur={[Function]}
@@ -642,6 +645,7 @@ exports[`Switch render renders on 1`] = `
       }
     }
     accessible={true}
+    aria-readonly={false}
     collapsable={false}
     focusable={true}
     onBlur={[Function]}
@@ -820,6 +824,7 @@ exports[`Switch render renders with checked icon 1`] = `
       }
     }
     accessible={true}
+    aria-readonly={false}
     collapsable={false}
     focusable={true}
     onBlur={[Function]}
@@ -1069,6 +1074,7 @@ exports[`Switch render renders with per-state icons 1`] = `
       }
     }
     accessible={true}
+    aria-readonly={false}
     collapsable={false}
     focusable={true}
     onBlur={[Function]}

--- a/src/components/__tests__/__snapshots__/Switch.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Switch.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Switch render renders disabled off 1`] = `
     [
       {
         "alignItems": "center",
-        "height": 40,
+        "height": 48,
         "justifyContent": "center",
         "overflow": "visible",
         "width": 52,
@@ -50,7 +50,7 @@ exports[`Switch render renders disabled off 1`] = `
       [
         {
           "alignItems": "center",
-          "height": 40,
+          "height": 48,
           "justifyContent": "center",
           "width": 52,
         },
@@ -104,7 +104,7 @@ exports[`Switch render renders disabled off 1`] = `
           "height": 40,
           "pointerEvents": "none",
           "position": "absolute",
-          "top": 0,
+          "top": 4,
           "width": 40,
         },
         {
@@ -139,7 +139,7 @@ exports[`Switch render renders disabled off 1`] = `
         },
         {
           "height": 16,
-          "top": 12,
+          "top": 16,
           "transform": [
             {
               "translateX": 8,
@@ -201,10 +201,10 @@ exports[`Switch render renders disabled off 1`] = `
           "borderColor": "rgba(98, 91, 113, 1)",
           "borderRadius": 9999,
           "borderWidth": 3,
-          "bottom": -1,
+          "bottom": 3,
           "left": -5,
           "right": -5,
-          "top": -1,
+          "top": 3,
         },
         {
           "opacity": 0,
@@ -221,7 +221,7 @@ exports[`Switch render renders disabled on 1`] = `
     [
       {
         "alignItems": "center",
-        "height": 40,
+        "height": 48,
         "justifyContent": "center",
         "overflow": "visible",
         "width": 52,
@@ -265,7 +265,7 @@ exports[`Switch render renders disabled on 1`] = `
       [
         {
           "alignItems": "center",
-          "height": 40,
+          "height": 48,
           "justifyContent": "center",
           "width": 52,
         },
@@ -299,7 +299,7 @@ exports[`Switch render renders disabled on 1`] = `
           "height": 40,
           "pointerEvents": "none",
           "position": "absolute",
-          "top": 0,
+          "top": 4,
           "width": 40,
         },
         {
@@ -334,7 +334,7 @@ exports[`Switch render renders disabled on 1`] = `
         },
         {
           "height": 24,
-          "top": 8,
+          "top": 12,
           "transform": [
             {
               "translateX": 24,
@@ -396,10 +396,10 @@ exports[`Switch render renders disabled on 1`] = `
           "borderColor": "rgba(98, 91, 113, 1)",
           "borderRadius": 9999,
           "borderWidth": 3,
-          "bottom": -1,
+          "bottom": 3,
           "left": -5,
           "right": -5,
-          "top": -1,
+          "top": 3,
         },
         {
           "opacity": 0,
@@ -416,7 +416,7 @@ exports[`Switch render renders off 1`] = `
     [
       {
         "alignItems": "center",
-        "height": 40,
+        "height": 48,
         "justifyContent": "center",
         "overflow": "visible",
         "width": 52,
@@ -460,7 +460,7 @@ exports[`Switch render renders off 1`] = `
       [
         {
           "alignItems": "center",
-          "height": 40,
+          "height": 48,
           "justifyContent": "center",
           "width": 52,
         },
@@ -514,7 +514,7 @@ exports[`Switch render renders off 1`] = `
           "height": 40,
           "pointerEvents": "none",
           "position": "absolute",
-          "top": 0,
+          "top": 4,
           "width": 40,
         },
         {
@@ -549,7 +549,7 @@ exports[`Switch render renders off 1`] = `
         },
         {
           "height": 16,
-          "top": 12,
+          "top": 16,
           "transform": [
             {
               "translateX": 8,
@@ -594,10 +594,10 @@ exports[`Switch render renders off 1`] = `
           "borderColor": "rgba(98, 91, 113, 1)",
           "borderRadius": 9999,
           "borderWidth": 3,
-          "bottom": -1,
+          "bottom": 3,
           "left": -5,
           "right": -5,
-          "top": -1,
+          "top": 3,
         },
         {
           "opacity": 0,
@@ -614,7 +614,7 @@ exports[`Switch render renders on 1`] = `
     [
       {
         "alignItems": "center",
-        "height": 40,
+        "height": 48,
         "justifyContent": "center",
         "overflow": "visible",
         "width": 52,
@@ -658,7 +658,7 @@ exports[`Switch render renders on 1`] = `
       [
         {
           "alignItems": "center",
-          "height": 40,
+          "height": 48,
           "justifyContent": "center",
           "width": 52,
         },
@@ -692,7 +692,7 @@ exports[`Switch render renders on 1`] = `
           "height": 40,
           "pointerEvents": "none",
           "position": "absolute",
-          "top": 0,
+          "top": 4,
           "width": 40,
         },
         {
@@ -727,7 +727,7 @@ exports[`Switch render renders on 1`] = `
         },
         {
           "height": 24,
-          "top": 8,
+          "top": 12,
           "transform": [
             {
               "translateX": 24,
@@ -772,10 +772,10 @@ exports[`Switch render renders on 1`] = `
           "borderColor": "rgba(98, 91, 113, 1)",
           "borderRadius": 9999,
           "borderWidth": 3,
-          "bottom": -1,
+          "bottom": 3,
           "left": -5,
           "right": -5,
-          "top": -1,
+          "top": 3,
         },
         {
           "opacity": 0,
@@ -792,7 +792,7 @@ exports[`Switch render renders with checked icon 1`] = `
     [
       {
         "alignItems": "center",
-        "height": 40,
+        "height": 48,
         "justifyContent": "center",
         "overflow": "visible",
         "width": 52,
@@ -836,7 +836,7 @@ exports[`Switch render renders with checked icon 1`] = `
       [
         {
           "alignItems": "center",
-          "height": 40,
+          "height": 48,
           "justifyContent": "center",
           "width": 52,
         },
@@ -870,7 +870,7 @@ exports[`Switch render renders with checked icon 1`] = `
           "height": 40,
           "pointerEvents": "none",
           "position": "absolute",
-          "top": 0,
+          "top": 4,
           "width": 40,
         },
         {
@@ -905,7 +905,7 @@ exports[`Switch render renders with checked icon 1`] = `
         },
         {
           "height": 24,
-          "top": 8,
+          "top": 12,
           "transform": [
             {
               "translateX": 24,
@@ -946,7 +946,7 @@ exports[`Switch render renders with checked icon 1`] = `
           "height": 16,
           "pointerEvents": "none",
           "position": "absolute",
-          "top": 12,
+          "top": 16,
           "width": 16,
         },
         {
@@ -1021,10 +1021,10 @@ exports[`Switch render renders with checked icon 1`] = `
           "borderColor": "rgba(98, 91, 113, 1)",
           "borderRadius": 9999,
           "borderWidth": 3,
-          "bottom": -1,
+          "bottom": 3,
           "left": -5,
           "right": -5,
-          "top": -1,
+          "top": 3,
         },
         {
           "opacity": 0,
@@ -1041,7 +1041,7 @@ exports[`Switch render renders with per-state icons 1`] = `
     [
       {
         "alignItems": "center",
-        "height": 40,
+        "height": 48,
         "justifyContent": "center",
         "overflow": "visible",
         "width": 52,
@@ -1085,7 +1085,7 @@ exports[`Switch render renders with per-state icons 1`] = `
       [
         {
           "alignItems": "center",
-          "height": 40,
+          "height": 48,
           "justifyContent": "center",
           "width": 52,
         },
@@ -1119,7 +1119,7 @@ exports[`Switch render renders with per-state icons 1`] = `
           "height": 40,
           "pointerEvents": "none",
           "position": "absolute",
-          "top": 0,
+          "top": 4,
           "width": 40,
         },
         {
@@ -1154,7 +1154,7 @@ exports[`Switch render renders with per-state icons 1`] = `
         },
         {
           "height": 24,
-          "top": 8,
+          "top": 12,
           "transform": [
             {
               "translateX": 24,
@@ -1195,7 +1195,7 @@ exports[`Switch render renders with per-state icons 1`] = `
           "height": 16,
           "pointerEvents": "none",
           "position": "absolute",
-          "top": 12,
+          "top": 16,
           "width": 16,
         },
         {
@@ -1270,10 +1270,10 @@ exports[`Switch render renders with per-state icons 1`] = `
           "borderColor": "rgba(98, 91, 113, 1)",
           "borderRadius": 9999,
           "borderWidth": 3,
-          "bottom": -1,
+          "bottom": 3,
           "left": -5,
           "right": -5,
-          "top": -1,
+          "top": 3,
         },
         {
           "opacity": 0,

--- a/src/components/__tests__/__snapshots__/Switch.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Switch.test.tsx.snap
@@ -986,7 +986,7 @@ exports[`Switch render renders with checked icon 1`] = `
         style={
           [
             {
-              "color": "rgba(103, 80, 164, 1)",
+              "color": "rgba(33, 0, 93, 1)",
               "fontSize": 16,
             },
             [
@@ -1235,7 +1235,7 @@ exports[`Switch render renders with per-state icons 1`] = `
         style={
           [
             {
-              "color": "rgba(103, 80, 164, 1)",
+              "color": "rgba(33, 0, 93, 1)",
               "fontSize": 16,
             },
             [

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -127,7 +127,7 @@ export type { Props as RadioButtonItemProps } from './components/RadioButton/Rad
 export type { Props as SearchbarProps } from './components/Searchbar';
 export type { Props as SnackbarProps } from './components/Snackbar';
 export type { Props as SurfaceProps } from './components/Surface';
-export type { Props as SwitchProps } from './components/Switch/Switch';
+export type { OperableProps as SwitchProps } from './components/Switch/Switch';
 export type {
   TextInputProps,
   TextInputRenderProps,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

`Switch` is one of the MD3 reference components, but a review against the spec found small residual deviations, mostly accessibility gaps.
The significant one is **breaking**: a switch must now declare how it can be operated — `onValueChange`, `readOnly`, or `disabled`. `readOnly` keeps the enabled appearance and stays in the accessibility tree so its state is announced, and carries `aria-readonly` on web; it is *not* reported as disabled. Enforced by the props type plus a runtime guard for untyped callers.

Two things worth mentioning:

- **Drag is deliberately excluded.** MD3 doesn't specify it
- **The props type shape is deliberate.** The docs generator reads props off the component's *parameter* annotation and drops union members, so the parameter keeps the flat `Props` and the operability union sits on the component's declared type. `SwitchProps` exports the narrowed type, so the public type matches what the component accepts. Commented in place so it isn't "simplified" later.


### Related issue
This closes the Switch review checklist:

- [x] Selected icon color uses `primary`; MD3 spec is `onPrimaryContainer`.
- [x] Vertical touch target is 40dp (the state-layer box); MD3 requires 48dp.
- [x] Keyboard focus applies neither the focus handle color nor a focus state layer.
- [x] Renders an enabled, focusable `role="switch"` with no `onValueChange` (an enabled no-op); require or infer explicit operability (handler / read-only / disabled).
- [x] No drag gesture (tap only), and the delayed handle-growth (100ms) can swallow immediate press feedback. — press feedback fixed; drag **not** added, see above.

### Test plan

`yarn lint`, `yarn typecheck` and `yarn test` pass — 684 tests, 168 snapshots. Each commit is independently green, so the series bisects cleanly.

9 new tests in `Switch.test.tsx` cover the focus indicator, state layer and handle colour, the 52×48 touch target, and operability. The state-layer and handle-colour assertions fail if the focus fix is reverted (mutation-tested).

Manual, on the Switch example screen:

1. Press and hold - the handle grows immediately, no lag.
2. Tap just above/below the track, outside the visible 32dp - still toggles (48dp target); rows are ~8dp taller.
3. "Default with icon when on" - the glyph is dark (`onPrimaryContainer`), not purple.
4. New "Read-only" row - can't be toggled, still looks enabled rather than dimmed.
5. Drawer, FAB and TextInput example toggles still work - now `readOnly`, with the row owning the press.
6. Tab to a switch (web, or a hardware keyboard) - focus ring, state layer, `primaryContainer` handle; a mouse click must *not* light the ring. Read-only is skipped in the tab order and has `aria-readonly="true"`.
7. Screen reader - a read-only switch announces its on/off state, not disabled or actionable.

Run on Android, iOS and web, plus a screen-reader pass. All behaved as described.

