### PR TITLE
feat: fix residual md3 deviation - checkbox component

### DIFF
--- a/docs/6.x/docs/guides/migration.md
+++ b/docs/6.x/docs/guides/migration.md
@@ -279,3 +279,9 @@ const theme = {
   style={{ fontSize: 16, color: '#1C1B1F' }}
 />
 ```
+
+### Checkbox
+
+#### Interaction state colors
+
+Hover and focus are now painted as a Material Design 3 state layer, so the tint follows the spec: a flat 40dp layer with `primary` when selected and `onSurface` when not, and `error` throughout an error checkbox. `color` and `uncheckedColor` replace the role they already override on the box, so a custom checkbox no longer picks up a `primary` halo.

--- a/docs/6.x/docs/guides/migration.md
+++ b/docs/6.x/docs/guides/migration.md
@@ -292,4 +292,4 @@ Interaction states are now painted as a Material Design 3 state layer on every p
 
 #### Custom style target
 
-The `style` prop now applies to the checkbox's outer container rather than the pressable inside it, so layout styles such as `margin`, `position` and `transform` move the whole component, focus ring included. `width` and `height` no longer resize the 48dp tap target, and paint styles land on a different shape: a `backgroundColor` used to fill the circular pressable and now fills the square container around it.
+The `style` prop now applies to the checkbox's outer container rather than the pressable inside it, so layout styles such as `margin`, `position` and `transform` move the whole component, focus ring included. `width` and `height` no longer resize the 48dp tap target, and paint styles land on a different shape: a `backgroundColor` used to fill the circular pressable and now fills the square container around it. Resizing the tap target now lives on the new `tapTargetStyle` prop, which reaches the pressable itself.

--- a/docs/6.x/docs/guides/migration.md
+++ b/docs/6.x/docs/guides/migration.md
@@ -289,3 +289,7 @@ Interaction states are now painted as a Material Design 3 state layer on every p
 #### Touch target height
 
 `Checkbox` now reserves the 48dp minimum touch target, so it occupies 48dp instead of 40dp. Nothing painted changed size, but rows containing a checkbox may become slightly taller.
+
+#### Custom style target
+
+The `style` prop now applies to the checkbox's outer container rather than the pressable inside it, so layout styles such as `margin`, `position` and `transform` move the whole component, focus ring included. `width` and `height` no longer resize the 48dp tap target, and paint styles land on a different shape: a `backgroundColor` used to fill the circular pressable and now fills the square container around it.

--- a/docs/6.x/docs/guides/migration.md
+++ b/docs/6.x/docs/guides/migration.md
@@ -285,3 +285,7 @@ const theme = {
 #### Interaction state colors
 
 Interaction states are now painted as a Material Design 3 state layer on every platform, so the tint follows the spec: hover and focus fill a flat 40dp layer with `primary` when selected and `onSurface` when not, a press ripples inside that same 40dp layer in the inverted color, and an error checkbox stays on `error` throughout. `color` and `uncheckedColor` replace the role they already override on the box, so a custom checkbox no longer picks up a `primary` halo. The platform ripple is turned off to make room for it; passing `rippleColor` on any platform, `background` on Android or `underlayColor` on iOS turns it back on and disables the built-in press instead. Setting `rippleEffectEnabled: false` on the `settings` prop of `PaperProvider` still suppresses both.
+
+#### Touch target height
+
+`Checkbox` now reserves the 48dp minimum touch target, so it occupies 48dp instead of 40dp. Nothing painted changed size, but rows containing a checkbox may become slightly taller.

--- a/docs/6.x/docs/guides/migration.md
+++ b/docs/6.x/docs/guides/migration.md
@@ -284,4 +284,4 @@ const theme = {
 
 #### Interaction state colors
 
-Hover and focus are now painted as a Material Design 3 state layer, so the tint follows the spec: a flat 40dp layer with `primary` when selected and `onSurface` when not, and `error` throughout an error checkbox. `color` and `uncheckedColor` replace the role they already override on the box, so a custom checkbox no longer picks up a `primary` halo.
+Interaction states are now painted as a Material Design 3 state layer on every platform, so the tint follows the spec: hover and focus fill a flat 40dp layer with `primary` when selected and `onSurface` when not, a press ripples inside that same 40dp layer in the inverted color, and an error checkbox stays on `error` throughout. `color` and `uncheckedColor` replace the role they already override on the box, so a custom checkbox no longer picks up a `primary` halo. The platform ripple is turned off to make room for it; passing `rippleColor` on any platform, `background` on Android or `underlayColor` on iOS turns it back on and disables the built-in press instead. Setting `rippleEffectEnabled: false` on the `settings` prop of `PaperProvider` still suppresses both.

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -3,6 +3,7 @@ import { Platform, StyleSheet, View } from 'react-native';
 import type {
   ColorValue,
   GestureResponderEvent,
+  MouseEvent,
   NativeSyntheticEvent,
   StyleProp,
   TargetedEvent,
@@ -12,12 +13,14 @@ import type {
 import Animated, { cubicBezier, type CSSStyle } from 'react-native-reanimated';
 
 import { CheckboxTokens } from './tokens';
-import { getSelectionVisualState } from './utils';
+import { getSelectionVisualState, getStateLayer } from './utils';
+import type { CheckboxInteraction } from './utils';
 import { useLocale } from '../../core/locale';
 import { useInternalTheme } from '../../core/theming';
 import { useReduceMotion } from '../../theme/accessibility/ReduceMotionContext';
 import { tokens } from '../../theme/tokens';
 import type { ThemeProp } from '../../theme/types';
+import hasTouchHandler from '../../utils/hasTouchHandler';
 import { isKeyboardFocusEvent } from '../../utils/isKeyboardFocusEvent';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import type { Props as TouchableRippleProps } from '../TouchableRipple/TouchableRipple';
@@ -39,11 +42,13 @@ export type Props = Omit<
    */
   onPress?: (e: GestureResponderEvent) => void;
   /**
-   * Custom color for unchecked checkbox.
+   * Custom color for unchecked checkbox. Replaces `onSurface` in the state
+   * layer as well as the outline.
    */
   uncheckedColor?: ColorValue;
   /**
-   * Custom color for checkbox.
+   * Custom color for checkbox. Replaces `primary` in the state layer as well
+   * as the container.
    */
   color?: ColorValue;
   /**
@@ -129,20 +134,49 @@ const Checkbox = ({
   // anchor manually for RTL. Native handles it via `I18nManager`.
   const flipMaskForWebRTL = Platform.OS === 'web' && direction === 'rtl';
   const [focused, setFocused] = React.useState(false);
+  const [hovered, setHovered] = React.useState(false);
 
   const selected = status === 'checked' || status === 'indeterminate';
 
-  // Visual state (colors + opacity) for the static layers. `hovered` /
-  // `pressed` aren't tracked here — `TouchableRipple` owns the press ripple
-  // and hover overlay.
-  const visual = getSelectionVisualState({
+  // Shared by the box and the state layer, so a custom color reaches both.
+  const selectionColors = {
     theme,
     selected,
-    disabled,
     error,
     customColor: color,
     customUncheckedColor: uncheckedColor,
-  });
+  };
+
+  const visual = getSelectionVisualState({ ...selectionColors, disabled });
+
+  // `TouchableRipple` disables itself when nothing can handle a press, so
+  // attaching press handlers unconditionally would make a handler-less
+  // checkbox enabled and focusable while doing nothing.
+  const isInteractive =
+    !disabled &&
+    hasTouchHandler({
+      onPress,
+      onLongPress: rest.onLongPress,
+      onPressIn: rest.onPressIn,
+      onPressOut: rest.onPressOut,
+    });
+
+  const interaction: CheckboxInteraction | null = !isInteractive
+    ? null
+    : focused
+      ? 'focused'
+      : hovered
+        ? 'hovered'
+        : null;
+
+  // Fade by opacity alone: under a dynamic theme the role is a `PlatformColor`,
+  // which Reanimated cannot interpolate, so the color stays put while idle
+  // instead of dropping to transparent.
+  const stateLayer = getStateLayer({ ...selectionColors, interaction });
+  const stateLayerColor = getStateLayer({
+    ...selectionColors,
+    interaction: interaction ?? 'hovered',
+  }).color;
 
   const fillTransitionTimingFunction = cubicBezier(
     ...theme.motion.easing.standard
@@ -171,6 +205,14 @@ const Checkbox = ({
   const fillStyle: CSSStyle<ViewStyle> = {
     backgroundColor: visual.containerColor,
     opacity: selected ? 1 : 0,
+    transitionDuration: fillTransitionDuration,
+    transitionProperty: ['opacity'],
+    transitionTimingFunction: fillTransitionTimingFunction,
+  };
+
+  const stateLayerStyle: CSSStyle<ViewStyle> = {
+    backgroundColor: stateLayerColor,
+    opacity: stateLayer.opacity,
     transitionDuration: fillTransitionDuration,
     transitionProperty: ['opacity'],
     transitionTimingFunction: fillTransitionTimingFunction,
@@ -215,6 +257,33 @@ const Checkbox = ({
     setFocused(false);
   }, []);
 
+  const interactionHandlers = isInteractive
+    ? {
+        onHoverIn: (e: MouseEvent) => {
+          setHovered(true);
+          rest.onHoverIn?.(e);
+        },
+        onHoverOut: (e: MouseEvent) => {
+          setHovered(false);
+          rest.onHoverOut?.(e);
+        },
+        onPressIn: (e: GestureResponderEvent) => {
+          rest.onPressIn?.(e);
+        },
+        onPressOut: (e: GestureResponderEvent) => {
+          rest.onPressOut?.(e);
+        },
+      }
+    : null;
+
+  // Losing the handlers means the matching hover-out never arrives, so the
+  // state would otherwise linger.
+  React.useEffect(() => {
+    if (isInteractive) return;
+
+    setHovered(false);
+  }, [isInteractive]);
+
   const checked: boolean | 'mixed' =
     status === 'indeterminate' ? 'mixed' : status === 'checked';
 
@@ -240,6 +309,7 @@ const Checkbox = ({
       onPress={onPress}
       onFocus={handleFocus}
       onBlur={handleBlur}
+      {...interactionHandlers}
       disabled={disabled}
       {...accessibilityProps}
       testID={testID}
@@ -250,6 +320,11 @@ const Checkbox = ({
       ]}
     >
       <View pointerEvents="none" style={styles.tapTargetInner}>
+        <Animated.View
+          pointerEvents="none"
+          testID={testID ? `${testID}-state-layer` : undefined}
+          style={[styles.stateLayer, stateLayerStyle]}
+        />
         {focused && !disabled ? (
           <View
             pointerEvents="none"
@@ -318,6 +393,12 @@ const styles = StyleSheet.create({
     height: STATE_LAYER_SIZE,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  stateLayer: {
+    position: 'absolute',
+    width: STATE_LAYER_SIZE,
+    height: STATE_LAYER_SIZE,
+    borderRadius: STATE_LAYER_SIZE / 2,
   },
   focusRing: {
     position: 'absolute',

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -78,8 +78,8 @@ export type Props = Omit<
    */
   testID?: string;
   /**
-   * Custom style to override the default tap target. Passed through to
-   * the underlying `TouchableRipple`.
+   * Custom style for the checkbox's outer container. The 48dp tap target is
+   * fixed, so `width` and `height` here do not resize it.
    */
   style?: StyleProp<ViewStyle>;
 };
@@ -93,13 +93,13 @@ const {
   touchTargetSize: TOUCH_TARGET_SIZE,
 } = CheckboxTokens;
 
-const FOCUS_THICKNESS = tokens.md.sys.state.focusIndicator.thickness;
-// Focus indicator is a circular ring at the 40dp state-layer boundary.
-// We don't apply `focusIndicator.outerOffset` here because the surrounding
-// `TouchableRipple borderless` clips overflow to the tap-target shape,
-// so a ring drawn outside the 40dp circle would be cropped.
-const FOCUS_RING_SIZE = STATE_LAYER_SIZE;
-const FOCUS_RING_RADIUS = STATE_LAYER_SIZE / 2;
+const { thickness: FOCUS_THICKNESS, outerOffset: FOCUS_OUTER_OFFSET } =
+  tokens.md.sys.state.focusIndicator;
+// The border is drawn inside the ring's own box, so the box spans the state
+// layer plus the offset and the border on each side.
+const FOCUS_RING_SIZE =
+  STATE_LAYER_SIZE + 2 * (FOCUS_OUTER_OFFSET + FOCUS_THICKNESS);
+const FOCUS_RING_RADIUS = FOCUS_RING_SIZE / 2;
 
 // Compose's `RippleAnimation` starts the ripple at 30% of the target layer's
 // size, i.e. 0.6 of the radius.
@@ -428,92 +428,101 @@ const Checkbox = ({
           'aria-live': 'polite' as const,
         };
 
+  const focusRing =
+    focused && !disabled ? (
+      <View
+        pointerEvents="none"
+        testID={testID ? `${testID}-focus-ring` : undefined}
+        style={[styles.focusRing, { borderColor: theme.colors.secondary }]}
+      />
+    ) : null;
+
   return (
-    <TouchableRipple
-      {...rest}
-      centered
-      onPress={onPress}
-      onFocus={handleFocus}
-      onBlur={handleBlur}
-      {...interactionHandlers}
-      // Keeps the platform press circular for a caller that hands it back
-      // with `rippleColor` or `underlayColor`.
-      borderless
-      {...platformPressOverride}
-      disabled={disabled}
-      {...accessibilityProps}
-      testID={testID}
-      style={[
-        styles.tapTarget,
-        Platform.OS === 'web' ? webNoOutline : undefined,
-        style,
-      ]}
-    >
-      <View pointerEvents="none" style={styles.tapTargetInner}>
-        <Animated.View
-          pointerEvents="none"
-          testID={testID ? `${testID}-state-layer` : undefined}
-          style={[styles.stateLayer, stateLayerStyle]}
-        />
-        {ownsPress ? (
+    // The ring is a sibling of the pressable, not a child: a foreground ripple
+    // forces `overflow: hidden` on it regardless of `borderless`.
+    <View style={[styles.root, style]}>
+      <TouchableRipple
+        {...rest}
+        centered
+        onPress={onPress}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        {...interactionHandlers}
+        // Keeps the platform press circular for a caller that hands it back
+        // with `rippleColor` or `underlayColor`.
+        borderless
+        {...platformPressOverride}
+        disabled={disabled}
+        {...accessibilityProps}
+        testID={testID}
+        style={[
+          styles.tapTarget,
+          Platform.OS === 'web' ? webNoOutline : undefined,
+        ]}
+      >
+        <View pointerEvents="none" style={styles.tapTargetInner}>
           <Animated.View
             pointerEvents="none"
-            testID={testID ? `${testID}-ripple` : undefined}
-            style={[
-              styles.stateLayer,
-              { backgroundColor: pressColor },
-              rippleStyle,
-            ]}
+            testID={testID ? `${testID}-state-layer` : undefined}
+            style={[styles.stateLayer, stateLayerStyle]}
           />
-        ) : null}
-        {focused && !disabled ? (
+          {ownsPress ? (
+            <Animated.View
+              pointerEvents="none"
+              testID={testID ? `${testID}-ripple` : undefined}
+              style={[
+                styles.stateLayer,
+                { backgroundColor: pressColor },
+                rippleStyle,
+              ]}
+            />
+          ) : null}
           <View
-            pointerEvents="none"
-            style={[styles.focusRing, { borderColor: theme.colors.secondary }]}
-          />
-        ) : null}
-        <View style={[styles.container, { opacity: visual.containerOpacity }]}>
-          <Animated.View
-            pointerEvents="none"
-            style={[styles.outline, outlineStyle]}
-          />
-          <Animated.View
-            pointerEvents="none"
-            style={[styles.fill, fillStyle]}
-          />
-          <Animated.View
-            style={[
-              flipMaskForWebRTL
-                ? styles.checkmarkMaskWebRTL
-                : styles.checkmarkMask,
-              maskStyle,
-            ]}
+            style={[styles.container, { opacity: visual.containerOpacity }]}
           >
-            {showIndeterminate ? (
-              <View style={styles.checkmarkContent}>
-                <View
-                  style={[styles.dash, { backgroundColor: visual.iconColor }]}
-                />
-              </View>
-            ) : (
-              <View style={styles.checkmarkContent}>
-                <View
-                  style={[
-                    styles.checkmarkGlyph,
-                    { borderColor: visual.iconColor },
-                    // Native platforms auto-swap border sides in RTL, so
-                    // pre-swap them to preserve the checkmark orientation.
-                    direction === 'rtl' && Platform.OS !== 'web'
-                      ? styles.checkmarkGlyphRTL
-                      : null,
-                  ]}
-                />
-              </View>
-            )}
-          </Animated.View>
+            <Animated.View
+              pointerEvents="none"
+              style={[styles.outline, outlineStyle]}
+            />
+            <Animated.View
+              pointerEvents="none"
+              style={[styles.fill, fillStyle]}
+            />
+            <Animated.View
+              style={[
+                flipMaskForWebRTL
+                  ? styles.checkmarkMaskWebRTL
+                  : styles.checkmarkMask,
+                maskStyle,
+              ]}
+            >
+              {showIndeterminate ? (
+                <View style={styles.checkmarkContent}>
+                  <View
+                    style={[styles.dash, { backgroundColor: visual.iconColor }]}
+                  />
+                </View>
+              ) : (
+                <View style={styles.checkmarkContent}>
+                  <View
+                    style={[
+                      styles.checkmarkGlyph,
+                      { borderColor: visual.iconColor },
+                      // Native platforms auto-swap border sides in RTL, so
+                      // pre-swap them to preserve the checkmark orientation.
+                      direction === 'rtl' && Platform.OS !== 'web'
+                        ? styles.checkmarkGlyphRTL
+                        : null,
+                    ]}
+                  />
+                </View>
+              )}
+            </Animated.View>
+          </View>
         </View>
-      </View>
-    </TouchableRipple>
+      </TouchableRipple>
+      {focusRing}
+    </View>
   );
 };
 
@@ -522,6 +531,10 @@ const Checkbox = ({
 const webNoOutline = { outline: 'none' } as unknown as ViewStyle;
 
 const styles = StyleSheet.create({
+  root: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   tapTarget: {
     width: TOUCH_TARGET_SIZE,
     height: TOUCH_TARGET_SIZE,

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -78,10 +78,17 @@ export type Props = Omit<
    */
   testID?: string;
   /**
-   * Custom style for the checkbox's outer container. The 48dp tap target is
-   * fixed, so `width` and `height` here do not resize it.
+   * Custom style for the checkbox's outer container. `width` and `height` here
+   * do not resize the tap target; `tapTargetStyle` does.
    */
   style?: StyleProp<ViewStyle>;
+  /**
+   * Custom style for the pressable that carries the 48dp tap target. Sizing it
+   * keeps the 24dp corner radius, and shrinking it clips the 40dp state layer.
+   * Margin, padding and transform belong in `style`: here they shift the
+   * pressable out from under the focus ring.
+   */
+  tapTargetStyle?: StyleProp<ViewStyle>;
 };
 
 // Spec dimensions (https://m3.material.io/components/checkbox/specs).
@@ -139,6 +146,7 @@ const Checkbox = ({
   color,
   uncheckedColor,
   style,
+  tapTargetStyle,
   ...rest
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
@@ -458,6 +466,7 @@ const Checkbox = ({
         style={[
           styles.tapTarget,
           Platform.OS === 'web' ? webNoOutline : undefined,
+          tapTargetStyle,
         ]}
       >
         <View pointerEvents="none" style={styles.tapTargetInner}>

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -90,6 +90,7 @@ const {
   containerRadius: CONTAINER_RADIUS,
   outlineWidth: OUTLINE_WIDTH,
   stateLayerSize: STATE_LAYER_SIZE,
+  touchTargetSize: TOUCH_TARGET_SIZE,
 } = CheckboxTokens;
 
 const FOCUS_THICKNESS = tokens.md.sys.state.focusIndicator.thickness;
@@ -208,14 +209,15 @@ const Checkbox = ({
     pressRipple.color
   );
 
-  // The platform press paints the wrong thing: it tints with a neutral role,
-  // and on web its hover overlay doubles up with the layer. Android also
-  // refuses a `PlatformColor`, which is what the dynamic theme resolves the
-  // roles to. A caller can still ask for that platform press back, but only
-  // through a prop this platform honours: `rippleColor` everywhere,
-  // `background` for the Android ripple, `underlayColor` for the iOS
-  // highlight. Counting one the platform drops would cost the MD3 ripple and
-  // hand back the neutral default instead.
+  // The platform press paints the wrong thing: it covers the whole 48dp target
+  // instead of the 40dp state layer, tints with a neutral role, and on web its
+  // hover overlay doubles up with the layer. Android also refuses a
+  // `PlatformColor`, which is what the dynamic theme resolves the roles to.
+  // A caller can still ask for that platform press back, but only through a
+  // prop this platform honours: `rippleColor` everywhere, `background` for the
+  // Android ripple, `underlayColor` for the iOS highlight. Counting one the
+  // platform drops would cost the MD3 ripple and hand back the neutral default
+  // instead.
   const platformOwnsPress =
     rest.rippleColor != null ||
     (Platform.OS === 'android' && rest.background != null) ||
@@ -521,9 +523,9 @@ const webNoOutline = { outline: 'none' } as unknown as ViewStyle;
 
 const styles = StyleSheet.create({
   tapTarget: {
-    width: STATE_LAYER_SIZE,
-    height: STATE_LAYER_SIZE,
-    borderRadius: STATE_LAYER_SIZE / 2,
+    width: TOUCH_TARGET_SIZE,
+    height: TOUCH_TARGET_SIZE,
+    borderRadius: TOUCH_TARGET_SIZE / 2,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -89,6 +89,13 @@ export type Props = Omit<
    * pressable out from under the focus ring.
    */
   tapTargetStyle?: StyleProp<ViewStyle>;
+  /**
+   * Accessibility label for the checkbox, read by a screen reader in place of
+   * a visible label. A standalone `Checkbox` has no label of its own, so it
+   * needs one here. `Checkbox.Item` names the whole row instead and does not
+   * require it.
+   */
+  'aria-label'?: string;
 };
 
 // Spec dimensions (https://m3.material.io/components/checkbox/specs).
@@ -135,6 +142,12 @@ const RIPPLE_START_SCALE = 0.6;
  *
  * export default MyComponent;
  * ```
+ *
+ * ## Accessibility
+ * A standalone `Checkbox` renders no visible label, so give it an `aria-label`
+ * to name it for assistive tech. Use `Checkbox.Item` when you want a labelled
+ * row: it owns the accessible name and keeps the inner checkbox out of the
+ * accessibility tree so the state is announced once.
  */
 const Checkbox = ({
   status,
@@ -418,6 +431,23 @@ const Checkbox = ({
     rippleAlpha.value = 0;
     rippleScale.value = RIPPLE_START_SCALE;
   }, [isInteractive, pressedSV, rippleHoldSV, rippleAlpha, rippleScale]);
+
+  // `Checkbox.Item` names the row and passes `accessible={false}` here.
+  const isInAccessibilityTree = rest.accessible !== false;
+  const hasAccessibleName = Boolean(
+    rest['aria-label'] ??
+    rest.accessibilityLabel ??
+    rest['aria-labelledby'] ??
+    rest.accessibilityLabelledBy
+  );
+
+  React.useEffect(() => {
+    if (!isInAccessibilityTree || hasAccessibleName) return;
+
+    console.warn(
+      'Checkbox: pass `aria-label` to name the checkbox for assistive tech, or use `Checkbox.Item` for a labelled row.'
+    );
+  }, [isInAccessibilityTree, hasAccessibleName]);
 
   const checked: boolean | 'mixed' =
     status === 'indeterminate' ? 'mixed' : status === 'checked';

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -10,12 +10,23 @@ import type {
   ViewStyle,
 } from 'react-native';
 
-import Animated, { cubicBezier, type CSSStyle } from 'react-native-reanimated';
+import Animated, {
+  cubicBezier,
+  Easing,
+  ReduceMotion,
+  useAnimatedReaction,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withTiming,
+  type CSSStyle,
+} from 'react-native-reanimated';
 
 import { CheckboxTokens } from './tokens';
 import { getSelectionVisualState, getStateLayer } from './utils';
 import type { CheckboxInteraction } from './utils';
 import { useLocale } from '../../core/locale';
+import { SettingsContext } from '../../core/settings';
 import { useInternalTheme } from '../../core/theming';
 import { useReduceMotion } from '../../theme/accessibility/ReduceMotionContext';
 import { tokens } from '../../theme/tokens';
@@ -89,6 +100,10 @@ const FOCUS_THICKNESS = tokens.md.sys.state.focusIndicator.thickness;
 const FOCUS_RING_SIZE = STATE_LAYER_SIZE;
 const FOCUS_RING_RADIUS = STATE_LAYER_SIZE / 2;
 
+// Compose's `RippleAnimation` starts the ripple at 30% of the target layer's
+// size, i.e. 0.6 of the radius.
+const RIPPLE_START_SCALE = 0.6;
+
 /**
  * Checkboxes allow the selection of multiple options from a set.
  *
@@ -128,6 +143,7 @@ const Checkbox = ({
   const theme = useInternalTheme(themeOverrides);
 
   const reduceMotion = useReduceMotion();
+  const { rippleEffectEnabled } = React.useContext(SettingsContext);
 
   const { direction } = useLocale();
   // Web (react-native-web) doesn't auto-mirror layout, so flip the mask
@@ -177,6 +193,42 @@ const Checkbox = ({
     ...selectionColors,
     interaction: interaction ?? 'hovered',
   }).color;
+  const pressRipple = getStateLayer({
+    ...selectionColors,
+    interaction: 'pressed',
+  });
+
+  // A controlled checkbox flips `status` from `onPress`, while the ripple is
+  // still held up. The inverted color previews the state being moved to, so
+  // recomputing it there would both flicker and start previewing the way back.
+  // Only the ripple is frozen: the flat layer above reports the current state,
+  // which the flip genuinely changed, so under a web hover it is expected to
+  // briefly converge on the hue the ripple is holding.
+  const [pressColor, setPressColor] = React.useState<ColorValue>(
+    pressRipple.color
+  );
+
+  // The platform press paints the wrong thing: it tints with a neutral role,
+  // and on web its hover overlay doubles up with the layer. Android also
+  // refuses a `PlatformColor`, which is what the dynamic theme resolves the
+  // roles to. A caller can still ask for that platform press back, but only
+  // through a prop this platform honours: `rippleColor` everywhere,
+  // `background` for the Android ripple, `underlayColor` for the iOS
+  // highlight. Counting one the platform drops would cost the MD3 ripple and
+  // hand back the neutral default instead.
+  const platformOwnsPress =
+    rest.rippleColor != null ||
+    (Platform.OS === 'android' && rest.background != null) ||
+    (Platform.OS === 'ios' && rest.underlayColor != null);
+
+  const platformPressOverride = platformOwnsPress
+    ? null
+    : ({ rippleColor: 'transparent' } as const);
+
+  // A disabled ripple effect asks for no press at all, on top of the platform
+  // press being spoken for above -- either way, nothing left for us to paint.
+  const ownsPress =
+    isInteractive && !platformOwnsPress && Boolean(rippleEffectEnabled);
 
   const fillTransitionTimingFunction = cubicBezier(
     ...theme.motion.easing.standard
@@ -226,6 +278,73 @@ const Checkbox = ({
     transitionTimingFunction: checkTransitionTimingFunction,
   };
 
+  const rippleAlpha = useSharedValue(0);
+  const rippleScale = useSharedValue(RIPPLE_START_SCALE);
+  const pressedSV = useSharedValue(0);
+  // Held for the length of the grow so a tap that releases mid-grow still
+  // shows the ripple instead of flashing sub-frame.
+  const rippleHoldSV = useSharedValue(0);
+
+  // Reanimated defaults an unset `reduceMotion` to the OS setting, which
+  // would fight `<PaperProvider reduceMotion="off">`. Mirror the provider's
+  // already-resolved preference explicitly instead, as `Switch` does.
+  const reanimatedReduceMotion = reduceMotion
+    ? ReduceMotion.Always
+    : ReduceMotion.Never;
+
+  // Durations follow Compose's `RippleAnimation` (fade in 75ms, grow 225ms,
+  // fade out 150ms) and material-web's `MINIMUM_PRESS_MS` (225), snapped to
+  // the motion tokens.
+  const rippleGrowDuration = reduceMotion ? 0 : theme.motion.duration.short4;
+  const rippleAlphaInDuration = reduceMotion ? 0 : theme.motion.duration.short2;
+  const rippleFadeOutDuration = reduceMotion ? 0 : theme.motion.duration.short3;
+  const rippleHoldDuration = theme.motion.duration.short4;
+
+  const startPressRipple = () => {
+    if (!ownsPress) return;
+
+    setPressColor(pressRipple.color);
+    pressedSV.value = 1;
+    rippleScale.value = RIPPLE_START_SCALE;
+    rippleScale.value = withTiming(1, {
+      duration: rippleGrowDuration,
+      easing: Easing.bezier(...theme.motion.easing.standard),
+      reduceMotion: reanimatedReduceMotion,
+    });
+    rippleAlpha.value = withTiming(pressRipple.opacity, {
+      duration: rippleAlphaInDuration,
+      reduceMotion: reanimatedReduceMotion,
+    });
+    rippleHoldSV.value = 1;
+    rippleHoldSV.value = withDelay(
+      rippleHoldDuration,
+      withTiming(0, { duration: 0 }),
+      // The hold gates visibility rather than movement, so it outlives both
+      // our own reduced-motion durations and the device setting.
+      ReduceMotion.Never
+    );
+  };
+
+  useAnimatedReaction(
+    () => ({ pressed: pressedSV.value, holding: rippleHoldSV.value }),
+    ({ pressed, holding }) => {
+      // Also runs on registration, with everything already at rest -- there's
+      // nothing to fade then.
+      if (pressed === 1 || holding === 1 || rippleAlpha.value === 0) return;
+
+      rippleAlpha.value = withTiming(0, {
+        duration: rippleFadeOutDuration,
+        reduceMotion: reanimatedReduceMotion,
+      });
+    },
+    [rippleFadeOutDuration, reanimatedReduceMotion]
+  );
+
+  const rippleStyle = useAnimatedStyle(() => ({
+    opacity: rippleAlpha.value,
+    transform: [{ scale: rippleScale.value }],
+  }));
+
   // Remember the last drawn glyph so the reveal-mask can finish collapsing
   // when `selected` flips back to false. Computed via the "derive state
   // during render" pattern (https://react.dev/reference/react/useState#storing-information-from-previous-renders)
@@ -268,21 +387,27 @@ const Checkbox = ({
           rest.onHoverOut?.(e);
         },
         onPressIn: (e: GestureResponderEvent) => {
+          startPressRipple();
           rest.onPressIn?.(e);
         },
         onPressOut: (e: GestureResponderEvent) => {
+          pressedSV.value = 0;
           rest.onPressOut?.(e);
         },
       }
     : null;
 
-  // Losing the handlers means the matching hover-out never arrives, so the
-  // state would otherwise linger.
+  // Losing the handlers means the matching hover-out or press-out never
+  // arrives, so the state would otherwise linger.
   React.useEffect(() => {
     if (isInteractive) return;
 
     setHovered(false);
-  }, [isInteractive]);
+    pressedSV.value = 0;
+    rippleHoldSV.value = 0;
+    rippleAlpha.value = 0;
+    rippleScale.value = RIPPLE_START_SCALE;
+  }, [isInteractive, pressedSV, rippleHoldSV, rippleAlpha, rippleScale]);
 
   const checked: boolean | 'mixed' =
     status === 'indeterminate' ? 'mixed' : status === 'checked';
@@ -304,12 +429,15 @@ const Checkbox = ({
   return (
     <TouchableRipple
       {...rest}
-      borderless
       centered
       onPress={onPress}
       onFocus={handleFocus}
       onBlur={handleBlur}
       {...interactionHandlers}
+      // Keeps the platform press circular for a caller that hands it back
+      // with `rippleColor` or `underlayColor`.
+      borderless
+      {...platformPressOverride}
       disabled={disabled}
       {...accessibilityProps}
       testID={testID}
@@ -325,6 +453,17 @@ const Checkbox = ({
           testID={testID ? `${testID}-state-layer` : undefined}
           style={[styles.stateLayer, stateLayerStyle]}
         />
+        {ownsPress ? (
+          <Animated.View
+            pointerEvents="none"
+            testID={testID ? `${testID}-ripple` : undefined}
+            style={[
+              styles.stateLayer,
+              { backgroundColor: pressColor },
+              rippleStyle,
+            ]}
+          />
+        ) : null}
         {focused && !disabled ? (
           <View
             pointerEvents="none"

--- a/src/components/Checkbox/tokens.ts
+++ b/src/components/Checkbox/tokens.ts
@@ -9,6 +9,8 @@ const sizes = {
   containerRadius: 2,
   outlineWidth: 2,
   stateLayerSize: 40,
+  /** Minimum interactive area; larger than the 40dp state layer. */
+  touchTargetSize: 48,
 } as const;
 
 const colors = {

--- a/src/components/Checkbox/tokens.ts
+++ b/src/components/Checkbox/tokens.ts
@@ -21,8 +21,13 @@ const colors = {
   iconColor: 'onPrimary',
   disabledIconColor: 'surface',
   errorIconColor: 'onError',
-  selectedStateLayerColor: 'primary',
-  unselectedStateLayerColor: 'onSurface',
+  // Hover and focus tint by selection; pressing inverts it.
+  selectedHoverStateLayerColor: 'primary',
+  selectedFocusStateLayerColor: 'primary',
+  selectedPressedStateLayerColor: 'onSurface',
+  unselectedHoverStateLayerColor: 'onSurface',
+  unselectedFocusStateLayerColor: 'onSurface',
+  unselectedPressedStateLayerColor: 'primary',
   errorStateLayerColor: 'error',
 } as const satisfies Record<string, ColorRole>;
 

--- a/src/components/Checkbox/utils.ts
+++ b/src/components/Checkbox/utils.ts
@@ -2,7 +2,7 @@ import type { ColorValue } from 'react-native';
 
 import { CheckboxTokens } from './tokens';
 import { tokens } from '../../theme/tokens';
-import type { InternalTheme } from '../../theme/types';
+import type { InternalTheme, StateOpacityKey } from '../../theme/types';
 
 // MD3 Checkbox spec: https://m3.material.io/components/checkbox/specs
 
@@ -76,8 +76,7 @@ const getIconColor = ({
 
 /**
  * Resolve the static (non-interactive) colors + opacity for the Checkbox
- * renderer. Hover / pressed / focused visuals are owned by `TouchableRipple`
- * and the focus-ring outline, so they don't appear here.
+ * renderer. The interaction states are resolved by `getStateLayer` instead.
  */
 export const getSelectionVisualState = ({
   theme,
@@ -114,4 +113,77 @@ export const getSelectionVisualState = ({
       customUncheckedColor,
     }),
   };
+};
+
+/** Interaction the state layer is painting, or `null` when it is idle. */
+export type CheckboxInteraction = Extract<
+  StateOpacityKey,
+  'hovered' | 'focused' | 'pressed'
+>;
+
+export type CheckboxStateLayer = {
+  color: ColorValue;
+  opacity: number;
+};
+
+type StateLayerState = {
+  theme: InternalTheme;
+  selected: boolean;
+  error?: boolean;
+  customColor?: ColorValue;
+  customUncheckedColor?: ColorValue;
+};
+
+/**
+ * Resolve the MD3 state layer for the current interaction. Hover and focus use
+ * `primary` when selected and `onSurface` when not; pressing swaps them. An
+ * error checkbox stays on `error` throughout, and `color`/`uncheckedColor`
+ * override the role they already override on the box itself.
+ */
+export const getStateLayer = ({
+  theme,
+  selected,
+  error,
+  interaction,
+  customColor,
+  customUncheckedColor,
+}: StateLayerState & {
+  interaction: CheckboxInteraction | null;
+}): CheckboxStateLayer => {
+  if (interaction === null) {
+    return { color: 'transparent', opacity: 0 };
+  }
+
+  const opacity = stateOpacity[interaction];
+
+  // A press previews the state being moved to, so the layer takes the opposite
+  // selection's color -- the same inversion the tokens below encode.
+  const followsSelected = interaction === 'pressed' ? !selected : selected;
+  const custom = followsSelected ? customColor : customUncheckedColor;
+
+  if (custom) {
+    return { color: custom, opacity };
+  }
+
+  if (error) {
+    return {
+      color: theme.colors[CheckboxTokens.errorStateLayerColor],
+      opacity,
+    };
+  }
+
+  const role =
+    interaction === 'pressed'
+      ? selected
+        ? CheckboxTokens.selectedPressedStateLayerColor
+        : CheckboxTokens.unselectedPressedStateLayerColor
+      : interaction === 'focused'
+        ? selected
+          ? CheckboxTokens.selectedFocusStateLayerColor
+          : CheckboxTokens.unselectedFocusStateLayerColor
+        : selected
+          ? CheckboxTokens.selectedHoverStateLayerColor
+          : CheckboxTokens.unselectedHoverStateLayerColor;
+
+  return { color: theme.colors[role], opacity };
 };

--- a/src/components/__tests__/Checkbox/Checkbox.test.tsx
+++ b/src/components/__tests__/Checkbox/Checkbox.test.tsx
@@ -1,7 +1,13 @@
-import { expect, it } from '@jest/globals';
+import { PlatformColor } from 'react-native';
 
-import { render } from '../../../test-utils';
+import { describe, expect, it } from '@jest/globals';
+import { getAnimatedStyle } from 'react-native-reanimated';
+
+import { defaultThemes } from '../../../core/theming';
+import { fireEvent, render, screen } from '../../../test-utils';
+import { tokens } from '../../../theme/tokens';
 import Checkbox from '../../Checkbox';
+import type { Props as CheckboxProps } from '../../Checkbox/Checkbox';
 
 it('renders checked Checkbox with onPress', async () => {
   const tree = (
@@ -57,4 +63,142 @@ it('renders Checkbox with custom testID', async () => {
   ).toJSON();
 
   expect(tree).toMatchSnapshot();
+});
+
+describe('Checkbox state layer', () => {
+  const { colors } = defaultThemes.light;
+  const { hovered, focused } = tokens.md.sys.state.opacity;
+
+  const stateLayer = () => screen.getByTestId('checkbox-state-layer');
+
+  const renderCheckbox = (props: Partial<CheckboxProps> = {}) =>
+    render(
+      <Checkbox
+        status="unchecked"
+        onPress={() => {}}
+        testID="checkbox"
+        {...props}
+      />
+    );
+
+  it('is idle until the checkbox is interacted with', async () => {
+    await renderCheckbox();
+
+    expect(stateLayer()).toHaveStyle({ opacity: 0 });
+  });
+
+  it('tints hover with onSurface when unselected', async () => {
+    await renderCheckbox();
+
+    await fireEvent(screen.getByRole('checkbox'), 'hoverIn');
+
+    expect(stateLayer()).toHaveStyle({
+      backgroundColor: colors.onSurface,
+      opacity: hovered,
+    });
+  });
+
+  it('tints hover with primary when selected', async () => {
+    await renderCheckbox({ status: 'checked' });
+
+    await fireEvent(screen.getByRole('checkbox'), 'hoverIn');
+
+    expect(stateLayer()).toHaveStyle({
+      backgroundColor: colors.primary,
+      opacity: hovered,
+    });
+  });
+
+  it('tints focus the same way as hover', async () => {
+    await renderCheckbox({ status: 'checked' });
+
+    await fireEvent(screen.getByRole('checkbox'), 'focus');
+
+    expect(stateLayer()).toHaveStyle({
+      backgroundColor: colors.primary,
+      opacity: focused,
+    });
+  });
+
+  it('stays on error for every interaction', async () => {
+    await renderCheckbox({ status: 'checked', error: true });
+
+    await fireEvent(screen.getByRole('checkbox'), 'hoverIn');
+    expect(stateLayer()).toHaveStyle({ backgroundColor: colors.error });
+
+    await fireEvent(screen.getByRole('checkbox'), 'focus');
+    expect(stateLayer()).toHaveStyle({ backgroundColor: colors.error });
+  });
+
+  it('tints hover with a custom color instead of the token role', async () => {
+    await renderCheckbox({ status: 'checked', color: 'teal' });
+
+    await fireEvent(screen.getByRole('checkbox'), 'hoverIn');
+
+    expect(stateLayer()).toHaveStyle({
+      backgroundColor: 'teal',
+      opacity: hovered,
+    });
+  });
+
+  it('stays idle on a disabled checkbox', async () => {
+    await renderCheckbox({ disabled: true });
+
+    await fireEvent(screen.getByRole('checkbox'), 'hoverIn');
+
+    expect(stateLayer()).toHaveStyle({ opacity: 0 });
+  });
+
+  it('fades out by opacity and keeps its color', async () => {
+    await renderCheckbox();
+
+    await fireEvent(screen.getByRole('checkbox'), 'hoverIn');
+    await fireEvent(screen.getByRole('checkbox'), 'hoverOut');
+
+    expect(stateLayer()).toHaveStyle({
+      backgroundColor: colors.onSurface,
+      opacity: 0,
+    });
+  });
+
+  it('transitions opacity only', async () => {
+    await renderCheckbox();
+
+    // `toHaveStyle` reads the props Reanimated leaves on the host node, which
+    // drops CSS-transition-only keys -- `getAnimatedStyle` mirrors how
+    // Surface.test.tsx asserts `transitionProperty` for the same reason.
+    expect(getAnimatedStyle(stateLayer())).toMatchObject({
+      transitionProperty: ['opacity'],
+    });
+  });
+
+  it('tints with a PlatformColor role as-is on hover', async () => {
+    const onSurface = PlatformColor('?attr/colorOnSurface');
+    await renderCheckbox({ theme: { colors: { onSurface } } });
+
+    await fireEvent(screen.getByRole('checkbox'), 'hoverIn');
+
+    expect(stateLayer()).toHaveStyle({
+      backgroundColor: onSurface,
+      opacity: hovered,
+    });
+  });
+});
+
+describe('Checkbox without a press handler', () => {
+  it('is reported as disabled rather than an enabled no-op', async () => {
+    await render(<Checkbox status="checked" testID="checkbox" />);
+
+    expect(screen.getByRole('checkbox')).toBeDisabled();
+  });
+
+  it('does not paint a state layer on hover', async () => {
+    await render(<Checkbox status="checked" testID="checkbox" />);
+
+    await fireEvent(screen.getByRole('checkbox'), 'hoverIn');
+
+    expect(screen.getByTestId('checkbox-state-layer')).toHaveStyle({
+      opacity: 0,
+    });
+  });
 });

--- a/src/components/__tests__/Checkbox/Checkbox.test.tsx
+++ b/src/components/__tests__/Checkbox/Checkbox.test.tsx
@@ -1,13 +1,19 @@
-import { PlatformColor } from 'react-native';
+import { Platform, PlatformColor } from 'react-native';
 
-import { describe, expect, it } from '@jest/globals';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import { getAnimatedStyle } from 'react-native-reanimated';
 
+import { Provider as SettingsProvider } from '../../../core/settings';
 import { defaultThemes } from '../../../core/theming';
 import { fireEvent, render, screen } from '../../../test-utils';
+import { ReduceMotionContext } from '../../../theme/accessibility/ReduceMotionContext';
 import { tokens } from '../../../theme/tokens';
 import Checkbox from '../../Checkbox';
 import type { Props as CheckboxProps } from '../../Checkbox/Checkbox';
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
 
 it('renders checked Checkbox with onPress', async () => {
   const tree = (
@@ -182,6 +188,314 @@ describe('Checkbox state layer', () => {
       backgroundColor: onSurface,
       opacity: hovered,
     });
+  });
+});
+
+describe('Checkbox press ripple', () => {
+  const { colors, motion } = defaultThemes.light;
+  const { hovered, pressed } = tokens.md.sys.state.opacity;
+  const GROW = motion.duration.short4;
+  const FADE_OUT = motion.duration.short3;
+  // Mirrors `RIPPLE_START_SCALE` in Checkbox.tsx.
+  const RIPPLE_START_SCALE = 0.6;
+  const platforms = ['ios', 'android', 'web'] as const;
+
+  const ripple = () => getAnimatedStyle(screen.getByTestId('checkbox-ripple'));
+
+  const renderCheckbox = (props: Partial<CheckboxProps> = {}) =>
+    render(
+      <Checkbox
+        status="unchecked"
+        onPress={() => {}}
+        testID="checkbox"
+        {...props}
+      />
+    );
+
+  const pressIn = () => fireEvent(screen.getByRole('checkbox'), 'pressIn');
+  const pressOut = () => fireEvent(screen.getByRole('checkbox'), 'pressOut');
+
+  // The ripple has no `Platform` branch; these two guard against one
+  // creeping back in (the old implementation split on it).
+  it.each(platforms)('grows to fill the state layer on %s', async (os) => {
+    jest.replaceProperty(Platform, 'OS', os);
+    await renderCheckbox();
+
+    await pressIn();
+    jest.advanceTimersByTime(GROW);
+
+    expect(ripple()).toMatchObject({
+      backgroundColor: colors.primary,
+      opacity: pressed,
+      transform: [{ scale: 1 }],
+    });
+  });
+
+  it.each(platforms)('inverts to onSurface when selected on %s', async (os) => {
+    jest.replaceProperty(Platform, 'OS', os);
+    await renderCheckbox({ status: 'checked' });
+
+    await pressIn();
+    jest.advanceTimersByTime(GROW);
+
+    expect(ripple()).toMatchObject({
+      backgroundColor: colors.onSurface,
+      opacity: pressed,
+      transform: [{ scale: 1 }],
+    });
+  });
+
+  it('resets the scale on a second press', async () => {
+    await renderCheckbox();
+
+    await pressIn();
+    await pressOut();
+    await jest.runAllTimersAsync();
+
+    await pressIn();
+    jest.advanceTimersByTime(0);
+    expect(ripple().transform).toEqual([{ scale: RIPPLE_START_SCALE }]);
+
+    jest.advanceTimersByTime(GROW);
+    expect(ripple().transform).toEqual([{ scale: 1 }]);
+  });
+
+  it('stays on error while pressed', async () => {
+    await renderCheckbox({ status: 'checked', error: true });
+
+    await pressIn();
+    jest.advanceTimersByTime(GROW);
+
+    expect(ripple()).toMatchObject({ backgroundColor: colors.error });
+  });
+
+  it('inverts a selected checkbox into its custom unchecked color', async () => {
+    await renderCheckbox({ status: 'checked', uncheckedColor: 'teal' });
+
+    await pressIn();
+    jest.advanceTimersByTime(GROW);
+
+    expect(ripple()).toMatchObject({ backgroundColor: 'teal' });
+  });
+
+  it('inverts an unselected checkbox into its custom color', async () => {
+    await renderCheckbox({ color: 'teal' });
+
+    await pressIn();
+    jest.advanceTimersByTime(GROW);
+
+    expect(ripple()).toMatchObject({ backgroundColor: 'teal' });
+  });
+
+  it('stays up for a minimum press when the finger lifts immediately', async () => {
+    await renderCheckbox();
+
+    await pressIn();
+    await pressOut();
+
+    jest.advanceTimersByTime(100);
+    expect(ripple()).toMatchObject({ opacity: pressed });
+
+    jest.advanceTimersByTime(GROW + FADE_OUT);
+    expect(ripple()).toMatchObject({ opacity: 0 });
+  });
+
+  it('takes the fade-out duration to reach zero', async () => {
+    await renderCheckbox();
+
+    await pressIn();
+    await pressOut();
+    jest.advanceTimersByTime(GROW + FADE_OUT / 2);
+
+    const { opacity } = ripple();
+    expect(opacity).toBeGreaterThan(0);
+    expect(opacity).toBeLessThan(pressed);
+
+    jest.advanceTimersByTime(FADE_OUT / 2);
+    expect(ripple()).toMatchObject({ opacity: 0 });
+  });
+
+  it('is not left behind by a rapid double tap', async () => {
+    await renderCheckbox();
+
+    await pressIn();
+    await pressOut();
+    jest.advanceTimersByTime(30);
+    await pressIn();
+    await pressOut();
+
+    // The first press's hold (armed at t=0) would have expired here if the
+    // second press (t=30) hadn't re-armed it -- the ripple must still be up.
+    jest.advanceTimersByTime(GROW - 30 + 1);
+    expect(ripple()).toMatchObject({ opacity: pressed });
+
+    await jest.runAllTimersAsync();
+    expect(ripple()).toMatchObject({ opacity: 0 });
+  });
+
+  it('keeps the minimum-press hold under reduce motion', async () => {
+    await render(
+      <ReduceMotionContext.Provider value={true}>
+        <Checkbox status="unchecked" onPress={() => {}} testID="checkbox" />
+      </ReduceMotionContext.Provider>
+    );
+
+    await pressIn();
+    jest.advanceTimersByTime(0);
+    expect(ripple()).toMatchObject({
+      opacity: pressed,
+      transform: [{ scale: 1 }],
+    });
+
+    await pressOut();
+    jest.advanceTimersByTime(GROW - 1);
+    expect(ripple()).toMatchObject({ opacity: pressed });
+
+    // Hold expires; the fade duration is 0 under reduce motion so it lands on
+    // 0 within this same tick.
+    jest.advanceTimersByTime(1);
+    expect(ripple()).toMatchObject({ opacity: 0 });
+  });
+
+  it('leaves the flat state layer on hover while it paints the press', async () => {
+    await renderCheckbox();
+
+    await fireEvent(screen.getByRole('checkbox'), 'hoverIn');
+    await pressIn();
+    jest.advanceTimersByTime(GROW);
+
+    expect(screen.getByTestId('checkbox-state-layer')).toHaveStyle({
+      backgroundColor: colors.onSurface,
+      opacity: hovered,
+    });
+    expect(ripple()).toMatchObject({
+      backgroundColor: colors.primary,
+      opacity: pressed,
+    });
+  });
+
+  it('tints with a PlatformColor role as-is', async () => {
+    const primary = PlatformColor('?attr/colorPrimary');
+    await renderCheckbox({ theme: { colors: { primary } } });
+
+    await pressIn();
+    jest.advanceTimersByTime(GROW);
+
+    expect(ripple()).toMatchObject({ backgroundColor: primary });
+  });
+
+  // Whether the platform press was suppressed or handed back only shows up on
+  // `TouchableRipple`'s own press underlay, so assert there: the absence of our
+  // ripple says nothing about what the platform paints in its place.
+  const underlay = () => screen.getByTestId('touchable-ripple-underlay');
+
+  it('suppresses the platform press by default', async () => {
+    await renderCheckbox({ testOnly_pressed: true });
+
+    expect(underlay()).toHaveStyle({ backgroundColor: 'transparent' });
+  });
+
+  it('hands the press back to the platform when a rippleColor is given', async () => {
+    await renderCheckbox({ rippleColor: 'teal', testOnly_pressed: true });
+
+    expect(screen.queryByTestId('checkbox-ripple')).toBeNull();
+    expect(underlay()).toHaveStyle({ backgroundColor: 'teal' });
+  });
+
+  it('hands the press back to the platform when an underlayColor is given on ios', async () => {
+    jest.replaceProperty(Platform, 'OS', 'ios');
+    await renderCheckbox({ underlayColor: 'teal', testOnly_pressed: true });
+
+    expect(screen.queryByTestId('checkbox-ripple')).toBeNull();
+    expect(underlay()).toHaveStyle({ backgroundColor: 'teal' });
+  });
+
+  it('hands the press back to the platform when a background is given on android', async () => {
+    jest.replaceProperty(Platform, 'OS', 'android');
+    await renderCheckbox({
+      background: { color: 'teal' },
+      testOnly_pressed: true,
+    });
+
+    expect(screen.queryByTestId('checkbox-ripple')).toBeNull();
+    expect(underlay()).toHaveStyle({
+      backgroundColor: colors.stateLayerPressed,
+    });
+  });
+
+  // Android discards `underlayColor`, so taking it for a hand-back there would
+  // drop our ripple for the platform's neutral default.
+  it('keeps painting the press despite an underlayColor on android', async () => {
+    jest.replaceProperty(Platform, 'OS', 'android');
+    await renderCheckbox({ underlayColor: 'teal' });
+
+    await pressIn();
+    jest.advanceTimersByTime(GROW);
+
+    expect(ripple()).toMatchObject({
+      backgroundColor: colors.primary,
+      opacity: pressed,
+    });
+  });
+
+  // Only the android ripple reads `background`; every other platform discards
+  // it, so taking it for a hand-back would trade our ripple for the platform's
+  // neutral default.
+  it('keeps painting the press despite a background off android', async () => {
+    jest.replaceProperty(Platform, 'OS', 'ios');
+    await renderCheckbox({ background: { color: 'teal' } });
+
+    await pressIn();
+    jest.advanceTimersByTime(GROW);
+
+    expect(ripple()).toMatchObject({
+      backgroundColor: colors.primary,
+      opacity: pressed,
+    });
+  });
+
+  it('keeps its press-start color when the status flips mid-press', async () => {
+    await renderCheckbox();
+
+    await pressIn();
+    jest.advanceTimersByTime(GROW);
+    expect(ripple()).toMatchObject({ backgroundColor: colors.primary });
+
+    // What a controlled parent does from `onPress`, while the ripple is still
+    // on screen.
+    await screen.rerender(
+      <Checkbox status="checked" onPress={() => {}} testID="checkbox" />
+    );
+    expect(ripple()).toMatchObject({ backgroundColor: colors.primary });
+
+    await pressOut();
+    await jest.runAllTimersAsync();
+
+    await pressIn();
+    jest.advanceTimersByTime(GROW);
+    expect(ripple()).toMatchObject({ backgroundColor: colors.onSurface });
+  });
+
+  it('paints nothing when the ripple effect is turned off', async () => {
+    await render(
+      <SettingsProvider value={{ rippleEffectEnabled: false }}>
+        <Checkbox status="unchecked" onPress={() => {}} testID="checkbox" />
+      </SettingsProvider>
+    );
+
+    expect(screen.queryByTestId('checkbox-ripple')).toBeNull();
+  });
+
+  it('is not rendered on a disabled checkbox', async () => {
+    await renderCheckbox({ disabled: true });
+
+    expect(screen.queryByTestId('checkbox-ripple')).toBeNull();
+  });
+
+  it('is not rendered without a press handler', async () => {
+    await render(<Checkbox status="unchecked" testID="checkbox" />);
+
+    expect(screen.queryByTestId('checkbox-ripple')).toBeNull();
   });
 });
 

--- a/src/components/__tests__/Checkbox/Checkbox.test.tsx
+++ b/src/components/__tests__/Checkbox/Checkbox.test.tsx
@@ -516,3 +516,19 @@ describe('Checkbox without a press handler', () => {
     });
   });
 });
+describe('Checkbox touch target', () => {
+  it('meets the 48dp minimum without resizing the state layer', async () => {
+    await render(
+      <Checkbox status="unchecked" onPress={() => {}} testID="checkbox" />
+    );
+
+    expect(screen.getByRole('checkbox')).toHaveStyle({
+      width: 48,
+      height: 48,
+    });
+    expect(screen.getByTestId('checkbox-state-layer')).toHaveStyle({
+      width: 40,
+      height: 40,
+    });
+  });
+});

--- a/src/components/__tests__/Checkbox/Checkbox.test.tsx
+++ b/src/components/__tests__/Checkbox/Checkbox.test.tsx
@@ -531,4 +531,94 @@ describe('Checkbox touch target', () => {
       height: 40,
     });
   });
+
+  it('takes the custom style on the outer container, not the pressable', async () => {
+    await render(
+      <Checkbox
+        status="unchecked"
+        onPress={() => {}}
+        testID="checkbox"
+        style={{ marginTop: 12 }}
+      />
+    );
+
+    // On the pressable the style would miss the focus ring beside it, and
+    // could shrink the tap target back below 48dp.
+    expect(screen.root).toHaveStyle({ marginTop: 12 });
+    expect(screen.getByRole('checkbox')).not.toHaveStyle({ marginTop: 12 });
+  });
+});
+describe('Checkbox focus ring', () => {
+  const renderFocused = async () => {
+    await render(
+      <Checkbox status="unchecked" onPress={() => {}} testID="checkbox" />
+    );
+    await fireEvent(screen.getByRole('checkbox'), 'focus');
+  };
+
+  it('is not rendered until the checkbox is focused', async () => {
+    await render(
+      <Checkbox status="unchecked" onPress={() => {}} testID="checkbox" />
+    );
+
+    expect(screen.queryByTestId('checkbox-focus-ring')).toBeNull();
+  });
+
+  it('stays hidden for pointer focus on web', async () => {
+    jest.replaceProperty(Platform, 'OS', 'web');
+
+    await render(
+      <Checkbox status="unchecked" onPress={() => {}} testID="checkbox" />
+    );
+    await fireEvent(screen.getByRole('checkbox'), 'focus', {
+      currentTarget: { matches: () => false },
+    });
+
+    expect(screen.queryByTestId('checkbox-focus-ring')).toBeNull();
+  });
+
+  it('is shown for keyboard focus on web', async () => {
+    jest.replaceProperty(Platform, 'OS', 'web');
+
+    await render(
+      <Checkbox status="unchecked" onPress={() => {}} testID="checkbox" />
+    );
+    await fireEvent(screen.getByRole('checkbox'), 'focus', {
+      currentTarget: { matches: () => true },
+    });
+
+    expect(screen.getByTestId('checkbox-focus-ring')).toBeOnTheScreen();
+  });
+
+  it('clears the 40dp state layer by the 2dp outer offset', async () => {
+    await renderFocused();
+
+    // 40dp state layer + 2dp offset + 3dp border on each side.
+    expect(screen.getByTestId('checkbox-focus-ring')).toHaveStyle({
+      width: 50,
+      height: 50,
+      borderWidth: 3,
+    });
+  });
+});
+
+it('renders the focus ring outside the pressable so clipping cannot crop it', async () => {
+  await render(
+    <Checkbox
+      status="checked"
+      onPress={() => {}}
+      aria-label="Notify me"
+      testID="checkbox"
+    />
+  );
+  await fireEvent(screen.getByRole('checkbox'), 'focus');
+
+  // Android P+ forces `overflow: hidden` on the pressable for the foreground
+  // ripple, so a ring nested inside it would be cropped.
+  const pressable = screen.getByRole('checkbox');
+  let node = screen.getByTestId('checkbox-focus-ring').parent;
+  while (node) {
+    expect(node).not.toBe(pressable);
+    node = node.parent;
+  }
 });

--- a/src/components/__tests__/Checkbox/Checkbox.test.tsx
+++ b/src/components/__tests__/Checkbox/Checkbox.test.tsx
@@ -547,6 +547,55 @@ describe('Checkbox touch target', () => {
     expect(screen.root).toHaveStyle({ marginTop: 12 });
     expect(screen.getByRole('checkbox')).not.toHaveStyle({ marginTop: 12 });
   });
+
+  it('puts the tap target style on the pressable, over the built-in size', async () => {
+    await render(
+      <Checkbox
+        status="unchecked"
+        onPress={() => {}}
+        testID="checkbox"
+        tapTargetStyle={{ width: 60, height: 60 }}
+      />
+    );
+
+    expect(screen.getByRole('checkbox')).toHaveStyle({
+      width: 60,
+      height: 60,
+    });
+    expect(screen.root).not.toHaveStyle({ width: 60 });
+  });
+
+  it('keeps the tap target style without a press handler', async () => {
+    await render(
+      <Checkbox
+        status="unchecked"
+        testID="checkbox"
+        tapTargetStyle={{ width: 60, height: 60 }}
+      />
+    );
+
+    expect(screen.getByRole('checkbox')).toHaveStyle({
+      width: 60,
+      height: 60,
+    });
+  });
+
+  it('keeps the tap target style on a disabled checkbox', async () => {
+    await render(
+      <Checkbox
+        status="unchecked"
+        onPress={() => {}}
+        disabled
+        testID="checkbox"
+        tapTargetStyle={{ width: 60, height: 60 }}
+      />
+    );
+
+    expect(screen.getByRole('checkbox')).toHaveStyle({
+      width: 60,
+      height: 60,
+    });
+  });
 });
 describe('Checkbox focus ring', () => {
   const renderFocused = async () => {

--- a/src/components/__tests__/Checkbox/Checkbox.test.tsx
+++ b/src/components/__tests__/Checkbox/Checkbox.test.tsx
@@ -651,6 +651,37 @@ describe('Checkbox focus ring', () => {
   });
 });
 
+describe('Checkbox accessible name', () => {
+  it('warns when a standalone checkbox has no accessible name', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await render(<Checkbox status="checked" onPress={() => {}} />);
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('aria-label')
+    );
+  });
+
+  it('is named by aria-label', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await render(
+      <Checkbox status="checked" onPress={() => {}} aria-label="Notify me" />
+    );
+
+    expect(screen.getByLabelText('Notify me')).toBeOnTheScreen();
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('does not warn for the checkbox inside a labelled Checkbox.Item', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await render(<Checkbox.Item label="Notify me" status="checked" />);
+
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+});
+
 it('renders the focus ring outside the pressable so clipping cannot crop it', async () => {
   await render(
     <Checkbox

--- a/src/components/__tests__/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -66,6 +66,25 @@ exports[`renders Checkbox with custom testID 1`] = `
     }
   >
     <View
+      collapsable={false}
+      pointerEvents="none"
+      style={
+        [
+          {
+            "borderRadius": 20,
+            "height": 40,
+            "position": "absolute",
+            "width": 40,
+          },
+          {
+            "backgroundColor": "rgba(103, 80, 164, 1)",
+            "opacity": 0,
+          },
+        ]
+      }
+      testID="custom:testID-state-layer"
+    />
+    <View
       style={
         [
           {
@@ -249,6 +268,24 @@ exports[`renders checked Checkbox with color 1`] = `
       }
     }
   >
+    <View
+      collapsable={false}
+      pointerEvents="none"
+      style={
+        [
+          {
+            "borderRadius": 20,
+            "height": 40,
+            "position": "absolute",
+            "width": 40,
+          },
+          {
+            "backgroundColor": "red",
+            "opacity": 0,
+          },
+        ]
+      }
+    />
     <View
       style={
         [
@@ -434,6 +471,24 @@ exports[`renders checked Checkbox with onPress 1`] = `
     }
   >
     <View
+      collapsable={false}
+      pointerEvents="none"
+      style={
+        [
+          {
+            "borderRadius": 20,
+            "height": 40,
+            "position": "absolute",
+            "width": 40,
+          },
+          {
+            "backgroundColor": "rgba(103, 80, 164, 1)",
+            "opacity": 0,
+          },
+        ]
+      }
+    />
+    <View
       style={
         [
           {
@@ -618,6 +673,24 @@ exports[`renders indeterminate Checkbox 1`] = `
     }
   >
     <View
+      collapsable={false}
+      pointerEvents="none"
+      style={
+        [
+          {
+            "borderRadius": 20,
+            "height": 40,
+            "position": "absolute",
+            "width": 40,
+          },
+          {
+            "backgroundColor": "rgba(103, 80, 164, 1)",
+            "opacity": 0,
+          },
+        ]
+      }
+    />
+    <View
       style={
         [
           {
@@ -789,6 +862,24 @@ exports[`renders indeterminate Checkbox with color 1`] = `
     }
   >
     <View
+      collapsable={false}
+      pointerEvents="none"
+      style={
+        [
+          {
+            "borderRadius": 20,
+            "height": 40,
+            "position": "absolute",
+            "width": 40,
+          },
+          {
+            "backgroundColor": "red",
+            "opacity": 0,
+          },
+        ]
+      }
+    />
+    <View
       style={
         [
           {
@@ -959,6 +1050,24 @@ exports[`renders unchecked Checkbox with color 1`] = `
       }
     }
   >
+    <View
+      collapsable={false}
+      pointerEvents="none"
+      style={
+        [
+          {
+            "borderRadius": 20,
+            "height": 40,
+            "position": "absolute",
+            "width": 40,
+          },
+          {
+            "backgroundColor": "red",
+            "opacity": 0,
+          },
+        ]
+      }
+    />
     <View
       style={
         [
@@ -1143,6 +1252,24 @@ exports[`renders unchecked Checkbox with onPress 1`] = `
       }
     }
   >
+    <View
+      collapsable={false}
+      pointerEvents="none"
+      style={
+        [
+          {
+            "borderRadius": 20,
+            "height": 40,
+            "position": "absolute",
+            "width": 40,
+          },
+          {
+            "backgroundColor": "rgba(29, 27, 32, 1)",
+            "opacity": 0,
+          },
+        ]
+      }
+    />
     <View
       style={
         [

--- a/src/components/__tests__/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -42,10 +42,10 @@ exports[`renders Checkbox with custom testID 1`] = `
       [
         {
           "alignItems": "center",
-          "borderRadius": 20,
-          "height": 40,
+          "borderRadius": 24,
+          "height": 48,
           "justifyContent": "center",
-          "width": 40,
+          "width": 48,
         },
         undefined,
         undefined,
@@ -246,10 +246,10 @@ exports[`renders checked Checkbox with color 1`] = `
       [
         {
           "alignItems": "center",
-          "borderRadius": 20,
-          "height": 40,
+          "borderRadius": 24,
+          "height": 48,
           "justifyContent": "center",
-          "width": 40,
+          "width": 48,
         },
         undefined,
         undefined,
@@ -448,10 +448,10 @@ exports[`renders checked Checkbox with onPress 1`] = `
       [
         {
           "alignItems": "center",
-          "borderRadius": 20,
-          "height": 40,
+          "borderRadius": 24,
+          "height": 48,
           "justifyContent": "center",
-          "width": 40,
+          "width": 48,
         },
         undefined,
         undefined,
@@ -675,10 +675,10 @@ exports[`renders indeterminate Checkbox 1`] = `
       [
         {
           "alignItems": "center",
-          "borderRadius": 20,
-          "height": 40,
+          "borderRadius": 24,
+          "height": 48,
           "justifyContent": "center",
-          "width": 40,
+          "width": 48,
         },
         undefined,
         undefined,
@@ -889,10 +889,10 @@ exports[`renders indeterminate Checkbox with color 1`] = `
       [
         {
           "alignItems": "center",
-          "borderRadius": 20,
-          "height": 40,
+          "borderRadius": 24,
+          "height": 48,
           "justifyContent": "center",
-          "width": 40,
+          "width": 48,
         },
         undefined,
         undefined,
@@ -1078,10 +1078,10 @@ exports[`renders unchecked Checkbox with color 1`] = `
       [
         {
           "alignItems": "center",
-          "borderRadius": 20,
-          "height": 40,
+          "borderRadius": 24,
+          "height": 48,
           "justifyContent": "center",
-          "width": 40,
+          "width": 48,
         },
         undefined,
         undefined,
@@ -1280,10 +1280,10 @@ exports[`renders unchecked Checkbox with onPress 1`] = `
       [
         {
           "alignItems": "center",
-          "borderRadius": 20,
-          "height": 40,
+          "borderRadius": 24,
+          "height": 48,
           "justifyContent": "center",
-          "width": 40,
+          "width": 48,
         },
         undefined,
         undefined,

--- a/src/components/__tests__/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -489,6 +489,31 @@ exports[`renders checked Checkbox with onPress 1`] = `
       }
     />
     <View
+      collapsable={false}
+      pointerEvents="none"
+      style={
+        [
+          {
+            "borderRadius": 20,
+            "height": 40,
+            "position": "absolute",
+            "width": 40,
+          },
+          {
+            "backgroundColor": "rgba(29, 27, 32, 1)",
+          },
+          {
+            "opacity": 0,
+            "transform": [
+              {
+                "scale": 0.6,
+              },
+            ],
+          },
+        ]
+      }
+    />
+    <View
       style={
         [
           {
@@ -686,6 +711,31 @@ exports[`renders indeterminate Checkbox 1`] = `
           {
             "backgroundColor": "rgba(103, 80, 164, 1)",
             "opacity": 0,
+          },
+        ]
+      }
+    />
+    <View
+      collapsable={false}
+      pointerEvents="none"
+      style={
+        [
+          {
+            "borderRadius": 20,
+            "height": 40,
+            "position": "absolute",
+            "width": 40,
+          },
+          {
+            "backgroundColor": "rgba(29, 27, 32, 1)",
+          },
+          {
+            "opacity": 0,
+            "transform": [
+              {
+                "scale": 0.6,
+              },
+            ],
           },
         ]
       }
@@ -1266,6 +1316,31 @@ exports[`renders unchecked Checkbox with onPress 1`] = `
           {
             "backgroundColor": "rgba(29, 27, 32, 1)",
             "opacity": 0,
+          },
+        ]
+      }
+    />
+    <View
+      collapsable={false}
+      pointerEvents="none"
+      style={
+        [
+          {
+            "borderRadius": 20,
+            "height": 40,
+            "position": "absolute",
+            "width": 40,
+          },
+          {
+            "backgroundColor": "rgba(103, 80, 164, 1)",
+          },
+          {
+            "opacity": 0,
+            "transform": [
+              {
+                "scale": 0.6,
+              },
+            ],
           },
         ]
       }

--- a/src/components/__tests__/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -59,6 +59,7 @@ exports[`renders Checkbox with custom testID 1`] = `
             "width": 48,
           },
           undefined,
+          undefined,
         ],
       ]
     }
@@ -274,6 +275,7 @@ exports[`renders checked Checkbox with color 1`] = `
             "width": 48,
           },
           undefined,
+          undefined,
         ],
       ]
     }
@@ -486,6 +488,7 @@ exports[`renders checked Checkbox with onPress 1`] = `
             "justifyContent": "center",
             "width": 48,
           },
+          undefined,
           undefined,
         ],
       ]
@@ -725,6 +728,7 @@ exports[`renders indeterminate Checkbox 1`] = `
             "width": 48,
           },
           undefined,
+          undefined,
         ],
       ]
     }
@@ -950,6 +954,7 @@ exports[`renders indeterminate Checkbox with color 1`] = `
             "width": 48,
           },
           undefined,
+          undefined,
         ],
       ]
     }
@@ -1149,6 +1154,7 @@ exports[`renders unchecked Checkbox with color 1`] = `
             "justifyContent": "center",
             "width": 48,
           },
+          undefined,
           undefined,
         ],
       ]
@@ -1362,6 +1368,7 @@ exports[`renders unchecked Checkbox with onPress 1`] = `
             "justifyContent": "center",
             "width": 48,
           },
+          undefined,
           undefined,
         ],
       ]

--- a/src/components/__tests__/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -2,103 +2,77 @@
 
 exports[`renders Checkbox with custom testID 1`] = `
 <View
-  accessibilityLiveRegion="polite"
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": true,
-      "disabled": true,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
-  accessible={true}
-  centered={true}
-  collapsable={false}
-  focusable={true}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  role="checkbox"
   style={
     [
       {
-        "overflow": "hidden",
+        "alignItems": "center",
+        "justifyContent": "center",
       },
-      [
-        {
-          "alignItems": "center",
-          "borderRadius": 24,
-          "height": 48,
-          "justifyContent": "center",
-          "width": 48,
-        },
-        undefined,
-        undefined,
-      ],
+      undefined,
     ]
   }
-  testID="custom:testID"
 >
   <View
-    pointerEvents="none"
-    style={
+    accessibilityLiveRegion="polite"
+    accessibilityState={
       {
-        "alignItems": "center",
-        "height": 40,
-        "justifyContent": "center",
-        "width": 40,
+        "busy": undefined,
+        "checked": true,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
       }
     }
-  >
-    <View
-      collapsable={false}
-      pointerEvents="none"
-      style={
-        [
-          {
-            "borderRadius": 20,
-            "height": 40,
-            "position": "absolute",
-            "width": 40,
-          },
-          {
-            "backgroundColor": "rgba(103, 80, 164, 1)",
-            "opacity": 0,
-          },
-        ]
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
       }
-      testID="custom:testID-state-layer"
-    />
-    <View
-      style={
+    }
+    accessible={true}
+    centered={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="checkbox"
+    style={
+      [
+        {
+          "overflow": "hidden",
+        },
         [
           {
             "alignItems": "center",
-            "borderRadius": 2,
-            "height": 18,
+            "borderRadius": 24,
+            "height": 48,
             "justifyContent": "center",
-            "overflow": "hidden",
-            "width": 18,
+            "width": 48,
           },
-          {
-            "opacity": 1,
-          },
-        ]
+          undefined,
+        ],
+      ]
+    }
+    testID="custom:testID"
+  >
+    <View
+      pointerEvents="none"
+      style={
+        {
+          "alignItems": "center",
+          "height": 40,
+          "justifyContent": "center",
+          "width": 40,
+        }
       }
     >
       <View
@@ -107,96 +81,133 @@ exports[`renders Checkbox with custom testID 1`] = `
         style={
           [
             {
-              "borderRadius": 2,
-              "borderWidth": 2,
-              "bottom": 0,
-              "left": 0,
+              "borderRadius": 20,
+              "height": 40,
               "position": "absolute",
-              "right": 0,
-              "top": 0,
+              "width": 40,
             },
             {
-              "borderColor": "rgba(73, 69, 79, 1)",
+              "backgroundColor": "rgba(103, 80, 164, 1)",
               "opacity": 0,
             },
           ]
         }
+        testID="custom:testID-state-layer"
       />
       <View
-        collapsable={false}
-        pointerEvents="none"
         style={
           [
             {
+              "alignItems": "center",
               "borderRadius": 2,
-              "bottom": 0,
-              "left": 0,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-            },
-            {
-              "backgroundColor": "rgba(103, 80, 164, 1)",
-              "opacity": 1,
-            },
-          ]
-        }
-      />
-      <View
-        collapsable={false}
-        style={
-          [
-            {
               "height": 18,
-              "left": 0,
+              "justifyContent": "center",
               "overflow": "hidden",
-              "position": "absolute",
-              "top": 0,
+              "width": 18,
             },
             {
               "opacity": 1,
-              "width": 18,
             },
           ]
         }
       >
         <View
+          collapsable={false}
+          pointerEvents="none"
           style={
-            {
-              "alignItems": "center",
-              "height": 18,
-              "justifyContent": "center",
-              "width": 18,
-            }
+            [
+              {
+                "borderRadius": 2,
+                "borderWidth": 2,
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              {
+                "borderColor": "rgba(73, 69, 79, 1)",
+                "opacity": 0,
+              },
+            ]
+          }
+        />
+        <View
+          collapsable={false}
+          pointerEvents="none"
+          style={
+            [
+              {
+                "borderRadius": 2,
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              {
+                "backgroundColor": "rgba(103, 80, 164, 1)",
+                "opacity": 1,
+              },
+            ]
+          }
+        />
+        <View
+          collapsable={false}
+          style={
+            [
+              {
+                "height": 18,
+                "left": 0,
+                "overflow": "hidden",
+                "position": "absolute",
+                "top": 0,
+              },
+              {
+                "opacity": 1,
+                "width": 18,
+              },
+            ]
           }
         >
           <View
             style={
-              [
-                {
-                  "borderBottomWidth": 2,
-                  "borderLeftWidth": 2,
-                  "height": 6,
-                  "transform": [
-                    {
-                      "rotate": "-45deg",
-                    },
-                    {
-                      "translateY": -1,
-                    },
-                    {
-                      "translateX": 1,
-                    },
-                  ],
-                  "width": 11,
-                },
-                {
-                  "borderColor": "rgba(255, 255, 255, 1)",
-                },
-                null,
-              ]
+              {
+                "alignItems": "center",
+                "height": 18,
+                "justifyContent": "center",
+                "width": 18,
+              }
             }
-          />
+          >
+            <View
+              style={
+                [
+                  {
+                    "borderBottomWidth": 2,
+                    "borderLeftWidth": 2,
+                    "height": 6,
+                    "transform": [
+                      {
+                        "rotate": "-45deg",
+                      },
+                      {
+                        "translateY": -1,
+                      },
+                      {
+                        "translateX": 1,
+                      },
+                    ],
+                    "width": 11,
+                  },
+                  {
+                    "borderColor": "rgba(255, 255, 255, 1)",
+                  },
+                  null,
+                ]
+              }
+            />
+          </View>
         </View>
       </View>
     </View>
@@ -206,101 +217,76 @@ exports[`renders Checkbox with custom testID 1`] = `
 
 exports[`renders checked Checkbox with color 1`] = `
 <View
-  accessibilityLiveRegion="polite"
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": true,
-      "disabled": true,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
-  accessible={true}
-  centered={true}
-  collapsable={false}
-  focusable={true}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  role="checkbox"
   style={
     [
       {
-        "overflow": "hidden",
+        "alignItems": "center",
+        "justifyContent": "center",
       },
-      [
-        {
-          "alignItems": "center",
-          "borderRadius": 24,
-          "height": 48,
-          "justifyContent": "center",
-          "width": 48,
-        },
-        undefined,
-        undefined,
-      ],
+      undefined,
     ]
   }
 >
   <View
-    pointerEvents="none"
-    style={
+    accessibilityLiveRegion="polite"
+    accessibilityState={
       {
-        "alignItems": "center",
-        "height": 40,
-        "justifyContent": "center",
-        "width": 40,
+        "busy": undefined,
+        "checked": true,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
       }
     }
-  >
-    <View
-      collapsable={false}
-      pointerEvents="none"
-      style={
-        [
-          {
-            "borderRadius": 20,
-            "height": 40,
-            "position": "absolute",
-            "width": 40,
-          },
-          {
-            "backgroundColor": "red",
-            "opacity": 0,
-          },
-        ]
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
       }
-    />
-    <View
-      style={
+    }
+    accessible={true}
+    centered={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="checkbox"
+    style={
+      [
+        {
+          "overflow": "hidden",
+        },
         [
           {
             "alignItems": "center",
-            "borderRadius": 2,
-            "height": 18,
+            "borderRadius": 24,
+            "height": 48,
             "justifyContent": "center",
-            "overflow": "hidden",
-            "width": 18,
+            "width": 48,
           },
-          {
-            "opacity": 1,
-          },
-        ]
+          undefined,
+        ],
+      ]
+    }
+  >
+    <View
+      pointerEvents="none"
+      style={
+        {
+          "alignItems": "center",
+          "height": 40,
+          "justifyContent": "center",
+          "width": 40,
+        }
       }
     >
       <View
@@ -309,96 +295,132 @@ exports[`renders checked Checkbox with color 1`] = `
         style={
           [
             {
-              "borderRadius": 2,
-              "borderWidth": 2,
-              "bottom": 0,
-              "left": 0,
+              "borderRadius": 20,
+              "height": 40,
               "position": "absolute",
-              "right": 0,
-              "top": 0,
+              "width": 40,
             },
             {
-              "borderColor": "rgba(73, 69, 79, 1)",
+              "backgroundColor": "red",
               "opacity": 0,
             },
           ]
         }
       />
       <View
-        collapsable={false}
-        pointerEvents="none"
         style={
           [
             {
+              "alignItems": "center",
               "borderRadius": 2,
-              "bottom": 0,
-              "left": 0,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-            },
-            {
-              "backgroundColor": "red",
-              "opacity": 1,
-            },
-          ]
-        }
-      />
-      <View
-        collapsable={false}
-        style={
-          [
-            {
               "height": 18,
-              "left": 0,
+              "justifyContent": "center",
               "overflow": "hidden",
-              "position": "absolute",
-              "top": 0,
+              "width": 18,
             },
             {
               "opacity": 1,
-              "width": 18,
             },
           ]
         }
       >
         <View
+          collapsable={false}
+          pointerEvents="none"
           style={
-            {
-              "alignItems": "center",
-              "height": 18,
-              "justifyContent": "center",
-              "width": 18,
-            }
+            [
+              {
+                "borderRadius": 2,
+                "borderWidth": 2,
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              {
+                "borderColor": "rgba(73, 69, 79, 1)",
+                "opacity": 0,
+              },
+            ]
+          }
+        />
+        <View
+          collapsable={false}
+          pointerEvents="none"
+          style={
+            [
+              {
+                "borderRadius": 2,
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              {
+                "backgroundColor": "red",
+                "opacity": 1,
+              },
+            ]
+          }
+        />
+        <View
+          collapsable={false}
+          style={
+            [
+              {
+                "height": 18,
+                "left": 0,
+                "overflow": "hidden",
+                "position": "absolute",
+                "top": 0,
+              },
+              {
+                "opacity": 1,
+                "width": 18,
+              },
+            ]
           }
         >
           <View
             style={
-              [
-                {
-                  "borderBottomWidth": 2,
-                  "borderLeftWidth": 2,
-                  "height": 6,
-                  "transform": [
-                    {
-                      "rotate": "-45deg",
-                    },
-                    {
-                      "translateY": -1,
-                    },
-                    {
-                      "translateX": 1,
-                    },
-                  ],
-                  "width": 11,
-                },
-                {
-                  "borderColor": "rgba(255, 255, 255, 1)",
-                },
-                null,
-              ]
+              {
+                "alignItems": "center",
+                "height": 18,
+                "justifyContent": "center",
+                "width": 18,
+              }
             }
-          />
+          >
+            <View
+              style={
+                [
+                  {
+                    "borderBottomWidth": 2,
+                    "borderLeftWidth": 2,
+                    "height": 6,
+                    "transform": [
+                      {
+                        "rotate": "-45deg",
+                      },
+                      {
+                        "translateY": -1,
+                      },
+                      {
+                        "translateX": 1,
+                      },
+                    ],
+                    "width": 11,
+                  },
+                  {
+                    "borderColor": "rgba(255, 255, 255, 1)",
+                  },
+                  null,
+                ]
+              }
+            />
+          </View>
         </View>
       </View>
     </View>
@@ -408,126 +430,76 @@ exports[`renders checked Checkbox with color 1`] = `
 
 exports[`renders checked Checkbox with onPress 1`] = `
 <View
-  accessibilityLiveRegion="polite"
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": true,
-      "disabled": false,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
-  accessible={true}
-  centered={true}
-  collapsable={false}
-  focusable={true}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  role="checkbox"
   style={
     [
       {
-        "overflow": "hidden",
+        "alignItems": "center",
+        "justifyContent": "center",
       },
-      [
-        {
-          "alignItems": "center",
-          "borderRadius": 24,
-          "height": 48,
-          "justifyContent": "center",
-          "width": 48,
-        },
-        undefined,
-        undefined,
-      ],
+      undefined,
     ]
   }
 >
   <View
-    pointerEvents="none"
-    style={
+    accessibilityLiveRegion="polite"
+    accessibilityState={
       {
-        "alignItems": "center",
-        "height": 40,
-        "justifyContent": "center",
-        "width": 40,
+        "busy": undefined,
+        "checked": true,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
       }
     }
-  >
-    <View
-      collapsable={false}
-      pointerEvents="none"
-      style={
-        [
-          {
-            "borderRadius": 20,
-            "height": 40,
-            "position": "absolute",
-            "width": 40,
-          },
-          {
-            "backgroundColor": "rgba(103, 80, 164, 1)",
-            "opacity": 0,
-          },
-        ]
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
       }
-    />
-    <View
-      collapsable={false}
-      pointerEvents="none"
-      style={
-        [
-          {
-            "borderRadius": 20,
-            "height": 40,
-            "position": "absolute",
-            "width": 40,
-          },
-          {
-            "backgroundColor": "rgba(29, 27, 32, 1)",
-          },
-          {
-            "opacity": 0,
-            "transform": [
-              {
-                "scale": 0.6,
-              },
-            ],
-          },
-        ]
-      }
-    />
-    <View
-      style={
+    }
+    accessible={true}
+    centered={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="checkbox"
+    style={
+      [
+        {
+          "overflow": "hidden",
+        },
         [
           {
             "alignItems": "center",
-            "borderRadius": 2,
-            "height": 18,
+            "borderRadius": 24,
+            "height": 48,
             "justifyContent": "center",
-            "overflow": "hidden",
-            "width": 18,
+            "width": 48,
           },
-          {
-            "opacity": 1,
-          },
-        ]
+          undefined,
+        ],
+      ]
+    }
+  >
+    <View
+      pointerEvents="none"
+      style={
+        {
+          "alignItems": "center",
+          "height": 40,
+          "justifyContent": "center",
+          "width": 40,
+        }
       }
     >
       <View
@@ -536,16 +508,13 @@ exports[`renders checked Checkbox with onPress 1`] = `
         style={
           [
             {
-              "borderRadius": 2,
-              "borderWidth": 2,
-              "bottom": 0,
-              "left": 0,
+              "borderRadius": 20,
+              "height": 40,
               "position": "absolute",
-              "right": 0,
-              "top": 0,
+              "width": 40,
             },
             {
-              "borderColor": "rgba(73, 69, 79, 1)",
+              "backgroundColor": "rgba(103, 80, 164, 1)",
               "opacity": 0,
             },
           ]
@@ -557,75 +526,139 @@ exports[`renders checked Checkbox with onPress 1`] = `
         style={
           [
             {
-              "borderRadius": 2,
-              "bottom": 0,
-              "left": 0,
+              "borderRadius": 20,
+              "height": 40,
               "position": "absolute",
-              "right": 0,
-              "top": 0,
+              "width": 40,
             },
             {
-              "backgroundColor": "rgba(103, 80, 164, 1)",
-              "opacity": 1,
+              "backgroundColor": "rgba(29, 27, 32, 1)",
+            },
+            {
+              "opacity": 0,
+              "transform": [
+                {
+                  "scale": 0.6,
+                },
+              ],
             },
           ]
         }
       />
       <View
-        collapsable={false}
         style={
           [
             {
+              "alignItems": "center",
+              "borderRadius": 2,
               "height": 18,
-              "left": 0,
+              "justifyContent": "center",
               "overflow": "hidden",
-              "position": "absolute",
-              "top": 0,
+              "width": 18,
             },
             {
               "opacity": 1,
-              "width": 18,
             },
           ]
         }
       >
         <View
+          collapsable={false}
+          pointerEvents="none"
           style={
-            {
-              "alignItems": "center",
-              "height": 18,
-              "justifyContent": "center",
-              "width": 18,
-            }
+            [
+              {
+                "borderRadius": 2,
+                "borderWidth": 2,
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              {
+                "borderColor": "rgba(73, 69, 79, 1)",
+                "opacity": 0,
+              },
+            ]
+          }
+        />
+        <View
+          collapsable={false}
+          pointerEvents="none"
+          style={
+            [
+              {
+                "borderRadius": 2,
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              {
+                "backgroundColor": "rgba(103, 80, 164, 1)",
+                "opacity": 1,
+              },
+            ]
+          }
+        />
+        <View
+          collapsable={false}
+          style={
+            [
+              {
+                "height": 18,
+                "left": 0,
+                "overflow": "hidden",
+                "position": "absolute",
+                "top": 0,
+              },
+              {
+                "opacity": 1,
+                "width": 18,
+              },
+            ]
           }
         >
           <View
             style={
-              [
-                {
-                  "borderBottomWidth": 2,
-                  "borderLeftWidth": 2,
-                  "height": 6,
-                  "transform": [
-                    {
-                      "rotate": "-45deg",
-                    },
-                    {
-                      "translateY": -1,
-                    },
-                    {
-                      "translateX": 1,
-                    },
-                  ],
-                  "width": 11,
-                },
-                {
-                  "borderColor": "rgba(255, 255, 255, 1)",
-                },
-                null,
-              ]
+              {
+                "alignItems": "center",
+                "height": 18,
+                "justifyContent": "center",
+                "width": 18,
+              }
             }
-          />
+          >
+            <View
+              style={
+                [
+                  {
+                    "borderBottomWidth": 2,
+                    "borderLeftWidth": 2,
+                    "height": 6,
+                    "transform": [
+                      {
+                        "rotate": "-45deg",
+                      },
+                      {
+                        "translateY": -1,
+                      },
+                      {
+                        "translateX": 1,
+                      },
+                    ],
+                    "width": 11,
+                  },
+                  {
+                    "borderColor": "rgba(255, 255, 255, 1)",
+                  },
+                  null,
+                ]
+              }
+            />
+          </View>
         </View>
       </View>
     </View>
@@ -635,126 +668,76 @@ exports[`renders checked Checkbox with onPress 1`] = `
 
 exports[`renders indeterminate Checkbox 1`] = `
 <View
-  accessibilityLiveRegion="polite"
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": "mixed",
-      "disabled": false,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
-  accessible={true}
-  centered={true}
-  collapsable={false}
-  focusable={true}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  role="checkbox"
   style={
     [
       {
-        "overflow": "hidden",
+        "alignItems": "center",
+        "justifyContent": "center",
       },
-      [
-        {
-          "alignItems": "center",
-          "borderRadius": 24,
-          "height": 48,
-          "justifyContent": "center",
-          "width": 48,
-        },
-        undefined,
-        undefined,
-      ],
+      undefined,
     ]
   }
 >
   <View
-    pointerEvents="none"
-    style={
+    accessibilityLiveRegion="polite"
+    accessibilityState={
       {
-        "alignItems": "center",
-        "height": 40,
-        "justifyContent": "center",
-        "width": 40,
+        "busy": undefined,
+        "checked": "mixed",
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
       }
     }
-  >
-    <View
-      collapsable={false}
-      pointerEvents="none"
-      style={
-        [
-          {
-            "borderRadius": 20,
-            "height": 40,
-            "position": "absolute",
-            "width": 40,
-          },
-          {
-            "backgroundColor": "rgba(103, 80, 164, 1)",
-            "opacity": 0,
-          },
-        ]
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
       }
-    />
-    <View
-      collapsable={false}
-      pointerEvents="none"
-      style={
-        [
-          {
-            "borderRadius": 20,
-            "height": 40,
-            "position": "absolute",
-            "width": 40,
-          },
-          {
-            "backgroundColor": "rgba(29, 27, 32, 1)",
-          },
-          {
-            "opacity": 0,
-            "transform": [
-              {
-                "scale": 0.6,
-              },
-            ],
-          },
-        ]
-      }
-    />
-    <View
-      style={
+    }
+    accessible={true}
+    centered={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="checkbox"
+    style={
+      [
+        {
+          "overflow": "hidden",
+        },
         [
           {
             "alignItems": "center",
-            "borderRadius": 2,
-            "height": 18,
+            "borderRadius": 24,
+            "height": 48,
             "justifyContent": "center",
-            "overflow": "hidden",
-            "width": 18,
+            "width": 48,
           },
-          {
-            "opacity": 1,
-          },
-        ]
+          undefined,
+        ],
+      ]
+    }
+  >
+    <View
+      pointerEvents="none"
+      style={
+        {
+          "alignItems": "center",
+          "height": 40,
+          "justifyContent": "center",
+          "width": 40,
+        }
       }
     >
       <View
@@ -763,16 +746,13 @@ exports[`renders indeterminate Checkbox 1`] = `
         style={
           [
             {
-              "borderRadius": 2,
-              "borderWidth": 2,
-              "bottom": 0,
-              "left": 0,
+              "borderRadius": 20,
+              "height": 40,
               "position": "absolute",
-              "right": 0,
-              "top": 0,
+              "width": 40,
             },
             {
-              "borderColor": "rgba(73, 69, 79, 1)",
+              "backgroundColor": "rgba(103, 80, 164, 1)",
               "opacity": 0,
             },
           ]
@@ -784,62 +764,126 @@ exports[`renders indeterminate Checkbox 1`] = `
         style={
           [
             {
-              "borderRadius": 2,
-              "bottom": 0,
-              "left": 0,
+              "borderRadius": 20,
+              "height": 40,
               "position": "absolute",
-              "right": 0,
-              "top": 0,
+              "width": 40,
             },
             {
-              "backgroundColor": "rgba(103, 80, 164, 1)",
-              "opacity": 1,
+              "backgroundColor": "rgba(29, 27, 32, 1)",
+            },
+            {
+              "opacity": 0,
+              "transform": [
+                {
+                  "scale": 0.6,
+                },
+              ],
             },
           ]
         }
       />
       <View
-        collapsable={false}
         style={
           [
             {
+              "alignItems": "center",
+              "borderRadius": 2,
               "height": 18,
-              "left": 0,
+              "justifyContent": "center",
               "overflow": "hidden",
-              "position": "absolute",
-              "top": 0,
+              "width": 18,
             },
             {
               "opacity": 1,
-              "width": 18,
             },
           ]
         }
       >
         <View
+          collapsable={false}
+          pointerEvents="none"
           style={
-            {
-              "alignItems": "center",
-              "height": 18,
-              "justifyContent": "center",
-              "width": 18,
-            }
+            [
+              {
+                "borderRadius": 2,
+                "borderWidth": 2,
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              {
+                "borderColor": "rgba(73, 69, 79, 1)",
+                "opacity": 0,
+              },
+            ]
+          }
+        />
+        <View
+          collapsable={false}
+          pointerEvents="none"
+          style={
+            [
+              {
+                "borderRadius": 2,
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              {
+                "backgroundColor": "rgba(103, 80, 164, 1)",
+                "opacity": 1,
+              },
+            ]
+          }
+        />
+        <View
+          collapsable={false}
+          style={
+            [
+              {
+                "height": 18,
+                "left": 0,
+                "overflow": "hidden",
+                "position": "absolute",
+                "top": 0,
+              },
+              {
+                "opacity": 1,
+                "width": 18,
+              },
+            ]
           }
         >
           <View
             style={
-              [
-                {
-                  "borderRadius": 1,
-                  "height": 2,
-                  "width": 10,
-                },
-                {
-                  "backgroundColor": "rgba(255, 255, 255, 1)",
-                },
-              ]
+              {
+                "alignItems": "center",
+                "height": 18,
+                "justifyContent": "center",
+                "width": 18,
+              }
             }
-          />
+          >
+            <View
+              style={
+                [
+                  {
+                    "borderRadius": 1,
+                    "height": 2,
+                    "width": 10,
+                  },
+                  {
+                    "backgroundColor": "rgba(255, 255, 255, 1)",
+                  },
+                ]
+              }
+            />
+          </View>
         </View>
       </View>
     </View>
@@ -849,101 +893,76 @@ exports[`renders indeterminate Checkbox 1`] = `
 
 exports[`renders indeterminate Checkbox with color 1`] = `
 <View
-  accessibilityLiveRegion="polite"
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": "mixed",
-      "disabled": true,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
-  accessible={true}
-  centered={true}
-  collapsable={false}
-  focusable={true}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  role="checkbox"
   style={
     [
       {
-        "overflow": "hidden",
+        "alignItems": "center",
+        "justifyContent": "center",
       },
-      [
-        {
-          "alignItems": "center",
-          "borderRadius": 24,
-          "height": 48,
-          "justifyContent": "center",
-          "width": 48,
-        },
-        undefined,
-        undefined,
-      ],
+      undefined,
     ]
   }
 >
   <View
-    pointerEvents="none"
-    style={
+    accessibilityLiveRegion="polite"
+    accessibilityState={
       {
-        "alignItems": "center",
-        "height": 40,
-        "justifyContent": "center",
-        "width": 40,
+        "busy": undefined,
+        "checked": "mixed",
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
       }
     }
-  >
-    <View
-      collapsable={false}
-      pointerEvents="none"
-      style={
-        [
-          {
-            "borderRadius": 20,
-            "height": 40,
-            "position": "absolute",
-            "width": 40,
-          },
-          {
-            "backgroundColor": "red",
-            "opacity": 0,
-          },
-        ]
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
       }
-    />
-    <View
-      style={
+    }
+    accessible={true}
+    centered={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="checkbox"
+    style={
+      [
+        {
+          "overflow": "hidden",
+        },
         [
           {
             "alignItems": "center",
-            "borderRadius": 2,
-            "height": 18,
+            "borderRadius": 24,
+            "height": 48,
             "justifyContent": "center",
-            "overflow": "hidden",
-            "width": 18,
+            "width": 48,
           },
-          {
-            "opacity": 1,
-          },
-        ]
+          undefined,
+        ],
+      ]
+    }
+  >
+    <View
+      pointerEvents="none"
+      style={
+        {
+          "alignItems": "center",
+          "height": 40,
+          "justifyContent": "center",
+          "width": 40,
+        }
       }
     >
       <View
@@ -952,83 +971,119 @@ exports[`renders indeterminate Checkbox with color 1`] = `
         style={
           [
             {
-              "borderRadius": 2,
-              "borderWidth": 2,
-              "bottom": 0,
-              "left": 0,
+              "borderRadius": 20,
+              "height": 40,
               "position": "absolute",
-              "right": 0,
-              "top": 0,
+              "width": 40,
             },
             {
-              "borderColor": "rgba(73, 69, 79, 1)",
+              "backgroundColor": "red",
               "opacity": 0,
             },
           ]
         }
       />
       <View
-        collapsable={false}
-        pointerEvents="none"
         style={
           [
             {
+              "alignItems": "center",
               "borderRadius": 2,
-              "bottom": 0,
-              "left": 0,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-            },
-            {
-              "backgroundColor": "red",
-              "opacity": 1,
-            },
-          ]
-        }
-      />
-      <View
-        collapsable={false}
-        style={
-          [
-            {
               "height": 18,
-              "left": 0,
+              "justifyContent": "center",
               "overflow": "hidden",
-              "position": "absolute",
-              "top": 0,
+              "width": 18,
             },
             {
               "opacity": 1,
-              "width": 18,
             },
           ]
         }
       >
         <View
+          collapsable={false}
+          pointerEvents="none"
           style={
-            {
-              "alignItems": "center",
-              "height": 18,
-              "justifyContent": "center",
-              "width": 18,
-            }
+            [
+              {
+                "borderRadius": 2,
+                "borderWidth": 2,
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              {
+                "borderColor": "rgba(73, 69, 79, 1)",
+                "opacity": 0,
+              },
+            ]
+          }
+        />
+        <View
+          collapsable={false}
+          pointerEvents="none"
+          style={
+            [
+              {
+                "borderRadius": 2,
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              {
+                "backgroundColor": "red",
+                "opacity": 1,
+              },
+            ]
+          }
+        />
+        <View
+          collapsable={false}
+          style={
+            [
+              {
+                "height": 18,
+                "left": 0,
+                "overflow": "hidden",
+                "position": "absolute",
+                "top": 0,
+              },
+              {
+                "opacity": 1,
+                "width": 18,
+              },
+            ]
           }
         >
           <View
             style={
-              [
-                {
-                  "borderRadius": 1,
-                  "height": 2,
-                  "width": 10,
-                },
-                {
-                  "backgroundColor": "rgba(255, 255, 255, 1)",
-                },
-              ]
+              {
+                "alignItems": "center",
+                "height": 18,
+                "justifyContent": "center",
+                "width": 18,
+              }
             }
-          />
+          >
+            <View
+              style={
+                [
+                  {
+                    "borderRadius": 1,
+                    "height": 2,
+                    "width": 10,
+                  },
+                  {
+                    "backgroundColor": "rgba(255, 255, 255, 1)",
+                  },
+                ]
+              }
+            />
+          </View>
         </View>
       </View>
     </View>
@@ -1038,101 +1093,76 @@ exports[`renders indeterminate Checkbox with color 1`] = `
 
 exports[`renders unchecked Checkbox with color 1`] = `
 <View
-  accessibilityLiveRegion="polite"
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": true,
-      "disabled": true,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
-  accessible={true}
-  centered={true}
-  collapsable={false}
-  focusable={true}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  role="checkbox"
   style={
     [
       {
-        "overflow": "hidden",
+        "alignItems": "center",
+        "justifyContent": "center",
       },
-      [
-        {
-          "alignItems": "center",
-          "borderRadius": 24,
-          "height": 48,
-          "justifyContent": "center",
-          "width": 48,
-        },
-        undefined,
-        undefined,
-      ],
+      undefined,
     ]
   }
 >
   <View
-    pointerEvents="none"
-    style={
+    accessibilityLiveRegion="polite"
+    accessibilityState={
       {
-        "alignItems": "center",
-        "height": 40,
-        "justifyContent": "center",
-        "width": 40,
+        "busy": undefined,
+        "checked": true,
+        "disabled": true,
+        "expanded": undefined,
+        "selected": undefined,
       }
     }
-  >
-    <View
-      collapsable={false}
-      pointerEvents="none"
-      style={
-        [
-          {
-            "borderRadius": 20,
-            "height": 40,
-            "position": "absolute",
-            "width": 40,
-          },
-          {
-            "backgroundColor": "red",
-            "opacity": 0,
-          },
-        ]
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
       }
-    />
-    <View
-      style={
+    }
+    accessible={true}
+    centered={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="checkbox"
+    style={
+      [
+        {
+          "overflow": "hidden",
+        },
         [
           {
             "alignItems": "center",
-            "borderRadius": 2,
-            "height": 18,
+            "borderRadius": 24,
+            "height": 48,
             "justifyContent": "center",
-            "overflow": "hidden",
-            "width": 18,
+            "width": 48,
           },
-          {
-            "opacity": 1,
-          },
-        ]
+          undefined,
+        ],
+      ]
+    }
+  >
+    <View
+      pointerEvents="none"
+      style={
+        {
+          "alignItems": "center",
+          "height": 40,
+          "justifyContent": "center",
+          "width": 40,
+        }
       }
     >
       <View
@@ -1141,96 +1171,132 @@ exports[`renders unchecked Checkbox with color 1`] = `
         style={
           [
             {
-              "borderRadius": 2,
-              "borderWidth": 2,
-              "bottom": 0,
-              "left": 0,
+              "borderRadius": 20,
+              "height": 40,
               "position": "absolute",
-              "right": 0,
-              "top": 0,
+              "width": 40,
             },
             {
-              "borderColor": "rgba(73, 69, 79, 1)",
+              "backgroundColor": "red",
               "opacity": 0,
             },
           ]
         }
       />
       <View
-        collapsable={false}
-        pointerEvents="none"
         style={
           [
             {
+              "alignItems": "center",
               "borderRadius": 2,
-              "bottom": 0,
-              "left": 0,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-            },
-            {
-              "backgroundColor": "red",
-              "opacity": 1,
-            },
-          ]
-        }
-      />
-      <View
-        collapsable={false}
-        style={
-          [
-            {
               "height": 18,
-              "left": 0,
+              "justifyContent": "center",
               "overflow": "hidden",
-              "position": "absolute",
-              "top": 0,
+              "width": 18,
             },
             {
               "opacity": 1,
-              "width": 18,
             },
           ]
         }
       >
         <View
+          collapsable={false}
+          pointerEvents="none"
           style={
-            {
-              "alignItems": "center",
-              "height": 18,
-              "justifyContent": "center",
-              "width": 18,
-            }
+            [
+              {
+                "borderRadius": 2,
+                "borderWidth": 2,
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              {
+                "borderColor": "rgba(73, 69, 79, 1)",
+                "opacity": 0,
+              },
+            ]
+          }
+        />
+        <View
+          collapsable={false}
+          pointerEvents="none"
+          style={
+            [
+              {
+                "borderRadius": 2,
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              {
+                "backgroundColor": "red",
+                "opacity": 1,
+              },
+            ]
+          }
+        />
+        <View
+          collapsable={false}
+          style={
+            [
+              {
+                "height": 18,
+                "left": 0,
+                "overflow": "hidden",
+                "position": "absolute",
+                "top": 0,
+              },
+              {
+                "opacity": 1,
+                "width": 18,
+              },
+            ]
           }
         >
           <View
             style={
-              [
-                {
-                  "borderBottomWidth": 2,
-                  "borderLeftWidth": 2,
-                  "height": 6,
-                  "transform": [
-                    {
-                      "rotate": "-45deg",
-                    },
-                    {
-                      "translateY": -1,
-                    },
-                    {
-                      "translateX": 1,
-                    },
-                  ],
-                  "width": 11,
-                },
-                {
-                  "borderColor": "rgba(255, 255, 255, 1)",
-                },
-                null,
-              ]
+              {
+                "alignItems": "center",
+                "height": 18,
+                "justifyContent": "center",
+                "width": 18,
+              }
             }
-          />
+          >
+            <View
+              style={
+                [
+                  {
+                    "borderBottomWidth": 2,
+                    "borderLeftWidth": 2,
+                    "height": 6,
+                    "transform": [
+                      {
+                        "rotate": "-45deg",
+                      },
+                      {
+                        "translateY": -1,
+                      },
+                      {
+                        "translateX": 1,
+                      },
+                    ],
+                    "width": 11,
+                  },
+                  {
+                    "borderColor": "rgba(255, 255, 255, 1)",
+                  },
+                  null,
+                ]
+              }
+            />
+          </View>
         </View>
       </View>
     </View>
@@ -1240,126 +1306,76 @@ exports[`renders unchecked Checkbox with color 1`] = `
 
 exports[`renders unchecked Checkbox with onPress 1`] = `
 <View
-  accessibilityLiveRegion="polite"
-  accessibilityState={
-    {
-      "busy": undefined,
-      "checked": false,
-      "disabled": false,
-      "expanded": undefined,
-      "selected": undefined,
-    }
-  }
-  accessibilityValue={
-    {
-      "max": undefined,
-      "min": undefined,
-      "now": undefined,
-      "text": undefined,
-    }
-  }
-  accessible={true}
-  centered={true}
-  collapsable={false}
-  focusable={true}
-  onBlur={[Function]}
-  onClick={[Function]}
-  onFocus={[Function]}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  role="checkbox"
   style={
     [
       {
-        "overflow": "hidden",
+        "alignItems": "center",
+        "justifyContent": "center",
       },
-      [
-        {
-          "alignItems": "center",
-          "borderRadius": 24,
-          "height": 48,
-          "justifyContent": "center",
-          "width": 48,
-        },
-        undefined,
-        undefined,
-      ],
+      undefined,
     ]
   }
 >
   <View
-    pointerEvents="none"
-    style={
+    accessibilityLiveRegion="polite"
+    accessibilityState={
       {
-        "alignItems": "center",
-        "height": 40,
-        "justifyContent": "center",
-        "width": 40,
+        "busy": undefined,
+        "checked": false,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
       }
     }
-  >
-    <View
-      collapsable={false}
-      pointerEvents="none"
-      style={
-        [
-          {
-            "borderRadius": 20,
-            "height": 40,
-            "position": "absolute",
-            "width": 40,
-          },
-          {
-            "backgroundColor": "rgba(29, 27, 32, 1)",
-            "opacity": 0,
-          },
-        ]
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
       }
-    />
-    <View
-      collapsable={false}
-      pointerEvents="none"
-      style={
-        [
-          {
-            "borderRadius": 20,
-            "height": 40,
-            "position": "absolute",
-            "width": 40,
-          },
-          {
-            "backgroundColor": "rgba(103, 80, 164, 1)",
-          },
-          {
-            "opacity": 0,
-            "transform": [
-              {
-                "scale": 0.6,
-              },
-            ],
-          },
-        ]
-      }
-    />
-    <View
-      style={
+    }
+    accessible={true}
+    centered={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    role="checkbox"
+    style={
+      [
+        {
+          "overflow": "hidden",
+        },
         [
           {
             "alignItems": "center",
-            "borderRadius": 2,
-            "height": 18,
+            "borderRadius": 24,
+            "height": 48,
             "justifyContent": "center",
-            "overflow": "hidden",
-            "width": 18,
+            "width": 48,
           },
-          {
-            "opacity": 1,
-          },
-        ]
+          undefined,
+        ],
+      ]
+    }
+  >
+    <View
+      pointerEvents="none"
+      style={
+        {
+          "alignItems": "center",
+          "height": 40,
+          "justifyContent": "center",
+          "width": 40,
+        }
       }
     >
       <View
@@ -1368,17 +1384,14 @@ exports[`renders unchecked Checkbox with onPress 1`] = `
         style={
           [
             {
-              "borderRadius": 2,
-              "borderWidth": 2,
-              "bottom": 0,
-              "left": 0,
+              "borderRadius": 20,
+              "height": 40,
               "position": "absolute",
-              "right": 0,
-              "top": 0,
+              "width": 40,
             },
             {
-              "borderColor": "rgba(73, 69, 79, 1)",
-              "opacity": 1,
+              "backgroundColor": "rgba(29, 27, 32, 1)",
+              "opacity": 0,
             },
           ]
         }
@@ -1389,75 +1402,139 @@ exports[`renders unchecked Checkbox with onPress 1`] = `
         style={
           [
             {
-              "borderRadius": 2,
-              "bottom": 0,
-              "left": 0,
+              "borderRadius": 20,
+              "height": 40,
               "position": "absolute",
-              "right": 0,
-              "top": 0,
+              "width": 40,
             },
             {
               "backgroundColor": "rgba(103, 80, 164, 1)",
+            },
+            {
               "opacity": 0,
+              "transform": [
+                {
+                  "scale": 0.6,
+                },
+              ],
             },
           ]
         }
       />
       <View
-        collapsable={false}
         style={
           [
             {
+              "alignItems": "center",
+              "borderRadius": 2,
               "height": 18,
-              "left": 0,
+              "justifyContent": "center",
               "overflow": "hidden",
-              "position": "absolute",
-              "top": 0,
+              "width": 18,
             },
             {
-              "opacity": 0,
-              "width": 0,
+              "opacity": 1,
             },
           ]
         }
       >
         <View
+          collapsable={false}
+          pointerEvents="none"
           style={
-            {
-              "alignItems": "center",
-              "height": 18,
-              "justifyContent": "center",
-              "width": 18,
-            }
+            [
+              {
+                "borderRadius": 2,
+                "borderWidth": 2,
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              {
+                "borderColor": "rgba(73, 69, 79, 1)",
+                "opacity": 1,
+              },
+            ]
+          }
+        />
+        <View
+          collapsable={false}
+          pointerEvents="none"
+          style={
+            [
+              {
+                "borderRadius": 2,
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              {
+                "backgroundColor": "rgba(103, 80, 164, 1)",
+                "opacity": 0,
+              },
+            ]
+          }
+        />
+        <View
+          collapsable={false}
+          style={
+            [
+              {
+                "height": 18,
+                "left": 0,
+                "overflow": "hidden",
+                "position": "absolute",
+                "top": 0,
+              },
+              {
+                "opacity": 0,
+                "width": 0,
+              },
+            ]
           }
         >
           <View
             style={
-              [
-                {
-                  "borderBottomWidth": 2,
-                  "borderLeftWidth": 2,
-                  "height": 6,
-                  "transform": [
-                    {
-                      "rotate": "-45deg",
-                    },
-                    {
-                      "translateY": -1,
-                    },
-                    {
-                      "translateX": 1,
-                    },
-                  ],
-                  "width": 11,
-                },
-                {
-                  "borderColor": "rgba(255, 255, 255, 1)",
-                },
-                null,
-              ]
+              {
+                "alignItems": "center",
+                "height": 18,
+                "justifyContent": "center",
+                "width": 18,
+              }
             }
-          />
+          >
+            <View
+              style={
+                [
+                  {
+                    "borderBottomWidth": 2,
+                    "borderLeftWidth": 2,
+                    "height": 6,
+                    "transform": [
+                      {
+                        "rotate": "-45deg",
+                      },
+                      {
+                        "translateY": -1,
+                      },
+                      {
+                        "translateX": 1,
+                      },
+                    ],
+                    "width": 11,
+                  },
+                  {
+                    "borderColor": "rgba(255, 255, 255, 1)",
+                  },
+                  null,
+                ]
+              }
+            />
+          </View>
         </View>
       </View>
     </View>

--- a/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.tsx.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.tsx.snap
@@ -95,10 +95,10 @@ exports[`can render leading checkbox control 1`] = `
           [
             {
               "alignItems": "center",
-              "borderRadius": 20,
-              "height": 40,
+              "borderRadius": 24,
+              "height": 48,
               "justifyContent": "center",
-              "width": 40,
+              "width": 48,
             },
             undefined,
             undefined,
@@ -428,10 +428,10 @@ exports[`renders unchecked 1`] = `
           [
             {
               "alignItems": "center",
-              "borderRadius": 20,
-              "height": 40,
+              "borderRadius": 24,
+              "height": 48,
               "justifyContent": "center",
-              "width": 40,
+              "width": 48,
             },
             undefined,
             undefined,

--- a/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.tsx.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.tsx.snap
@@ -118,6 +118,24 @@ exports[`can render leading checkbox control 1`] = `
         }
       >
         <View
+          collapsable={false}
+          pointerEvents="none"
+          style={
+            [
+              {
+                "borderRadius": 20,
+                "height": 40,
+                "position": "absolute",
+                "width": 40,
+              },
+              {
+                "backgroundColor": "rgba(29, 27, 32, 1)",
+                "opacity": 0,
+              },
+            ]
+          }
+        />
+        <View
           style={
             [
               {
@@ -432,6 +450,24 @@ exports[`renders unchecked 1`] = `
           }
         }
       >
+        <View
+          collapsable={false}
+          pointerEvents="none"
+          style={
+            [
+              {
+                "borderRadius": 20,
+                "height": 40,
+                "position": "absolute",
+                "width": 40,
+              },
+              {
+                "backgroundColor": "rgba(29, 27, 32, 1)",
+                "opacity": 0,
+              },
+            ]
+          }
+        />
         <View
           style={
             [

--- a/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.tsx.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.tsx.snap
@@ -57,99 +57,74 @@ exports[`can render leading checkbox control 1`] = `
     }
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={false}
-      centered={true}
-      collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
         [
           {
-            "overflow": "hidden",
+            "alignItems": "center",
+            "justifyContent": "center",
           },
-          [
-            {
-              "alignItems": "center",
-              "borderRadius": 24,
-              "height": 48,
-              "justifyContent": "center",
-              "width": 48,
-            },
-            undefined,
-            undefined,
-          ],
+          undefined,
         ]
       }
     >
       <View
-        pointerEvents="none"
-        style={
+        accessibilityState={
           {
-            "alignItems": "center",
-            "height": 40,
-            "justifyContent": "center",
-            "width": 40,
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": true,
+            "expanded": undefined,
+            "selected": undefined,
           }
         }
-      >
-        <View
-          collapsable={false}
-          pointerEvents="none"
-          style={
-            [
-              {
-                "borderRadius": 20,
-                "height": 40,
-                "position": "absolute",
-                "width": 40,
-              },
-              {
-                "backgroundColor": "rgba(29, 27, 32, 1)",
-                "opacity": 0,
-              },
-            ]
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
           }
-        />
-        <View
-          style={
+        }
+        accessible={false}
+        centered={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "overflow": "hidden",
+            },
             [
               {
                 "alignItems": "center",
-                "borderRadius": 2,
-                "height": 18,
+                "borderRadius": 24,
+                "height": 48,
                 "justifyContent": "center",
-                "overflow": "hidden",
-                "width": 18,
+                "width": 48,
               },
-              {
-                "opacity": 1,
-              },
-            ]
+              undefined,
+            ],
+          ]
+        }
+      >
+        <View
+          pointerEvents="none"
+          style={
+            {
+              "alignItems": "center",
+              "height": 40,
+              "justifyContent": "center",
+              "width": 40,
+            }
           }
         >
           <View
@@ -158,96 +133,132 @@ exports[`can render leading checkbox control 1`] = `
             style={
               [
                 {
-                  "borderRadius": 2,
-                  "borderWidth": 2,
-                  "bottom": 0,
-                  "left": 0,
+                  "borderRadius": 20,
+                  "height": 40,
                   "position": "absolute",
-                  "right": 0,
-                  "top": 0,
+                  "width": 40,
                 },
                 {
-                  "borderColor": "rgba(73, 69, 79, 1)",
-                  "opacity": 1,
-                },
-              ]
-            }
-          />
-          <View
-            collapsable={false}
-            pointerEvents="none"
-            style={
-              [
-                {
-                  "borderRadius": 2,
-                  "bottom": 0,
-                  "left": 0,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                },
-                {
-                  "backgroundColor": "rgba(103, 80, 164, 1)",
+                  "backgroundColor": "rgba(29, 27, 32, 1)",
                   "opacity": 0,
                 },
               ]
             }
           />
           <View
-            collapsable={false}
             style={
               [
                 {
+                  "alignItems": "center",
+                  "borderRadius": 2,
                   "height": 18,
-                  "left": 0,
+                  "justifyContent": "center",
                   "overflow": "hidden",
-                  "position": "absolute",
-                  "top": 0,
+                  "width": 18,
                 },
                 {
-                  "opacity": 0,
-                  "width": 0,
+                  "opacity": 1,
                 },
               ]
             }
           >
             <View
+              collapsable={false}
+              pointerEvents="none"
               style={
-                {
-                  "alignItems": "center",
-                  "height": 18,
-                  "justifyContent": "center",
-                  "width": 18,
-                }
+                [
+                  {
+                    "borderRadius": 2,
+                    "borderWidth": 2,
+                    "bottom": 0,
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                  {
+                    "borderColor": "rgba(73, 69, 79, 1)",
+                    "opacity": 1,
+                  },
+                ]
+              }
+            />
+            <View
+              collapsable={false}
+              pointerEvents="none"
+              style={
+                [
+                  {
+                    "borderRadius": 2,
+                    "bottom": 0,
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                  {
+                    "backgroundColor": "rgba(103, 80, 164, 1)",
+                    "opacity": 0,
+                  },
+                ]
+              }
+            />
+            <View
+              collapsable={false}
+              style={
+                [
+                  {
+                    "height": 18,
+                    "left": 0,
+                    "overflow": "hidden",
+                    "position": "absolute",
+                    "top": 0,
+                  },
+                  {
+                    "opacity": 0,
+                    "width": 0,
+                  },
+                ]
               }
             >
               <View
                 style={
-                  [
-                    {
-                      "borderBottomWidth": 2,
-                      "borderLeftWidth": 2,
-                      "height": 6,
-                      "transform": [
-                        {
-                          "rotate": "-45deg",
-                        },
-                        {
-                          "translateY": -1,
-                        },
-                        {
-                          "translateX": 1,
-                        },
-                      ],
-                      "width": 11,
-                    },
-                    {
-                      "borderColor": "rgba(255, 255, 255, 1)",
-                    },
-                    null,
-                  ]
+                  {
+                    "alignItems": "center",
+                    "height": 18,
+                    "justifyContent": "center",
+                    "width": 18,
+                  }
                 }
-              />
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "borderBottomWidth": 2,
+                        "borderLeftWidth": 2,
+                        "height": 6,
+                        "transform": [
+                          {
+                            "rotate": "-45deg",
+                          },
+                          {
+                            "translateY": -1,
+                          },
+                          {
+                            "translateX": 1,
+                          },
+                        ],
+                        "width": 11,
+                      },
+                      {
+                        "borderColor": "rgba(255, 255, 255, 1)",
+                      },
+                      null,
+                    ]
+                  }
+                />
+              </View>
             </View>
           </View>
         </View>
@@ -390,99 +401,74 @@ exports[`renders unchecked 1`] = `
       Unchecked Button
     </Text>
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={false}
-      centered={true}
-      collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
         [
           {
-            "overflow": "hidden",
+            "alignItems": "center",
+            "justifyContent": "center",
           },
-          [
-            {
-              "alignItems": "center",
-              "borderRadius": 24,
-              "height": 48,
-              "justifyContent": "center",
-              "width": 48,
-            },
-            undefined,
-            undefined,
-          ],
+          undefined,
         ]
       }
     >
       <View
-        pointerEvents="none"
-        style={
+        accessibilityState={
           {
-            "alignItems": "center",
-            "height": 40,
-            "justifyContent": "center",
-            "width": 40,
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": true,
+            "expanded": undefined,
+            "selected": undefined,
           }
         }
-      >
-        <View
-          collapsable={false}
-          pointerEvents="none"
-          style={
-            [
-              {
-                "borderRadius": 20,
-                "height": 40,
-                "position": "absolute",
-                "width": 40,
-              },
-              {
-                "backgroundColor": "rgba(29, 27, 32, 1)",
-                "opacity": 0,
-              },
-            ]
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
           }
-        />
-        <View
-          style={
+        }
+        accessible={false}
+        centered={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "overflow": "hidden",
+            },
             [
               {
                 "alignItems": "center",
-                "borderRadius": 2,
-                "height": 18,
+                "borderRadius": 24,
+                "height": 48,
                 "justifyContent": "center",
-                "overflow": "hidden",
-                "width": 18,
+                "width": 48,
               },
-              {
-                "opacity": 1,
-              },
-            ]
+              undefined,
+            ],
+          ]
+        }
+      >
+        <View
+          pointerEvents="none"
+          style={
+            {
+              "alignItems": "center",
+              "height": 40,
+              "justifyContent": "center",
+              "width": 40,
+            }
           }
         >
           <View
@@ -491,96 +477,132 @@ exports[`renders unchecked 1`] = `
             style={
               [
                 {
-                  "borderRadius": 2,
-                  "borderWidth": 2,
-                  "bottom": 0,
-                  "left": 0,
+                  "borderRadius": 20,
+                  "height": 40,
                   "position": "absolute",
-                  "right": 0,
-                  "top": 0,
+                  "width": 40,
                 },
                 {
-                  "borderColor": "rgba(73, 69, 79, 1)",
-                  "opacity": 1,
-                },
-              ]
-            }
-          />
-          <View
-            collapsable={false}
-            pointerEvents="none"
-            style={
-              [
-                {
-                  "borderRadius": 2,
-                  "bottom": 0,
-                  "left": 0,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                },
-                {
-                  "backgroundColor": "rgba(103, 80, 164, 1)",
+                  "backgroundColor": "rgba(29, 27, 32, 1)",
                   "opacity": 0,
                 },
               ]
             }
           />
           <View
-            collapsable={false}
             style={
               [
                 {
+                  "alignItems": "center",
+                  "borderRadius": 2,
                   "height": 18,
-                  "left": 0,
+                  "justifyContent": "center",
                   "overflow": "hidden",
-                  "position": "absolute",
-                  "top": 0,
+                  "width": 18,
                 },
                 {
-                  "opacity": 0,
-                  "width": 0,
+                  "opacity": 1,
                 },
               ]
             }
           >
             <View
+              collapsable={false}
+              pointerEvents="none"
               style={
-                {
-                  "alignItems": "center",
-                  "height": 18,
-                  "justifyContent": "center",
-                  "width": 18,
-                }
+                [
+                  {
+                    "borderRadius": 2,
+                    "borderWidth": 2,
+                    "bottom": 0,
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                  {
+                    "borderColor": "rgba(73, 69, 79, 1)",
+                    "opacity": 1,
+                  },
+                ]
+              }
+            />
+            <View
+              collapsable={false}
+              pointerEvents="none"
+              style={
+                [
+                  {
+                    "borderRadius": 2,
+                    "bottom": 0,
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                  {
+                    "backgroundColor": "rgba(103, 80, 164, 1)",
+                    "opacity": 0,
+                  },
+                ]
+              }
+            />
+            <View
+              collapsable={false}
+              style={
+                [
+                  {
+                    "height": 18,
+                    "left": 0,
+                    "overflow": "hidden",
+                    "position": "absolute",
+                    "top": 0,
+                  },
+                  {
+                    "opacity": 0,
+                    "width": 0,
+                  },
+                ]
               }
             >
               <View
                 style={
-                  [
-                    {
-                      "borderBottomWidth": 2,
-                      "borderLeftWidth": 2,
-                      "height": 6,
-                      "transform": [
-                        {
-                          "rotate": "-45deg",
-                        },
-                        {
-                          "translateY": -1,
-                        },
-                        {
-                          "translateX": 1,
-                        },
-                      ],
-                      "width": 11,
-                    },
-                    {
-                      "borderColor": "rgba(255, 255, 255, 1)",
-                    },
-                    null,
-                  ]
+                  {
+                    "alignItems": "center",
+                    "height": 18,
+                    "justifyContent": "center",
+                    "width": 18,
+                  }
                 }
-              />
+              >
+                <View
+                  style={
+                    [
+                      {
+                        "borderBottomWidth": 2,
+                        "borderLeftWidth": 2,
+                        "height": 6,
+                        "transform": [
+                          {
+                            "rotate": "-45deg",
+                          },
+                          {
+                            "translateY": -1,
+                          },
+                          {
+                            "translateX": 1,
+                          },
+                        ],
+                        "width": 11,
+                      },
+                      {
+                        "borderColor": "rgba(255, 255, 255, 1)",
+                      },
+                      null,
+                    ]
+                  }
+                />
+              </View>
             </View>
           </View>
         </View>

--- a/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.tsx.snap
+++ b/src/components/__tests__/Checkbox/__snapshots__/CheckboxItem.test.tsx.snap
@@ -112,6 +112,7 @@ exports[`can render leading checkbox control 1`] = `
                 "width": 48,
               },
               undefined,
+              undefined,
             ],
           ]
         }
@@ -455,6 +456,7 @@ exports[`renders unchecked 1`] = `
                 "justifyContent": "center",
                 "width": 48,
               },
+              undefined,
               undefined,
             ],
           ]

--- a/src/components/__tests__/Checkbox/utils.test.tsx
+++ b/src/components/__tests__/Checkbox/utils.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 
 import { getTheme } from '../../../core/theming';
 import { tokens } from '../../../theme/tokens';
-import { getSelectionVisualState } from '../../Checkbox/utils';
+import { getSelectionVisualState, getStateLayer } from '../../Checkbox/utils';
 
 const stateOpacity = tokens.md.sys.state.opacity;
 const theme = getTheme();
@@ -126,6 +126,134 @@ describe('getSelectionVisualState', () => {
       const v = getSelectionVisualState({ theme: darkTheme, selected: true });
       expect(v.containerColor).toBe(darkTheme.colors.primary);
       expect(v.iconColor).toBe(darkTheme.colors.onPrimary);
+    });
+  });
+});
+
+describe('getStateLayer', () => {
+  const { colors } = theme;
+  const { hovered, focused, pressed } = tokens.md.sys.state.opacity;
+
+  it('is fully transparent when idle', () => {
+    expect(
+      getStateLayer({ theme, selected: false, interaction: null })
+    ).toEqual({ color: 'transparent', opacity: 0 });
+  });
+
+  it.each([
+    ['hovered' as const, hovered],
+    ['focused' as const, focused],
+  ])('tints %s with primary when selected', (interaction, opacity) => {
+    expect(getStateLayer({ theme, selected: true, interaction })).toEqual({
+      color: colors.primary,
+      opacity,
+    });
+  });
+
+  it.each([
+    ['hovered' as const, hovered],
+    ['focused' as const, focused],
+  ])('tints %s with onSurface when unselected', (interaction, opacity) => {
+    expect(getStateLayer({ theme, selected: false, interaction })).toEqual({
+      color: colors.onSurface,
+      opacity,
+    });
+  });
+
+  it('inverts to onSurface when a selected checkbox is pressed', () => {
+    expect(
+      getStateLayer({ theme, selected: true, interaction: 'pressed' })
+    ).toEqual({ color: colors.onSurface, opacity: pressed });
+  });
+
+  it('inverts to primary when an unselected checkbox is pressed', () => {
+    expect(
+      getStateLayer({ theme, selected: false, interaction: 'pressed' })
+    ).toEqual({ color: colors.primary, opacity: pressed });
+  });
+
+  it.each(['hovered' as const, 'focused' as const, 'pressed' as const])(
+    'stays on error for %s regardless of selection',
+    (interaction) => {
+      expect(
+        getStateLayer({ theme, selected: true, error: true, interaction })
+      ).toEqual({ color: colors.error, opacity: expect.any(Number) });
+      expect(
+        getStateLayer({ theme, selected: false, error: true, interaction })
+      ).toEqual({ color: colors.error, opacity: expect.any(Number) });
+    }
+  );
+
+  describe('custom colors', () => {
+    const custom = {
+      customColor: 'rebeccapurple',
+      customUncheckedColor: 'teal',
+    };
+
+    it.each([
+      ['hovered' as const, hovered],
+      ['focused' as const, focused],
+    ])('uses customColor for %s when selected', (interaction, opacity) => {
+      expect(
+        getStateLayer({ theme, selected: true, interaction, ...custom })
+      ).toEqual({ color: 'rebeccapurple', opacity });
+    });
+
+    it.each([
+      ['hovered' as const, hovered],
+      ['focused' as const, focused],
+    ])(
+      'uses customUncheckedColor for %s when unselected',
+      (interaction, opacity) => {
+        expect(
+          getStateLayer({ theme, selected: false, interaction, ...custom })
+        ).toEqual({ color: 'teal', opacity });
+      }
+    );
+
+    it('takes the unchecked color when a selected checkbox is pressed', () => {
+      expect(
+        getStateLayer({
+          theme,
+          selected: true,
+          interaction: 'pressed',
+          ...custom,
+        })
+      ).toEqual({ color: 'teal', opacity: pressed });
+    });
+
+    it('takes the checked color when an unselected checkbox is pressed', () => {
+      expect(
+        getStateLayer({
+          theme,
+          selected: false,
+          interaction: 'pressed',
+          ...custom,
+        })
+      ).toEqual({ color: 'rebeccapurple', opacity: pressed });
+    });
+
+    it('overrides error, matching the box', () => {
+      expect(
+        getStateLayer({
+          theme,
+          selected: true,
+          error: true,
+          interaction: 'hovered',
+          ...custom,
+        })
+      ).toEqual({ color: 'rebeccapurple', opacity: hovered });
+    });
+
+    it('leaves the other side on its token role', () => {
+      expect(
+        getStateLayer({
+          theme,
+          selected: true,
+          interaction: 'hovered',
+          customUncheckedColor: 'teal',
+        })
+      ).toEqual({ color: colors.primary, opacity: hovered });
     });
   });
 });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->
### Motivation

`Checkbox` is one of the MD3 reference components, but a review against the spec found residual deviations: the state-layer tokens were dead code, so every interaction fell back to `TouchableRipple`'s neutral ripple; the touch target was 40dp; the focus ring sat on the state-layer edge; and a standalone checkbox had no accessible-name contract.

Things worth mentioning:

- **The checkbox paints its own press.** MD3 draws the press as a ripple bounded to the 40dp state layer in the *inverted* role (Compose `Checkbox.kt`: `ripple(bounded = false, radius = StateLayerSize / 2)`; material-web `_checkbox.scss`: `md-ripple` sized to the state layer). `TouchableRipple` can't get there: Android's ripple only accepts a numeric colour, so a dynamic theme's `PlatformColor` roles can never tint it; the ripple and iOS highlight fill the whole pressable, now 48dp; and on web its hover overlay doubles up with the layer. So the platform press is turned off (`rippleColor: 'transparent'`, as `Switch` and `BottomNavigation` already do) and a 40dp ripple is drawn with Reanimated shared values — static colour, only `opacity`/`transform` animate, 200 ms grow with a 200 ms minimum hold so a quick tap still reads (Compose `RippleAnimation`, material-web `MINIMUM_PRESS_MS`). An explicit `rippleColor` or `underlayColor` hands the press back to the platform; `rippleEffectEnabled: false` still disables it.
- **The flat hover/focus layer fades by opacity only**, keeping its colour static, because Reanimated cannot interpolate a `PlatformColor`

Visible behaviour changes, both in the migration guide: the checkbox occupies 48dp instead of 40dp, so rows get ~8dp taller; interaction tints follow selection instead of being neutral. A standalone `Checkbox` with no accessible name now warns.


### Related issue

Checkbox review checklist:

- [x]  Standalone checkbox touch target is 40dp (no default `hitSlop`); MD3 requires 48dp (the 40dp state layer itself already matches).
- [x]  State-layer colours don't follow the per-state spec, which **inverts on press** — hover + focus: selected `primary` / unselected `onSurface`; **pressed: selected `onSurface` / unselected `primary`**. The lib applies one colour per selection state across all three interaction states (`src/components/Checkbox/tokens.ts:24-25`), so hover/focus are correct and pressed is wrong in both directions. Do **not** simply swap the two constants. Error states already match (`error` throughout).
- [x]  Focus ring omits the 2dp outer offset.
- [x]  Standalone Checkbox has no visible-label / whole-row accessible-name contract (`Checkbox.Item` is the labeled wrapper) — document and guarantee the standalone accessible-name path.

### Test plan

`yarn lint`, `yarn typecheck` and `yarn test` pass — 738 tests, 168 snapshots. Each commit is independently green, so the series bisects cleanly.

60 new tests in `Checkbox.test.tsx` and `utils.test.tsx` cover the state-layer colour per interaction (custom colours and the pressed inversion included), the ripple on all three `Platform.OS` values, the minimum-press hold, the fade-out duration, the scale reset on a second press, reduce motion, the `rippleColor`/`underlayColor` escape hatches, `rippleEffectEnabled: false`, `PlatformColor` roles, the 48×48 target, the 50dp ring geometry and the accessible-name warning. Mutation-tested: removing the inversion, the hold, the scale reset, the fade duration or the custom-colour path each fails its test.

Manual, on the Checkbox example screen:

1. Press and hold "Default" - a 40dp ripple grows inside the state layer: `primary` when unchecked, `onSurface` when checked. On Android with dynamic colour on it takes the system accent.
2. Quick tap - the ripple still completes before fading; a rapid double tap doesn't leave one behind.
3. "Error" - `error` ripple. "Custom color (tertiary)" - tertiary ripple, no `primary` halo.
4. Tap just outside the visible 40dp - still toggles (48dp target); rows are ~8dp taller.
5. Web: hover paints the flat layer in the non-inverted colour with no doubled overlay; Tab to a checkbox - 3dp `secondary` ring with a 2dp gap around the 40dp layer; a mouse click must *not* light the ring.
6. Drawer → "Ripple effect" off - no press paint, hover and focus unaffected. Dynamic theme off - baseline `primary`.
7. Screen reader - a standalone checkbox with `aria-label` announces its name and state; `Checkbox.Item` announces once for the row; one without a name logs the warning.


https://github.com/user-attachments/assets/d0fc7713-f4d4-48e9-8669-cb3be445ed33

https://github.com/user-attachments/assets/c3b321e4-23cb-4d58-bd21-85d4e97c9dc1

https://github.com/user-attachments/assets/ee4819ca-45b0-490e-850b-66b70ee23907



