### PR TITLE
feat(motion): adopt spring tokens and add shared CSS-transition helper

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -4,6 +4,8 @@ import { StyleSheet } from 'react-native';
 import Animated, { type AnimatedStyle } from 'react-native-reanimated';
 
 import { useInternalTheme } from '../core/theming';
+import { useReduceMotion } from '../theme/accessibility/ReduceMotionContext';
+import { getTransition } from '../theme/tokens/sys/motion';
 import { cornerFull } from '../theme/tokens/sys/shape';
 import type { ThemeProp } from '../theme/types';
 
@@ -56,10 +58,7 @@ const Badge = ({
   ...rest
 }: Props) => {
   const theme = useInternalTheme(themeOverrides);
-
-  const {
-    animation: { scale },
-  } = theme;
+  const reduceMotion = useReduceMotion();
 
   const textColor = theme.colors.onError;
 
@@ -69,8 +68,7 @@ const Badge = ({
 
   const transitionStyle = {
     opacity: visible ? 1 : 0,
-    transitionDuration: 150 * scale,
-    transitionProperty: 'opacity',
+    ...getTransition(theme, 'opacity', 'short3', 'standard', reduceMotion),
   };
 
   return (

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -9,7 +9,7 @@ import type {
   ViewStyle,
 } from 'react-native';
 
-import Animated, { cubicBezier, type CSSStyle } from 'react-native-reanimated';
+import Animated, { type CSSStyle } from 'react-native-reanimated';
 
 import { CheckboxTokens } from './tokens';
 import { getSelectionVisualState } from './utils';
@@ -17,6 +17,7 @@ import { useLocale } from '../../core/locale';
 import { useInternalTheme } from '../../core/theming';
 import { useReduceMotion } from '../../theme/accessibility/ReduceMotionContext';
 import { tokens } from '../../theme/tokens';
+import { getTransition } from '../../theme/tokens/sys/motion';
 import type { ThemeProp } from '../../theme/types';
 import { isKeyboardFocusEvent } from '../../utils/isKeyboardFocusEvent';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
@@ -144,44 +145,38 @@ const Checkbox = ({
     customUncheckedColor: uncheckedColor,
   });
 
-  const fillTransitionTimingFunction = cubicBezier(
-    ...theme.motion.easing.standard
+  const fillTransition = getTransition(
+    theme,
+    ['opacity'],
+    'short2',
+    'standard',
+    reduceMotion
   );
 
-  const fillTransitionDuration = reduceMotion
-    ? 0
-    : theme.motion.duration.short2;
-
-  const checkTransitionDuration = reduceMotion
-    ? 0
-    : theme.motion.duration.short3;
-
-  const checkTransitionTimingFunction = cubicBezier(
-    ...theme.motion.easing.standard
+  const checkTransition = getTransition(
+    theme,
+    ['width', 'opacity'],
+    'short3',
+    'standard',
+    reduceMotion
   );
 
   const outlineStyle: CSSStyle<ViewStyle> = {
     borderColor: visual.outlineColor,
     opacity: selected ? 0 : 1,
-    transitionDuration: fillTransitionDuration,
-    transitionProperty: ['opacity'],
-    transitionTimingFunction: fillTransitionTimingFunction,
+    ...fillTransition,
   };
 
   const fillStyle: CSSStyle<ViewStyle> = {
     backgroundColor: visual.containerColor,
     opacity: selected ? 1 : 0,
-    transitionDuration: fillTransitionDuration,
-    transitionProperty: ['opacity'],
-    transitionTimingFunction: fillTransitionTimingFunction,
+    ...fillTransition,
   };
 
   const maskStyle: CSSStyle<ViewStyle> = {
     width: selected ? CONTAINER_SIZE : 0,
     opacity: selected ? 1 : 0,
-    transitionDuration: checkTransitionDuration,
-    transitionProperty: ['width', 'opacity'],
-    transitionTimingFunction: checkTransitionTimingFunction,
+    ...checkTransition,
   };
 
   // Remember the last drawn glyph so the reveal-mask can finish collapsing

--- a/src/components/SegmentedButtons/SegmentedButtonItem.tsx
+++ b/src/components/SegmentedButtons/SegmentedButtonItem.tsx
@@ -22,18 +22,13 @@ import {
 } from './utils';
 import { useInternalTheme } from '../../core/theming';
 import { useReduceMotion } from '../../theme/accessibility/ReduceMotionContext';
+import { toRawSpring } from '../../theme/tokens/sys/motion';
 import type { ThemeProp } from '../../theme/types';
 import type { IconSource } from '../Icon';
 import Icon from '../Icon';
 import TouchableRipple from '../TouchableRipple/TouchableRipple';
 import type { Props as TouchableRippleProps } from '../TouchableRipple/TouchableRipple';
 import Text from '../Typography/Text';
-
-const CHECK_SPRING_CONFIG = {
-  stiffness: 230.2,
-  damping: 22,
-  mass: 1,
-};
 
 export type Props = {
   /**
@@ -139,16 +134,21 @@ const SegmentedButtonItem = ({
 
   const checkScale = useSharedValue(0);
 
+  const checkSpringConfig = React.useMemo(
+    () => ({
+      ...toRawSpring(theme.motion.spring.slow.spatial),
+      reduceMotion: reduceMotion ? ReduceMotion.Always : ReduceMotion.Never,
+    }),
+    [theme.motion.spring.slow.spatial, reduceMotion]
+  );
+
   React.useEffect(() => {
     if (!showSelectedCheck) {
       return;
     }
 
-    checkScale.value = withSpring(checked ? 1 : 0, {
-      ...CHECK_SPRING_CONFIG,
-      reduceMotion: reduceMotion ? ReduceMotion.Always : ReduceMotion.Never,
-    });
-  }, [checked, checkScale, reduceMotion, showSelectedCheck]);
+    checkScale.value = withSpring(checked ? 1 : 0, checkSpringConfig);
+  }, [checked, checkScale, checkSpringConfig, showSelectedCheck]);
 
   const checkAnimatedStyle = useAnimatedStyle(() => ({
     transform: [{ scale: checkScale.value }],

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -32,12 +32,6 @@ export type TextInputAnimationState = {
   animatedActiveOutlineStyle?: StyleProp<AnimatedStyle<StyleProp<ViewStyle>>>;
 };
 
-export type TextInputAnimationHandlers = {
-  runFocusAnimation: (hasText: boolean) => void;
-  runBlurAnimation: (hasText: boolean) => void;
-  syncFloatToValue: (hasText: boolean) => void;
-};
-
 export type TextInputFlags = {
   isRTL: boolean;
   isDisabled: boolean;

--- a/src/components/TextInput/constants.ts
+++ b/src/components/TextInput/constants.ts
@@ -1,9 +1,6 @@
 import { PixelRatio } from 'react-native';
 
-import { Easing } from 'react-native-reanimated';
-
 import { tokens } from '../../theme/tokens';
-import { motionDuration, motionEasing } from '../../theme/tokens/sys/motion';
 import { defaultShapes } from '../../theme/tokens/sys/shape';
 
 export const fontScale = PixelRatio.getFontScale();
@@ -46,15 +43,8 @@ export const SUPPORTING_TEXT_FONT_SIZE =
 
 export const SUPPORTING_TEXT_MARGIN_TOP = 4;
 
-export const ANIMATION_DURATION_MS = motionDuration.short3;
-
 export const ACTIVE_INDICATOR_SIZE = 2;
 export const INACTIVE_INDICATOR_SIZE = 1;
-
-export const TIMING_CONFIG = {
-  duration: ANIMATION_DURATION_MS,
-  easing: Easing.bezier(...motionEasing.standard),
-} as const;
 
 /**
  * Constants for the filled variant.

--- a/src/components/TextInput/hooks.ts
+++ b/src/components/TextInput/hooks.ts
@@ -1,29 +1,11 @@
-import {
-  useEffect,
-  useImperativeHandle,
-  useRef,
-  useState,
-  type RefObject,
-} from 'react';
+import { useImperativeHandle, useRef, useState, type RefObject } from 'react';
 import { TextInput as NativeTextInput } from 'react-native';
 import type { BlurEvent, FocusEvent } from 'react-native';
 
-import {
-  interpolate,
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated';
-
-import {
-  ACTIVE_LABEL_FONT_SIZE,
-  INACTIVE_LABEL_FONT_SIZE,
-  TIMING_CONFIG,
-} from './constants';
+import { ACTIVE_LABEL_FONT_SIZE, INACTIVE_LABEL_FONT_SIZE } from './constants';
 import type {
   TextInputAnimationState,
   TextInputFlags,
-  TextInputAnimationHandlers,
   TextInputHookReturn,
   TextInputLayoutState,
   TextInputProps,
@@ -38,26 +20,33 @@ import {
 } from './utils';
 import { useLocale } from '../../core/locale';
 import { useInternalTheme } from '../../core/theming';
+import { useReduceMotion } from '../../theme/accessibility/ReduceMotionContext';
+import { getTransition } from '../../theme/tokens/sys/motion';
 import type { InternalTheme } from '../../theme/types';
 
+// The label float (top/translateX/fontSize/opacity) and the outlined active
+// border (scaleX) are both driven by a single boolean state transition
+// (focus/blur, or text appearing/disappearing) — not a continuous or
+// interruptible drag — so each ends up a plain discrete CSS transition
+// between two fixed values per property, with no shared progress value
+// needed. That keeps this on the CSS tier per the motion decision rule.
 const useTextInputAnimation = ({
   variant,
   isRTL,
   hasAccessory,
-  value,
-  defaultValue,
+  isFloating,
+  isFocused,
+  theme,
+  reduceMotion,
 }: {
   variant: TextInputVariant;
   isRTL: boolean;
   hasAccessory: boolean;
-  value: string | undefined;
-  defaultValue: string | undefined;
-}): TextInputAnimationState & TextInputAnimationHandlers => {
-  const initialText = value ?? defaultValue ?? '';
-
-  const focusSV = useSharedValue(0);
-  const floatSV = useSharedValue(initialText.length > 0 ? 1 : 0);
-
+  isFloating: boolean;
+  isFocused: boolean;
+  theme: InternalTheme;
+  reduceMotion: boolean;
+}): TextInputAnimationState => {
   const { activeTop, inactiveTop, translateXEnd } = getTextInputAnimationLayout(
     {
       variant,
@@ -66,64 +55,57 @@ const useTextInputAnimation = ({
     }
   );
 
-  const runFocusAnimation = (hasText: boolean) => {
-    focusSV.value = withTiming(1, TIMING_CONFIG);
+  const top = isFloating ? activeTop : inactiveTop;
 
-    if (!hasText) {
-      floatSV.value = withTiming(1, TIMING_CONFIG);
-    }
-  };
+  const animatedLabelWrapperStyle: TextInputAnimationState['animatedLabelWrapperStyle'] =
+    variant === 'filled'
+      ? {
+          top,
+          ...getTransition(theme, 'top', 'short3', 'standard', reduceMotion),
+        }
+      : {
+          top,
+          transform: [{ translateX: isFloating ? translateXEnd : 0 }],
+          ...getTransition(
+            theme,
+            ['top', 'transform'],
+            'short3',
+            'standard',
+            reduceMotion
+          ),
+        };
 
-  const runBlurAnimation = (hasText: boolean) => {
-    focusSV.value = withTiming(0, TIMING_CONFIG);
-
-    floatSV.value = withTiming(hasText ? 1 : 0, TIMING_CONFIG);
-  };
-
-  const syncFloatToValue = (hasText: boolean) => {
-    floatSV.value = withTiming(hasText ? 1 : 0, TIMING_CONFIG);
-  };
-
-  const animatedLabelWrapperStyle = useAnimatedStyle(() => {
-    const top = interpolate(floatSV.value, [0, 1], [inactiveTop, activeTop]);
-
-    if (variant === 'filled') {
-      return { top };
-    }
-
-    return {
-      top,
-      transform: [
-        { translateX: interpolate(floatSV.value, [0, 1], [0, translateXEnd]) },
-      ],
+  const animatedLabelTextStyle: TextInputAnimationState['animatedLabelTextStyle'] =
+    {
+      fontSize: isFloating ? ACTIVE_LABEL_FONT_SIZE : INACTIVE_LABEL_FONT_SIZE,
+      ...getTransition(theme, 'fontSize', 'short3', 'standard', reduceMotion),
     };
-  });
 
-  const animatedLabelTextStyle = useAnimatedStyle(() => ({
-    fontSize: interpolate(
-      floatSV.value,
-      [0, 1],
-      [INACTIVE_LABEL_FONT_SIZE, ACTIVE_LABEL_FONT_SIZE]
-    ),
-  }));
+  const animatedContainerStyle: TextInputAnimationState['animatedContainerStyle'] =
+    {
+      opacity: isFloating ? 1 : 0,
+      ...getTransition(theme, 'opacity', 'short3', 'standard', reduceMotion),
+    };
 
-  const animatedContainerStyle = useAnimatedStyle(() => ({
-    opacity: floatSV.value,
-  }));
-
-  const animatedActiveOutlineStyle = useAnimatedStyle(() => ({
-    transform: [{ scaleX: focusSV.value }],
-  }));
+  const animatedActiveOutlineStyle: TextInputAnimationState['animatedActiveOutlineStyle'] =
+    variant === 'filled'
+      ? {
+          transform: [{ scaleX: isFocused ? 1 : 0 }],
+          ...getTransition(
+            theme,
+            'transform',
+            'short3',
+            'standard',
+            reduceMotion
+          ),
+        }
+      : undefined;
 
   return {
     animatedLabelWrapperStyle,
     animatedLabelTextStyle,
     animatedContainerStyle,
-    animatedActiveOutlineStyle:
-      variant === 'filled' ? animatedActiveOutlineStyle : undefined,
-    runFocusAnimation,
-    runBlurAnimation,
-    syncFloatToValue,
+    animatedActiveOutlineStyle,
   };
 };
 
@@ -138,8 +120,6 @@ const useTextInputInput = (
 
   const initialText = isControlled ? props.value : props.defaultValue;
 
-  const ref = useRef(initialText ?? '');
-
   const [hasValue, setHasValue] = useState(!!initialText);
   const [charCount, setCharCount] = useState(initialText?.length ?? 0);
 
@@ -151,17 +131,7 @@ const useTextInputInput = (
         ? 1
         : 0;
 
-  const getHasText = () => {
-    if (isControlled) {
-      return !!props.value;
-    }
-
-    return ref.current.length > 0;
-  };
-
   const onChangeText = (text: string) => {
-    ref.current = text;
-
     if (!isControlled) {
       const next = text.length > 0;
 
@@ -180,7 +150,6 @@ const useTextInputInput = (
   return {
     hasValue: isControlled ? !!props.value : hasValue,
     inputLength,
-    getHasText,
     onChangeText,
   };
 };
@@ -188,9 +157,7 @@ const useTextInputInput = (
 const useTextInputFocus = (
   props: Pick<TextInputProps, 'onFocus' | 'onBlur'>,
   input: RefObject<NativeTextInput | null>,
-  isDisabled: boolean,
-  { runFocusAnimation, runBlurAnimation }: TextInputAnimationHandlers,
-  getHasText: () => boolean
+  isDisabled: boolean
 ) => {
   const [isFocused, setIsFocused] = useState(false);
 
@@ -198,16 +165,12 @@ const useTextInputFocus = (
     props.onFocus?.(e);
 
     setIsFocused(true);
-
-    runFocusAnimation(getHasText());
   };
 
   const onBlur = (e: BlurEvent) => {
     props.onBlur?.(e);
 
     setIsFocused(false);
-
-    runBlurAnimation(getHasText());
   };
 
   const focusInput = () => {
@@ -323,33 +286,21 @@ export const useTextInput = (props: TextInputProps): TextInputHookReturn => {
   const { ref, variant = 'filled', theme: themeOverride } = props;
 
   const input = useRef<NativeTextInput>(null);
-  const init = useRef(false);
 
   const theme = useInternalTheme(themeOverride);
+  const reduceMotion = useReduceMotion();
 
   const { direction } = useLocale();
 
-  const isControlled = props.value !== undefined;
   const isRTL = direction === 'rtl';
   const hasAccessory = isRTL ? !!props.endAccessory : !!props.startAccessory;
 
-  const { hasValue, inputLength, getHasText, onChangeText } =
-    useTextInputInput(props);
-
-  const animation = useTextInputAnimation({
-    variant,
-    isRTL,
-    hasAccessory,
-    value: props.value,
-    defaultValue: props.defaultValue,
-  });
+  const { hasValue, inputLength, onChangeText } = useTextInputInput(props);
 
   const { isFocused, onFocus, onBlur, focusInput } = useTextInputFocus(
     props,
     input,
-    !!props.disabled,
-    animation,
-    getHasText
+    !!props.disabled
   );
 
   const flags = useTextInputFlags(
@@ -360,24 +311,19 @@ export const useTextInput = (props: TextInputProps): TextInputHookReturn => {
     hasAccessory
   );
 
-  /**
-   * Edge case: a controlled `value` can change programmatically.
-   * Reconcile the float animation with the new text here.
-   * While focused the label is always floated, so we skip to avoid fighting the
-   * focus animation, and depend only on `value` to avoid re-running on
-   * focus/blur transitions (those are already handled by their own handlers)
-   */
-  useEffect(() => {
-    if (!init.current) {
-      init.current = true;
-      return;
-    }
-
-    if (isControlled && !isFocused) {
-      animation.syncFloatToValue(!!props.value);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- [props.value] is the only dep that should act as a trigger
-  }, [props.value]);
+  // `isFloating` is derived every render from `isFocused`/`hasValue` (itself
+  // reconciled with a controlled `value` by `useTextInputInput`), so the
+  // label float and active-border animations below stay in sync with
+  // programmatic value changes with no extra effect needed.
+  const animation = useTextInputAnimation({
+    variant,
+    isRTL,
+    hasAccessory,
+    isFloating: flags.isFloating,
+    isFocused,
+    theme,
+    reduceMotion,
+  });
 
   useImperativeHandle(ref, () => ({
     focus: () => {
@@ -389,10 +335,6 @@ export const useTextInput = (props: TextInputProps): TextInputHookReturn => {
       input.current?.clear();
 
       onChangeText('');
-
-      if (!input.current?.isFocused()) {
-        animation.runBlurAnimation(false);
-      }
     },
     blur: () => input.current?.blur(),
     isFocused: () => input.current?.isFocused() || false,

--- a/src/components/TextInput/hooks.ts
+++ b/src/components/TextInput/hooks.ts
@@ -24,10 +24,10 @@ import { useReduceMotion } from '../../theme/accessibility/ReduceMotionContext';
 import { getTransition } from '../../theme/tokens/sys/motion';
 import type { InternalTheme } from '../../theme/types';
 
-// The label float (top/translateX/fontSize/opacity) and the outlined active
-// border (scaleX) are both driven by a single boolean state transition
-// (focus/blur, or text appearing/disappearing) — not a continuous or
-// interruptible drag — so each ends up a plain discrete CSS transition
+// The label float (top/translateX/fontSize/opacity) and the filled variant's
+// active indicator (scaleX) are both driven by a single boolean state
+// transition (focus/blur, or text appearing/disappearing) — not a continuous
+// or interruptible drag — so each ends up a plain discrete CSS transition
 // between two fixed values per property, with no shared progress value
 // needed. That keeps this on the CSS tier per the motion decision rule.
 const useTextInputAnimation = ({

--- a/src/components/__tests__/TextInput.test.tsx
+++ b/src/components/__tests__/TextInput.test.tsx
@@ -20,6 +20,15 @@ import type { TestInstance } from 'test-renderer';
 import { act, fireEvent, render, screen, userEvent } from '../../test-utils';
 import { tokens } from '../../theme/tokens';
 import TextInput from '../TextInput';
+import {
+  ACTIVE_LABEL_FONT_SIZE,
+  FILLED_ACTIVE_LABEL_TOP_POSITION,
+  FILLED_INACTIVE_LABEL_TOP_POSITION,
+  INACTIVE_LABEL_FONT_SIZE,
+  OUTLINED_ACTIVE_LABEL_TOP_POSITION,
+  OUTLINED_INACTIVE_LABEL_TOP_POSITION,
+  OUTLINED_LABEL_TRANSLATE_DISTANCE_WITHOUT_ACCESSORY,
+} from '../TextInput/constants';
 import type {
   TextInputRenderProps,
   TextInputHandles,
@@ -53,6 +62,24 @@ const getOuterTextInputPressable = (root: TestInstance | null) => {
   }
 
   return pressable;
+};
+
+/** The label's animated wrapper has no public testID — it's marked `aria-hidden`. */
+const getLabelWrapper = (root: TestInstance | null) => {
+  const [wrapper] =
+    // eslint-disable-next-line no-restricted-syntax -- TODO: replace non-accessible label wrapper lookup with a public behavior assertion.
+    root?.queryAll(
+      (instance) =>
+        // eslint-disable-next-line no-restricted-syntax -- TODO: replace TestInstance props access with a user-visible assertion.
+        instance.props['aria-hidden'] === true,
+      { includeSelf: true }
+    ) ?? [];
+
+  if (!wrapper) {
+    throw new Error('Expected label wrapper');
+  }
+
+  return wrapper;
 };
 
 const getConstantsOriginal = I18nManager.getConstants.bind(I18nManager);
@@ -607,6 +634,90 @@ it('invokes onFocus and onBlur on the TextInput', async () => {
 
   expect(onFocus).toHaveBeenCalledTimes(1);
   expect(onBlur).toHaveBeenCalledTimes(1);
+});
+
+it('floats the label up and shrinks it on focus, and back down on blur when empty (filled)', async () => {
+  const { root } = await render(
+    <TextInput
+      label="Email"
+      value=""
+      onChangeText={() => {}}
+      testID="tf-input"
+    />
+  );
+
+  const input = screen.getByTestId('tf-input');
+  const label = screen.getByText('Email', includeHiddenElements);
+
+  expect(getLabelWrapper(root)).toHaveStyle({
+    top: FILLED_INACTIVE_LABEL_TOP_POSITION,
+  });
+  expect(label).toHaveStyle({ fontSize: INACTIVE_LABEL_FONT_SIZE });
+
+  await fireEvent(input, 'focus');
+
+  expect(getLabelWrapper(root)).toHaveStyle({
+    top: FILLED_ACTIVE_LABEL_TOP_POSITION,
+  });
+  expect(label).toHaveStyle({ fontSize: ACTIVE_LABEL_FONT_SIZE });
+
+  await fireEvent(input, 'blur');
+
+  expect(getLabelWrapper(root)).toHaveStyle({
+    top: FILLED_INACTIVE_LABEL_TOP_POSITION,
+  });
+  expect(label).toHaveStyle({ fontSize: INACTIVE_LABEL_FONT_SIZE });
+});
+
+it('keeps the label floated after blur when the field already has a value (filled)', async () => {
+  const { root } = await render(
+    <TextInput
+      label="Email"
+      value="a@b.co"
+      onChangeText={() => {}}
+      testID="tf-input"
+    />
+  );
+
+  const input = screen.getByTestId('tf-input');
+
+  await fireEvent(input, 'focus');
+  await fireEvent(input, 'blur');
+
+  expect(getLabelWrapper(root)).toHaveStyle({
+    top: FILLED_ACTIVE_LABEL_TOP_POSITION,
+  });
+  expect(screen.getByText('Email', includeHiddenElements)).toHaveStyle({
+    fontSize: ACTIVE_LABEL_FONT_SIZE,
+  });
+});
+
+it('floats the label up and slides it into the outline gap on focus (outlined)', async () => {
+  const { root } = await render(
+    <TextInput
+      variant="outlined"
+      label="Email"
+      value=""
+      onChangeText={() => {}}
+      testID="tf-input"
+    />
+  );
+
+  const input = screen.getByTestId('tf-input');
+
+  expect(getLabelWrapper(root)).toHaveStyle({
+    top: OUTLINED_INACTIVE_LABEL_TOP_POSITION,
+    transform: [{ translateX: 0 }],
+  });
+
+  await fireEvent(input, 'focus');
+
+  expect(getLabelWrapper(root)).toHaveStyle({
+    top: OUTLINED_ACTIVE_LABEL_TOP_POSITION,
+    transform: [
+      { translateX: -OUTLINED_LABEL_TRANSLATE_DISTANCE_WITHOUT_ACCESSORY },
+    ],
+  });
 });
 
 it('focuses the TextInput when the outer Pressable is pressed', async () => {

--- a/src/theme/__tests__/motion.test.ts
+++ b/src/theme/__tests__/motion.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { expressiveMotion, getTransition } from '../tokens/sys/motion';
+
+const theme = { motion: expressiveMotion };
+
+describe('getTransition', () => {
+  it('passes the property through unchanged for a single property', () => {
+    expect(
+      getTransition(theme, 'opacity', 'short3', 'standard', false)
+    ).toMatchObject({ transitionProperty: 'opacity' });
+  });
+
+  it('passes the property through unchanged for multiple properties', () => {
+    expect(
+      getTransition(theme, ['width', 'opacity'], 'short3', 'standard', false)
+    ).toMatchObject({ transitionProperty: ['width', 'opacity'] });
+  });
+
+  it('reads the duration from the given token', () => {
+    expect(
+      getTransition(theme, 'opacity', 'short2', 'standard', false)
+        .transitionDuration
+    ).toBe(expressiveMotion.duration.short2);
+  });
+
+  it('zeroes the duration when reduceMotion is set, regardless of the token', () => {
+    expect(
+      getTransition(theme, 'opacity', 'short2', 'standard', true)
+        .transitionDuration
+    ).toBe(0);
+  });
+
+  it('builds a cubicBezier timing function from the given easing token', () => {
+    const { transitionTimingFunction } = getTransition(
+      theme,
+      'opacity',
+      'short3',
+      'standardAccelerate',
+      false
+    );
+
+    expect(transitionTimingFunction?.toString()).toBe(
+      `cubicBezier(${expressiveMotion.easing.standardAccelerate.join(', ')})`
+    );
+  });
+});

--- a/src/theme/tokens/sys/motion.ts
+++ b/src/theme/tokens/sys/motion.ts
@@ -1,3 +1,8 @@
+import {
+  cubicBezier,
+  type CSSTransitionProperties,
+} from 'react-native-reanimated';
+
 import type {
   MotionConfig,
   MotionDuration,
@@ -109,5 +114,35 @@ export function toRawSpring({
     stiffness,
     damping: ratio * 2 * Math.sqrt(stiffness),
     mass: 1, // as per MD specs
+  };
+}
+
+/**
+ * Builds the three CSS-transition style props (duration, easing, property)
+ * from theme motion tokens, so components don't re-derive them by hand.
+ * Zeroes the duration when `reduceMotion` is set, per the CSS tier's
+ * reduce-motion contract (a Reanimated `ReduceMotion` option doesn't apply
+ * to CSS transitions).
+ *
+ * @example
+ * <Animated.View
+ *   style={[
+ *     { opacity: visible ? 1 : 0 },
+ *     getTransition(theme, 'opacity', 'short3', 'standard', reduceMotion),
+ *   ]}
+ * />
+ */
+export function getTransition<S extends object = Record<string, unknown>>(
+  theme: { motion: MotionConfig },
+  property: NonNullable<CSSTransitionProperties<S>['transitionProperty']>,
+  durationToken: keyof MotionDuration,
+  easingToken: keyof MotionEasing,
+  reduceMotion: boolean
+): Required<Pick<CSSTransitionProperties<S>, 'transitionProperty'>> &
+  CSSTransitionProperties<S> {
+  return {
+    transitionProperty: property,
+    transitionDuration: reduceMotion ? 0 : theme.motion.duration[durationToken],
+    transitionTimingFunction: cubicBezier(...theme.motion.easing[easingToken]),
   };
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

MD3 Expressive replaces the easing+duration motion model with spring physics where motion is genuinely spring-shaped, and the library's preferred mechanism otherwise is Reanimated CSS transitions. #5015 already handled the library swap (`Animated` → Reanimated) and the CSS-transition conversion for most components; this PR handles what it didn't: spring adoption, plus a shared helper so the CSS tier stops re-deriving duration/easing/reduce-motion by hand in every component.

Concretely:
- Added `getTransition(theme, property, durationToken, easingToken, reduceMotion)` in `theme/tokens/sys/motion.ts` — the shared CSS-transition helper.
- `Badge`: switched to the helper, fixing a hardcoded `150ms` duration (now `theme.motion.duration.short3`), a missing `transitionTimingFunction`, and reduce-motion wired through the legacy `theme.animation.scale` instead of `useReduceMotion()`.
- `Checkbox`: already correct (CSS transitions, `useReduceMotion()`, right tokens) — deduped onto the new helper, no behavior change.
- `TextInput`: converted the label-float and outlined active-border animation from imperative `withTiming`/shared-values/`interpolate()` to CSS transitions. Both only ever animate between two fixed endpoints per boolean state (focus/blur, text present or not) — not a continuous drag — so each derived property becomes an independent CSS transition driven by render state, which also let me delete the effect that used to hand-resync a controlled `value` change.
- `SegmentedButtonItem`: the checkmark's `withSpring` was using a hand-rolled raw spring config (`stiffness: 230.2, damping: 22`) instead of a theme token. Converted to `toRawSpring(theme.motion.spring.slow.spatial)`, which is the actual "spring adoption" this task is about.

**Not included, flagged separately**: while reviewing every `withTiming`/`withSpring` site in `src/`, I found several #5015-touched files that still animate with imperative `withTiming` rather than CSS transitions (`Banner`, `Snackbar`, `Drawer/DrawerCollapsedItem`, `Menu/Menu.tsx`, `CrossFadeIcon`, `DataTable/DataTableTitle`). None look spring-shaped, so they're CSS-transition (mechanism) candidates, not spring-adoption candidates — out of scope here per this task's "splittable" note. I'll file a follow-up issue for these and link it here.

### Related issue

This is part of the ongoing MD3 Expressive motion modernization (spring tokens + CSS-transition helper); there's no existing tracking issue for it yet. The out-of-scope items noted above will get their own follow-up issue, referenced here once filed.

### Test plan

- `yarn typecheck`, `yarn lint`, and `yarn jest` all pass (686 tests, 56 suites), including new coverage:
  - `src/theme/__tests__/motion.test.ts` — unit tests for `getTransition` (property passthrough, duration token lookup, reduce-motion zeroing, cubicBezier easing construction).
  - `src/components/__tests__/TextInput.test.tsx` — asserts the label wrapper's `top`/`fontSize`/`translateX` across focus/blur for both filled and outlined variants, now that they're plain computed values instead of worklet-interpolated ones.
- Manual verification (reviewers, run through this in the example app):
  - **Badge** (`Examples → Badge`): toggle visibility — opacity should fade smoothly at a normal, snappy speed, not pop instantly.
  - **Checkbox / Checkbox Item**: check/uncheck repeatedly, including rapid double-taps mid-transition — this is a dedup-only refactor, so behavior should be unchanged from before.
  - **TextInput** (filled + outlined): focus/blur with empty and pre-filled values, type then clear while focused, change a controlled value programmatically, rapid focus/blur between fields — label float and active-border/outline-slide animations should track correctly and interrupt cleanly with no glitches.
  - **Segmented Buttons** (`Examples → SegmentedButtons → With Selected Check`): selecting a segment should show the checkmark scale in with a slight spring overshoot, not a linear/eased grow.
  - Reduce Motion (OS-level accessibility setting): repeat the Badge and TextInput checks — transitions should be instant, not just faster.

#### Screenshots

##### Badge
https://github.com/user-attachments/assets/7d757377-aa6b-4277-821b-fa3486aa0399

#####  Checkbox / Checkbox Item
https://github.com/user-attachments/assets/d2315cbc-d357-446b-ab16-d1a7d4ba709e

#####  TextInput
https://github.com/user-attachments/assets/06dc5a96-28d3-47b9-869a-40182d0377a1

#####  Segmented Buttons
https://github.com/user-attachments/assets/f219fb2a-5fc2-481e-8484-f56d697da8eb