### PR TITLE
fix(text-input): correct MD3 states and accessibility

### DIFF
--- a/docs/6.x/docs/guides/migration.md
+++ b/docs/6.x/docs/guides/migration.md
@@ -256,6 +256,20 @@ import { TextInput, type TextInputProps } from 'react-native-paper';
 />
 ```
 
+`TextInput.Icon` is decorative when no press handlers are provided. Decorative icons are
+hidden from assistive technology and do not create a keyboard focus stop.
+Icons with `onPress`, `onLongPress`, `onPressIn`, or `onPressOut` require an accessible name:
+
+```tsx
+<TextInput
+  label="Search"
+  startAccessory={(props) => <TextInput.Icon {...props} icon="magnify" />}
+  endAccessory={(props) => (
+    <TextInput.Icon {...props} icon="close" aria-label="Clear search" onPress={() => setValue('')} />
+  )}
+/>
+```
+
 #### Label and supporting text
 
 - **`label: React.Element | string`** → **`string`**
@@ -282,6 +296,26 @@ import { TextInput, type TextInputProps } from 'react-native-paper';
   supportingText="Enter a valid email"
 />
 ```
+
+Supporting text and the character counter describe the field without becoming
+part of its accessible name. On web, their generated `nativeID` values are
+referenced by the input's `aria-describedby`. Additional IDs passed through
+`aria-describedby` are preserved. On Android and iOS, these descriptions are
+included in `accessibilityHint`, alongside any hint you provide, because React
+Native does not support native described-by relationships.
+
+Error supporting text uses `role="alert"`. Android uses an assertive live region;
+iOS announces changed error messages through `AccessibilityInfo`.
+Custom input renderers should forward the accessibility props they receive.
+Explicit `aria-invalid` values are preserved; when omitted, validity is derived
+from `error` and the character counter.
+Empty fields remain visible to native accessibility before focus and after
+clearing. The field content no longer fades with the floating label.
+
+The filled resting indicator now uses `onSurfaceVariant` and changes to
+`onSurface` on hover. An invalid filled field uses `error` at rest and
+`onErrorContainer` on hover. The focused indicator continues to use `primary` (or
+`error` for an invalid field). Outlined fields continue to use `outline` at rest.
 
 #### Removed props
 

--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -81,7 +81,12 @@ const TextInputDemo = ({ variant }: TextInputDemoProps) => {
   );
 
   const trailingIcon = (props: TextInputAccessoryProps) => (
-    <TextInput.Icon {...props} icon="close" onPress={() => setValue('')} />
+    <TextInput.Icon
+      {...props}
+      icon="close"
+      aria-label="Clear text"
+      onPress={() => setValue('')}
+    />
   );
 
   const inputColor = theme.colors.onSurfaceVariant;
@@ -100,8 +105,8 @@ const TextInputDemo = ({ variant }: TextInputDemoProps) => {
     { label: 'Error', key: 'error' },
     { label: 'Disabled', key: 'disabled' },
     { label: 'Readonly', key: 'readOnly' },
-    { label: 'Leading icon', key: 'leadingIcon' },
-    { label: 'Trailing icon', key: 'trailingIcon' },
+    { label: 'Decorative leading icon', key: 'leadingIcon' },
+    { label: 'Clear text action', key: 'trailingIcon' },
     { label: 'Counter', key: 'counter' },
     { label: 'Prefix', key: 'showPrefix' },
     { label: 'Suffix', key: 'showSuffix' },
@@ -123,7 +128,11 @@ const TextInputDemo = ({ variant }: TextInputDemoProps) => {
         variant={variant}
         label={modifiers.label || undefined}
         placeholder={modifiers.placeholder || undefined}
-        supportingText={modifiers.helperText || undefined}
+        supportingText={
+          controls.error
+            ? 'Please check the entered text'
+            : modifiers.helperText || undefined
+        }
         error={controls.error}
         disabled={controls.disabled}
         editable={!controls.readOnly}

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  Platform,
   Pressable,
   Text,
   TextInput as NativeTextInput,
@@ -28,7 +29,6 @@ import type { InternalTheme, ThemeProp } from '../../theme/types';
 export type TextInputAnimationState = {
   animatedLabelWrapperStyle: StyleProp<AnimatedStyle<StyleProp<ViewStyle>>>;
   animatedLabelTextStyle: StyleProp<AnimatedStyle<StyleProp<TextStyle>>>;
-  animatedContainerStyle: StyleProp<AnimatedStyle<StyleProp<ViewStyle>>>;
   animatedActiveOutlineStyle?: StyleProp<AnimatedStyle<StyleProp<ViewStyle>>>;
 };
 
@@ -57,13 +57,18 @@ export type TextInputColors = {
 };
 
 export type GetAccessibilityDataReturn = {
-  input: AccessibilityProps & { 'aria-invalid'?: boolean };
-  supportingText: AccessibilityProps;
-  counter: AccessibilityProps;
+  input: AccessibilityProps & {
+    'aria-invalid'?: TextInputProps['aria-invalid'];
+    'aria-describedby'?: string;
+  };
+  label: { nativeID: string };
+  supportingText: AccessibilityProps & { nativeID: string };
+  counter: AccessibilityProps & { nativeID: string };
 };
 
 export type GetAccessibilityDataProps = {
   data: TextInputProps;
+  id: string;
   inputLength: number;
   hasError: boolean;
   hasCounter: boolean;
@@ -76,6 +81,7 @@ export type TextInputSharedApi = {
   input: React.RefObject<NativeTextInput | null>;
   theme: InternalTheme;
   isFocused: boolean;
+  isHovered?: boolean;
   isRTL: boolean;
   isDisabled: boolean;
   hasAccessory: boolean;
@@ -147,7 +153,6 @@ export type TextInputHookReturn = SharedTextInputStyleData & {
   animatedActiveOutlineStyles:
     | StyleProp<AnimatedStyle<StyleProp<ViewStyle>>>
     | undefined;
-  animatedContainerStyle: StyleProp<AnimatedStyle<StyleProp<ViewStyle>>>;
   animatedLabelWrapperStyles: StyleProp<AnimatedStyle<StyleProp<ViewStyle>>>;
   containerStyles: StyleProp<ViewStyle>;
   fieldStyles: StyleProp<ViewStyle>;
@@ -167,12 +172,16 @@ export type TextInputHookReturn = SharedTextInputStyleData & {
   onFocus: (e: FocusEvent) => void;
   onBlur: (e: BlurEvent) => void;
   focusInput: () => void;
+  onHoverIn: () => void;
+  onHoverOut: () => void;
 };
 
 export type TextInputRenderProps = React.ComponentPropsWithoutRef<
   typeof NativeTextInput
 > & {
   ref?: React.RefObject<NativeTextInput | null>;
+  'aria-describedby'?: string;
+  'aria-invalid'?: TextInputProps['aria-invalid'];
 };
 
 export type TextInputHandles = Pick<
@@ -181,6 +190,17 @@ export type TextInputHandles = Pick<
 >;
 
 export type TextInputProps = NativeTextInputProps & {
+  /**
+   * Overrides the field's invalid state on web, including grammar or spelling
+   * errors. Defaults to the error state or an exceeded character counter.
+   */
+  'aria-invalid'?: React.AriaAttributes['aria-invalid'];
+  /**
+   * Space-separated IDs of additional descriptions on web. The IDs of rendered
+   * supporting text and the character counter are appended automatically.
+   * On Android and iOS, provide external descriptions with `accessibilityHint`.
+   */
+  'aria-describedby'?: string;
   /**
    * Imperative handle exposing a subset of native `TextInput` methods
    * with side-effect handling (e.g. `clear()` syncs internal state and animations).
@@ -204,11 +224,15 @@ export type TextInputProps = NativeTextInputProps & {
   label?: string;
   /**
    * Supporting text to display below the input (Material Design 3).
+   * Associated with the field through `aria-describedby` on web and included
+   * in the native accessibility hint. When `error` is true, it is announced
+   * as an alert. It does not become part of the field's accessible name.
    */
   supportingText?: string;
   /**
    * When `true`, displays a character counter below the input on the trailing
    * side, showing `currentLength/maxLength`. Requires `maxLength` to be set.
+   * Associated with the field alongside supporting text.
    */
   counter?: boolean;
   /**
@@ -324,7 +348,6 @@ function TextInput({
     animatedActiveOutlineStyles,
     animatedLabelWrapperStyles,
     animatedLabelTextStyles,
-    animatedContainerStyle,
     containerStyles,
     inputStyles,
     prefixStyles,
@@ -343,6 +366,8 @@ function TextInput({
     onChangeText,
     onFocus,
     onBlur,
+    onHoverIn,
+    onHoverOut,
   } = useTextInput({
     ref,
     error,
@@ -360,8 +385,25 @@ function TextInput({
   });
 
   return (
-    <Pressable onPress={focusInput} accessible={false} role="none">
-      <View style={fieldStyles}>
+    <Pressable
+      onPress={focusInput}
+      onHoverIn={Platform.OS === 'web' ? undefined : onHoverIn}
+      onHoverOut={Platform.OS === 'web' ? undefined : onHoverOut}
+      accessible={false}
+      role="none"
+    >
+      <View
+        style={fieldStyles}
+        // Nested web Pressables contain hover events; track the whole field.
+        onPointerEnter={
+          Platform.OS === 'web'
+            ? (event) => {
+                if (event.nativeEvent.pointerType !== 'touch') onHoverIn();
+              }
+            : undefined
+        }
+        onPointerLeave={Platform.OS === 'web' ? onHoverOut : undefined}
+      >
         {/* Disabled tint overlay — filled variant only. A childless
           absolutely-positioned View whose translucent fill is applied via the
           `opacity` style, so it never affects label/input rendering and works
@@ -383,7 +425,10 @@ function TextInput({
 
         {!!label && (
           <Animated.View aria-hidden style={animatedLabelWrapperStyles}>
-            <Animated.Text style={animatedLabelTextStyles}>
+            <Animated.Text
+              {...accessibilityProps.label}
+              style={animatedLabelTextStyles}
+            >
               {label}
             </Animated.Text>
           </Animated.View>
@@ -398,7 +443,8 @@ function TextInput({
             })
           : null}
 
-        <Animated.View style={[containerStyles, animatedContainerStyle]}>
+        {/* Keep the field visible to native accessibility even before focus. */}
+        <View style={containerStyles}>
           {hasPrefix && <Text style={prefixStyles}>{prefix}</Text>}
 
           {render({
@@ -406,9 +452,10 @@ function TextInput({
             selectionColor,
             cursorColor,
             placeholderTextColor,
-            ...accessibilityProps.input,
             ...rest,
+            ...accessibilityProps.input,
             editable: isEditable,
+            readOnly: disabled ? true : rest.readOnly,
             placeholder,
             style: inputStyles,
             onChangeText,
@@ -417,7 +464,7 @@ function TextInput({
           })}
 
           {hasSuffix && <Text style={suffixStyles}>{suffix}</Text>}
-        </Animated.View>
+        </View>
 
         {renderTrailingAccessory ? (
           renderTrailingAccessory({
@@ -434,6 +481,7 @@ function TextInput({
       <View style={styles.addendum}>
         {!!supportingText && (
           <Text
+            key={hasError ? 'error' : 'supporting'}
             {...accessibilityProps.supportingText}
             style={supportingTextStyles}
           >

--- a/src/components/TextInput/TextInputIcon.tsx
+++ b/src/components/TextInput/TextInputIcon.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { View } from 'react-native';
 import type { StyleProp, ViewStyle } from 'react-native';
 
@@ -5,6 +6,7 @@ import { ACCESSORY_SIZE } from './constants';
 import { styles } from './styles';
 import { getIconColor } from './utils';
 import { useInternalTheme } from '../../core/theming';
+import hasTouchHandler from '../../utils/hasTouchHandler';
 import IconButton from '../IconButton/IconButton';
 import type { Props as IconButtonProps } from '../IconButton/IconButton';
 
@@ -16,12 +18,30 @@ export type TextInputAccessoryProps = {
 };
 
 export type TextInputIconProps = TextInputAccessoryProps &
-  Omit<IconButtonProps, keyof TextInputAccessoryProps>;
+  Omit<
+    IconButtonProps,
+    keyof TextInputAccessoryProps | 'aria-label' | 'accessibilityLabel'
+  > &
+  (
+    | {
+        onPress?: undefined;
+        onLongPress?: undefined;
+        onPressIn?: undefined;
+        onPressOut?: undefined;
+        'aria-label'?: string;
+        accessibilityLabel?: string;
+      }
+    | { 'aria-label': string; accessibilityLabel?: string }
+    | { 'aria-label'?: string; accessibilityLabel: string }
+  );
 
 /**
  * A component to render a leading / trailing icon in the TextInput
  * (return it from `startAccessory` or `endAccessory`). Accepts icon-specific props as well as
  * `TextInputAccessoryProps`, which TextInput passes into those render props.
+ * Without press handlers, the icon is decorative and hidden from assistive technology.
+ * An actionable icon requires an `aria-label` (or `accessibilityLabel`) that names
+ * its action, such as "Clear text" or "Show password".
  *
  * ## Usage
  * ```js
@@ -36,7 +56,7 @@ export type TextInputIconProps = TextInputAccessoryProps &
  *   );
  *
  *   const clearAccessory = (props) => (
- *     <TextInput.Icon {...props} icon="close" onPress={() => setText('')} />
+ *     <TextInput.Icon {...props} icon="close" aria-label="Clear text" onPress={() => setText('')} />
  *   );
  *
  *   return (
@@ -64,6 +84,7 @@ const TextInputIcon = ({
   disabled,
   theme: themeOverride,
   onPress,
+  multiline: _multiline,
   ...rest
 }: TextInputIconProps) => {
   const theme = useInternalTheme(themeOverride);
@@ -77,17 +98,52 @@ const TextInputIcon = ({
     isDisabled: disabled,
   });
 
+  const actionable = hasTouchHandler({ onPress, ...rest });
+  const iconRef = React.useRef<View>(null);
+  React.useImperativeHandle<View | null, View | null>(
+    rest.ref,
+    () => iconRef.current,
+    []
+  );
+  const accessibleName = rest['aria-label'] ?? rest.accessibilityLabel;
+  React.useEffect(() => {
+    if (__DEV__ && actionable && !accessibleName?.trim()) {
+      console.warn(
+        'TextInput.Icon: an actionable icon requires an aria-label or accessibilityLabel.'
+      );
+    }
+  }, [actionable, accessibleName]);
+
+  void _multiline;
+
   const onPressHandler = disabled ? undefined : onPress;
 
   return (
-    <View style={styles.iconWrapper}>
+    <View
+      style={styles.iconWrapper}
+      aria-hidden={!actionable}
+      pointerEvents={actionable ? 'auto' : 'none'}
+    >
       <IconButton
         {...rest}
+        ref={rest.ref ? iconRef : undefined}
+        {...(!actionable && {
+          role: 'none',
+          accessibilityRole: 'none',
+          accessible: false,
+          focusable: false,
+          tabIndex: -1,
+          'aria-hidden': true,
+        })}
         icon={icon}
         iconColor={color}
         size={iconSize}
         style={[styles.icon, style]}
+        aria-disabled={disabled}
         onPress={onPressHandler}
+        onLongPress={disabled ? undefined : rest.onLongPress}
+        onPressIn={disabled ? undefined : rest.onPressIn}
+        onPressOut={disabled ? undefined : rest.onPressOut}
       />
     </View>
   );

--- a/src/components/TextInput/hooks.ts
+++ b/src/components/TextInput/hooks.ts
@@ -1,11 +1,16 @@
 import {
   useEffect,
   useImperativeHandle,
+  useId,
   useRef,
   useState,
   type RefObject,
 } from 'react';
-import { TextInput as NativeTextInput } from 'react-native';
+import {
+  AccessibilityInfo,
+  Platform,
+  TextInput as NativeTextInput,
+} from 'react-native';
 import type { BlurEvent, FocusEvent } from 'react-native';
 
 import {
@@ -107,10 +112,6 @@ const useTextInputAnimation = ({
     ),
   }));
 
-  const animatedContainerStyle = useAnimatedStyle(() => ({
-    opacity: floatSV.value,
-  }));
-
   const animatedActiveOutlineStyle = useAnimatedStyle(() => ({
     transform: [{ scaleX: focusSV.value }],
   }));
@@ -118,7 +119,6 @@ const useTextInputAnimation = ({
   return {
     animatedLabelWrapperStyle,
     animatedLabelTextStyle,
-    animatedContainerStyle,
     animatedActiveOutlineStyle:
       variant === 'filled' ? animatedActiveOutlineStyle : undefined,
     runFocusAnimation,
@@ -253,6 +253,7 @@ const useTextInputLayout = ({
   theme,
   flags,
   isFocused,
+  isHovered,
   animation,
 }: {
   variant: TextInputVariant;
@@ -261,6 +262,7 @@ const useTextInputLayout = ({
   theme: InternalTheme;
   flags: TextInputFlags;
   isFocused: boolean;
+  isHovered: boolean;
   animation: TextInputAnimationState;
 }): TextInputLayoutState => {
   const { isRTL, isDisabled, hasError, hasAccessory, hasSuffix } = flags;
@@ -283,6 +285,7 @@ const useTextInputLayout = ({
           input,
           theme,
           isFocused,
+          isHovered,
           isRTL,
           isDisabled,
           hasAccessory,
@@ -299,6 +302,7 @@ const useTextInputLayout = ({
           input,
           theme,
           isFocused,
+          isHovered,
           isRTL,
           isDisabled,
           hasAccessory,
@@ -323,6 +327,8 @@ export const useTextInput = (props: TextInputProps): TextInputHookReturn => {
   const { ref, variant = 'filled', theme: themeOverride } = props;
 
   const input = useRef<NativeTextInput>(null);
+  const id = useId();
+  const [isHovered, setIsHovered] = useState(false);
   const init = useRef(false);
 
   const theme = useInternalTheme(themeOverride);
@@ -416,16 +422,27 @@ export const useTextInput = (props: TextInputProps): TextInputHookReturn => {
     theme,
     flags,
     isFocused,
+    isHovered,
     animation,
   });
 
   const accessibilityProps = getAccessibilityData({
+    id,
     hasError: flags.hasError,
     hasCounter: flags.hasCounter,
     isDisabled: flags.isDisabled,
     data: props,
     inputLength,
   });
+
+  // Native iOS does not implement live regions. Announce changed errors once,
+  // while Android and web use the rendered alert/live region.
+  const errorMessage = flags.hasError ? props.supportingText : undefined;
+  useEffect(() => {
+    if (Platform.OS === 'ios' && errorMessage) {
+      AccessibilityInfo.announceForAccessibility(errorMessage);
+    }
+  }, [errorMessage]);
 
   const counterText = `${inputLength}/${props.maxLength}`;
 
@@ -452,7 +469,6 @@ export const useTextInput = (props: TextInputProps): TextInputHookReturn => {
     selectionColor,
     cursorColor,
     animatedActiveOutlineStyles: undefined,
-    animatedContainerStyle: animation.animatedContainerStyle,
     placeholder,
     counterText,
     accessibilityProps,
@@ -463,5 +479,7 @@ export const useTextInput = (props: TextInputProps): TextInputHookReturn => {
     onFocus,
     onBlur,
     focusInput,
+    onHoverIn: () => setIsHovered(true),
+    onHoverOut: () => setIsHovered(false),
   };
 };

--- a/src/components/TextInput/utils.ts
+++ b/src/components/TextInput/utils.ts
@@ -168,37 +168,37 @@ export const getIconColor = ({
 };
 
 /**
- * Returns the raw outline color for a filled field. The disabled state's
- * alpha is intentionally NOT baked in here — it is applied via the `opacity`
- * style on the (childless) outline View so the value can be a `PlatformColor`
- * on Android, which the `color` library cannot parse at runtime.
+ * Resolve the filled indicator or outlined border color. Disabled opacity is
+ * applied by the outline View so native PlatformColor values stay intact.
  */
 export const getOutlineColor = ({
   theme,
   hasError,
   isFocused,
   isDisabled,
+  isHovered = false,
+  variant = 'outlined',
 }: {
   theme: InternalTheme;
   isFocused: boolean;
   hasError: boolean;
   isDisabled: boolean;
+  isHovered?: boolean;
+  variant?: TextInputVariant;
 }) => {
-  const {
-    colors: { error, onSurface, primary, outline },
-  } = theme;
+  const { colors } = theme;
 
+  if (isDisabled) return colors.onSurface;
   if (hasError) {
-    return error;
+    return variant === 'filled' && isHovered && !isFocused
+      ? colors.onErrorContainer
+      : colors.error;
   }
-  if (isDisabled) {
-    return onSurface;
+  if (isFocused) return colors.primary;
+  if (variant === 'filled') {
+    return isHovered ? colors.onSurface : colors.onSurfaceVariant;
   }
-  if (isFocused) {
-    return primary;
-  }
-
-  return outline;
+  return colors.outline;
 };
 
 /**
@@ -330,6 +330,8 @@ export const getFilledTextInputData = (
     hasError,
     isFocused: false,
     isDisabled,
+    variant: 'filled',
+    isHovered: api.isHovered,
   });
 
   const activeOutlineColor = getOutlineColor({
@@ -363,10 +365,7 @@ export const getFilledTextInputData = (
     animatedLabelWrapperStyle,
   ];
 
-  const containerStyles: StyleProp<ViewStyle> = [
-    filledStyles.container,
-    isDisabled && styles.disabled,
-  ];
+  const containerStyles = filledStyles.container;
 
   const fieldStyles: StyleProp<ViewStyle> = [
     styles.field,
@@ -491,10 +490,7 @@ export const getOutlinedTextInputData = (
    * Variant-specific styles
    */
 
-  const containerStyles: StyleProp<ViewStyle> = [
-    outlinedStyles.container,
-    isDisabled && styles.disabled,
-  ];
+  const containerStyles = outlinedStyles.container;
 
   const fieldStyles: StyleProp<ViewStyle> = [
     styles.field,
@@ -568,65 +564,74 @@ export const getOutlinedTextInputData = (
 
 export const getAccessibilityData = ({
   data,
+  id,
   hasError,
   hasCounter,
   isDisabled,
   inputLength,
 }: GetAccessibilityDataProps): GetAccessibilityDataReturn => {
-  const { label, supportingText, ...props } = data;
-
-  const maxLength = props.maxLength;
-  const shouldEvaluateCounter = !!maxLength && hasCounter;
-  const isEmptyString = inputLength === 0;
-  const isCounterExceeded = shouldEvaluateCounter && inputLength > maxLength;
-  const isCounterReached = shouldEvaluateCounter && inputLength === maxLength;
-  const isInvalid = hasError || isCounterExceeded;
-  const isSupportingTextHidden = !!(supportingText && !hasError);
-
-  const chunks: string[] = [];
-
-  if (label) {
-    chunks.push(label);
-  }
-
-  if (isSupportingTextHidden) {
-    chunks.push(supportingText);
-  }
-
-  if (isEmptyString && props.placeholder && !hasError) {
-    chunks.push(props.placeholder);
-  }
-
-  const ariaLabel = chunks.length > 0 ? chunks.join(', ') : label;
-
-  let hint: string | undefined;
-
-  if (isCounterExceeded && !(hasError && supportingText)) {
-    hint = `Character limit exceeded ${inputLength} of ${maxLength}`;
-  }
-
-  const counterAccessibilityLabel = shouldEvaluateCounter
+  const { label, supportingText, maxLength, ...props } = data;
+  const isCounterExceeded =
+    hasCounter && maxLength != null && inputLength > maxLength;
+  const counterAccessibilityLabel = hasCounter
     ? isCounterExceeded
       ? `Character limit exceeded ${inputLength} of ${maxLength}`
       : `Characters entered ${inputLength} of ${maxLength}`
     : undefined;
 
+  const labelId = `${id}-label`;
+  const supportingTextId = `${id}-supporting-text`;
+  const counterId = `${id}-counter`;
+  const describedBy =
+    [
+      props['aria-describedby'],
+      supportingText ? supportingTextId : undefined,
+      hasCounter ? counterId : undefined,
+    ]
+      .filter(Boolean)
+      .join(' ') || undefined;
+  const explicitLabel = props['aria-label'] ?? props.accessibilityLabel;
+  const labelledBy =
+    props['aria-labelledby'] ??
+    (Platform.OS === 'web' &&
+    label &&
+    explicitLabel == null &&
+    !props.accessibilityLabelledBy
+      ? labelId
+      : undefined);
+
+  // React Native 0.85 does not implement described-by relationships on native.
+  // Expose the same description as a hint without changing the field's name.
+  const hint =
+    Platform.OS === 'web'
+      ? props.accessibilityHint
+      : [props.accessibilityHint, supportingText, counterAccessibilityLabel]
+          .filter(Boolean)
+          .join(', ') || undefined;
+
   return {
     input: {
-      'aria-label': ariaLabel,
-      'aria-valuemax': isCounterReached ? maxLength : undefined,
-      'aria-valuenow': isCounterReached ? inputLength : undefined,
-      'aria-disabled': isDisabled,
-      'aria-invalid': isInvalid,
+      'aria-label': explicitLabel ?? label,
+      'aria-labelledby': labelledBy,
+      'aria-describedby': describedBy,
+      'aria-disabled': props['aria-disabled'] ?? isDisabled,
+      'aria-invalid': props['aria-invalid'] ?? (hasError || isCounterExceeded),
       accessibilityHint: hint,
     },
+    label: { nativeID: labelId },
     supportingText: {
-      'aria-hidden': isSupportingTextHidden,
-      'aria-live': hasError && supportingText ? 'polite' : undefined,
+      nativeID: supportingTextId,
+      role: hasError && supportingText ? 'alert' : undefined,
+      accessibilityLiveRegion:
+        Platform.OS === 'android' && hasError && supportingText
+          ? 'assertive'
+          : undefined,
     },
     counter: {
+      nativeID: counterId,
       'aria-label': counterAccessibilityLabel,
-      'aria-live': 'polite',
+      'aria-live': Platform.OS === 'web' ? 'polite' : undefined,
+      accessibilityLiveRegion: Platform.OS === 'android' ? 'polite' : undefined,
     },
   };
 };

--- a/src/components/__tests__/TextInput.test.tsx
+++ b/src/components/__tests__/TextInput.test.tsx
@@ -161,7 +161,12 @@ it('renders filled TextInput with TextInput.Icon accessories when error is true'
           <TextInput.Icon {...props} icon="magnify" />
         )}
         endAccessory={(props: TextInputAccessoryProps) => (
-          <TextInput.Icon {...props} icon="close" onPress={() => {}} />
+          <TextInput.Icon
+            {...props}
+            icon="close"
+            aria-label="Clear"
+            onPress={() => {}}
+          />
         )}
       />
     )
@@ -183,7 +188,12 @@ it('renders outlined TextInput with TextInput.Icon accessories when error is tru
           <TextInput.Icon {...props} icon="magnify" />
         )}
         endAccessory={(props: TextInputAccessoryProps) => (
-          <TextInput.Icon {...props} icon="close" onPress={() => {}} />
+          <TextInput.Icon
+            {...props}
+            icon="close"
+            aria-label="Clear"
+            onPress={() => {}}
+          />
         )}
       />
     )
@@ -227,10 +237,20 @@ it('disables TextInput.Icon when the field is disabled', async () => {
       onChangeText={() => {}}
       disabled
       startAccessory={(props: TextInputAccessoryProps) => (
-        <TextInput.Icon {...props} icon="magnify" onPress={() => {}} />
+        <TextInput.Icon
+          {...props}
+          icon="magnify"
+          aria-label="Search"
+          onPress={() => {}}
+        />
       )}
       endAccessory={(props: TextInputAccessoryProps) => (
-        <TextInput.Icon {...props} icon="close" onPress={() => {}} />
+        <TextInput.Icon
+          {...props}
+          icon="close"
+          aria-label="Clear"
+          onPress={() => {}}
+        />
       )}
     />
   );
@@ -248,10 +268,20 @@ it('does not disable TextInput.Icon when the field is read-only (editable false)
       onChangeText={() => {}}
       editable={false}
       startAccessory={(props: TextInputAccessoryProps) => (
-        <TextInput.Icon {...props} icon="magnify" onPress={() => {}} />
+        <TextInput.Icon
+          {...props}
+          icon="magnify"
+          aria-label="Search"
+          onPress={() => {}}
+        />
       )}
       endAccessory={(props: TextInputAccessoryProps) => (
-        <TextInput.Icon {...props} icon="close" onPress={() => {}} />
+        <TextInput.Icon
+          {...props}
+          icon="close"
+          aria-label="Clear"
+          onPress={() => {}}
+        />
       )}
     />
   );
@@ -276,7 +306,7 @@ it('renders supporting text below the field', async () => {
   ).toBeOnTheScreen();
 });
 
-it('uses polite aria-live on error supporting text', async () => {
+it('uses an alert for error supporting text', async () => {
   await render(
     <TextInput
       label="Email"
@@ -288,7 +318,7 @@ it('uses polite aria-live on error supporting text', async () => {
     />
   );
 
-  expect(screen.getByText('Invalid')).toHaveProp('aria-live', 'polite');
+  expect(screen.getByText('Invalid')).toHaveProp('role', 'alert');
   expect(screen.getByLabelText('Email')).toHaveProp('aria-invalid', true);
 });
 
@@ -308,7 +338,7 @@ it('marks the input invalid when error is true without supporting text', async (
   expect(input).not.toHaveProp('accessibilityHint');
 });
 
-it('hides helper supporting text from the accessibility tree and omits aria-live', async () => {
+it('exposes helper supporting text without including it in the field name', async () => {
   await render(
     <TextInput
       label="Email"
@@ -320,12 +350,12 @@ it('hides helper supporting text from the accessibility tree and omits aria-live
   );
 
   const supportingText = screen.getByText('Optional', includeHiddenElements);
-  expect(supportingText).toHaveProp('aria-hidden', true);
+  expect(supportingText).not.toHaveProp('aria-hidden', true);
   expect(supportingText).not.toHaveProp('aria-live');
-  expect(screen.getByLabelText('Email, Optional')).toBeOnTheScreen();
+  expect(screen.getByLabelText('Email')).toBeOnTheScreen();
 });
 
-it('includes supporting text in aria-label when label is omitted', async () => {
+it('keeps supporting text separate when label is omitted', async () => {
   await render(
     <TextInput
       value=""
@@ -335,7 +365,8 @@ it('includes supporting text in aria-label when label is omitted', async () => {
     />
   );
 
-  expect(screen.getByLabelText('Helper only')).toBeOnTheScreen();
+  expect(screen.getByTestId('tf-input')).not.toHaveProp('aria-label');
+  expect(screen.getByText('Helper only')).toBeOnTheScreen();
 });
 
 it('does not mark the input as aria-disabled when editable is false (read-only)', async () => {

--- a/src/components/__tests__/TextInputAccessibility.test.tsx
+++ b/src/components/__tests__/TextInputAccessibility.test.tsx
@@ -1,0 +1,437 @@
+import {
+  AccessibilityInfo,
+  Text,
+  Platform,
+  TextInput as NativeTextInput,
+} from 'react-native';
+
+import { afterEach, expect, it, jest } from '@jest/globals';
+
+import { fireEvent, render, screen, userEvent } from '../../test-utils';
+import TextInput from '../TextInput';
+import type { TextInputRenderProps } from '../TextInput/TextInput';
+
+const renderInput = jest.fn((props: TextInputRenderProps) => (
+  <NativeTextInput {...props} />
+));
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  renderInput.mockClear();
+});
+
+it.each(['filled', 'outlined'] as const)(
+  'keeps an empty unfocused %s field visible to assistive technology',
+  async (variant) => {
+    await render(<TextInput variant={variant} label="Email" />);
+
+    expect(screen.getByLabelText('Email')).toBeVisible();
+    await fireEvent(screen.getByLabelText('Email'), 'focus');
+    await fireEvent(screen.getByLabelText('Email'), 'blur');
+    expect(screen.getByLabelText('Email')).toBeVisible();
+  }
+);
+
+it('preserves accessory refs when switching between decoration and action', async () => {
+  const cleanup = jest.fn<() => void>();
+  const ref = jest.fn(() => cleanup);
+  const props = {
+    icon: 'magnify',
+    style: {},
+    disabled: false,
+    error: false,
+    multiline: false,
+    ref,
+  };
+  const { rerender, unmount } = await render(<TextInput.Icon {...props} />);
+  const decoration = ref.mock.lastCall;
+  expect(ref).toHaveBeenCalledWith(
+    expect.objectContaining({ measure: expect.any(Function) })
+  );
+
+  await rerender(
+    <TextInput.Icon {...props} onPress={() => {}} aria-label="Search" />
+  );
+  expect(cleanup).not.toHaveBeenCalled();
+  expect(ref.mock.lastCall).toEqual(decoration);
+
+  await rerender(<TextInput.Icon {...props} />);
+  expect(cleanup).not.toHaveBeenCalled();
+  await unmount();
+  expect(cleanup).toHaveBeenCalledTimes(1);
+});
+
+it.each(['filled', 'outlined'] as const)(
+  'associates helper and counter without changing the %s field name',
+  async (variant) => {
+    await render(
+      <TextInput
+        variant={variant}
+        label="Email"
+        supportingText="Use a work address"
+        counter
+        maxLength={40}
+        render={renderInput}
+      />
+    );
+    const inputProps = renderInput.mock.lastCall?.[0];
+    const ids = inputProps?.['aria-describedby']?.split(' ');
+
+    expect(screen.getByLabelText('Email')).toBeOnTheScreen();
+    expect(inputProps?.['aria-describedby']).toEqual(expect.any(String));
+    expect(ids).toHaveLength(2);
+    expect(screen.getByText('Use a work address')).toHaveProp(
+      'nativeID',
+      ids?.[0]
+    );
+    expect(screen.getByText('0/40')).toHaveProp('nativeID', ids?.[1]);
+  }
+);
+
+it('keeps generated IDs stable as helper text becomes an error and removes absent descriptions', async () => {
+  const { rerender } = await render(
+    <TextInput label="Email" supportingText="Optional" render={renderInput} />
+  );
+  const describedBy = renderInput.mock.lastCall?.[0]['aria-describedby'];
+  expect(describedBy).toEqual(expect.any(String));
+
+  await rerender(
+    <TextInput
+      label="Email"
+      supportingText="Invalid address"
+      error
+      render={renderInput}
+    />
+  );
+  expect(screen.getByLabelText('Email')).toHaveProp(
+    'aria-describedby',
+    describedBy
+  );
+  expect(screen.getByRole('alert')).toHaveTextContent('Invalid address');
+  expect(screen.getByRole('alert')).toHaveProp('nativeID', describedBy);
+
+  await rerender(<TextInput label="Email" render={renderInput} />);
+  expect(screen.getByLabelText('Email')).not.toHaveProp('aria-describedby');
+  expect(screen.queryByRole('alert')).toBeNull();
+});
+
+it('gives different fields distinct description IDs even with the same test ID', async () => {
+  await render(
+    <>
+      <TextInput
+        label="First"
+        supportingText="First help"
+        testID="field"
+        render={renderInput}
+      />
+      <TextInput
+        label="Second"
+        supportingText="Second help"
+        testID="field"
+        render={renderInput}
+      />
+    </>
+  );
+  const first = renderInput.mock.calls[0]?.[0]['aria-describedby'];
+  const second = renderInput.mock.calls[1]?.[0]['aria-describedby'];
+  expect(first).toEqual(expect.any(String));
+  expect(second).toEqual(expect.any(String));
+  expect(first).not.toBe(second);
+});
+
+it('merges external descriptions and preserves an explicit accessible name in a custom renderer', async () => {
+  await render(
+    <TextInput
+      label="Email"
+      aria-label="Work email"
+      aria-describedby="privacy"
+      supportingText="Use a work address"
+      render={renderInput}
+    />
+  );
+  const describedBy = renderInput.mock.lastCall?.[0]['aria-describedby'];
+  expect(describedBy).toMatch(/^privacy \S+$/);
+  expect(screen.getByLabelText('Work email')).toHaveProp(
+    'aria-describedby',
+    describedBy
+  );
+  expect(screen.getByText('Use a work address')).toHaveProp(
+    'nativeID',
+    describedBy?.split(' ')[1]
+  );
+});
+
+it.each(['ios', 'android'] as const)(
+  'provides field descriptions as a native hint on %s',
+  async (platform) => {
+    jest.replaceProperty(Platform, 'OS', platform);
+    await render(
+      <TextInput
+        label="Bio"
+        accessibilityHint="Double tap to edit"
+        supportingText="Keep it short"
+        defaultValue="Hi"
+        counter
+        maxLength={20}
+      />
+    );
+    expect(screen.getByLabelText('Bio')).toHaveProp(
+      'accessibilityHint',
+      'Double tap to edit, Keep it short, Characters entered 2 of 20'
+    );
+  }
+);
+
+it('uses web descriptions without duplicating them in a hint', async () => {
+  jest.replaceProperty(Platform, 'OS', 'web');
+  await render(<TextInput label="Bio" supportingText="Keep it short" />);
+  expect(screen.getByLabelText('Bio')).not.toHaveProp('accessibilityHint');
+});
+
+it.each([true, false, 'true', 'false', 'grammar', 'spelling'] as const)(
+  'preserves explicit aria-invalid=%s independently of the error prop',
+  async (invalid) => {
+    jest.replaceProperty(Platform, 'OS', 'web');
+    const { rerender } = await render(
+      <TextInput label="Email" aria-invalid={invalid} render={renderInput} />
+    );
+    expect(renderInput.mock.lastCall?.[0]['aria-invalid']).toBe(invalid);
+
+    await rerender(
+      <TextInput
+        label="Email"
+        aria-invalid={invalid}
+        error
+        render={renderInput}
+      />
+    );
+    expect(renderInput.mock.lastCall?.[0]['aria-invalid']).toBe(invalid);
+
+    await rerender(<TextInput label="Email" error render={renderInput} />);
+    expect(renderInput.mock.lastCall?.[0]['aria-invalid']).toBe(true);
+
+    await rerender(<TextInput label="Email" render={renderInput} />);
+    expect(renderInput.mock.lastCall?.[0]['aria-invalid']).toBe(false);
+  }
+);
+
+it('announces each changed error message once on iOS', async () => {
+  jest.replaceProperty(Platform, 'OS', 'ios');
+  const announce = jest
+    .spyOn(AccessibilityInfo, 'announceForAccessibility')
+    .mockClear();
+  const { rerender } = await render(
+    <TextInput label="Email" supportingText="Optional" />
+  );
+  expect(announce).not.toHaveBeenCalled();
+
+  await rerender(
+    <TextInput label="Email" supportingText="Invalid address" error />
+  );
+  expect(announce).toHaveBeenLastCalledWith('Invalid address');
+  await rerender(
+    <TextInput label="Email" supportingText="Invalid address" error value="a" />
+  );
+  expect(announce).toHaveBeenCalledTimes(1);
+  await rerender(
+    <TextInput label="Email" supportingText="Address is required" error />
+  );
+  expect(announce).toHaveBeenLastCalledWith('Address is required');
+  await rerender(<TextInput label="Email" supportingText="Optional" />);
+  expect(announce).toHaveBeenCalledTimes(2);
+});
+
+it('uses an assertive Android live region for an error', async () => {
+  jest.replaceProperty(Platform, 'OS', 'android');
+  await render(
+    <TextInput label="Email" supportingText="Invalid address" error />
+  );
+  expect(screen.getByRole('alert')).toHaveProp(
+    'accessibilityLiveRegion',
+    'assertive'
+  );
+});
+
+it('uses a native Android live region for counter updates', async () => {
+  jest.replaceProperty(Platform, 'OS', 'android');
+  await render(<TextInput label="Email" counter maxLength={40} />);
+  expect(screen.getByText('0/40')).toHaveProp(
+    'accessibilityLiveRegion',
+    'polite'
+  );
+});
+
+it('keeps a disabled native input read-only when readOnly is explicitly false', async () => {
+  await render(
+    <TextInput label="Email" disabled readOnly={false} render={renderInput} />
+  );
+  expect(renderInput.mock.lastCall?.[0].editable).toBe(false);
+  expect(renderInput.mock.lastCall?.[0].readOnly).toBe(true);
+});
+
+it.each(['onLongPress', 'onPressIn', 'onPressOut'] as const)(
+  'preserves an accessory using only %s',
+  async (handler) => {
+    const onAction = jest.fn<() => void>();
+    await render(
+      <TextInput
+        label="Search"
+        endAccessory={(props) => (
+          <TextInput.Icon
+            {...props}
+            icon="magnify"
+            aria-label="Search action"
+            {...{ [handler]: onAction }}
+          />
+        )}
+      />
+    );
+    await userEvent.longPress(
+      screen.getByRole('button', { name: 'Search action' })
+    );
+    expect(onAction).toHaveBeenCalledTimes(1);
+  }
+);
+
+it('renders decorative accessories outside the accessibility tree without buttons', async () => {
+  await render(
+    <TextInput
+      label="Search"
+      startAccessory={(props) => <TextInput.Icon {...props} icon="magnify" />}
+      endAccessory={(props) => <TextInput.Icon {...props} icon="account" />}
+    />
+  );
+  expect(screen.queryAllByRole('button')).toHaveLength(0);
+  expect(screen.queryByText('magnify')).toBeNull();
+  expect(
+    screen.getByText('magnify', { includeHiddenElements: true })
+  ).toBeOnTheScreen();
+});
+
+it('preserves decorative loading and container visuals without accessible controls', async () => {
+  await render(
+    <TextInput
+      label="Search"
+      endAccessory={(props) => (
+        <TextInput.Icon
+          {...props}
+          icon="magnify"
+          loading
+          mode="outlined"
+          containerColor="pink"
+          contentStyle={{ padding: 2 }}
+          testID="search-decoration"
+        />
+      )}
+    />
+  );
+  expect(screen.queryAllByRole('button')).toHaveLength(0);
+  expect(screen.queryByRole('progressbar')).toBeNull();
+  expect(
+    screen.getByRole('progressbar', { includeHiddenElements: true })
+  ).toBeOnTheScreen();
+  expect(
+    screen.getByTestId('search-decoration-container', {
+      includeHiddenElements: true,
+    })
+  ).toHaveStyle({ backgroundColor: 'pink', borderWidth: 1 });
+  expect(
+    screen.getByTestId('search-decoration', { includeHiddenElements: true })
+  ).toHaveStyle({ padding: 2 });
+});
+
+it('keeps a named disabled accessory inoperable', async () => {
+  const onPress = jest.fn<() => void>();
+  await render(
+    <TextInput
+      label="Search"
+      disabled
+      endAccessory={(props) => (
+        <TextInput.Icon
+          {...props}
+          icon="close"
+          aria-label="Clear search"
+          onPress={onPress}
+        />
+      )}
+    />
+  );
+  const button = screen.getByRole('button', { name: 'Clear search' });
+  expect(button).toBeDisabled();
+  await userEvent.press(button);
+  expect(onPress).not.toHaveBeenCalled();
+});
+
+it('blocks every accessory activation handler when the field is disabled', async () => {
+  const onPress = jest.fn<() => void>();
+  const onLongPress = jest.fn<() => void>();
+  const onPressIn = jest.fn();
+  const onPressOut = jest.fn();
+  await render(
+    <TextInput
+      label="Search"
+      disabled
+      endAccessory={(props) => (
+        <TextInput.Icon
+          {...props}
+          icon="close"
+          aria-label="Clear search"
+          onPress={onPress}
+          onLongPress={onLongPress}
+          onPressIn={onPressIn}
+          onPressOut={onPressOut}
+        />
+      )}
+    />
+  );
+  const button = screen.getByRole('button', { name: 'Clear search' });
+  await userEvent.longPress(button);
+  expect(onPress).not.toHaveBeenCalled();
+  expect(onLongPress).not.toHaveBeenCalled();
+  expect(onPressIn).not.toHaveBeenCalled();
+  expect(onPressOut).not.toHaveBeenCalled();
+});
+
+it.each(['aria-labelledby', 'accessibilityLabelledBy'] as const)(
+  'preserves caller %s relationships',
+  async (attribute) => {
+    await render(
+      <>
+        <Text nativeID="external-label">Work address</Text>
+        <TextInput
+          label="Email"
+          {...{ [attribute]: 'external-label' }}
+          supportingText="Use your work address"
+          render={renderInput}
+        />
+      </>
+    );
+    expect(renderInput.mock.lastCall?.[0][attribute]).toBe('external-label');
+    expect(renderInput.mock.lastCall?.[0]['aria-describedby']).toEqual(
+      expect.any(String)
+    );
+  }
+);
+
+it('forwards decorative accessory layout callbacks and native IDs', async () => {
+  const onLayout = jest.fn();
+  await render(
+    <TextInput
+      label="Search"
+      startAccessory={(props) => (
+        <TextInput.Icon
+          {...props}
+          icon="magnify"
+          testID="decoration"
+          nativeID="search-icon"
+          onLayout={onLayout}
+        />
+      )}
+    />
+  );
+  const icon = screen.getByTestId('decoration', {
+    includeHiddenElements: true,
+  });
+  expect(icon).toHaveProp('nativeID', 'search-icon');
+  expect(icon).toHaveProp('onLayout', onLayout);
+});

--- a/src/components/__tests__/TextInputStates.test.tsx
+++ b/src/components/__tests__/TextInputStates.test.tsx
@@ -1,0 +1,91 @@
+import { Platform, StyleSheet } from 'react-native';
+
+import { afterEach, expect, it, jest } from '@jest/globals';
+import { renderHook } from '@testing-library/react-native';
+
+import PaperProvider from '../../core/PaperProvider';
+import { getTheme } from '../../core/theming';
+import { act } from '../../test-utils';
+import { useTextInput } from '../TextInput/hooks';
+
+const theme = getTheme();
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+it.each(['filled', 'outlined'] as const)(
+  'applies disabled opacity once to %s text and affixes',
+  async (variant) => {
+    const { result } = await renderHook(
+      () =>
+        useTextInput({
+          variant,
+          disabled: true,
+          value: 'Sample',
+          prefix: '$',
+          suffix: '/100',
+        }),
+      { wrapper: PaperProvider }
+    );
+    const containerOpacity =
+      StyleSheet.flatten(result.current.containerStyles)?.opacity ?? 1;
+    expect(containerOpacity).toBe(1);
+    for (const styles of [
+      result.current.inputStyles,
+      result.current.prefixStyles,
+      result.current.suffixStyles,
+    ]) {
+      expect(StyleSheet.flatten(styles)?.opacity).toBe(0.38);
+    }
+  }
+);
+
+it('uses MD3 filled resting and hover colors without overriding the focused or disabled indicator', async () => {
+  jest.replaceProperty(Platform, 'OS', 'web');
+  const { result, rerender } = await renderHook(
+    (props: { error?: boolean; disabled?: boolean }) => useTextInput(props),
+    { initialProps: {}, wrapper: PaperProvider }
+  );
+  expect(
+    StyleSheet.flatten(result.current.outlineStyles)?.backgroundColor
+  ).toBe(theme.colors.onSurfaceVariant);
+  await act(() => result.current.onHoverIn());
+  expect(
+    StyleSheet.flatten(result.current.outlineStyles)?.backgroundColor
+  ).toBe(theme.colors.onSurface);
+  expect(
+    StyleSheet.flatten(result.current.animatedActiveOutlineStyles)
+  ).toMatchObject({ backgroundColor: theme.colors.primary });
+  await rerender({ error: true });
+  expect(
+    StyleSheet.flatten(result.current.outlineStyles)?.backgroundColor
+  ).toBe(theme.colors.onErrorContainer);
+  expect(
+    StyleSheet.flatten(result.current.animatedActiveOutlineStyles)
+  ).toMatchObject({ backgroundColor: theme.colors.error });
+  await act(() => result.current.onHoverOut());
+  expect(
+    StyleSheet.flatten(result.current.outlineStyles)?.backgroundColor
+  ).toBe(theme.colors.error);
+  await act(() => result.current.onHoverIn());
+  await rerender({ error: true, disabled: true });
+  expect(
+    StyleSheet.flatten(result.current.outlineStyles)?.backgroundColor
+  ).toBe(theme.colors.onSurface);
+  await act(() => result.current.onHoverOut());
+  await rerender({});
+  expect(
+    StyleSheet.flatten(result.current.outlineStyles)?.backgroundColor
+  ).toBe(theme.colors.onSurfaceVariant);
+});
+
+it('preserves the outlined resting color on hover', async () => {
+  const { result } = await renderHook(
+    () => useTextInput({ variant: 'outlined' }),
+    { wrapper: PaperProvider }
+  );
+  await act(() => result.current.onHoverIn());
+  expect(StyleSheet.flatten(result.current.outlineStyles)?.borderColor).toBe(
+    theme.colors.outline
+  );
+});

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
             "right": 0,
           },
           {
-            "backgroundColor": "rgba(121, 116, 126, 1)",
+            "backgroundColor": "rgba(73, 69, 79, 1)",
             "height": 1,
           },
           false,
@@ -115,6 +115,7 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
     >
       <Text
         collapsable={false}
+        nativeID="_r_2_-label"
         style={
           [
             {
@@ -137,6 +138,8 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
       </Text>
     </View>
     <View
+      aria-hidden={true}
+      pointerEvents="none"
       style={
         {
           "alignItems": "center",
@@ -178,6 +181,7 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
         }
       >
         <View
+          accessibilityRole="none"
           accessibilityState={
             {
               "busy": undefined,
@@ -195,10 +199,11 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
               "text": undefined,
             }
           }
-          accessible={true}
+          accessible={false}
+          aria-hidden={true}
           centered={true}
           collapsable={false}
-          focusable={true}
+          focusable={false}
           hitSlop={
             {
               "bottom": 6,
@@ -207,7 +212,6 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
               "top": 6,
             }
           }
-          multiline={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -217,7 +221,7 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
           onResponderTerminate={[Function]}
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
-          role="button"
+          role="none"
           style={
             [
               {
@@ -233,6 +237,7 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
               ],
             ]
           }
+          tabIndex={-1}
         >
           <View
             style={
@@ -275,20 +280,13 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
       </View>
     </View>
     <View
-      collapsable={false}
       style={
-        [
-          {
-            "alignItems": "flex-end",
-            "flex": 1,
-            "flexDirection": "row",
-            "paddingHorizontal": 16,
-          },
-          false,
-          {
-            "opacity": 1,
-          },
-        ]
+        {
+          "alignItems": "flex-end",
+          "flex": 1,
+          "flexDirection": "row",
+          "paddingHorizontal": 16,
+        }
       }
     >
       <TextInput
@@ -326,6 +324,8 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
       />
     </View>
     <View
+      aria-hidden={true}
+      pointerEvents="none"
       style={
         {
           "alignItems": "center",
@@ -367,6 +367,7 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
         }
       >
         <View
+          accessibilityRole="none"
           accessibilityState={
             {
               "busy": undefined,
@@ -384,10 +385,11 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
               "text": undefined,
             }
           }
-          accessible={true}
+          accessible={false}
+          aria-hidden={true}
           centered={true}
           collapsable={false}
-          focusable={true}
+          focusable={false}
           hitSlop={
             {
               "bottom": 6,
@@ -396,7 +398,6 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
               "top": 6,
             }
           }
-          multiline={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -406,7 +407,7 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
           onResponderTerminate={[Function]}
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
-          role="button"
+          role="none"
           style={
             [
               {
@@ -422,6 +423,7 @@ exports[`renders filled TextInput with TextInput.Icon accessories 1`] = `
               ],
             ]
           }
+          tabIndex={-1}
         >
           <View
             style={
@@ -589,6 +591,7 @@ exports[`renders filled TextInput with TextInput.Icon accessories when error is 
     >
       <Text
         collapsable={false}
+        nativeID="_r_4_-label"
         style={
           [
             {
@@ -611,6 +614,8 @@ exports[`renders filled TextInput with TextInput.Icon accessories when error is 
       </Text>
     </View>
     <View
+      aria-hidden={true}
+      pointerEvents="none"
       style={
         {
           "alignItems": "center",
@@ -652,6 +657,7 @@ exports[`renders filled TextInput with TextInput.Icon accessories when error is 
         }
       >
         <View
+          accessibilityRole="none"
           accessibilityState={
             {
               "busy": undefined,
@@ -669,10 +675,11 @@ exports[`renders filled TextInput with TextInput.Icon accessories when error is 
               "text": undefined,
             }
           }
-          accessible={true}
+          accessible={false}
+          aria-hidden={true}
           centered={true}
           collapsable={false}
-          focusable={true}
+          focusable={false}
           hitSlop={
             {
               "bottom": 6,
@@ -681,7 +688,6 @@ exports[`renders filled TextInput with TextInput.Icon accessories when error is 
               "top": 6,
             }
           }
-          multiline={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -691,7 +697,7 @@ exports[`renders filled TextInput with TextInput.Icon accessories when error is 
           onResponderTerminate={[Function]}
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
-          role="button"
+          role="none"
           style={
             [
               {
@@ -707,6 +713,7 @@ exports[`renders filled TextInput with TextInput.Icon accessories when error is 
               ],
             ]
           }
+          tabIndex={-1}
         >
           <View
             style={
@@ -749,20 +756,13 @@ exports[`renders filled TextInput with TextInput.Icon accessories when error is 
       </View>
     </View>
     <View
-      collapsable={false}
       style={
-        [
-          {
-            "alignItems": "flex-end",
-            "flex": 1,
-            "flexDirection": "row",
-            "paddingHorizontal": 16,
-          },
-          false,
-          {
-            "opacity": 1,
-          },
-        ]
+        {
+          "alignItems": "flex-end",
+          "flex": 1,
+          "flexDirection": "row",
+          "paddingHorizontal": 16,
+        }
       }
     >
       <TextInput
@@ -800,6 +800,8 @@ exports[`renders filled TextInput with TextInput.Icon accessories when error is 
       />
     </View>
     <View
+      aria-hidden={false}
+      pointerEvents="auto"
       style={
         {
           "alignItems": "center",
@@ -841,6 +843,7 @@ exports[`renders filled TextInput with TextInput.Icon accessories when error is 
         }
       >
         <View
+          accessibilityLabel="Clear"
           accessibilityState={
             {
               "busy": undefined,
@@ -870,7 +873,6 @@ exports[`renders filled TextInput with TextInput.Icon accessories when error is 
               "top": 6,
             }
           }
-          multiline={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -1010,7 +1012,7 @@ exports[`renders filled TextInput with label and value 1`] = `
             "right": 0,
           },
           {
-            "backgroundColor": "rgba(121, 116, 126, 1)",
+            "backgroundColor": "rgba(73, 69, 79, 1)",
             "height": 1,
           },
           false,
@@ -1063,6 +1065,7 @@ exports[`renders filled TextInput with label and value 1`] = `
     >
       <Text
         collapsable={false}
+        nativeID="_r_0_-label"
         style={
           [
             {
@@ -1085,20 +1088,13 @@ exports[`renders filled TextInput with label and value 1`] = `
       </Text>
     </View>
     <View
-      collapsable={false}
       style={
-        [
-          {
-            "alignItems": "flex-end",
-            "flex": 1,
-            "flexDirection": "row",
-            "paddingHorizontal": 16,
-          },
-          false,
-          {
-            "opacity": 1,
-          },
-        ]
+        {
+          "alignItems": "flex-end",
+          "flex": 1,
+          "flexDirection": "row",
+          "paddingHorizontal": 16,
+        }
       }
     >
       <TextInput
@@ -1241,6 +1237,7 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
     >
       <Text
         collapsable={false}
+        nativeID="_r_3_-label"
         style={
           [
             {
@@ -1263,6 +1260,8 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
       </Text>
     </View>
     <View
+      aria-hidden={true}
+      pointerEvents="none"
       style={
         {
           "alignItems": "center",
@@ -1304,6 +1303,7 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
         }
       >
         <View
+          accessibilityRole="none"
           accessibilityState={
             {
               "busy": undefined,
@@ -1321,10 +1321,11 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
               "text": undefined,
             }
           }
-          accessible={true}
+          accessible={false}
+          aria-hidden={true}
           centered={true}
           collapsable={false}
-          focusable={true}
+          focusable={false}
           hitSlop={
             {
               "bottom": 6,
@@ -1333,7 +1334,6 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
               "top": 6,
             }
           }
-          multiline={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -1343,7 +1343,7 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
           onResponderTerminate={[Function]}
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
-          role="button"
+          role="none"
           style={
             [
               {
@@ -1359,6 +1359,7 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
               ],
             ]
           }
+          tabIndex={-1}
         >
           <View
             style={
@@ -1401,20 +1402,13 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
       </View>
     </View>
     <View
-      collapsable={false}
       style={
-        [
-          {
-            "alignItems": "center",
-            "flex": 1,
-            "flexDirection": "row",
-            "paddingHorizontal": 16,
-          },
-          false,
-          {
-            "opacity": 1,
-          },
-        ]
+        {
+          "alignItems": "center",
+          "flex": 1,
+          "flexDirection": "row",
+          "paddingHorizontal": 16,
+        }
       }
     >
       <TextInput
@@ -1452,6 +1446,8 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
       />
     </View>
     <View
+      aria-hidden={true}
+      pointerEvents="none"
       style={
         {
           "alignItems": "center",
@@ -1493,6 +1489,7 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
         }
       >
         <View
+          accessibilityRole="none"
           accessibilityState={
             {
               "busy": undefined,
@@ -1510,10 +1507,11 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
               "text": undefined,
             }
           }
-          accessible={true}
+          accessible={false}
+          aria-hidden={true}
           centered={true}
           collapsable={false}
-          focusable={true}
+          focusable={false}
           hitSlop={
             {
               "bottom": 6,
@@ -1522,7 +1520,6 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
               "top": 6,
             }
           }
-          multiline={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -1532,7 +1529,7 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
           onResponderTerminate={[Function]}
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
-          role="button"
+          role="none"
           style={
             [
               {
@@ -1548,6 +1545,7 @@ exports[`renders outlined TextInput with TextInput.Icon accessories 1`] = `
               ],
             ]
           }
+          tabIndex={-1}
         >
           <View
             style={
@@ -1695,6 +1693,7 @@ exports[`renders outlined TextInput with TextInput.Icon accessories when error i
     >
       <Text
         collapsable={false}
+        nativeID="_r_5_-label"
         style={
           [
             {
@@ -1717,6 +1716,8 @@ exports[`renders outlined TextInput with TextInput.Icon accessories when error i
       </Text>
     </View>
     <View
+      aria-hidden={true}
+      pointerEvents="none"
       style={
         {
           "alignItems": "center",
@@ -1758,6 +1759,7 @@ exports[`renders outlined TextInput with TextInput.Icon accessories when error i
         }
       >
         <View
+          accessibilityRole="none"
           accessibilityState={
             {
               "busy": undefined,
@@ -1775,10 +1777,11 @@ exports[`renders outlined TextInput with TextInput.Icon accessories when error i
               "text": undefined,
             }
           }
-          accessible={true}
+          accessible={false}
+          aria-hidden={true}
           centered={true}
           collapsable={false}
-          focusable={true}
+          focusable={false}
           hitSlop={
             {
               "bottom": 6,
@@ -1787,7 +1790,6 @@ exports[`renders outlined TextInput with TextInput.Icon accessories when error i
               "top": 6,
             }
           }
-          multiline={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -1797,7 +1799,7 @@ exports[`renders outlined TextInput with TextInput.Icon accessories when error i
           onResponderTerminate={[Function]}
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
-          role="button"
+          role="none"
           style={
             [
               {
@@ -1813,6 +1815,7 @@ exports[`renders outlined TextInput with TextInput.Icon accessories when error i
               ],
             ]
           }
+          tabIndex={-1}
         >
           <View
             style={
@@ -1855,20 +1858,13 @@ exports[`renders outlined TextInput with TextInput.Icon accessories when error i
       </View>
     </View>
     <View
-      collapsable={false}
       style={
-        [
-          {
-            "alignItems": "center",
-            "flex": 1,
-            "flexDirection": "row",
-            "paddingHorizontal": 16,
-          },
-          false,
-          {
-            "opacity": 1,
-          },
-        ]
+        {
+          "alignItems": "center",
+          "flex": 1,
+          "flexDirection": "row",
+          "paddingHorizontal": 16,
+        }
       }
     >
       <TextInput
@@ -1906,6 +1902,8 @@ exports[`renders outlined TextInput with TextInput.Icon accessories when error i
       />
     </View>
     <View
+      aria-hidden={false}
+      pointerEvents="auto"
       style={
         {
           "alignItems": "center",
@@ -1947,6 +1945,7 @@ exports[`renders outlined TextInput with TextInput.Icon accessories when error i
         }
       >
         <View
+          accessibilityLabel="Clear"
           accessibilityState={
             {
               "busy": undefined,
@@ -1976,7 +1975,6 @@ exports[`renders outlined TextInput with TextInput.Icon accessories when error i
               "top": 6,
             }
           }
-          multiline={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -2149,6 +2147,7 @@ exports[`renders outlined TextInput with label and value 1`] = `
     >
       <Text
         collapsable={false}
+        nativeID="_r_1_-label"
         style={
           [
             {
@@ -2171,20 +2170,13 @@ exports[`renders outlined TextInput with label and value 1`] = `
       </Text>
     </View>
     <View
-      collapsable={false}
       style={
-        [
-          {
-            "alignItems": "center",
-            "flex": 1,
-            "flexDirection": "row",
-            "paddingHorizontal": 16,
-          },
-          false,
-          {
-            "opacity": 1,
-          },
-        ]
+        {
+          "alignItems": "center",
+          "flex": 1,
+          "flexDirection": "row",
+          "paddingHorizontal": 16,
+        }
       }
     >
       <TextInput


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->
### Motivation

`TextInput` is one of the MD3 reference components. The review found the filled active indicator using the wrong resting colour with no hover state, the field's supporting text, error and counter never programmatically associated with the input, and decorative accessories rendering as focusable buttons.

This worth mentioning:

- **Supporting text is no longer part of the field's name.** It was concatenated into `aria-label`, so a screen reader read label and helper as one blob. It now carries a generated `nativeID` referenced by `aria-describedby` on web. React Native 0.85 has no native described-by, so on Android and iOS the same text goes into `accessibilityHint`, which describes without renaming.
- **Error announcement is per-platform**, because live regions are not portable: `role="alert"`, an assertive region on Android, and a one-shot `AccessibilityInfo` announcement on iOS, which implements neither.
- **An accessory is decorative unless it can be pressed. Breaking.** With no press handler it is `aria-hidden` and unfocusable, so a plain leading icon no longer creates a tab stop that announces "button". With one, it requires an accessible name, enforced by the props type and a `__DEV__` warning.
- **Indicator colours now match the tokens**: filled `onSurfaceVariant` at rest, `onSurface` hovered, `primary` focused, `error` invalid, `onErrorContainer` invalid and hovered. Outlined keeps `outline` and correctly does not react to hover.

Also fixed: the field container was opacity-bound to the label animation, which faded an empty unfocused field out of the native accessibility tree, and a disabled input is now `readOnly` so it cannot be operated. `aria-invalid` and `aria-describedby` are public props, and an explicit value wins over the derived one.

Indicator values were verified against material-web's generated `_md-comp-filled-text-field.scss`, since the spec site is JS-rendered.

### Related issue

The TextInput review checklist:

- [x] Filled active-indicator resting color uses `outline`; MD3 uses `onSurfaceVariant`.
- [x] Filled active indicator has no hover state (MD3 hover = on-surface). Also adds the error-hover token (`onErrorContainer`), missing for the same reason.
- [x] Helper/error/counter text is not programmatically associated with the field; supporting text is folded into the input `aria-label`, and the error is `aria-live="polite"` rather than `role="alert"`. Associate them (`aria-describedby` / `nativeID`) and announce errors.
- [x] Decorative left/right accessories always render a focusable `IconButton` (`role="button"`) even when non-actionable; render decorative icons non-interactively and require names for actionable ones.

### Test plan

`yarn lint`, `yarn typecheck` and `yarn test` pass - 713 tests, 168 snapshots.

35 new tests (TextInput: 62 to 97) in two new suites. `TextInputAccessibility.test.tsx` covers ID stability as helper text becomes an error, distinct IDs across fields sharing a testID, merged external `aria-describedby`, web descriptions not duplicated into a hint, the iOS announcement firing once per changed message, the Android live regions, a disabled field staying read-only when `readOnly={false}`, decorative accessories rendering outside the accessibility tree with no button, named disabled accessories staying inoperable, and refs and layout callbacks surviving the decorative/actionable switch. `TextInputStates.test.tsx` pins the filled resting and hover colours without disturbing the focused or disabled indicator, and pins that outlined ignores hover.

Manual, on the TextInput example screen, for both variants:

1. Toggle **Error** - supporting text becomes the error and is announced: an alert on web, an assertive region on Android, one spoken announcement on iOS. A changed message announces again; the same message re-rendered does not.
2. **Decorative leading icon** - not a tab stop, not announced.
3. **Clear text action** - focusable, announced as "Clear text", clears the field. Removing its `aria-label` logs a dev warning.
4. Web: hover the filled field - the indicator moves `onSurfaceVariant` to `onSurface`; with Error on, `error` to `onErrorContainer`. Outlined does not change. Focus overrides hover.
5. **Counter** - announced as "Characters entered N of M", and "Character limit exceeded N of M" past the limit; the field reports invalid.
6. **Disabled** - cannot be focused or edited, indicator `onSurface` at 38%.
7. An empty, unfocused field is still reachable and announced.

Run on Android, iOS and web, plus a screen-reader pass.