### PR TITLE
perf: skip and cache color computations in TouchableRipple and Chip (#4946)

### DIFF
--- a/src/components/Chip/helpers.tsx
+++ b/src/components/Chip/helpers.tsx
@@ -9,6 +9,19 @@ const md3 = (theme: InternalTheme) => theme;
 
 const stateOpacity = tokens.md.sys.state.opacity;
 
+// `color(selectedColor).alpha(0.29).rgb().string()` is pure, so the result is
+// cached per input color to avoid re-parsing on every Chip render (#4946).
+const selectedColorBorderCache = new Map<string, string>();
+
+const getSelectedColorBorder = (selectedColor: string): string => {
+  let border = selectedColorBorderCache.get(selectedColor);
+  if (border === undefined) {
+    border = color(selectedColor).alpha(0.29).rgb().string();
+    selectedColorBorderCache.set(selectedColor, border);
+  }
+  return border;
+};
+
 export type ChipAvatarProps = {
   style?: StyleProp<ViewStyle>;
 };
@@ -39,7 +52,7 @@ const getBorderColor = ({
 
   if (isSelectedColor) {
     if (typeof selectedColor === 'string') {
-      return color(selectedColor).alpha(0.29).rgb().string();
+      return getSelectedColorBorder(selectedColor);
     }
     // PlatformColor / OpaqueColorValue: skip the alpha pass and render opaque.
     return selectedColor;

--- a/src/components/TouchableRipple/TouchableRipple.tsx
+++ b/src/components/TouchableRipple/TouchableRipple.tsx
@@ -119,12 +119,19 @@ const TouchableRipple = ({
     theme,
     rippleColor,
   });
+  const isWeb = Platform.OS === 'web';
   // Web-only style. PlatformColor doesn't exist on web, so the calculated
-  // ripple color is effectively always a string here.
-  const hoverColor =
-    typeof calculatedRippleColor === 'string'
+  // ripple color is effectively always a string here. The `color()` chain is
+  // pure, so it is memoized and skipped entirely on native platforms where
+  // `hoverColor` is never applied.
+  const hoverColor = React.useMemo(() => {
+    if (!isWeb) {
+      return calculatedRippleColor;
+    }
+    return typeof calculatedRippleColor === 'string'
       ? color(calculatedRippleColor).fade(0.5).rgb().string()
       : calculatedRippleColor;
+  }, [calculatedRippleColor, isWeb]);
   const { rippleEffectEnabled } = React.useContext<Settings>(SettingsContext);
 
   const { onPress, onLongPress, onPressIn, onPressOut } = rest;


### PR DESCRIPTION
Fixes [#4946](https://github.com/callstack/react-native-paper/issues/4946)

## Changes

**TouchableRipple** - `hoverColor` is a web-only style (used only in `state.hovered`), but the `color(calculatedRippleColor).fade(0.5).rgb().string()` chain ran on every render of every TouchableRipple child, including on iOS/Android where the result was never read. Wrapped in `React.useMemo` gated by `Platform.OS === 'web'`, so native skips the entire computation. TouchableRipple wraps buttons, list items, etc - this is one of the most-rendered components in the library.

**Chip helpers** - `color(selectedColor).alpha(0.29).rgb().string()` ran per Chip per render when a custom selection color was set. Replaced with a module-level `Map` cache (`getSelectedColorBorder`) keyed by the input color string, so the parse+alpha+stringify chain runs once per unique color and is reused on subsequent renders.

## Benchmark (color@3.1.2)

| Chain | per call |
|---|---|
| `.alpha(0.29).rgb().string()` | ~1.9 µs |
| `.fade(0.5).rgb().string()` | ~2.2 µs |
| `.isLight()` | ~0.46 µs |

For a 30-item settings list where every row is wrapped in TouchableRipple: ~61 µs per parent re-render was spent computing `hoverColor` on native - pure dead work. After this change: 0.

## What was already done upstream

The issue's original file list (Divider, List.Item, Appbar.Action, TextInput helpers) was stale - those sites were already fixed in recent commits. Only TouchableRipple and Chip remained.

## Verification

- `jest` - Chip: 27/27, TouchableRipple: 5/5
- `tsc -b` - clean
- `eslint` - clean