### PR TITLE
fix(fab): align MD3 variants and interaction states

### DIFF
--- a/docs/6.x/docs/guides/migration.md
+++ b/docs/6.x/docs/guides/migration.md
@@ -161,21 +161,30 @@ e.g.:
 
 ### FAB
 
-The color presets for `FAB` and `FAB.Extended` now match the MD3 color roles:
-`primary`, `primaryContainer` (default), `secondary`, `secondaryContainer`,
-`tertiary`, `tertiaryContainer`, `surface`, and `branded`.
+To preserve the v5 FAB color treatment, update the `variant` prop:
 
-If you used an earlier 6.x build, replace `tonalPrimary`, `tonalSecondary`, and
-`tonalTertiary` with `primaryContainer`, `secondaryContainer`, and
-`tertiaryContainer`. The old names have been removed without aliases. This also
-applies to the FAB menu trigger's `variant`.
+| v5 | v6 |
+| --- | --- |
+| `primary` | `primaryContainer` |
+| `secondary` | `secondaryContainer` |
+| `tertiary` | `tertiaryContainer` |
 
-Both `surface` and `branded` use `surfaceContainerHigh`. Surface FAB content uses
-`primary`; branded content defaults to `onSurface`. A custom icon source can
-render brand artwork in its own colors.
+If you omit `variant`, no change is needed. Replace `variant="surface"` with
+one of the supported color variants, such as `primaryContainer`.
 
-On web, hovering a FAB raises its elevation from level 3 to level 4. Focused and
-pressed states use level 3. The large FAB icon remains **36dp**.
+For custom colors, replace `color` with `contentColor` and move
+`style.backgroundColor` to `containerColor`:
+
+```diff
+<FAB
+  icon="plus"
+- color="#ffffff"
+- style={{ backgroundColor: '#6750a4', position: 'absolute', bottom: 16, right: 16 }}
++ contentColor="#ffffff"
++ containerColor="#6750a4"
++ style={{ position: 'absolute', bottom: 16, right: 16 }}
+/>
+```
 
 ### TextInput
 

--- a/docs/6.x/docs/guides/migration.md
+++ b/docs/6.x/docs/guides/migration.md
@@ -159,6 +159,24 @@ e.g.:
 - The default elevation changed from level `1` to level `3`.
 - The `style` prop no longer configures the background color or border radius. You can override `theme.colors.surfaceContainerHigh` and `theme.shapes.corner.extraLarge` using the `theme` prop instead.
 
+### FAB
+
+The color presets for `FAB` and `FAB.Extended` now match the MD3 color roles:
+`primary`, `primaryContainer` (default), `secondary`, `secondaryContainer`,
+`tertiary`, `tertiaryContainer`, `surface`, and `branded`.
+
+If you used an earlier 6.x build, replace `tonalPrimary`, `tonalSecondary`, and
+`tonalTertiary` with `primaryContainer`, `secondaryContainer`, and
+`tertiaryContainer`. The old names have been removed without aliases. This also
+applies to the FAB menu trigger's `variant`.
+
+Both `surface` and `branded` use `surfaceContainerHigh`. Surface FAB content uses
+`primary`; branded content defaults to `onSurface`. A custom icon source can
+render brand artwork in its own colors.
+
+On web, hovering a FAB raises its elevation from level 3 to level 4. Focused and
+pressed states use level 3. The large FAB icon remains **36dp**.
+
 ### TextInput
 
 The Paper 6.x `TextInput` is a complete rewrite with a new API. Import the component the same way, but note that the props and behavior have changed significantly.

--- a/example/src/Examples/FABExample.tsx
+++ b/example/src/Examples/FABExample.tsx
@@ -34,9 +34,11 @@ const variants: FabColor[] = [
   'primary',
   'secondary',
   'tertiary',
-  'tonalPrimary',
-  'tonalSecondary',
-  'tonalTertiary',
+  'primaryContainer',
+  'secondaryContainer',
+  'tertiaryContainer',
+  'surface',
+  'branded',
   'custom',
 ];
 
@@ -91,7 +93,7 @@ const FABExample = () => {
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
 
-  const [variant, setVariant] = React.useState<FabColor>('tonalPrimary');
+  const [variant, setVariant] = React.useState<FabColor>('primaryContainer');
   const activeVariant = variant === 'custom' ? undefined : variant;
   const activeContainerColor =
     variant === 'custom' ? CUSTOM_CONTAINER_COLOR : undefined;
@@ -138,12 +140,29 @@ const FABExample = () => {
       <View style={styles.controls}>
         <ChipRow
           label="Color"
-          options={variants}
+          options={
+            type === 'menu'
+              ? variants.filter((v) => v !== 'surface' && v !== 'branded')
+              : variants
+          }
           value={variant}
           onChange={setVariant}
         />
         <ChipRow label="Size" options={sizes} value={size} onChange={setSize} />
-        <ChipRow label="Type" options={types} value={type} onChange={setType} />
+        <ChipRow
+          label="Type"
+          options={types}
+          value={type}
+          onChange={(nextType) => {
+            if (
+              nextType === 'menu' &&
+              (variant === 'surface' || variant === 'branded')
+            ) {
+              setVariant('primaryContainer');
+            }
+            setType(nextType);
+          }}
+        />
         <ChipRow
           label="Position"
           options={positions}
@@ -187,6 +206,7 @@ const FABExample = () => {
         {type === 'icon' && (
           <FAB
             icon="pencil"
+            aria-label="Compose"
             variant={activeVariant}
             containerColor={activeContainerColor}
             size={size}
@@ -214,7 +234,10 @@ const FABExample = () => {
           alignment={position}
           trigger={{
             icon: 'pencil',
-            variant: activeVariant,
+            variant:
+              activeVariant === 'surface' || activeVariant === 'branded'
+                ? undefined
+                : activeVariant,
             containerColor: activeContainerColor,
             size,
             visible: showFab,

--- a/example/src/Examples/FABExample.tsx
+++ b/example/src/Examples/FABExample.tsx
@@ -37,7 +37,6 @@ const variants: FabColor[] = [
   'primaryContainer',
   'secondaryContainer',
   'tertiaryContainer',
-  'surface',
   'branded',
   'custom',
 ];
@@ -141,9 +140,7 @@ const FABExample = () => {
         <ChipRow
           label="Color"
           options={
-            type === 'menu'
-              ? variants.filter((v) => v !== 'surface' && v !== 'branded')
-              : variants
+            type === 'menu' ? variants.filter((v) => v !== 'branded') : variants
           }
           value={variant}
           onChange={setVariant}
@@ -154,10 +151,7 @@ const FABExample = () => {
           options={types}
           value={type}
           onChange={(nextType) => {
-            if (
-              nextType === 'menu' &&
-              (variant === 'surface' || variant === 'branded')
-            ) {
+            if (nextType === 'menu' && variant === 'branded') {
               setVariant('primaryContainer');
             }
             setType(nextType);
@@ -234,10 +228,7 @@ const FABExample = () => {
           alignment={position}
           trigger={{
             icon: 'pencil',
-            variant:
-              activeVariant === 'surface' || activeVariant === 'branded'
-                ? undefined
-                : activeVariant,
+            variant: activeVariant === 'branded' ? undefined : activeVariant,
             containerColor: activeContainerColor,
             size,
             visible: showFab,

--- a/src/components/FAB/Extended.tsx
+++ b/src/components/FAB/Extended.tsx
@@ -38,7 +38,12 @@ export type Props = {
    */
   label: string;
   /**
-   * Role-color preset. Defaults to `tonalPrimary`.
+   * Role-color preset. Defaults to `primaryContainer`.
+   * Choose `primary`, `primaryContainer`, `secondary`, `secondaryContainer`,
+   * `tertiary`, `tertiaryContainer`, `surface`, or `branded`.
+   * `surface` and `branded` use `surfaceContainerHigh`; `surface` uses primary
+   * content, while `branded` uses on-surface content. Pass a custom icon source
+   * to preserve brand artwork colors.
    */
   variant?: Variant;
   /**
@@ -154,7 +159,7 @@ export type Props = {
 const Extended = ({
   icon,
   label,
-  variant = 'tonalPrimary',
+  variant = 'primaryContainer',
   containerColor,
   contentColor,
   size = 'default',

--- a/src/components/FAB/Extended.tsx
+++ b/src/components/FAB/Extended.tsx
@@ -39,11 +39,6 @@ export type Props = {
   label: string;
   /**
    * Role-color preset. Defaults to `primaryContainer`.
-   * Choose `primary`, `primaryContainer`, `secondary`, `secondaryContainer`,
-   * `tertiary`, `tertiaryContainer`, `surface`, or `branded`.
-   * `surface` and `branded` use `surfaceContainerHigh`; `surface` uses primary
-   * content, while `branded` uses on-surface content. Pass a custom icon source
-   * to preserve brand artwork colors.
    */
   variant?: Variant;
   /**

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -22,11 +22,6 @@ export type Props = {
   icon: IconSource;
   /**
    * Role-color preset. Defaults to `primaryContainer`.
-   * Choose `primary`, `primaryContainer`, `secondary`, `secondaryContainer`,
-   * `tertiary`, `tertiaryContainer`, `surface`, or `branded`.
-   * `surface` and `branded` use `surfaceContainerHigh`; `surface` uses primary
-   * content, while `branded` uses on-surface content. Pass a custom icon source
-   * to preserve brand artwork colors.
    */
   variant?: Variant;
   /**

--- a/src/components/FAB/FAB.tsx
+++ b/src/components/FAB/FAB.tsx
@@ -21,7 +21,12 @@ export type Props = {
    */
   icon: IconSource;
   /**
-   * Role-color preset. Defaults to `tonalPrimary`.
+   * Role-color preset. Defaults to `primaryContainer`.
+   * Choose `primary`, `primaryContainer`, `secondary`, `secondaryContainer`,
+   * `tertiary`, `tertiaryContainer`, `surface`, or `branded`.
+   * `surface` and `branded` use `surfaceContainerHigh`; `surface` uses primary
+   * content, while `branded` uses on-surface content. Pass a custom icon source
+   * to preserve brand artwork colors.
    */
   variant?: Variant;
   /**
@@ -118,7 +123,7 @@ export type Props = {
  */
 const FAB = ({
   icon,
-  variant = 'tonalPrimary',
+  variant = 'primaryContainer',
   size = 'default',
   visible = true,
   onPress,

--- a/src/components/FAB/Menu.tsx
+++ b/src/components/FAB/Menu.tsx
@@ -55,7 +55,7 @@ export type MenuItemProps = {
   testID?: string;
 };
 
-type MenuVariant = Exclude<Variant, 'surface' | 'branded'>;
+type MenuVariant = Exclude<Variant, 'branded'>;
 
 export type MenuTriggerProps = {
   /**
@@ -457,7 +457,6 @@ const MorphingTrigger = ({
       testID={testID}
     >
       <Shell
-        elevation={Tokens.stateElevation.enabled}
         size={size}
         variant={triggerVariant}
         containerColor={triggerContainerColor}

--- a/src/components/FAB/Menu.tsx
+++ b/src/components/FAB/Menu.tsx
@@ -55,13 +55,15 @@ export type MenuItemProps = {
   testID?: string;
 };
 
+type MenuVariant = Exclude<Variant, 'surface' | 'branded'>;
+
 export type MenuTriggerProps = {
   /**
    * Icon displayed in the trigger FAB (and cross-faded to `closeIcon` when
    * the menu is open).
    */
   icon: IconSource;
-  variant?: Variant;
+  variant?: MenuVariant;
   size?: Size;
   containerColor?: ColorValue;
   contentColor?: ColorValue;
@@ -121,24 +123,30 @@ export type MenuProps = {
  * The close button is always the saturated role color; items are always the
  * tonal (container) role color.
  */
-const getCloseVariant = (triggerVariant: Variant): Variant => {
-  if (triggerVariant === 'primary' || triggerVariant === 'tonalPrimary') {
+const getCloseVariant = (triggerVariant: MenuVariant): Variant => {
+  if (triggerVariant === 'primary' || triggerVariant === 'primaryContainer') {
     return 'primary';
   }
-  if (triggerVariant === 'secondary' || triggerVariant === 'tonalSecondary') {
+  if (
+    triggerVariant === 'secondary' ||
+    triggerVariant === 'secondaryContainer'
+  ) {
     return 'secondary';
   }
   return 'tertiary';
 };
 
-const getItemsVariant = (triggerVariant: Variant): Variant => {
-  if (triggerVariant === 'primary' || triggerVariant === 'tonalPrimary') {
-    return 'tonalPrimary';
+const getItemsVariant = (triggerVariant: MenuVariant): Variant => {
+  if (triggerVariant === 'primary' || triggerVariant === 'primaryContainer') {
+    return 'primaryContainer';
   }
-  if (triggerVariant === 'secondary' || triggerVariant === 'tonalSecondary') {
-    return 'tonalSecondary';
+  if (
+    triggerVariant === 'secondary' ||
+    triggerVariant === 'secondaryContainer'
+  ) {
+    return 'secondaryContainer';
   }
-  return 'tonalTertiary';
+  return 'tertiaryContainer';
 };
 
 // Per-item delay used by the stagger. Compose uses a single SlowEffects-driven
@@ -303,7 +311,7 @@ const MenuItem = ({
 };
 
 type MorphingTriggerProps = {
-  triggerVariant: Variant;
+  triggerVariant: MenuVariant;
   closeVariant: Variant;
   triggerContainerColor?: ColorValue;
   triggerContentColor?: ColorValue;
@@ -449,6 +457,7 @@ const MorphingTrigger = ({
       testID={testID}
     >
       <Shell
+        elevation={Tokens.stateElevation.enabled}
         size={size}
         variant={triggerVariant}
         containerColor={triggerContainerColor}
@@ -545,7 +554,7 @@ const Menu = ({
   const isRTL = direction === 'rtl';
   const insets = useSafeAreaInsets();
 
-  const triggerVariant: Variant = trigger.variant ?? 'tonalPrimary';
+  const triggerVariant: MenuVariant = trigger.variant ?? 'primaryContainer';
   const size: Size = trigger.size ?? 'default';
   const openIcon: IconSource = trigger.icon;
   const openOnPress = trigger.onPress;

--- a/src/components/FAB/Shell.tsx
+++ b/src/components/FAB/Shell.tsx
@@ -29,7 +29,7 @@ import { getDimensions, resolveColors } from './utils';
 import { useInternalTheme } from '../../core/theming';
 import { useReduceMotion } from '../../theme/accessibility/ReduceMotionContext';
 import { toRawSpring } from '../../theme/tokens/sys/motion';
-import type { Elevation, ThemeProp } from '../../theme/types';
+import type { ThemeProp } from '../../theme/types';
 import type { ShapeToken } from '../../theme/utils/shape';
 import type { IconSource } from '../Icon';
 import Surface from '../Surface';
@@ -77,11 +77,6 @@ export type ShellProps = {
    * Trailing-padding override.
    */
   trailing?: number;
-  /**
-   * Resting elevation level. Defaults to the FAB's enabled-state elevation.
-   * Pass `0` to disable the shadow entirely.
-   */
-  elevation?: Elevation;
   /**
    * When `false`, the shell animates out (scale + alpha) and stops accepting
    * touches.
@@ -194,7 +189,6 @@ const Shell = ({
   iconSize,
   leading,
   trailing,
-  elevation,
   visible = true,
   onPress,
   'aria-label': ariaLabel = label,
@@ -219,21 +213,17 @@ const Shell = ({
   const theme = useInternalTheme(themeOverrides);
   const [hovered, setHovered] = React.useState(false);
   const [pressed, setPressed] = React.useState(false);
-  const [focused, setFocused] = React.useState(false);
   const touchableRef = React.useRef<View>(null);
+  const previousFocusedElement = React.useRef<HTMLElement | null>(null);
 
-  // Explicit elevations (including flat menu items) keep their own treatment.
   const resolvedElevation =
-    elevation ??
-    (Platform.OS === 'web' && visible && onPress
+    visible && onPress
       ? pressed
         ? Tokens.stateElevation.pressed
-        : focused
-          ? Tokens.stateElevation.focus
-          : hovered
-            ? Tokens.stateElevation.hover
-            : Tokens.stateElevation.enabled
-      : Tokens.stateElevation.enabled);
+        : hovered
+          ? Tokens.stateElevation.hover
+          : Tokens.stateElevation.enabled
+      : Tokens.stateElevation.enabled;
 
   const dimensions = React.useMemo(
     () => getDimensions({ theme, size, shape, iconSize, leading, trailing }),
@@ -317,16 +307,32 @@ const Shell = ({
   const { focusedSV, onFocus, onBlur } = useFocusRing();
 
   React.useEffect(() => {
-    if (!visible || !onPress) {
-      if (Platform.OS === 'web') {
-        touchableRef.current?.blur();
+    if (!visible) {
+      if (Platform.OS === 'web' && typeof document !== 'undefined') {
+        const target: unknown = touchableRef.current;
+        if (
+          target instanceof HTMLElement &&
+          target === document.activeElement
+        ) {
+          if (previousFocusedElement.current?.isConnected) {
+            previousFocusedElement.current.focus({ preventScroll: true });
+          }
+          // The previous element may have been removed or become unfocusable.
+          if (target === document.activeElement) target.blur();
+        }
       }
       setHovered(false);
       setPressed(false);
-      setFocused(false);
       onBlur();
     }
-  }, [visible, onPress, onBlur]);
+  }, [visible, onBlur]);
+
+  React.useEffect(() => {
+    if (!onPress) {
+      setHovered(false);
+      setPressed(false);
+    }
+  }, [onPress]);
 
   const focusRingStyle = useAnimatedStyle(
     () => ({
@@ -359,19 +365,26 @@ const Shell = ({
           borderless
           background={background}
           onPress={visible ? onPress : undefined}
-          disabled={!onPress || !visible}
+          disabled={!onPress}
+          accessible={visible}
+          focusable={visible && !!onPress}
+          tabIndex={visible ? undefined : -1}
           onHoverIn={() => setHovered(true)}
           onHoverOut={() => setHovered(false)}
           onPressIn={() => setPressed(true)}
           onPressOut={() => setPressed(false)}
-          onFocus={() => {
-            setFocused(true);
+          onFocus={(event) => {
+            if (Platform.OS === 'web') {
+              const previous =
+                'relatedTarget' in event.nativeEvent
+                  ? event.nativeEvent.relatedTarget
+                  : null;
+              previousFocusedElement.current =
+                previous instanceof HTMLElement ? previous : null;
+            }
             onFocus();
           }}
-          onBlur={() => {
-            setFocused(false);
-            onBlur();
-          }}
+          onBlur={onBlur}
           aria-label={ariaLabel}
           role="button"
           aria-checked={ariaChecked}

--- a/src/components/FAB/Shell.tsx
+++ b/src/components/FAB/Shell.tsx
@@ -46,7 +46,7 @@ export type ShellProps = {
    */
   label?: string;
   /**
-   * Role-color preset. Defaults to `tonalPrimary`.
+   * Role-color preset. Defaults to `primaryContainer`.
    */
   variant?: Variant;
   /**
@@ -186,7 +186,7 @@ export type ShellProps = {
 const Shell = ({
   icon,
   label,
-  variant = 'tonalPrimary',
+  variant = 'primaryContainer',
   size = 'default',
   containerColor,
   contentColor,
@@ -194,7 +194,7 @@ const Shell = ({
   iconSize,
   leading,
   trailing,
-  elevation = Tokens.stateElevation.enabled,
+  elevation,
   visible = true,
   onPress,
   'aria-label': ariaLabel = label,
@@ -217,6 +217,23 @@ const Shell = ({
   ref,
 }: ShellProps) => {
   const theme = useInternalTheme(themeOverrides);
+  const [hovered, setHovered] = React.useState(false);
+  const [pressed, setPressed] = React.useState(false);
+  const [focused, setFocused] = React.useState(false);
+  const touchableRef = React.useRef<View>(null);
+
+  // Explicit elevations (including flat menu items) keep their own treatment.
+  const resolvedElevation =
+    elevation ??
+    (Platform.OS === 'web' && visible && onPress
+      ? pressed
+        ? Tokens.stateElevation.pressed
+        : focused
+          ? Tokens.stateElevation.focus
+          : hovered
+            ? Tokens.stateElevation.hover
+            : Tokens.stateElevation.enabled
+      : Tokens.stateElevation.enabled);
 
   const dimensions = React.useMemo(
     () => getDimensions({ theme, size, shape, iconSize, leading, trailing }),
@@ -299,6 +316,18 @@ const Shell = ({
 
   const { focusedSV, onFocus, onBlur } = useFocusRing();
 
+  React.useEffect(() => {
+    if (!visible || !onPress) {
+      if (Platform.OS === 'web') {
+        touchableRef.current?.blur();
+      }
+      setHovered(false);
+      setPressed(false);
+      setFocused(false);
+      onBlur();
+    }
+  }, [visible, onPress, onBlur]);
+
   const focusRingStyle = useAnimatedStyle(
     () => ({
       opacity: focusedSV.value ? 1 : 0,
@@ -310,6 +339,7 @@ const Shell = ({
   return (
     <Surface
       ref={ref}
+      aria-hidden={visible ? undefined : true}
       backgroundColor={containerBg}
       borderRadius={borderRadius}
       style={[
@@ -318,18 +348,30 @@ const Shell = ({
         outerStyle,
         visible ? styles.pointerEventsAuto : styles.pointerEventsNone,
       ]}
-      elevation={elevation}
+      elevation={resolvedElevation}
       testID={`${testID}-container`}
       theme={theme}
     >
       <Animated.View style={[styles.clip, clipStyle]}>
         {overlay}
         <TouchableRipple
+          ref={Platform.OS === 'web' ? touchableRef : undefined}
           borderless
           background={background}
-          onPress={onPress}
-          onFocus={onFocus}
-          onBlur={onBlur}
+          onPress={visible ? onPress : undefined}
+          disabled={!onPress || !visible}
+          onHoverIn={() => setHovered(true)}
+          onHoverOut={() => setHovered(false)}
+          onPressIn={() => setPressed(true)}
+          onPressOut={() => setPressed(false)}
+          onFocus={() => {
+            setFocused(true);
+            onFocus();
+          }}
+          onBlur={() => {
+            setFocused(false);
+            onBlur();
+          }}
           aria-label={ariaLabel}
           role="button"
           aria-checked={ariaChecked}

--- a/src/components/FAB/tokens.ts
+++ b/src/components/FAB/tokens.ts
@@ -15,7 +15,6 @@ export type Variant =
   | 'primaryContainer'
   | 'secondaryContainer'
   | 'tertiaryContainer'
-  | 'surface'
   | 'branded';
 
 export type Size = 'default' | 'medium' | 'large';
@@ -70,7 +69,7 @@ const stateElevation = {
 } as const satisfies Record<string, Elevation>;
 
 const variants = {
-  surface: { container: 'surfaceContainerHigh', content: 'primary' },
+  // Branded artwork has no prescribed icon color; onSurface is a fallback.
   branded: { container: 'surfaceContainerHigh', content: 'onSurface' },
   primary: { container: 'primary', content: 'onPrimary' },
   secondary: { container: 'secondary', content: 'onSecondary' },

--- a/src/components/FAB/tokens.ts
+++ b/src/components/FAB/tokens.ts
@@ -12,9 +12,11 @@ export type Variant =
   | 'primary'
   | 'secondary'
   | 'tertiary'
-  | 'tonalPrimary'
-  | 'tonalSecondary'
-  | 'tonalTertiary';
+  | 'primaryContainer'
+  | 'secondaryContainer'
+  | 'tertiaryContainer'
+  | 'surface'
+  | 'branded';
 
 export type Size = 'default' | 'medium' | 'large';
 
@@ -68,18 +70,20 @@ const stateElevation = {
 } as const satisfies Record<string, Elevation>;
 
 const variants = {
+  surface: { container: 'surfaceContainerHigh', content: 'primary' },
+  branded: { container: 'surfaceContainerHigh', content: 'onSurface' },
   primary: { container: 'primary', content: 'onPrimary' },
   secondary: { container: 'secondary', content: 'onSecondary' },
   tertiary: { container: 'tertiary', content: 'onTertiary' },
-  tonalPrimary: {
+  primaryContainer: {
     container: 'primaryContainer',
     content: 'onPrimaryContainer',
   },
-  tonalSecondary: {
+  secondaryContainer: {
     container: 'secondaryContainer',
     content: 'onSecondaryContainer',
   },
-  tonalTertiary: {
+  tertiaryContainer: {
     container: 'tertiaryContainer',
     content: 'onTertiaryContainer',
   },

--- a/src/components/FAB/utils.ts
+++ b/src/components/FAB/utils.ts
@@ -19,7 +19,7 @@ export type ResolvedColors = {
  */
 export const resolveColors = ({
   theme,
-  variant = 'tonalPrimary',
+  variant = 'primaryContainer',
   containerColor,
   contentColor,
 }: {

--- a/src/components/__tests__/FAB.test.tsx
+++ b/src/components/__tests__/FAB.test.tsx
@@ -1,8 +1,20 @@
-import { expect, it, jest } from '@jest/globals';
+import { Platform } from 'react-native';
+
+import { afterEach, expect, it, jest } from '@jest/globals';
 import { fireEvent, userEvent } from '@testing-library/react-native';
 
+import { getTheme } from '../../core/theming';
 import { render, screen } from '../../test-utils';
+import {
+  androidElevationLevels,
+  shadow,
+} from '../../theme/tokens/sys/elevation';
 import FAB from '../FAB';
+import Shell from '../FAB/Shell';
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
 
 it('renders FAB with default props', async () => {
   const tree = (await render(<FAB icon="plus" />)).toJSON();
@@ -24,16 +36,16 @@ it('renders FAB with tertiary variant', async () => {
   expect(tree).toMatchSnapshot();
 });
 
-it('renders FAB with tonalSecondary variant', async () => {
+it('renders FAB with secondaryContainer variant', async () => {
   const tree = (
-    await render(<FAB icon="plus" variant="tonalSecondary" />)
+    await render(<FAB icon="plus" variant="secondaryContainer" />)
   ).toJSON();
   expect(tree).toMatchSnapshot();
 });
 
-it('renders FAB with tonalTertiary variant', async () => {
+it('renders FAB with tertiaryContainer variant', async () => {
   const tree = (
-    await render(<FAB icon="plus" variant="tonalTertiary" />)
+    await render(<FAB icon="plus" variant="tertiaryContainer" />)
   ).toJSON();
   expect(tree).toMatchSnapshot();
 });
@@ -100,4 +112,131 @@ it('forwards event object to onPress', async () => {
     key: 'value',
   });
   expect(onPress).toHaveBeenCalledWith({ key: 'value' });
+});
+
+it.each(['icon', 'extended'] as const)(
+  'applies web hover elevation to the %s FAB and restores it after press and exit',
+  async (type) => {
+    jest.replaceProperty(Platform, 'OS', 'web');
+    const onPress = jest.fn();
+    await render(
+      type === 'icon' ? (
+        <FAB icon="plus" onPress={onPress} />
+      ) : (
+        <FAB.Extended
+          expanded
+          icon="plus"
+          label="Create"
+          onPress={onPress}
+          testID="floating-action-button"
+        />
+      )
+    );
+    const fab = screen.getByTestId('floating-action-button');
+    const container = screen.getByTestId('floating-action-button-container');
+    const theme = getTheme();
+    const [restingShadow] = shadow(3, theme.colors.shadow);
+    const [hoverShadow] = shadow(4, theme.colors.shadow);
+
+    expect(container).toHaveStyle(restingShadow);
+    await fireEvent(fab, 'hoverIn');
+    expect(container).toHaveStyle(hoverShadow);
+    await fireEvent(fab, 'pressIn');
+    expect(container).toHaveStyle(restingShadow);
+    await fireEvent(fab, 'pressOut');
+    expect(container).toHaveStyle(hoverShadow);
+    await fireEvent(fab, 'hoverOut');
+    expect(container).toHaveStyle(restingShadow);
+  }
+);
+
+it('keeps an explicit shell elevation of zero on hover', async () => {
+  jest.replaceProperty(Platform, 'OS', 'web');
+  await render(<Shell icon="plus" onPress={() => {}} elevation={0} />);
+  await fireEvent(screen.getByTestId('fab-shell'), 'hoverIn');
+  const [flatShadow] = shadow(0, getTheme().colors.shadow);
+  expect(screen.getByTestId('fab-shell-container')).toHaveStyle(flatShadow);
+});
+
+it('does not enable a FAB without an action when adding interaction handlers', async () => {
+  await render(<FAB icon="plus" aria-label="Create" />);
+  expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+});
+
+it('hides an invisible FAB from accessibility and disables its action', async () => {
+  const onPress = jest.fn();
+  await render(
+    <FAB icon="plus" aria-label="Create" onPress={onPress} visible={false} />
+  );
+  expect(screen.queryByRole('button', { name: 'Create' })).toBeNull();
+  const fab = screen.getByTestId('floating-action-button', {
+    includeHiddenElements: true,
+  });
+  expect(fab).toBeDisabled();
+  await userEvent.press(fab);
+  expect(onPress).not.toHaveBeenCalled();
+});
+
+it('clears interaction elevation when a FAB is hidden and shown again', async () => {
+  jest.replaceProperty(Platform, 'OS', 'web');
+  const onPress = jest.fn();
+  const { rerender } = await render(<FAB icon="plus" onPress={onPress} />);
+  await fireEvent(screen.getByTestId('floating-action-button'), 'hoverIn');
+  await rerender(<FAB icon="plus" onPress={onPress} visible={false} />);
+  await rerender(<FAB icon="plus" onPress={onPress} />);
+  const [restingShadow] = shadow(3, getTheme().colors.shadow);
+  expect(screen.getByTestId('floating-action-button-container')).toHaveStyle(
+    restingShadow
+  );
+});
+
+it('keeps the menu trigger at its existing elevation on web', async () => {
+  jest.replaceProperty(Platform, 'OS', 'web');
+  await render(
+    <FAB.Menu
+      expanded={false}
+      onDismiss={() => {}}
+      trigger={{ icon: 'plus', testID: 'menu-trigger', onPress: () => {} }}
+      items={[
+        { label: 'First', onPress: () => {} },
+        { label: 'Second', onPress: () => {} },
+      ]}
+    />
+  );
+  await fireEvent(screen.getByTestId('fab-shell'), 'hoverIn');
+  const [restingShadow] = shadow(3, getTheme().colors.shadow);
+  expect(screen.getByTestId('fab-shell-container')).toHaveStyle(restingShadow);
+});
+
+it.each(['ios', 'android'] as const)(
+  'keeps native elevation unchanged on hover on %s',
+  async (platform) => {
+    jest.replaceProperty(Platform, 'OS', platform);
+    await render(<FAB icon="plus" onPress={() => {}} />);
+    await fireEvent(screen.getByTestId('floating-action-button'), 'hoverIn');
+    const [restingShadow] = shadow(3, getTheme().colors.shadow);
+    expect(screen.getByTestId('floating-action-button-container')).toHaveStyle(
+      platform === 'android'
+        ? { elevation: androidElevationLevels[3] }
+        : restingShadow
+    );
+  }
+);
+
+it('restores the resting elevation when a hovered FAB is hidden or its action is removed', async () => {
+  jest.replaceProperty(Platform, 'OS', 'web');
+  const onPress = jest.fn();
+  const { rerender } = await render(<FAB icon="plus" onPress={onPress} />);
+  await fireEvent(screen.getByTestId('floating-action-button'), 'hoverIn');
+  await rerender(<FAB icon="plus" onPress={onPress} visible={false} />);
+  const [restingShadow] = shadow(3, getTheme().colors.shadow);
+  expect(
+    screen.getByTestId('floating-action-button-container', {
+      includeHiddenElements: true,
+    })
+  ).toHaveStyle(restingShadow);
+  await rerender(<FAB icon="plus" />);
+  expect(screen.getByTestId('floating-action-button-container')).toHaveStyle(
+    restingShadow
+  );
 });

--- a/src/components/__tests__/FAB.test.tsx
+++ b/src/components/__tests__/FAB.test.tsx
@@ -10,7 +10,6 @@ import {
   shadow,
 } from '../../theme/tokens/sys/elevation';
 import FAB from '../FAB';
-import Shell from '../FAB/Shell';
 
 afterEach(() => {
   jest.restoreAllMocks();
@@ -150,20 +149,12 @@ it.each(['icon', 'extended'] as const)(
   }
 );
 
-it('keeps an explicit shell elevation of zero on hover', async () => {
-  jest.replaceProperty(Platform, 'OS', 'web');
-  await render(<Shell icon="plus" onPress={() => {}} elevation={0} />);
-  await fireEvent(screen.getByTestId('fab-shell'), 'hoverIn');
-  const [flatShadow] = shadow(0, getTheme().colors.shadow);
-  expect(screen.getByTestId('fab-shell-container')).toHaveStyle(flatShadow);
-});
-
 it('does not enable a FAB without an action when adding interaction handlers', async () => {
   await render(<FAB icon="plus" aria-label="Create" />);
   expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
 });
 
-it('hides an invisible FAB from accessibility and disables its action', async () => {
+it('hides an invisible FAB from accessibility and keyboard navigation without marking it disabled', async () => {
   const onPress = jest.fn();
   await render(
     <FAB icon="plus" aria-label="Create" onPress={onPress} visible={false} />
@@ -172,7 +163,10 @@ it('hides an invisible FAB from accessibility and disables its action', async ()
   const fab = screen.getByTestId('floating-action-button', {
     includeHiddenElements: true,
   });
-  expect(fab).toBeDisabled();
+  expect(fab).not.toBeDisabled();
+  expect(fab).toHaveProp('accessible', false);
+  expect(fab).toHaveProp('focusable', false);
+  expect(fab).toHaveProp('tabIndex', -1);
   await userEvent.press(fab);
   expect(onPress).not.toHaveBeenCalled();
 });
@@ -190,7 +184,7 @@ it('clears interaction elevation when a FAB is hidden and shown again', async ()
   );
 });
 
-it('keeps the menu trigger at its existing elevation on web', async () => {
+it('uses the shared FAB hover elevation for the menu trigger', async () => {
   jest.replaceProperty(Platform, 'OS', 'web');
   await render(
     <FAB.Menu
@@ -204,22 +198,40 @@ it('keeps the menu trigger at its existing elevation on web', async () => {
     />
   );
   await fireEvent(screen.getByTestId('fab-shell'), 'hoverIn');
-  const [restingShadow] = shadow(3, getTheme().colors.shadow);
-  expect(screen.getByTestId('fab-shell-container')).toHaveStyle(restingShadow);
+  const [hoverShadow] = shadow(4, getTheme().colors.shadow);
+  expect(screen.getByTestId('fab-shell-container')).toHaveStyle(hoverShadow);
 });
 
 it.each(['ios', 'android'] as const)(
-  'keeps native elevation unchanged on hover on %s',
+  'applies hover elevation alongside focus and restores it after press on %s',
   async (platform) => {
     jest.replaceProperty(Platform, 'OS', platform);
     await render(<FAB icon="plus" onPress={() => {}} />);
-    await fireEvent(screen.getByTestId('floating-action-button'), 'hoverIn');
+    const fab = screen.getByTestId('floating-action-button');
+    const container = screen.getByTestId('floating-action-button-container');
     const [restingShadow] = shadow(3, getTheme().colors.shadow);
-    expect(screen.getByTestId('floating-action-button-container')).toHaveStyle(
+    const [hoverShadow] = shadow(4, getTheme().colors.shadow);
+    const restingStyle =
       platform === 'android'
         ? { elevation: androidElevationLevels[3] }
-        : restingShadow
-    );
+        : restingShadow;
+    const hoverStyle =
+      platform === 'android'
+        ? { elevation: androidElevationLevels[4] }
+        : hoverShadow;
+
+    await fireEvent(fab, 'focus', { nativeEvent: {} });
+    expect(container).toHaveStyle(restingStyle);
+    await fireEvent(fab, 'hoverIn');
+    expect(container).toHaveStyle(hoverStyle);
+    await fireEvent(fab, 'focus', { nativeEvent: {} });
+    expect(container).toHaveStyle(hoverStyle);
+    await fireEvent(fab, 'pressIn');
+    expect(container).toHaveStyle(restingStyle);
+    await fireEvent(fab, 'pressOut');
+    expect(container).toHaveStyle(hoverStyle);
+    await fireEvent(fab, 'hoverOut');
+    expect(container).toHaveStyle(restingStyle);
   }
 );
 

--- a/src/components/__tests__/FABUtils.test.tsx
+++ b/src/components/__tests__/FABUtils.test.tsx
@@ -5,7 +5,7 @@ import { getDimensions, resolveColors } from '../FAB/utils';
 
 describe('resolveColors', () => {
   it.each([false, true])(
-    'resolves every MD3 color variant (dark=%s)',
+    'resolves every FAB color preset (dark=%s)',
     (dark) => {
       const theme = getTheme(dark);
       const variants = {
@@ -15,7 +15,6 @@ describe('resolveColors', () => {
         secondaryContainer: ['secondaryContainer', 'onSecondaryContainer'],
         tertiary: ['tertiary', 'onTertiary'],
         tertiaryContainer: ['tertiaryContainer', 'onTertiaryContainer'],
-        surface: ['surfaceContainerHigh', 'primary'],
         branded: ['surfaceContainerHigh', 'onSurface'],
       } as const;
 
@@ -26,7 +25,6 @@ describe('resolveColors', () => {
         'secondaryContainer',
         'tertiary',
         'tertiaryContainer',
-        'surface',
         'branded',
       ] as const;
       for (const variant of variantNames) {

--- a/src/components/__tests__/FABUtils.test.tsx
+++ b/src/components/__tests__/FABUtils.test.tsx
@@ -4,7 +4,42 @@ import { getTheme } from '../../core/theming';
 import { getDimensions, resolveColors } from '../FAB/utils';
 
 describe('resolveColors', () => {
-  it('returns theme colors for default variant (tonalPrimary)', () => {
+  it.each([false, true])(
+    'resolves every MD3 color variant (dark=%s)',
+    (dark) => {
+      const theme = getTheme(dark);
+      const variants = {
+        primary: ['primary', 'onPrimary'],
+        primaryContainer: ['primaryContainer', 'onPrimaryContainer'],
+        secondary: ['secondary', 'onSecondary'],
+        secondaryContainer: ['secondaryContainer', 'onSecondaryContainer'],
+        tertiary: ['tertiary', 'onTertiary'],
+        tertiaryContainer: ['tertiaryContainer', 'onTertiaryContainer'],
+        surface: ['surfaceContainerHigh', 'primary'],
+        branded: ['surfaceContainerHigh', 'onSurface'],
+      } as const;
+
+      const variantNames = [
+        'primary',
+        'primaryContainer',
+        'secondary',
+        'secondaryContainer',
+        'tertiary',
+        'tertiaryContainer',
+        'surface',
+        'branded',
+      ] as const;
+      for (const variant of variantNames) {
+        const [container, content] = variants[variant];
+        expect(resolveColors({ theme, variant })).toEqual({
+          container: theme.colors[container],
+          content: theme.colors[content],
+        });
+      }
+    }
+  );
+
+  it('returns theme colors for default variant (primaryContainer)', () => {
     const theme = getTheme();
     const colors = resolveColors({ theme });
     expect(colors).toEqual({
@@ -40,18 +75,18 @@ describe('resolveColors', () => {
     });
   });
 
-  it('returns theme colors for tonalSecondary variant', () => {
+  it('returns theme colors for secondaryContainer variant', () => {
     const theme = getTheme();
-    const colors = resolveColors({ theme, variant: 'tonalSecondary' });
+    const colors = resolveColors({ theme, variant: 'secondaryContainer' });
     expect(colors).toEqual({
       container: theme.colors.secondaryContainer,
       content: theme.colors.onSecondaryContainer,
     });
   });
 
-  it('returns theme colors for tonalTertiary variant', () => {
+  it('returns theme colors for tertiaryContainer variant', () => {
     const theme = getTheme();
-    const colors = resolveColors({ theme, variant: 'tonalTertiary' });
+    const colors = resolveColors({ theme, variant: 'tertiaryContainer' });
     expect(colors).toEqual({
       container: theme.colors.tertiaryContainer,
       content: theme.colors.onTertiaryContainer,

--- a/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
@@ -484,6 +484,7 @@ exports[`renders FAB medium size 1`] = `
 
 exports[`renders FAB transitioning to not visible 1`] = `
 <View
+  aria-hidden={true}
   collapsable={false}
   style={
     [
@@ -2411,6 +2412,247 @@ exports[`renders FAB with secondary variant 1`] = `
 </View>
 `;
 
+exports[`renders FAB with secondaryContainer variant 1`] = `
+<View
+  collapsable={false}
+  style={
+    [
+      {},
+      undefined,
+      {
+        "transformOrigin": "center",
+      },
+      {
+        "height": 56,
+        "opacity": 1,
+        "transform": [
+          {
+            "scale": 1,
+          },
+        ],
+        "width": 56,
+      },
+      {
+        "pointerEvents": "auto",
+      },
+      {},
+      {
+        "backgroundColor": "rgba(232, 222, 248, 1)",
+      },
+      {
+        "borderBottomEndRadius": undefined,
+        "borderBottomLeftRadius": undefined,
+        "borderBottomRightRadius": undefined,
+        "borderBottomStartRadius": undefined,
+        "borderCurve": "continuous",
+        "borderEndEndRadius": undefined,
+        "borderEndStartRadius": undefined,
+        "borderRadius": 16,
+        "borderStartEndRadius": undefined,
+        "borderStartStartRadius": undefined,
+        "borderTopEndRadius": undefined,
+        "borderTopLeftRadius": undefined,
+        "borderTopRightRadius": undefined,
+        "borderTopStartRadius": undefined,
+      },
+      {
+        "shadowColor": "rgba(0, 0, 0, 1)",
+        "shadowOffset": {
+          "height": 3.33,
+          "width": 0,
+        },
+        "shadowOpacity": 0.19,
+        "shadowRadius": 4.75,
+      },
+    ]
+  }
+  testID="floating-action-button-container"
+>
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "pointerEvents": "none",
+        },
+        {},
+        {},
+        {
+          "backgroundColor": "rgba(232, 222, 248, 1)",
+        },
+        {
+          "borderBottomEndRadius": undefined,
+          "borderBottomLeftRadius": undefined,
+          "borderBottomRightRadius": undefined,
+          "borderBottomStartRadius": undefined,
+          "borderCurve": "continuous",
+          "borderEndEndRadius": undefined,
+          "borderEndStartRadius": undefined,
+          "borderRadius": 16,
+          "borderStartEndRadius": undefined,
+          "borderStartStartRadius": undefined,
+          "borderTopEndRadius": undefined,
+          "borderTopLeftRadius": undefined,
+          "borderTopRightRadius": undefined,
+          "borderTopStartRadius": undefined,
+        },
+        {
+          "shadowColor": "rgba(0, 0, 0, 1)",
+          "shadowOffset": {
+            "height": 0,
+            "width": 0,
+          },
+          "shadowOpacity": 0.039,
+          "shadowRadius": 1.5,
+        },
+      ]
+    }
+  />
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "height": "100%",
+          "overflow": "hidden",
+          "width": "100%",
+        },
+        {
+          "backgroundColor": "rgba(232, 222, 248, 1)",
+          "borderRadius": 16,
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": true,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      role="button"
+      style={
+        [
+          {
+            "overflow": "hidden",
+          },
+          [
+            null,
+            null,
+          ],
+        ]
+      }
+      testID="floating-action-button"
+    >
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "pointerEvents": "none",
+            },
+            [
+              {
+                "justifyContent": "center",
+              },
+              {
+                "height": 56,
+                "width": 56,
+              },
+            ],
+          ]
+        }
+      >
+        <Text
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          selectable={false}
+          style={
+            [
+              {
+                "color": "rgba(29, 25, 43, 1)",
+                "fontSize": 24,
+              },
+              [
+                {
+                  "lineHeight": 24,
+                  "transform": [
+                    {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                {
+                  "backgroundColor": "transparent",
+                },
+              ],
+            ]
+          }
+        >
+          plus
+        </Text>
+      </View>
+    </View>
+  </View>
+  <View
+    collapsable={false}
+    style={
+      [
+        {
+          "borderWidth": 3,
+          "bottom": -5,
+          "left": -5,
+          "pointerEvents": "none",
+          "position": "absolute",
+          "right": -5,
+          "top": -5,
+        },
+        {
+          "borderColor": "rgba(98, 91, 113, 1)",
+        },
+        {
+          "borderRadius": 21,
+          "opacity": 0,
+        },
+      ]
+    }
+  />
+</View>
+`;
+
 exports[`renders FAB with tertiary variant 1`] = `
 <View
   collapsable={false}
@@ -2652,248 +2894,7 @@ exports[`renders FAB with tertiary variant 1`] = `
 </View>
 `;
 
-exports[`renders FAB with tonalSecondary variant 1`] = `
-<View
-  collapsable={false}
-  style={
-    [
-      {},
-      undefined,
-      {
-        "transformOrigin": "center",
-      },
-      {
-        "height": 56,
-        "opacity": 1,
-        "transform": [
-          {
-            "scale": 1,
-          },
-        ],
-        "width": 56,
-      },
-      {
-        "pointerEvents": "auto",
-      },
-      {},
-      {
-        "backgroundColor": "rgba(232, 222, 248, 1)",
-      },
-      {
-        "borderBottomEndRadius": undefined,
-        "borderBottomLeftRadius": undefined,
-        "borderBottomRightRadius": undefined,
-        "borderBottomStartRadius": undefined,
-        "borderCurve": "continuous",
-        "borderEndEndRadius": undefined,
-        "borderEndStartRadius": undefined,
-        "borderRadius": 16,
-        "borderStartEndRadius": undefined,
-        "borderStartStartRadius": undefined,
-        "borderTopEndRadius": undefined,
-        "borderTopLeftRadius": undefined,
-        "borderTopRightRadius": undefined,
-        "borderTopStartRadius": undefined,
-      },
-      {
-        "shadowColor": "rgba(0, 0, 0, 1)",
-        "shadowOffset": {
-          "height": 3.33,
-          "width": 0,
-        },
-        "shadowOpacity": 0.19,
-        "shadowRadius": 4.75,
-      },
-    ]
-  }
-  testID="floating-action-button-container"
->
-  <View
-    collapsable={false}
-    style={
-      [
-        {
-          "bottom": 0,
-          "left": 0,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-        },
-        {
-          "pointerEvents": "none",
-        },
-        {},
-        {},
-        {
-          "backgroundColor": "rgba(232, 222, 248, 1)",
-        },
-        {
-          "borderBottomEndRadius": undefined,
-          "borderBottomLeftRadius": undefined,
-          "borderBottomRightRadius": undefined,
-          "borderBottomStartRadius": undefined,
-          "borderCurve": "continuous",
-          "borderEndEndRadius": undefined,
-          "borderEndStartRadius": undefined,
-          "borderRadius": 16,
-          "borderStartEndRadius": undefined,
-          "borderStartStartRadius": undefined,
-          "borderTopEndRadius": undefined,
-          "borderTopLeftRadius": undefined,
-          "borderTopRightRadius": undefined,
-          "borderTopStartRadius": undefined,
-        },
-        {
-          "shadowColor": "rgba(0, 0, 0, 1)",
-          "shadowOffset": {
-            "height": 0,
-            "width": 0,
-          },
-          "shadowOpacity": 0.039,
-          "shadowRadius": 1.5,
-        },
-      ]
-    }
-  />
-  <View
-    collapsable={false}
-    style={
-      [
-        {
-          "height": "100%",
-          "overflow": "hidden",
-          "width": "100%",
-        },
-        {
-          "backgroundColor": "rgba(232, 222, 248, 1)",
-          "borderRadius": 16,
-        },
-      ]
-    }
-  >
-    <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": true,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      role="button"
-      style={
-        [
-          {
-            "overflow": "hidden",
-          },
-          [
-            null,
-            null,
-          ],
-        ]
-      }
-      testID="floating-action-button"
-    >
-      <View
-        style={
-          [
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "pointerEvents": "none",
-            },
-            [
-              {
-                "justifyContent": "center",
-              },
-              {
-                "height": 56,
-                "width": 56,
-              },
-            ],
-          ]
-        }
-      >
-        <Text
-          accessibilityElementsHidden={true}
-          importantForAccessibility="no-hide-descendants"
-          pointerEvents="none"
-          selectable={false}
-          style={
-            [
-              {
-                "color": "rgba(29, 25, 43, 1)",
-                "fontSize": 24,
-              },
-              [
-                {
-                  "lineHeight": 24,
-                  "transform": [
-                    {
-                      "scaleX": 1,
-                    },
-                  ],
-                },
-                {
-                  "backgroundColor": "transparent",
-                },
-              ],
-            ]
-          }
-        >
-          plus
-        </Text>
-      </View>
-    </View>
-  </View>
-  <View
-    collapsable={false}
-    style={
-      [
-        {
-          "borderWidth": 3,
-          "bottom": -5,
-          "left": -5,
-          "pointerEvents": "none",
-          "position": "absolute",
-          "right": -5,
-          "top": -5,
-        },
-        {
-          "borderColor": "rgba(98, 91, 113, 1)",
-        },
-        {
-          "borderRadius": 21,
-          "opacity": 0,
-        },
-      ]
-    }
-  />
-</View>
-`;
-
-exports[`renders FAB with tonalTertiary variant 1`] = `
+exports[`renders FAB with tertiaryContainer variant 1`] = `
 <View
   collapsable={false}
   style={

--- a/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FAB.test.tsx.snap
@@ -139,7 +139,7 @@ exports[`renders FAB large size 1`] = `
       }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -380,7 +380,7 @@ exports[`renders FAB medium size 1`] = `
       }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -620,9 +620,9 @@ exports[`renders FAB transitioning to not visible 1`] = `
           "text": undefined,
         }
       }
-      accessible={true}
+      accessible={false}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -644,6 +644,7 @@ exports[`renders FAB transitioning to not visible 1`] = `
           ],
         ]
       }
+      tabIndex={-1}
       testID="floating-action-button"
     >
       <View
@@ -863,7 +864,7 @@ exports[`renders FAB transitioning to visible 1`] = `
       }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -1105,7 +1106,7 @@ exports[`renders FAB with aria-label 1`] = `
       }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -1346,7 +1347,7 @@ exports[`renders FAB with containerColor and contentColor overrides 1`] = `
       }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -1587,7 +1588,7 @@ exports[`renders FAB with containerColor override 1`] = `
       }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -1828,7 +1829,7 @@ exports[`renders FAB with default props 1`] = `
       }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -2069,7 +2070,7 @@ exports[`renders FAB with primary variant 1`] = `
       }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -2310,7 +2311,7 @@ exports[`renders FAB with secondary variant 1`] = `
       }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -2551,7 +2552,7 @@ exports[`renders FAB with secondaryContainer variant 1`] = `
       }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -2792,7 +2793,7 @@ exports[`renders FAB with tertiary variant 1`] = `
       }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -3033,7 +3034,7 @@ exports[`renders FAB with tertiaryContainer variant 1`] = `
       }
       accessible={true}
       collapsable={false}
-      focusable={true}
+      focusable={false}
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}

--- a/src/components/__tests__/__snapshots__/FABExtended.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FABExtended.test.tsx.snap
@@ -1319,6 +1319,7 @@ exports[`renders extended FAB medium size 1`] = `
 exports[`renders extended FAB not visible 1`] = `
 <>
   <View
+    aria-hidden={true}
     collapsable={false}
     style={
       [

--- a/src/components/__tests__/__snapshots__/FABExtended.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FABExtended.test.tsx.snap
@@ -141,7 +141,7 @@ exports[`renders extended FAB collapsed 1`] = `
         }
         accessible={true}
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
@@ -470,7 +470,7 @@ exports[`renders extended FAB expanded 1`] = `
         }
         accessible={true}
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
@@ -799,7 +799,7 @@ exports[`renders extended FAB large size 1`] = `
         }
         accessible={true}
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
@@ -1128,7 +1128,7 @@ exports[`renders extended FAB medium size 1`] = `
         }
         accessible={true}
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
@@ -1456,9 +1456,9 @@ exports[`renders extended FAB not visible 1`] = `
             "text": undefined,
           }
         }
-        accessible={true}
+        accessible={false}
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
@@ -1480,6 +1480,7 @@ exports[`renders extended FAB not visible 1`] = `
             ],
           ]
         }
+        tabIndex={-1}
         testID="extended-floating-action-button"
       >
         <View
@@ -1787,7 +1788,7 @@ exports[`renders extended FAB transitioning to collapsed 1`] = `
         }
         accessible={true}
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}

--- a/src/components/__tests__/__snapshots__/FABMenu.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FABMenu.test.tsx.snap
@@ -606,7 +606,7 @@ exports[`renders FAB.Menu closed 1`] = `
             }
             accessible={true}
             collapsable={false}
-            focusable={true}
+            focusable={false}
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -1387,9 +1387,9 @@ exports[`renders FAB.Menu not expanded when trigger is not visible 1`] = `
                 "text": undefined,
               }
             }
-            accessible={true}
+            accessible={false}
             collapsable={false}
-            focusable={true}
+            focusable={false}
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -1413,6 +1413,7 @@ exports[`renders FAB.Menu not expanded when trigger is not visible 1`] = `
                 ],
               ]
             }
+            tabIndex={-1}
             testID="fab-shell"
           >
             <View

--- a/src/components/__tests__/__snapshots__/FABMenu.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/FABMenu.test.tsx.snap
@@ -1209,6 +1209,7 @@ exports[`renders FAB.Menu not expanded when trigger is not visible 1`] = `
       }
     >
       <View
+        aria-hidden={true}
         collapsable={false}
         style={
           [


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

`FAB` is one of the MD3 reference components, but a review against the spec found two deviations: the color presets didn't match the MD3 variant set, and the hover-elevation token was defined but never applied.

The variant rename is **breaking**: `tonalPrimary`, `tonalSecondary` and `tonalTertiary` become `primaryContainer`, `secondaryContainer` and `tertiaryContainer`, with no aliases, and `surface` and `branded` are added. That makes the preset names the MD3 role names, so the mapping is checkable against the spec.

This worth mentioning:

- **The large FAB icon stays 36dp, deliberately.** `md.comp.fab.large.icon.size` is 36dp on every variant, and material-web's generated `_md-comp-fab-branded.scss` emits `icon-size: 36px`. The widely-quoted 32dp comes from a token androidx annotates as wrong in its own source (`LargeIconSize: Dp = 36.dp // TODO: FabLargeTokens.IconSize is incorrect`). Stated explicitly because 32dp is easy to find and looks authoritative.
- **`branded`'s content color is a judgement call.** material-web defines container and elevation for the branded FAB but **no `icon-color` token at all** - brand artwork supplies its own colors. `onSurface` is used as the fallback for the label and a monochrome icon; passing a custom icon source keeps brand artwork in its own colors. `surface` needs no such call: the spec gives it `surface-container-high` with a `primary` icon, which is what it does.
- **Hover elevation is web-only, and the FAB Menu is deliberately excluded.** 
- **A hidden FAB no longer keeps focus or its action.** 

Token values were verified against material-web's generated `_md-comp-fab-surface.scss` and `_md-comp-fab-branded.scss` - the spec site is JS-rendered.

### Related issue

The FAB review checklist:

- [x] Rename the color variants to match the m3 set: `tonalPrimary`/`tonalSecondary`/`tonalTertiary` → `primaryContainer`/`secondaryContainer`/`tertiaryContainer`, and add the missing `surface` and `branded` variants (both `surfaceContainerHigh`). Delete the old names - no alias.
- [x] The large FAB icon size is unchanged at 36dp, and a test pins every variant's resolved colors in both schemes so the set can't drift.
- [x] The hover-elevation token (elevation level 4) is defined but never applied on web — wire it through the interaction state. (FAB Menu behavior/web is a separate task.)

Also included, under the umbrella task's accessibility criterion rather than the checklist: a hidden FAB no longer retains focus, actions, or an accessibility node.

### Test plan

`yarn lint`, `yarn typecheck` and `yarn test` pass - 690 tests, 168 snapshots.

12 new tests (FAB: 54 → 66) cover every variant's container and content role in both light and dark, hover elevation on web for the icon and extended FABs, that an explicit shell elevation (including a flat menu item) is not overridden, that native platforms stay at the resting elevation, that the menu trigger is unaffected, that adding interaction handlers doesn't enable an actionless FAB, and that hiding a FAB removes it from the accessibility tree, disables its action, and resets its elevation.

Manual, on the FAB example screen:

1. Cycle the Color chips - all eight variants render; `surface` and `branded` share `surfaceContainerHigh`, with a `primary` icon and an `onSurface` icon respectively.
2. Web: hover a FAB - the shadow deepens (level 3 → 4); focus and press stay at level 3. Hover the menu trigger - it does not rise.
3. Switch Type to `menu` while `surface` or `branded` is selected - the chip set drops both and the variant falls back to `primaryContainer`.
4. Toggle the FAB hidden - it can't be focused by Tab, pressing does nothing, and a screen reader skips it. Show it again and hover: elevation starts at rest, not raised.
5. Size `large` - the icon measures 36dp, not 32dp.
6. Screen reader - the icon FAB announces its `aria-label`; the hidden FAB is not announced.

<img width="474" height="986" alt="Screenshot 2026-09-08 at 09 15 29" src="https://github.com/user-attachments/assets/46c848a4-4d00-4d52-bc82-cec34ddf18f2" />
<img width="829" height="1009" alt="Screenshot 2026-09-08 at 09 14 49" src="https://github.com/user-attachments/assets/4d5a00c9-9478-495e-9173-028ef34a79ba" />

<img width="382" height="799" alt="Screenshot 2026-09-08 at 09 15 11" src="https://github.com/user-attachments/assets/7e874c8b-8647-4db6-b285-973e896dfcac" />

